### PR TITLE
[WebGPU] Sampler::samplerState() will throw an exception if the device is nil

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277552-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277552-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277552.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277552.html
@@ -1,0 +1,26962 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let device0 = await adapter0.requestDevice({
+  label: '\u{1f99c}\udb32\u{1fc7c}\u02d6\u0277\u{1f787}',
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 40,
+    maxVertexAttributes: 20,
+    maxVertexBufferArrayStride: 42417,
+    maxStorageTexturesPerShaderStage: 20,
+    maxStorageBuffersPerShaderStage: 44,
+    maxDynamicStorageBuffersPerPipelineLayout: 19863,
+    maxDynamicUniformBuffersPerPipelineLayout: 37845,
+    maxBindingsPerBindGroup: 3981,
+    maxTextureArrayLayers: 679,
+    maxTextureDimension1D: 11015,
+    maxTextureDimension2D: 15458,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 119062205,
+    maxStorageBufferBindingSize: 183762648,
+    maxUniformBuffersPerShaderStage: 42,
+    maxSampledTexturesPerShaderStage: 41,
+    maxInterStageShaderVariables: 82,
+    maxInterStageShaderComponents: 92,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1221,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler0 = device0.createSampler({
+  label: '\u{1fe1d}\u06e5\uc79c\u{1f9b8}\u080f',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.7277,
+  lodMaxClamp: 9.076,
+});
+let buffer0 = device0.createBuffer({size: 145032, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u55d0\u2fc1\u41ab\u0108\u0544\uad78\u9188'});
+let texture0 = device0.createTexture({
+  label: '\u89a6\u6207\u065e\u{1f728}',
+  size: [15],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView0 = texture0.createView({label: '\u{1f88a}\u7780\ube36\uccb1'});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\uc45a\u{1f851}'});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(80)), /* required buffer size: 610 */
+{offset: 610, bytesPerRow: 429}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\uc9dc\u81ce\u1442',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let sampler1 = device0.createSampler({
+  label: '\u0513\u7a95\ud169\u{1fc5d}\u6e1d\u0b9f\u482f\u449b\ua404',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.701,
+  lodMaxClamp: 71.80,
+  compare: 'never',
+  maxAnisotropy: 13,
+});
+let textureView1 = texture0.createView({label: '\u3ea4\ube8c\u1efa', format: 'rgba32uint', baseMipLevel: 0, baseArrayLayer: 0});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let img0 = await imageWithData(173, 169, '#144af5be', '#3da40810');
+let commandEncoder1 = device0.createCommandEncoder({label: '\u997d\u021a\u93db\u53a0\u9ec7\u{1fb5a}\uba16'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\ub24a\u02c7\u0de9',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let sampler2 = device0.createSampler({
+  label: '\u{1fc2f}\u{1fae6}\u0914\u{1fd76}\u{1fde5}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.13,
+  lodMaxClamp: 61.25,
+  maxAnisotropy: 14,
+});
+try {
+commandEncoder1.pushDebugGroup('\uba60');
+} catch {}
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let texture1 = device0.createTexture({
+  label: '\uaf22\u{1fc4c}\u191f\u5057\ubf14\udc75\u7378\u118c\u387f\uaaba\u66a1',
+  size: [384, 480, 1],
+  mipLevelCount: 8,
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView2 = texture1.createView({label: '\uc45c\u70a2\u0296\u0a2e\u0a91\u0738', dimension: '2d-array'});
+let renderBundle0 = renderBundleEncoder1.finish({label: '\u{1fd0a}\u014e\u0fe0'});
+try {
+renderBundleEncoder0.insertDebugMarker('\u0bfb');
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView3 = texture0.createView({baseMipLevel: 0});
+let sampler3 = device0.createSampler({
+  label: '\u0f5d\u0c90\u{1fd0a}\u8a32\uf130\u{1f6a1}\u0c8c\u{1fc67}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.51,
+  compare: 'less',
+  maxAnisotropy: 8,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 711 */
+{offset: 711}, {width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let buffer1 = device0.createBuffer({
+  label: '\u0237\u{1f687}\u5c4c\u0b36\u0891\uf176\u0c90\u0bee\u030c',
+  size: 40702,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView4 = texture1.createView({
+  label: '\u7d8c\u0907\u936b\u9a66\u0739',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 4,
+});
+let sampler4 = device0.createSampler({
+  label: '\u0085\u1ef6\ub77f\u5533\u2740',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.32,
+  lodMaxClamp: 46.04,
+  compare: 'less',
+  maxAnisotropy: 19,
+});
+try {
+renderBundleEncoder0.setVertexBuffer(4844, undefined, 2729504088, 1531317279);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 12320 */
+  offset: 12320,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u{1ff04}\udded\u09ca\uf9c6\u{1f867}\ua023\uf550',
+  size: 309182,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let commandEncoder3 = device0.createCommandEncoder({label: '\u1c23\u{1fff7}\u0b2b\u8d2b\ua3f0'});
+let texture2 = device0.createTexture({
+  label: '\u{1f74b}\u2525\u8906\u6148\u5155\u1eb6\ud4fe\u39d5\u5613',
+  size: [322],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+let textureView5 = texture2.createView({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 83.17,
+});
+let externalTexture0 = device0.importExternalTexture({
+  label: '\u{1f710}\u4c26\u{1febe}\u8ff2\ud9f3\u08b7\u74ca\u9a1c\u48e3',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let img1 = await imageWithData(237, 15, '#5dd895ec', '#4a2ead3c');
+let videoFrame1 = new VideoFrame(img1, {timestamp: 0});
+let buffer3 = device0.createBuffer({label: '\u2293\u{1fa3e}', size: 145806, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 183});
+let commandBuffer0 = commandEncoder3.finish({label: '\u0157\u{1f62c}\u1608\uaf7e\u0c27\u019b\u0114\u05c6\u{1f766}\u0cb5'});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+commandEncoder1.copyBufferToBuffer(buffer1, 32456, buffer3, 51192, 1568);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder1.clearBuffer(buffer3, 128584, 9768);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let imageData0 = new ImageData(56, 132);
+let computePassEncoder1 = commandEncoder2.beginComputePass({label: '\u{1f9a5}\u{1f79b}\u625b'});
+let renderBundle2 = renderBundleEncoder1.finish({label: '\u{1fca1}\u0645\u0947\u4470\u56d0\u862c\u0cb7\ud1e8'});
+let externalTexture1 = device0.importExternalTexture({label: '\u{1f9cc}\u8a5c', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder1.end();
+} catch {}
+let img2 = await imageWithData(175, 103, '#70b3bc6c', '#9498d09c');
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fe9d}\u93b4\u0d3b\u77c7\u{1f826}\u662c\u0e33'});
+let texture3 = device0.createTexture({
+  label: '\u081b\u0073\u801b\u9d9b\u696c\ue960\u79b7\u03e4\u0bc9\u{1f72b}',
+  size: {width: 1440},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32uint'],
+});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\u0521\u{1fa08}\u900c\u0020'});
+let externalTexture2 = device0.importExternalTexture({label: '\u1db9\u0e5a\u80e7\u0ed9\ub9b6\u77ef', source: videoFrame0, colorSpace: 'srgb'});
+try {
+commandEncoder4.clearBuffer(buffer3, 133044, 2588);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let img3 = await imageWithData(28, 293, '#ff1027c4', '#be32388a');
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1fd89}\u43ce'});
+let externalTexture3 = device0.importExternalTexture({
+  label: '\u2427\u45fc\u{1ff39}\u5775\u8286\u4ee2\u{1f81c}\u8041',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder4.copyBufferToBuffer(buffer1, 13508, buffer3, 28764, 26260);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer1, 2172, buffer3, 129728, 9876);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(querySet0, 95, 87, buffer0, 107776);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 18924, new DataView(new ArrayBuffer(50510)), 30280, 3588);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(40)), /* required buffer size: 117 */
+{offset: 117}, {width: 1283, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({label: '\u1c1a\u{1ff73}\u{1f93f}\u0911\u{1feec}', entries: []});
+let buffer4 = device0.createBuffer({
+  label: '\u01a0\u49b9\u06da',
+  size: 76096,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true,
+});
+try {
+commandEncoder5.copyBufferToBuffer(buffer4, 71752, buffer3, 64616, 3096);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 2400 widthInBlocks: 600 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20788 */
+  offset: 20788,
+  bytesPerRow: 2560,
+  buffer: buffer1,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 600, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 755 */
+{offset: 755}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u9a22\u099a\u9f2a',
+  entries: [
+    {
+      binding: 1922,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let bindGroup0 = device0.createBindGroup({
+  label: '\u0289\ub801\u{1faaf}\u6bc5\u0455\u{1fd8e}\ufc4c\u0feb\u051e\u3d8a',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler4}],
+});
+let commandEncoder6 = device0.createCommandEncoder({label: '\ub98f\u{1fc5b}\u{1f64a}\u22c1\uf2e7\uc036'});
+let texture4 = device0.createTexture({
+  size: {width: 645, height: 1, depthOrArrayLayers: 32},
+  mipLevelCount: 8,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView6 = texture3.createView({label: '\uf11d\u7be5\u212b\ua309\u07ac\u{1f60b}\ub4ab\u3b24\ua16d\u0bd9\u74c1'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0a4a\u6b11\u02c9\u0bad',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let renderBundle4 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder2.setBindGroup(9, bindGroup0);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer1, 39964, buffer3, 98196, 584);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet0, 132, 26, buffer0, 118016);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 35928, new BigUint64Array(18078), 17445, 400);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let texture5 = device0.createTexture({
+  label: '\u9352\u0b21',
+  size: {width: 62, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView7 = texture1.createView({label: '\u0a67\u6d8f\u02fa\ua0ee\u0b8a\ufece\u6578', dimension: '2d-array', mipLevelCount: 1});
+let sampler6 = device0.createSampler({
+  label: '\u891b\uf6b1\u176b\u0451\uc661\uf82f\ue5df',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.571,
+  lodMaxClamp: 17.51,
+  maxAnisotropy: 9,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(8)), /* required buffer size: 128 */
+{offset: 128}, {width: 374, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let querySet1 = device0.createQuerySet({label: '\uc7d5\u076c\uae1b\u1818\u015c', type: 'occlusion', count: 656});
+try {
+texture1.destroy();
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer1, 19352, buffer4, 30068, 15636);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise2 = adapter0.requestAdapterInfo();
+let buffer5 = device0.createBuffer({label: '\u6298\u{1fae6}', size: 35478, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder8 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder4.finish({label: '\u{1fd13}\u4365\u{1f6b5}\u5baa\u069f\u63c0\u19d7\u0971\u5888\u4421'});
+let textureView8 = texture1.createView({baseMipLevel: 3, mipLevelCount: 4});
+let renderBundle5 = renderBundleEncoder0.finish({label: '\u8bda\uf0e1\u{1fb5c}\u49b8\uec9a\ua74e'});
+let externalTexture4 = device0.importExternalTexture({label: '\uc5fe\udb0a', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+commandEncoder6.copyBufferToBuffer(buffer1, 40592, buffer4, 55976, 52);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 2200 widthInBlocks: 550 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15584 */
+  offset: 15584,
+  rowsPerImage: 32,
+  buffer: buffer1,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 550, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 976 */
+  offset: 976,
+  buffer: buffer3,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder1.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame2 = new VideoFrame(videoFrame1, {timestamp: 0});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1f611}\u{1f951}\u89c3\ub226\u{1f867}'});
+let textureView9 = texture1.createView({
+  label: '\u42a6\ud5b7\u7ab1\u79f0',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 6,
+  arrayLayerCount: 1,
+});
+let sampler7 = device0.createSampler({
+  label: '\u6ae1\u0da6\u8bd0\u068d\ua9f3\u{1fd45}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  lodMinClamp: 23.84,
+  lodMaxClamp: 82.33,
+});
+try {
+commandEncoder8.copyBufferToBuffer(buffer1, 12196, buffer4, 63944, 7384);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer3, 46652, 51764);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 122 */
+{offset: 122}, {width: 48, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({entries: []});
+let textureView10 = texture3.createView({label: '\u59cf\u0d6d\u0a25\u031b\u0df7\u2d45\u{1fb56}\u092f\u2ac8', mipLevelCount: 1});
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 652 */
+  offset: 652,
+  buffer: buffer3,
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet1, 500, 73, buffer0, 6400);
+} catch {}
+try {
+textureView9.label = '\u4e9f\u{1f875}\u{1ff5d}\uaa1a';
+} catch {}
+let buffer6 = device0.createBuffer({
+  label: '\u0936\uaafe\u019b\u4aef\u7e9a\u0748\uec5f\u{1fe44}\u1ed6\u2248\u{1fa65}',
+  size: 75191,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView11 = texture2.createView({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 0, 287852);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let textureView12 = texture4.createView({dimension: '2d', baseMipLevel: 6});
+let computePassEncoder2 = commandEncoder5.beginComputePass({label: '\u{1fc28}\u{1f633}\u{1fe90}'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let sampler8 = device0.createSampler({
+  label: '\u0e72\u08b2\u01b3\u{1fb39}\u0ce1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 5.586,
+  lodMaxClamp: 18.07,
+});
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer6, 0, 17528);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer4, 72804, 1364);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let bindGroup1 = device0.createBindGroup({label: '\u2a3b\u3d8e\u698f', layout: bindGroupLayout3, entries: []});
+let commandEncoder10 = device0.createCommandEncoder({label: '\uec70\ud1e3\u04ca\u07e5\u97d6\ue2f3\uc443'});
+let texture6 = device0.createTexture({
+  label: '\uf689\ua11f\u{1faca}\ud7f9\uc5a8',
+  size: {width: 2880},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let sampler9 = device0.createSampler({
+  label: '\ubac6\u5be0\u5b23\u06b0\u6016\u8140\u0758\u0879\ude64',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.86,
+  lodMaxClamp: 65.82,
+  maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup1, new Uint32Array(3805), 590, 0);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet0, 46, 129, buffer0, 131328);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 27004, new DataView(new ArrayBuffer(24630)), 18074, 3536);
+} catch {}
+document.body.prepend(img3);
+let video0 = await videoWithData();
+let buffer7 = device0.createBuffer({
+  label: '\ua9b3\u0d63\uab4e\uc027\uac92\u{1ffbc}\u{1f98a}\u839a\u68bc',
+  size: 117492,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder11 = device0.createCommandEncoder({label: '\u0ef2\u1a01\u972b'});
+let texture7 = device0.createTexture({
+  size: [2580],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler10 = device0.createSampler({
+  label: '\u7cf5\uedb3\uee9f\u90ef\u{1f8f1}\u1789\ud6bd',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 42.71,
+  lodMaxClamp: 87.71,
+});
+let externalTexture5 = device0.importExternalTexture({label: '\u5d37\u3d48\u020e', source: video0, colorSpace: 'display-p3'});
+let arrayBuffer0 = buffer2.getMappedRange(0, 141804);
+try {
+commandEncoder9.copyBufferToBuffer(buffer7, 95600, buffer3, 71328, 1828);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 387, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 315, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 14600, new BigUint64Array(62553), 15605, 1936);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 296 */
+{offset: 296}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let commandEncoder12 = device0.createCommandEncoder();
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 2144});
+let textureView13 = texture7.createView({label: '\u0dd2\u009b\u6337\u0807\uae8e\u074c\u3a57\u0df4'});
+let renderBundle6 = renderBundleEncoder1.finish();
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u0316\u0888\u{1fdde}\u243d\u0058\u{1f64f}\u95c4\u27bd\u{1f85a}',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(8, bindGroup0);
+} catch {}
+document.body.prepend(img1);
+let videoFrame3 = new VideoFrame(videoFrame1, {timestamp: 0});
+let bindGroup2 = device0.createBindGroup({
+  label: '\ua42f\u93a6\u5522\u{1f85d}\u9997\u{1fdb6}\ubf6f\u{1f932}\u04f5\u{1fd14}\u073a',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler4}],
+});
+let buffer8 = device0.createBuffer({
+  label: '\ue2c6\ufb75\u8bd9\ud910\u0284\ud86c\u9124\uf865\u{1f63d}\u077b\u5ae6',
+  size: 19504,
+  usage: GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let texture8 = device0.createTexture({
+  label: '\ucfa8\u0fd5\u{1f631}\u0707\u036a\u0655\u6b79\u011e\ub83d\u1356',
+  size: [645],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let sampler11 = device0.createSampler({
+  label: '\u6a3b\uc8e0\udbe3\u080e\u8d70\ue60e\u{1fea9}\u0169\u9899\u{1f9d8}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.290,
+  lodMaxClamp: 34.16,
+  maxAnisotropy: 12,
+});
+try {
+commandEncoder1.copyBufferToBuffer(buffer7, 69892, buffer6, 17088, 21928);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 26076, new BigUint64Array(19580), 14704, 2048);
+} catch {}
+video0.height = 159;
+let textureView14 = texture8.createView({});
+let externalTexture7 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder2.setVertexBuffer(5, buffer6, 0, 5194);
+} catch {}
+let arrayBuffer1 = buffer8.getMappedRange(10488, 5808);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise2;
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+adapter0.label = '\u{1f6e1}\u70f0\u09bf';
+} catch {}
+let texture9 = device0.createTexture({
+  label: '\u8fe9\ua6a5\uad08\u{1fe9e}\u17b0\u05bb\u8243\u{1f72b}\uc808',
+  size: [360, 3, 227],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle7 = renderBundleEncoder0.finish({label: '\u0a0f\u0000\u4729\u{1f808}\uf604\uaeb2\u{1ffed}\u43e2\u{1fc39}\u0242'});
+try {
+computePassEncoder0.setBindGroup(8, bindGroup2);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 42880 */
+  offset: 42880,
+  bytesPerRow: 256,
+  buffer: buffer7,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(querySet1, 113, 447, buffer0, 96000);
+} catch {}
+let buffer9 = device0.createBuffer({
+  label: '\u0954\u64d0\u9249\uda4e\u{1fa49}\ube39\u981b',
+  size: 59724,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u4aca\u0242\u0e52\uf33c\ucb13\u08f3\u0c32'});
+let querySet3 = device0.createQuerySet({label: '\u099c\u0b9e\u4ea5', type: 'occlusion', count: 1936});
+let texture10 = device0.createTexture({
+  size: [720, 6, 61],
+  mipLevelCount: 5,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer10 = device0.createBuffer({
+  label: '\ub1fe\u0098\u{1fa98}',
+  size: 19706,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture11 = device0.createTexture({
+  label: '\u3dcd\u0975\u088d',
+  size: [62],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9496 */
+  offset: 9496,
+  bytesPerRow: 0,
+  rowsPerImage: 68,
+  buffer: buffer1,
+}, {
+  texture: texture9,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 5});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\ufc63');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(0)), /* required buffer size: 769 */
+{offset: 769, bytesPerRow: 666}, {width: 121, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u{1fa55}\u{1fb0f}\ua58e\ueb6c\u0e40\u493a',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler3}],
+});
+let commandEncoder14 = device0.createCommandEncoder({label: '\u{1fb05}\u047f\u4f2f\u091b\u{1fb6b}\u225a\u03c6\ua7a9'});
+let textureView15 = texture10.createView({label: '\u0b2f\u{1fb2b}', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 57, arrayLayerCount: 1});
+try {
+commandEncoder10.resolveQuerySet(querySet3, 645, 1028, buffer0, 102656);
+} catch {}
+document.body.prepend(video0);
+let imageBitmap0 = await createImageBitmap(videoFrame3);
+let imageData1 = new ImageData(160, 212);
+let buffer11 = device0.createBuffer({
+  label: '\u{1f90e}\u9fc2\u0009\u0fec\u0704\u09e0\u0f3d\u0966\u0e55\u{1fda3}\u1a54',
+  size: 180169,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  label: '\u730f\u0944',
+  size: [31, 1, 1],
+  mipLevelCount: 5,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundle8 = renderBundleEncoder3.finish({label: '\u0114\u679a\ua36b\u075a'});
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(5101), 3016, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(8, buffer6, 0, 28001);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer10, 8724, buffer4, 51708, 8544);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16720 */
+  offset: 16720,
+  buffer: buffer7,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 77, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet2, 1918, 29, buffer0, 82944);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 516 */
+{offset: 516}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let canvas1 = document.createElement('canvas');
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 37, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 550,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 113373896, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder16 = device0.createCommandEncoder({label: '\u72c4\u138c\u{1f606}\u0baa\u08aa\u098e\u0474\u6b55\u{1fc26}'});
+let textureView16 = texture3.createView({dimension: '1d'});
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer1, 11480, buffer6, 48668, 5612);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet3, 719, 149, buffer0, 33280);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 843 */
+{offset: 843, bytesPerRow: 16162, rowsPerImage: 219}, {width: 2004, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let textureView17 = texture7.createView({label: '\u696c\u61e5\u3ea9\u2499\u{1ff7f}\uab00\ue920', mipLevelCount: 1});
+let renderBundle9 = renderBundleEncoder4.finish({label: '\u{1fd15}\u0790\uf808\u0b94\u016a\uae33\ue1a7\u15b3\u0821\u1226'});
+try {
+commandEncoder6.copyBufferToBuffer(buffer1, 29108, buffer11, 65300, 4804);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 37, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.height = 231;
+let buffer12 = device0.createBuffer({
+  label: '\u53b6\u{1fe98}\u0e0b\uae82\ub3cf\u088b\u0026',
+  size: 43411,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer2 = commandEncoder11.finish({label: '\u0348\u4bdb\u{1ffcb}\ueb1d\u10b5\u{1fa6d}\u{1fef1}\uc2f5'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({label: '\u0c4b\u0665\u{1fbd7}\u{1fde5}', colorFormats: ['rgba16float', 'r32float']});
+let renderBundle10 = renderBundleEncoder4.finish({label: '\ud4fa\u7086'});
+try {
+renderBundleEncoder2.setBindGroup(8, bindGroup1);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8444 */
+  offset: 8444,
+  bytesPerRow: 0,
+  rowsPerImage: 231,
+  buffer: buffer7,
+}, {
+  texture: texture4,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 28});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 30008, new DataView(new ArrayBuffer(26272)), 4518, 10696);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 28, y: 24 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({label: '\ufe1f\ubdf9\u{1fa0c}\u{1f746}\u6184\u1aef\u0b68\u{1fd9b}\u1847'});
+let querySet4 = device0.createQuerySet({label: '\u2e36\u{1f7d0}\u08a6\u011a\u0d9d', type: 'occlusion', count: 3837});
+let texture13 = device0.createTexture({
+  label: '\u{1fd4c}\u6a82\u{1fed8}\u{1f69f}\u04b8\u50f5\u{1fc4c}\u35f3\ud565\ue8d0\u{1fdc1}',
+  size: {width: 1290},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let sampler12 = device0.createSampler({
+  label: '\u{1feb3}\u95b2\u0e82\u{1fd6d}\u03e7\ud760\u1dab\udc22\ue328\u0c14',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.09,
+  lodMaxClamp: 99.84,
+});
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 292, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 308, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer3, 127340, 8264);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet2, 1475, 206, buffer0, 48128);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 15, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({label: '\u688a\u5af8\u6aa4\u{1fef4}\u0d34\u0dff\u0b93\u0cf7\u0a91'});
+let computePassEncoder3 = commandEncoder5.beginComputePass({label: '\u{1fb7d}\u{1fed5}\uef1a\u6a1f\u09e1\u1338\u095e\u{1fb1c}\ud386'});
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup2, new Uint32Array(9381), 6162, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1352 widthInBlocks: 169 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 11024 */
+  offset: 9672,
+  buffer: buffer11,
+}, {width: 169, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u{1f7e8}\u0abf\ub55f\u0340\u{1f636}', bindGroupLayouts: [bindGroupLayout3]});
+let buffer13 = device0.createBuffer({
+  label: '\uc019\ue2bf\u{1feb9}\u{1fead}\u{1f93c}\u0a12\u5d8b\u0f05\u41aa\u4a38',
+  size: 80636,
+  usage: GPUBufferUsage.INDEX,
+});
+let sampler13 = device0.createSampler({
+  label: '\u2797\u8e85\u{1fff1}\u2a15\u0104',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 20.96,
+  lodMaxClamp: 59.39,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder2.setBindGroup(7, bindGroup2, new Uint32Array(1477), 1474, 0);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let adapter1 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+try {
+canvas1.getContext('bitmaprenderer');
+} catch {}
+let commandBuffer3 = commandEncoder13.finish({});
+let renderBundle11 = renderBundleEncoder3.finish({label: '\u8f1c\u0112\u04a7\u934d\u2ffe\u{1fce1}\u3435\u{1fb3e}\u{1ff81}\u0fb9'});
+try {
+renderBundleEncoder2.setBindGroup(9, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(6, buffer6, 0, 49242);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 209, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 33, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 149_018 */
+{offset: 934, bytesPerRow: 78, rowsPerImage: 73}, {width: 10, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let imageBitmap1 = await createImageBitmap(canvas1);
+let commandBuffer4 = commandEncoder15.finish({label: '\u7ccb\ua802\u8b61\u{1feea}\u0d7c\u7f95\u52ab\u0cb6\u3ddc\u{1f905}\u3dc4'});
+let textureView18 = texture9.createView({
+  label: '\u0ffe\u6ae8\uf013\u0f4c\u0bc7\uf6e6\u{1fa11}\u8be7\u0ea7\udcb8\uebba',
+  aspect: 'all',
+  baseMipLevel: 5,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 570 */
+{offset: 570, bytesPerRow: 9552}, {width: 2379, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame4 = new VideoFrame(img1, {timestamp: 0});
+let bindGroup4 = device0.createBindGroup({
+  label: '\u{1feeb}\u08a6\u{1fe91}\u2768\u263b\u133b\u70f5',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler3}],
+});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u735d\uabea\u{1f6f2}\ua6f8\u7d21\u4922\u{1fad5}'});
+let textureView19 = texture1.createView({
+  label: '\u0805\u5930\u02d3\u{1f8e6}\u{1fed7}',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+let renderBundle12 = renderBundleEncoder3.finish({label: '\uba51\ueb03\u{1fdf0}\u029b\u3b87\u{1ff44}\u5c39\u8755\u{1fcb8}'});
+let sampler14 = device0.createSampler({
+  label: '\u7cc5\u{1ff96}\u1c0b\u{1fb75}\u0d9a\u0f5f',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 45.93,
+  lodMaxClamp: 64.13,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(7, buffer6, 0);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 96, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 67088, new BigUint64Array(38317), 6142, 468);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(932, 635);
+let img4 = await imageWithData(241, 178, '#f1382769', '#78285d0a');
+let texture14 = device0.createTexture({
+  size: [31, 1, 121],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView20 = texture14.createView({label: '\u04cd\ua798', baseMipLevel: 3});
+try {
+computePassEncoder3.setBindGroup(4, bindGroup3, new Uint32Array(3498), 53, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(6, bindGroup3, new Uint32Array(4950), 397, 0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(5, buffer6, 0, 13477);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer7, 103952, buffer6, 40884, 4796);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 15760 */
+  offset: 15760,
+  bytesPerRow: 256,
+  buffer: buffer12,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({label: '\u4fed\u02dd\u09d3\u7433\u0051\u{1f61c}\u06bc\u92d3', entries: []});
+let bindGroup5 = device0.createBindGroup({label: '\u0fa8\u0ca6', layout: bindGroupLayout2, entries: [{binding: 1922, resource: sampler3}]});
+let commandEncoder20 = device0.createCommandEncoder({label: '\u{1f642}\u{1fa81}\u{1ff8f}\u0414\uf97c\u019d'});
+let querySet5 = device0.createQuerySet({label: '\u0099\u{1fc9e}\uc3fd\u3aa2\u0d44\u8f82', type: 'occlusion', count: 3620});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.submit([commandBuffer3, commandBuffer4, commandBuffer1]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 24, y: 3 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+offscreenCanvas0.getContext('2d');
+} catch {}
+let textureView21 = texture13.createView({});
+let sampler15 = device0.createSampler({
+  label: '\u{1f69a}\u{1fd0a}\u7718\u0c2d',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.10,
+  lodMaxClamp: 99.98,
+  maxAnisotropy: 20,
+});
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 31328 */
+  offset: 31328,
+  buffer: buffer11,
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 22284, new Int16Array(61710), 1658, 27848);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let texture15 = device0.createTexture({
+  label: '\u{1f6d6}\u9c23\u{1f983}\u0ed4\u362b\u{1f83f}\u{1ff1b}',
+  size: {width: 1290, height: 1, depthOrArrayLayers: 275},
+  mipLevelCount: 9,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView22 = texture2.createView({label: '\u0a00\ub3a2\uc38f\ufb35\u5335\u3887\u0285\u63ae\u0c29\u119d\u01df'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u0ed3\u0f53\u{1fd81}\u{1fa28}\u0401\ucec9\u8890\uc026\u{1fd09}\u05d4',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\u0db4\u3ab9\u0cc7\u43c8\u{1f7b3}\u1009\u{1f6f8}\u0a62\u1496\u0e7c\uf85e',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 0, 128140);
+} catch {}
+let buffer14 = device0.createBuffer({
+  label: '\uab62\u083e\u66b0\u07f6\u06c3\u12a1\u07be\u{1f65d}\u013c',
+  size: 438468,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView23 = texture12.createView({dimension: '2d-array', baseMipLevel: 3});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u084b\u0816\uef27\ufed2\u0a8e\u4680\u{1fcf3}\u{1fbbc}\uc2fe',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle13 = renderBundleEncoder4.finish({});
+let externalTexture9 = device0.importExternalTexture({
+  label: '\uddad\u1fd0\ud209\ua8d3\u{1f7ab}\u68c1\u97de\uffbb\u0eba',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer13, 'uint32', 48716, 27213);
+} catch {}
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 3713});
+let texture16 = device0.createTexture({
+  label: '\u{1fde7}\ued45\u5c36\u1306\u1127\u7d35',
+  size: [645, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let externalTexture10 = device0.importExternalTexture({label: '\u021b\uc8ca\u9d29\u0921\u37f1\uf9e0', source: video0});
+try {
+renderBundleEncoder5.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(6, buffer6, 0);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 4240 widthInBlocks: 1060 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10180 */
+  offset: 10180,
+  buffer: buffer7,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 219, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1060, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({label: '\u1a03\u025c\u0476\udfcd\u0bf3\u{1ffb6}\ufbac\u9466\u05c7\u1c85\u9306'});
+let textureView24 = texture2.createView({label: '\u{1f9d7}\ub332\uacb0\u8e91\u6e5f\u{1f7b8}\u{1f75c}\u{1f7d8}'});
+try {
+commandEncoder5.clearBuffer(buffer11, 127296, 37428);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let video1 = await videoWithData();
+let imageBitmap2 = await createImageBitmap(video1);
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer6, 0);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u1a0a\u06ad\u0fb6\u{1fbc9}\u095c\u5020\u6305\u75fe\u06bd\u{1f75b}'});
+let commandBuffer5 = commandEncoder18.finish({label: '\u159c\u03ba\u03da\u{1f6eb}\uffd1'});
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17996 */
+  offset: 6476,
+  bytesPerRow: 256,
+  rowsPerImage: 15,
+  buffer: buffer10,
+}, {
+  texture: texture10,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 26},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\ufbc5');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\ucc15\u{1fc26}\uf80e\u{1f8d2}\u{1fbf4}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler1}],
+});
+let texture17 = device0.createTexture({
+  label: '\ucb98\u0840\u07c3\u02a5\u9e22\u{1fbe7}\u{1f7f2}\u5dfe\u00e7\u{1fac4}\u2347',
+  size: {width: 31, height: 1, depthOrArrayLayers: 121},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView25 = texture0.createView({});
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer6, 0, 48864);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 3176, new Float32Array(8545), 2363, 2472);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 4, y: 32 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet7 = device0.createQuerySet({label: '\u00bf\u{1f736}', type: 'occlusion', count: 680});
+let texture18 = device0.createTexture({
+  size: {width: 768, height: 960, depthOrArrayLayers: 42},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\uaa18\u{1fb43}\u8eed\u0b93\u{1f6e0}',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder6.setIndexBuffer(buffer5, 'uint16', 38, 35034);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 48, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 536, new Float32Array(55660), 18717, 6684);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 116, y: 14 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder();
+let querySet8 = device0.createQuerySet({label: '\u9e89\u6bd5\u3066\u{1fbb2}\u0fa1\u9572', type: 'occlusion', count: 2478});
+let textureView26 = texture9.createView({label: '\u06d7\u080e\u5217\u0dad\u00c9\u{1fc12}\u222a\u0f88\u2ef0', dimension: '3d', mipLevelCount: 5});
+let computePassEncoder4 = commandEncoder14.beginComputePass({label: '\u31f3\u5a35\u{1fd6e}'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float', 'r32float'], depthReadOnly: true});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(5, bindGroup2, new Uint32Array(2324), 4, 0);
+} catch {}
+let arrayBuffer2 = buffer4.getMappedRange(0, 28652);
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 3044 widthInBlocks: 761 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24400 */
+  offset: 24400,
+  rowsPerImage: 195,
+  buffer: buffer12,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 126, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 761, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 3740, new BigUint64Array(59889), 10981, 2184);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u7df6\u0c3e\u06f3\uc660\u0235\u490c',
+  entries: [
+    {
+      binding: 3682,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 1191,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({label: '\udb81\u085a\ueddf\u3d68\u083b\u6185\u05cf\u07f4\u{1fbca}', bindGroupLayouts: []});
+let querySet9 = device0.createQuerySet({label: '\ufa5e\u62b9\u{1f7f0}\udb00\u8410', type: 'occlusion', count: 3936});
+try {
+renderBundleEncoder7.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer6, 0, 31305);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32140 */
+  offset: 32140,
+  bytesPerRow: 256,
+  buffer: buffer12,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4580 */
+  offset: 4356,
+  rowsPerImage: 180,
+  buffer: buffer11,
+}, {width: 56, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet8, 2389, 62, buffer0, 109056);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 310 */
+{offset: 310}, {width: 2498, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup7 = device0.createBindGroup({label: '\u{1f892}\u96d7\u7591\u0c6b\u329e\u{1fdc1}\ue882', layout: bindGroupLayout3, entries: []});
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView27 = texture14.createView({label: '\u0987\u{1fd68}\ub490\u00a9\u{1f864}\u17d7', baseMipLevel: 2});
+let renderBundle14 = renderBundleEncoder5.finish({label: '\u01b6\u5c28\u195c\uc749\u8f37\u0a5c\u325f\u05d9\u0bab'});
+let sampler16 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.27,
+});
+try {
+renderBundleEncoder9.setBindGroup(7, bindGroup4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 20692, new Int16Array(64852));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 17 */
+{offset: 17}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({label: '\u{1f89f}\u05c9\u077e\u0d47\u3f02\u026c\u3bfb\u{1ffa3}\uce86'});
+try {
+computePassEncoder4.insertDebugMarker('\u0a93');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({label: '\ud293\u{1fb60}', type: 'occlusion', count: 1799});
+let texture19 = device0.createTexture({
+  label: '\u206e\u0969\u067d\u0933\u{1f965}',
+  size: [322, 1, 113],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder6.copyBufferToBuffer(buffer4, 27484, buffer11, 72972, 34016);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 800 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5320 */
+  offset: 5320,
+  bytesPerRow: 1024,
+  buffer: buffer11,
+}, {width: 100, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(9, bindGroup0, new Uint32Array(3866), 3648, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer13, 'uint16');
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer6, 0, 37900);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 107, y: 136, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 212, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 44232, new Int16Array(13764), 10136, 2032);
+} catch {}
+document.body.prepend(video1);
+let imageData2 = new ImageData(112, 188);
+let texture20 = device0.createTexture({
+  label: '\u57e0\u064f\uf6cd\uc84a',
+  size: {width: 322},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView28 = texture17.createView({
+  label: '\u66e7\u8f69\u0f49\u6512\u{1faef}\ua722\u5aa8\u527a\u8ad0',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+});
+let computePassEncoder5 = commandEncoder17.beginComputePass({label: '\ub896\ud53e'});
+let externalTexture11 = device0.importExternalTexture({label: '\uef89\u02e8\ucb54', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setBindGroup(4, bindGroup2, new Uint32Array(1518), 23, 0);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2004, new Int16Array(39332), 1106, 3648);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(56)), /* required buffer size: 489 */
+{offset: 485, bytesPerRow: 127}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let texture21 = device0.createTexture({
+  label: '\u03bf\u{1fa8d}\u3fd0\u{1fe8b}\ua76b\uff71\ufceb',
+  size: [645, 1, 180],
+  mipLevelCount: 9,
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+try {
+computePassEncoder4.setBindGroup(7, bindGroup7, new Uint32Array(4888), 4768, 0);
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer4, 27532, 22492);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet4, 323, 2074, buffer0, 109312);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 993 */
+{offset: 993}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u27f0\uf0ab\u{1fc1c}\u00b5',
+  entries: [{binding: 3198, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }}],
+});
+let textureView29 = texture11.createView({label: '\u{1fc9a}\uceae\u09ed\u0ff2', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder6 = commandEncoder9.beginComputePass();
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer5, 'uint16', 15236, 3478);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer4, 48840, buffer6, 17132, 6468);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 46256 */
+  offset: 46256,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 42, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u182f\u{1f9f6}\u1a6e\u6623\u06fa\uec0d\u{1ff9b}\uf790\u07f3\udb04\u{1ff51}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 1191, resource: sampler12}, {binding: 3682, resource: sampler5}],
+});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u0de3\u7090\u{1fd15}\u8bce\u{1f9ed}\u{1f73d}\u1211'});
+let texture22 = device0.createTexture({
+  label: '\u{1f9f2}\u{1fdfe}',
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder5.beginComputePass();
+let sampler17 = device0.createSampler({
+  label: '\u{1fe20}\uf204\u07dc\u070c\u2ef9\u3b86\u{1fd89}\u{1ffed}\u71c0',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.28,
+  lodMaxClamp: 95.68,
+  compare: 'less',
+  maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder9.setIndexBuffer(buffer5, 'uint16', 1732, 3870);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer4, 70040, buffer3, 73232, 1256);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 23},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  label: '\ue819\u{1f7e2}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 3682, resource: sampler10}, {binding: 1191, resource: sampler12}],
+});
+let commandBuffer6 = commandEncoder21.finish();
+let textureView30 = texture7.createView({label: '\u5e10\u{1fbac}\u9014\ue8a2\u1923\u0ed9\u7c0a\ud520', baseArrayLayer: 0});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup8, new Uint32Array(3021), 172, 0);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 5436 widthInBlocks: 1359 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11772 */
+  offset: 11772,
+  buffer: buffer12,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1359, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 5,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 14, y: 5 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise4;
+} catch {}
+let videoFrame5 = new VideoFrame(video0, {timestamp: 0});
+let querySet11 = device0.createQuerySet({label: '\uca75\u{1fcc0}\u0025\u7b79\u0caf', type: 'occlusion', count: 3786});
+let textureView31 = texture10.createView({
+  label: '\u6681\uf30a\u059b\u{1f60c}\ua8fd\u9325\u1bf2\u{1faec}',
+  format: 'r32uint',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+  baseArrayLayer: 36,
+  arrayLayerCount: 14,
+});
+try {
+renderBundleEncoder8.setBindGroup(5, bindGroup8);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet5, 1241, 1927, buffer0, 71680);
+} catch {}
+try {
+commandEncoder10.insertDebugMarker('\u17aa');
+} catch {}
+let videoFrame6 = new VideoFrame(canvas0, {timestamp: 0});
+let commandEncoder28 = device0.createCommandEncoder();
+let textureView32 = texture5.createView({baseMipLevel: 1});
+let computePassEncoder8 = commandEncoder27.beginComputePass({label: '\u{1fc45}\u{1ffd4}\u{1f796}\u{1fd1a}\u0500\uace1\u050a'});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 48.68,
+  lodMaxClamp: 73.34,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder7.setVertexBuffer(2569, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 12},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 9_199_486 */
+{offset: 786, bytesPerRow: 459, rowsPerImage: 167}, {width: 85, height: 1, depthOrArrayLayers: 121});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 21, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({label: '\u{1fada}\u1e6c\u6c36\u16e9\ud6d1\ub981\u6ddf\u0634', entries: []});
+let pipelineLayout4 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1, bindGroupLayout8, bindGroupLayout5, bindGroupLayout4, bindGroupLayout2, bindGroupLayout5, bindGroupLayout3, bindGroupLayout0, bindGroupLayout6],
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u0ed6\u5fe4',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let sampler19 = device0.createSampler({
+  label: '\u56c6\u999c\u0efa\u282a\u{1f8ca}\u4e44\u03d3',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 49.33,
+  lodMaxClamp: 51.20,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder8.setVertexBuffer(9305, undefined, 4030850581);
+} catch {}
+try {
+renderBundleEncoder9.insertDebugMarker('\u0ae9');
+} catch {}
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout8, entries: []});
+let commandEncoder29 = device0.createCommandEncoder();
+let querySet12 = device0.createQuerySet({
+  label: '\uf62f\u9246\u{1f6f4}\u09e4\ue879\u0b02\u043b\u9851\u{1f93f}\u2884',
+  type: 'occlusion',
+  count: 1127,
+});
+let texture23 = device0.createTexture({
+  label: '\uf75b\ubbc6\u{1fb41}\u0760\u{1f63b}\u0ce8\u{1f638}\uddc6',
+  size: {width: 192, height: 240, depthOrArrayLayers: 10},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView33 = texture12.createView({label: '\u0ce3\u08a7\ua78c\u{1f6ad}\u4dbb\u071f\uc2f1', baseMipLevel: 3, mipLevelCount: 1});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(1, buffer6);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer7, 43024, buffer9, 3652, 10784);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 5,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 36216, new Float32Array(54034), 33312, 232);
+} catch {}
+let querySet13 = device0.createQuerySet({label: '\u6ce3\uaa6b\u052d\u6b86\u{1f950}\ua180\u9349', type: 'occlusion', count: 264});
+let textureView34 = texture15.createView({
+  label: '\ude13\u3040\uec96\u09c1\ub89c\ufa1f',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+  baseArrayLayer: 260,
+});
+let computePassEncoder9 = commandEncoder0.beginComputePass({label: '\u{1f669}\u{1fa49}\u9ffb\u5b5f\u1893\u{1fa9c}\ua6e8\ue159\u039d\u042c'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\ucd5e\u2c87\u0e2f\u2193', colorFormats: ['rgba16float', 'r32float']});
+try {
+computePassEncoder8.setBindGroup(8, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(9, bindGroup2, new Uint32Array(967), 736, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer13, 'uint32', 20484, 47430);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1956 widthInBlocks: 489 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7712 */
+  offset: 7712,
+  bytesPerRow: 2048,
+  buffer: buffer6,
+}, {width: 489, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer3, 21636, 87632);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img4);
+let bindGroup11 = device0.createBindGroup({
+  label: '\uea3b\u0c8f\ud5db\u{1f935}\u0fcf\u208c\uae38\u9ca3\u0f12',
+  layout: bindGroupLayout1,
+  entries: [],
+});
+let buffer15 = device0.createBuffer({
+  size: 99868,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+try {
+commandEncoder24.copyBufferToBuffer(buffer4, 476, buffer14, 6864, 64484);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 2472 widthInBlocks: 618 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7820 */
+  offset: 5348,
+  buffer: buffer12,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 618, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let imageBitmap3 = await createImageBitmap(videoFrame4);
+let querySet14 = device0.createQuerySet({label: '\u0a70\u39cb\u0786\ua99d\u{1fdae}\u0371\u4c0e\u3e3d\u0d95', type: 'occlusion', count: 1694});
+let textureView35 = texture16.createView({dimension: '2d-array'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float', 'r32float'], depthReadOnly: false});
+let sampler20 = device0.createSampler({
+  label: '\u0583\u{1fd79}\u{1f9e5}\u{1fb6b}\uff52\u{1f7a4}\u8133\u5d59',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 43.62,
+  lodMaxClamp: 72.74,
+});
+try {
+commandEncoder1.copyBufferToBuffer(buffer7, 16928, buffer14, 402064, 25408);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 7, y: 26, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 17, y: 22, z: 0},
+  aspect: 'all',
+},
+{width: 77, height: 51, depthOrArrayLayers: 5});
+} catch {}
+let textureView36 = texture10.createView({
+  label: '\u{1fafe}\u{1ff54}\u0b20\u52d8',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 32,
+  arrayLayerCount: 7,
+});
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer6, 26676);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2848, new Int16Array(49297), 22640, 1732);
+} catch {}
+document.body.prepend(img4);
+let bindGroup12 = device0.createBindGroup({
+  label: '\u0f00\u0c63\u04c4\u{1ff96}\u90ac\u0fb4\ue38a\u9ca3\u{1fdc6}',
+  layout: bindGroupLayout5,
+  entries: [],
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+try {
+computePassEncoder4.setBindGroup(9, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint32', 34288, 69);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer14, 77640);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet1, 288, 284, buffer0, 118272);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 2556 widthInBlocks: 639 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18984 */
+  offset: 18984,
+  buffer: buffer10,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1184, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 639, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer11, 47292, 30524);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet7, 430, 104, buffer15, 80128);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({label: '\u{1fba1}\u8957\u0073\u9901\u7160\u49f2'});
+let querySet15 = device0.createQuerySet({label: '\ud24a\u2284\u{1fe7e}\u0db8\u330a', type: 'occlusion', count: 297});
+let texture24 = device0.createTexture({
+  label: '\u035e\u{1fdd9}\u0328\ud6e6\u401f\ube06\u0eb4\u028a\u7edf\u0ef9',
+  size: [192, 240, 486],
+  mipLevelCount: 6,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16float'],
+});
+let textureView37 = texture17.createView({label: '\u6203\ue5b9\u{1fc99}\u{1f97e}\u9482', baseMipLevel: 2, mipLevelCount: 3, baseArrayLayer: 0});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1f869}\uf136\ub050',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder11.setBindGroup(8, bindGroup11, []);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer6, 20700, 8452);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer1, 712, buffer6, 55708, 1324);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 70000 */
+  offset: 27504,
+  bytesPerRow: 256,
+  rowsPerImage: 166,
+  buffer: buffer14,
+}, {width: 1, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 135, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer3, 126000, 16416);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 14352, new Int16Array(31948), 28894, 136);
+} catch {}
+let textureView38 = texture10.createView({
+  label: '\u{1fe2a}\ub0ab\u{1ff5e}\u17f6\u{1fd15}\ud7fa',
+  format: 'r32uint',
+  baseMipLevel: 2,
+  baseArrayLayer: 15,
+  arrayLayerCount: 29,
+});
+let renderBundle15 = renderBundleEncoder8.finish({label: '\u0369\ucdbd\u750a\u{1f601}\u0f85\ue529\u9ec9\u0047\u92dc\u5e0e'});
+try {
+renderBundleEncoder13.setIndexBuffer(buffer13, 'uint32', 34816, 5109);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet6, 36, 2477, buffer0, 107008);
+} catch {}
+let imageBitmap4 = await createImageBitmap(offscreenCanvas0);
+let commandBuffer7 = commandEncoder29.finish({});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(6, bindGroup0, []);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer4, 8328, buffer3, 132992, 7208);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+gc();
+let device1 = await adapter2.requestDevice({
+  defaultQueue: {label: '\u28e8\u{1f614}\u6679\u03b2'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 9,
+    maxColorAttachmentBytesPerSample: 64,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 44203,
+    maxStorageTexturesPerShaderStage: 39,
+    maxStorageBuffersPerShaderStage: 39,
+    maxDynamicStorageBuffersPerPipelineLayout: 48361,
+    maxDynamicUniformBuffersPerPipelineLayout: 65180,
+    maxBindingsPerBindGroup: 9278,
+    maxTextureArrayLayers: 1431,
+    maxTextureDimension1D: 13698,
+    maxTextureDimension2D: 12435,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 26,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 240193493,
+    maxStorageBufferBindingSize: 188739116,
+    maxUniformBuffersPerShaderStage: 25,
+    maxSampledTexturesPerShaderStage: 33,
+    maxInterStageShaderVariables: 119,
+    maxInterStageShaderComponents: 115,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let querySet16 = device1.createQuerySet({
+  label: '\u0cff\u00e7\u{1f8e6}\u0897\u2ebf\u57d0\u2418\u{1f872}\u9d74\u1369',
+  type: 'occlusion',
+  count: 4049,
+});
+let texture25 = device1.createTexture({
+  size: {width: 288, height: 640, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView39 = texture25.createView({
+  label: '\u0cac\u01ed\u049b\u9a5b\u0c9c\u2944\ue09b\u00fd\ufc55\uc754',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({label: '\u8146\uca84', colorFormats: ['rg16sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle16 = renderBundleEncoder14.finish({label: '\ub9e8\udd07\u{1fec0}\u1b39\u2437'});
+let externalTexture12 = device1.importExternalTexture({source: video1});
+let textureView40 = texture12.createView({
+  label: '\u0188\u{1f9c6}\u0eee\u{1f6fb}\u2c83\u{1f7c4}\uc81b\u7e77\u2abd\uc314\u09fa',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder2.setBindGroup(9, bindGroup12, new Uint32Array(7406), 295, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer13, 'uint16', 42722, 15206);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer10, 18572, buffer15, 80700, 92);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 2,
+  origin: {x: 214, y: 0, z: 46},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u0979\u033a\u02e8\u0b3d',
+  entries: [
+    {
+      binding: 2060,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 3477, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView41 = texture0.createView({label: '\u9ccb\u43dd\ubd70\u7127\u50e1\u{1fbf7}\u5f3e\u5581\ub60b', arrayLayerCount: 1});
+let renderBundle17 = renderBundleEncoder0.finish({label: '\u0fad\u0975\u{1f7f3}'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup3, new Uint32Array(3530), 2860, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer5, 'uint32', 3280, 13606);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 904 widthInBlocks: 113 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 40048 */
+  offset: 39144,
+  rowsPerImage: 253,
+  buffer: buffer14,
+}, {width: 113, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1330, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 860 */
+{offset: 860}, {width: 330, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+gc();
+let textureView42 = texture25.createView({label: '\u{1ffe8}\u{1f9e5}\uee16\u0555\u73b0\ubf36\u75b6', mipLevelCount: 1});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({
+  label: '\u{1fa58}\u984b\u08b1\u{1feef}\u5669',
+  colorFormats: ['rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let texture26 = device0.createTexture({
+  label: '\u{1fa79}\ucbc9\u4131\u2969\u0c5e',
+  size: [720],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView43 = texture19.createView({label: '\ubdc7\u0b6e\u6331\u340a\uf0ec\u82d1', baseMipLevel: 2, mipLevelCount: 2});
+let computePassEncoder10 = commandEncoder10.beginComputePass({});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float', 'r32float'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\u6ee2\u5993\u{1fe66}\ue1bb\u02d1\u6fb0\u0ef5\uc12b\u70ac\u553c',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder4.setBindGroup(9, bindGroup3, new Uint32Array(469), 33, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(5, buffer6, 50036, 10218);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1280 */
+  offset: 1280,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 2, y: 32, z: 1},
+  aspect: 'all',
+},
+{width: 74, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet12, 273, 830, buffer0, 100864);
+} catch {}
+let texture27 = device1.createTexture({
+  label: '\uc091\u{1f61f}\u7b13\ubcd3\u0278\u9a61\u{1fd5a}',
+  size: {width: 36, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'etc2-rgb8a1unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['etc2-rgb8a1unorm-srgb'],
+});
+let textureView44 = texture27.createView({
+  label: '\uaebe\ub569\u{1ffba}\uce51',
+  dimension: '2d-array',
+  format: 'etc2-rgb8a1unorm-srgb',
+  mipLevelCount: 1,
+});
+let renderBundle18 = renderBundleEncoder15.finish({label: '\u8a48\u0a30\ue0f9\u6302\uf4cb'});
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 4, y: 64, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 20_295 */
+{offset: 721, bytesPerRow: 706}, {width: 128, height: 112, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise5;
+} catch {}
+let bindGroupLayout10 = device1.createBindGroupLayout({
+  label: '\uf0b1\udab7\u{1ffc2}\u07e7\u49cd\ud856\u0de6\u57c9\u0cd6\u1629\u417f',
+  entries: [
+    {
+      binding: 1552,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet17 = device1.createQuerySet({type: 'occlusion', count: 472});
+let videoFrame7 = new VideoFrame(videoFrame2, {timestamp: 0});
+let commandEncoder32 = device1.createCommandEncoder({label: '\uf221\u8952\u0788'});
+let textureView45 = texture25.createView({
+  label: '\u0323\u69d9\u6bcb\u646d\u{1f624}\u0d3b\u7dfe\u61d2',
+  dimension: '2d-array',
+  format: 'etc2-rgba8unorm',
+  baseMipLevel: 1,
+});
+let sampler21 = device1.createSampler({
+  label: '\u1df0\u0f94',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.25,
+  lodMaxClamp: 77.63,
+  maxAnisotropy: 11,
+});
+let bindGroup13 = device1.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 1552, resource: sampler21}]});
+let commandEncoder33 = device1.createCommandEncoder({label: '\u0425\u{1f9bc}\u{1fd97}\ube1d\u{1fcd8}'});
+let commandBuffer8 = commandEncoder33.finish();
+let commandEncoder34 = device1.createCommandEncoder({label: '\u0c28\u{1fbee}\u{1ff31}\u0a66\u{1f862}'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer6, 22140, 32288);
+} catch {}
+let textureView46 = texture25.createView({label: '\u69ff\u6f06'});
+let renderBundle19 = renderBundleEncoder14.finish({label: '\u7a1d\u{1fa5c}'});
+let externalTexture14 = device1.importExternalTexture({label: '\u084e\u{1fb68}\ud31f\ueefa\u{1fce8}', source: videoFrame5, colorSpace: 'srgb'});
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1_499 */
+{offset: 492, bytesPerRow: 325}, {width: 16, height: 16, depthOrArrayLayers: 1});
+} catch {}
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 3146});
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer6, 44668, 27950);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer7, 51920, buffer11, 27644, 47708);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 372, new Float32Array(50454));
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView47 = texture27.createView({label: '\uee09\u{1fd24}', baseMipLevel: 1});
+let computePassEncoder11 = commandEncoder32.beginComputePass({label: '\u953a\u56e0'});
+try {
+commandEncoder34.insertDebugMarker('\u{1fe94}');
+} catch {}
+let videoFrame8 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let texture28 = device0.createTexture({
+  label: '\udddf\u6a5e\u0a63\u072a',
+  size: {width: 62, height: 1, depthOrArrayLayers: 398},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView48 = texture24.createView({
+  label: '\ue592\u{1fdb9}\uc20e\u{1f776}',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 438,
+  arrayLayerCount: 41,
+});
+let sampler22 = device0.createSampler({
+  label: '\u0fe1\u0721\u05c2\u{1fd6d}\u{1f7d6}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.97,
+  lodMaxClamp: 90.30,
+});
+let promise8 = buffer11.mapAsync(GPUMapMode.READ, 0, 25660);
+try {
+commandEncoder31.copyBufferToBuffer(buffer10, 6820, buffer9, 32904, 1804);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1151, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 361, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder1.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder25.pushDebugGroup('\uebca');
+} catch {}
+let img5 = await imageWithData(238, 73, '#2449a2eb', '#76e9ce7f');
+let videoFrame9 = new VideoFrame(videoFrame8, {timestamp: 0});
+let pipelineLayout5 = device1.createPipelineLayout({
+  label: '\u7292\u9326\u4dc8\u0865\u{1f63b}\u9ead',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10],
+});
+let texture29 = device1.createTexture({
+  label: '\u6dcf\u0e35\u7d54\u0367',
+  size: {width: 144},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView49 = texture29.createView({label: '\u3879\u9584\u{1fc58}\u02b4\uca49\u09ed\u{1fb05}\u88f0'});
+let renderBundle20 = renderBundleEncoder14.finish({label: '\u0fbe\u28d0\u6d4e\ue8eb\u66bf\ua23e\ufadc\u017e\u2bde'});
+let externalTexture15 = device1.importExternalTexture({label: '\u1a26\u0c01\ufd4a\ufb80\u9ac3\u823c\udd4b', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img6 = await imageWithData(118, 291, '#576bd523', '#2728e4fd');
+let querySet19 = device1.createQuerySet({label: '\u0ed9\u{1fbef}\u2e99', type: 'occlusion', count: 2966});
+let texture30 = device1.createTexture({
+  label: '\u{1fc55}\u{1ffdf}\ucd3e\u8e69\ue859\u04b7\u7358',
+  size: {width: 273},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+canvas0.height = 233;
+let bindGroup14 = device0.createBindGroup({label: '\u{1f7ac}\u{1f96e}\u03a3\ufbcd\u7bcf\u{1ff01}', layout: bindGroupLayout5, entries: []});
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\uc21d\ud708\u{1fafc}',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout0, bindGroupLayout3, bindGroupLayout2, bindGroupLayout7, bindGroupLayout7, bindGroupLayout9, bindGroupLayout4, bindGroupLayout5, bindGroupLayout3],
+});
+let textureView50 = texture24.createView({
+  label: '\u3970\u0c0c\uf0d4\u{1ff70}\u0816\u{1f741}\u7f6e\u8ea7\u3867\ub132',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 194,
+});
+let renderBundle21 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer12, 27812, buffer11, 30824, 1716);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer3, 106048, 26248);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let promise9 = adapter1.requestAdapterInfo();
+let commandEncoder35 = device1.createCommandEncoder({});
+let texture31 = device1.createTexture({
+  label: '\u{1fd29}\u{1ff95}\u431c\u{1fd86}\u0f02\u14c5\u825b',
+  size: {width: 72, height: 160, depthOrArrayLayers: 1366},
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let renderBundle22 = renderBundleEncoder14.finish({label: '\u0bea\u40f5\u0674\u288a\u0367'});
+let shaderModule0 = device0.createShaderModule({
+  label: '\u2bf9\u37d7\u04fe\ue9bd',
+  code: `@group(0) @binding(3198)
+var<storage, read_write> function0: array<u32>;
+@group(7) @binding(37)
+var<storage, read_write> global0: array<u32>;
+@group(7) @binding(550)
+var<storage, read_write> parameter0: array<u32>;
+@group(5) @binding(3198)
+var<storage, read_write> function1: array<u32>;
+@group(6) @binding(2060)
+var<storage, read_write> parameter1: array<u32>;
+@group(3) @binding(1922)
+var<storage, read_write> local0: array<u32>;
+@group(1) @binding(1221)
+var<storage, read_write> n0: array<u32>;
+@group(6) @binding(3477)
+var<storage, read_write> field0: array<u32>;
+@group(4) @binding(3198)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(41) f0: vec3<f32>,
+  @location(24) f1: vec4<u32>,
+  @builtin(position) f2: vec4<f32>,
+  @location(80) f3: u32,
+  @location(42) f4: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(69) a0: vec4<u32>, @location(12) a1: vec3<f16>, @location(1) a2: vec3<u32>, @location(68) a3: vec4<f16>, @location(7) a4: vec2<i32>, @location(18) a5: vec4<f32>, a6: S1, @location(33) a7: vec2<i32>, @location(30) a8: u32, @location(17) a9: vec2<i32>, @location(13) a10: vec4<i32>, @location(51) a11: vec2<f32>, @location(72) a12: vec3<f16>, @location(46) a13: vec3<i32>, @location(11) a14: i32, @location(59) a15: vec4<f32>, @location(61) a16: vec3<f16>, @location(54) a17: u32, @location(4) a18: vec3<f16>, @location(52) a19: vec3<u32>, @location(73) a20: vec3<u32>, @location(6) a21: vec4<f32>, @location(64) a22: vec4<f32>, @location(34) a23: vec4<f32>, @location(58) a24: vec3<f16>, @location(66) a25: vec4<f16>, @location(81) a26: f32, @location(39) a27: f16, @location(37) a28: vec2<f16>, @location(50) a29: vec2<f16>, @builtin(sample_index) a30: u32, @builtin(sample_mask) a31: u32, @builtin(front_facing) a32: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(6) f0: vec4<u32>,
+  @location(13) f1: vec4<f16>,
+  @location(1) f2: vec3<f16>,
+  @location(9) f3: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(4) f0: vec3<f16>,
+  @location(46) f1: vec3<i32>,
+  @location(13) f2: vec4<i32>,
+  @location(54) f3: u32,
+  @location(52) f4: vec3<u32>,
+  @location(17) f5: vec2<i32>,
+  @location(30) f6: u32,
+  @location(69) f7: vec4<u32>,
+  @location(34) f8: vec4<f32>,
+  @location(42) f9: vec4<u32>,
+  @location(11) f10: i32,
+  @location(73) f11: vec3<u32>,
+  @location(41) f12: vec3<f32>,
+  @location(39) f13: f16,
+  @location(18) f14: vec4<f32>,
+  @location(12) f15: vec3<f16>,
+  @location(58) f16: vec3<f16>,
+  @location(1) f17: vec3<u32>,
+  @location(33) f18: vec2<i32>,
+  @location(51) f19: vec2<f32>,
+  @location(61) f20: vec3<f16>,
+  @location(6) f21: vec4<f32>,
+  @location(59) f22: vec4<f32>,
+  @location(64) f23: vec4<f32>,
+  @location(80) f24: u32,
+  @location(81) f25: f32,
+  @location(50) f26: vec2<f16>,
+  @location(66) f27: vec4<f16>,
+  @location(24) f28: vec4<u32>,
+  @location(7) f29: vec2<i32>,
+  @location(37) f30: vec2<f16>,
+  @location(72) f31: vec3<f16>,
+  @builtin(position) f32: vec4<f32>,
+  @location(68) f33: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<i32>, @location(4) a1: f32, @location(12) a2: vec3<i32>, @location(3) a3: vec3<u32>, @location(0) a4: vec2<f32>, @location(11) a5: vec2<f32>, @location(10) a6: vec3<i32>, @location(7) a7: vec3<u32>, @location(16) a8: vec4<f16>, @location(5) a9: vec3<u32>, @location(14) a10: f16, @location(19) a11: vec4<f32>, @location(17) a12: vec4<i32>, @location(18) a13: vec3<f32>, a14: S0, @location(15) a15: f32, @location(8) a16: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder36 = device0.createCommandEncoder({label: '\ua070\u{1f805}\u7234\u9834\u05b4\u0e4a\u137d\u0f2d\u0e6d\u0fd5'});
+let querySet20 = device0.createQuerySet({label: '\u0716\u5709\u{1fdb0}', type: 'occlusion', count: 337});
+let sampler23 = device0.createSampler({
+  label: '\u{1f9ef}\u737a\u3156\u0eec\u1faa\u{1fa41}\u04c5\u5ad4',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 71.58,
+  lodMaxClamp: 96.73,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 751 */
+{offset: 751}, {width: 479, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({});
+let computePassEncoder12 = commandEncoder1.beginComputePass({label: '\u{1f661}\u059b\uf57a\u880a\ue9dc\u0c9a\ud0c3\u0e35\u8733'});
+try {
+renderBundleEncoder7.setBindGroup(5, bindGroup12);
+} catch {}
+let buffer16 = device1.createBuffer({
+  label: '\u00cc\u01e4\u0e43\u040d\u699d\ufef2',
+  size: 65840,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture32 = device1.createTexture({
+  label: '\u05d4\u0530\u66ca\u0579\u91d5\u{1fad1}\u56b2',
+  size: [68, 1, 586],
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture16 = device1.importExternalTexture({label: '\uc38e\u{1fca0}\u26b7', source: videoFrame1, colorSpace: 'srgb'});
+try {
+  await buffer16.mapAsync(GPUMapMode.WRITE, 0, 40860);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let device2 = await adapter1.requestDevice({
+  label: '\u018e\ua78e\uc8ea\u41a9\u0cc8\u{1f65d}\u{1fddb}\u1d35\u3cf2\u{1ff06}\u70c3',
+  defaultQueue: {label: '\uc16c\u0ec9\u0744\u{1f8f0}\u7324\u{1f620}\u0a17\u{1f6ca}\u{1febf}\ua3f5\u{1f724}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 59,
+    maxVertexAttributes: 28,
+    maxVertexBufferArrayStride: 46822,
+    maxStorageTexturesPerShaderStage: 11,
+    maxDynamicStorageBuffersPerPipelineLayout: 17701,
+    maxDynamicUniformBuffersPerPipelineLayout: 30649,
+    maxBindingsPerBindGroup: 8301,
+    maxTextureArrayLayers: 1943,
+    maxTextureDimension1D: 8980,
+    maxTextureDimension2D: 13712,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 107552105,
+    maxStorageBufferBindingSize: 145203153,
+    maxUniformBuffersPerShaderStage: 18,
+    maxSampledTexturesPerShaderStage: 34,
+    maxInterStageShaderVariables: 117,
+    maxInterStageShaderComponents: 91,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let bindGroup15 = device1.createBindGroup({
+  label: '\u05c6\uaffb\u8e21\ue152',
+  layout: bindGroupLayout10,
+  entries: [{binding: 1552, resource: sampler21}],
+});
+let querySet21 = device1.createQuerySet({
+  label: '\u{1f7a8}\u5815\u{1f6dd}\u00e5\udb99\u39e0\u{1fca0}\u15ad\u0c59\u03ef\uda02',
+  type: 'occlusion',
+  count: 1541,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({label: '\u{1fafa}\u0f39\u0ccb\u0046\u{1f6af}\uaf96\u2965'});
+let textureView51 = texture9.createView({
+  label: '\u0627\u3fc4\u{1f625}\u8674\u026f\u88c9\u3bcb\ue6d2\u0071\u6e67\u{1fdb7}',
+  format: 'rgb10a2uint',
+  mipLevelCount: 3,
+});
+let renderBundle23 = renderBundleEncoder16.finish({});
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer6, 16648, 43591);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer12, 1400, buffer3, 77944, 4500);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 104, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3884 widthInBlocks: 971 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18184 */
+  offset: 14300,
+  bytesPerRow: 4096,
+  buffer: buffer6,
+}, {width: 971, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+gc();
+let buffer17 = device1.createBuffer({
+  label: '\u2edc\u05da\u{1f612}\u0cc0\ub23b\u6753\u{1f605}',
+  size: 250112,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder39 = device1.createCommandEncoder({label: '\ud935\ue79e\u{1fa9b}\ua37a\ub889\u8b75\u033f'});
+let textureView52 = texture31.createView({label: '\u0077\u0f75\u0feb\u4c2a\u04c5', format: 'rg16sint', baseArrayLayer: 257, arrayLayerCount: 111});
+let computePassEncoder13 = commandEncoder35.beginComputePass({label: '\u4f56\u0d62\u3453\u1e05\u03b0\u034b'});
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 72, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1904,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let texture33 = device0.createTexture({
+  label: '\ue5a2\u{1ff2c}\ue251\u692f\u{1fadb}\u20b6\u{1fe11}\ued2f\ucc32\u0ef1',
+  size: {width: 322},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView53 = texture5.createView({label: '\u1c11\u3bd0\ucc77\u2eff', dimension: '2d'});
+let renderBundle24 = renderBundleEncoder10.finish();
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 8376 widthInBlocks: 1047 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2232 */
+  offset: 2232,
+  buffer: buffer10,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 187, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1047, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  label: '\ueb48\u7671\u{1f6b6}\uc22d\u643d\u{1fc26}\u042e\u{1f836}',
+  layout: pipelineLayout1,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src'},
+  },
+}, {format: 'r32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 2508, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 1168, shaderLocation: 9},
+          {format: 'float32', offset: 504, shaderLocation: 13},
+          {format: 'uint32x4', offset: 528, shaderLocation: 3},
+          {format: 'uint16x4', offset: 412, shaderLocation: 5},
+          {format: 'sint32x2', offset: 280, shaderLocation: 10},
+          {format: 'float32x3', offset: 236, shaderLocation: 18},
+          {format: 'float32x4', offset: 632, shaderLocation: 11},
+          {format: 'sint16x2', offset: 104, shaderLocation: 12},
+          {format: 'sint32x3', offset: 204, shaderLocation: 2},
+          {format: 'float16x4', offset: 2008, shaderLocation: 15},
+          {format: 'uint8x2', offset: 20, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 1668, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 436, shaderLocation: 0},
+          {format: 'float16x4', offset: 932, shaderLocation: 1},
+          {format: 'uint32x3', offset: 0, shaderLocation: 7},
+          {format: 'sint8x4', offset: 32, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 632, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 13576, attributes: [{format: 'float32', offset: 2988, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+  await promise9;
+} catch {}
+let commandEncoder40 = device1.createCommandEncoder({label: '\u0700\u1613\uec84\u{1fbaf}\u{1f732}'});
+let textureView54 = texture30.createView({label: '\uada9\u057c\u0e29\uc93f'});
+try {
+computePassEncoder13.setBindGroup(5, bindGroup13);
+} catch {}
+let bindGroup16 = device0.createBindGroup({label: '\u0aed\u{1fe75}\u07ad\u0b2d\u06a3\u3291', layout: bindGroupLayout3, entries: []});
+let commandEncoder41 = device0.createCommandEncoder({label: '\uaac3\u074e\u05b5\u{1f770}\u008b\u0871\u{1f645}\u630e'});
+let querySet22 = device0.createQuerySet({label: '\uf6f5\u1041\u{1fb7e}\u2ab1\ua27b\ua926\ud81d\ud003\u991f', type: 'occlusion', count: 628});
+let textureView55 = texture2.createView({label: '\ub3c8\u0c1f\u{1fb73}\u3b20', dimension: '1d', baseMipLevel: 0});
+try {
+computePassEncoder9.setBindGroup(6, bindGroup6, []);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1160 widthInBlocks: 290 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2988 */
+  offset: 2988,
+  buffer: buffer6,
+}, {width: 290, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4952, new Float32Array(23575), 21430, 332);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder42 = device1.createCommandEncoder({label: '\ub9b4\u00f1\u{1fe5d}'});
+let commandBuffer9 = commandEncoder40.finish({label: '\u{1fb52}\u{1f94a}\u1381\u1622\u9d47\u{1f7d8}\u00bc\ua49a'});
+let renderBundle25 = renderBundleEncoder14.finish({label: '\u{1fb06}\uc09b\ue4b4'});
+let bindGroupLayout12 = device2.createBindGroupLayout({label: '\ud943\u5772\uf671', entries: [{binding: 6715, visibility: 0, externalTexture: {}}]});
+let commandEncoder43 = device2.createCommandEncoder({});
+let renderBundleEncoder17 = device2.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'], depthReadOnly: false});
+let imageData3 = new ImageData(220, 108);
+let shaderModule1 = device1.createShaderModule({
+  code: `@group(3) @binding(1552)
+var<storage, read_write> n1: array<u32>;
+@group(1) @binding(1552)
+var<storage, read_write> global1: array<u32>;
+@group(4) @binding(1552)
+var<storage, read_write> field1: array<u32>;
+@group(2) @binding(1552)
+var<storage, read_write> function2: array<u32>;
+@group(5) @binding(1552)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(1552)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(53) f0: vec4<f16>,
+  @location(50) f1: u32,
+  @location(18) f2: vec2<i32>,
+  @location(104) f3: f16,
+  @location(48) f4: u32,
+  @location(109) f5: vec3<f16>,
+  @location(25) f6: vec4<i32>,
+  @location(10) f7: f16,
+  @location(89) f8: vec3<i32>,
+  @location(63) f9: vec4<u32>,
+  @location(115) f10: vec3<f16>,
+  @location(116) f11: vec2<u32>,
+  @location(42) f12: vec2<f16>,
+  @builtin(position) f13: vec4<f32>,
+  @location(69) f14: vec2<i32>,
+  @builtin(front_facing) f15: bool,
+  @location(71) f16: vec3<f32>,
+  @location(52) f17: vec4<u32>,
+  @location(77) f18: vec3<f32>,
+  @location(73) f19: vec3<u32>,
+  @location(81) f20: vec2<u32>,
+  @location(55) f21: f16,
+  @location(15) f22: f32,
+  @location(3) f23: i32,
+  @location(80) f24: vec2<f32>,
+  @location(99) f25: vec4<i32>,
+  @location(46) f26: vec3<f16>,
+  @location(67) f27: i32,
+  @location(8) f28: vec4<i32>,
+  @location(65) f29: vec2<f16>,
+  @location(6) f30: vec4<f32>,
+  @location(117) f31: vec3<f16>,
+  @location(56) f32: i32,
+  @location(64) f33: f32,
+  @location(40) f34: u32,
+  @location(107) f35: vec4<i32>,
+  @location(16) f36: vec3<f32>,
+  @location(36) f37: u32,
+  @location(31) f38: vec2<i32>,
+  @location(41) f39: vec3<f16>
+}
+
+@fragment
+fn fragment0(@location(96) a0: vec2<i32>, @location(27) a1: vec2<i32>, @location(39) a2: vec4<i32>, @location(9) a3: f32, @location(103) a4: vec4<i32>, @location(68) a5: vec2<f32>, @location(66) a6: f32, @location(24) a7: vec4<i32>, @location(49) a8: vec2<f32>, @location(47) a9: f16, @location(114) a10: vec2<f16>, a11: S3, @builtin(sample_mask) a12: u32, @builtin(sample_index) a13: u32) -> @location(200) vec4<i32> {
+return vec4<i32>();
+}
+
+struct S2 {
+  @location(8) f0: i32,
+  @location(9) f1: vec4<f32>,
+  @location(16) f2: f16,
+  @location(4) f3: vec3<f32>,
+  @location(3) f4: f32,
+  @location(17) f5: vec4<u32>,
+  @location(15) f6: u32,
+  @location(6) f7: f16,
+  @location(2) f8: vec2<f32>,
+  @location(11) f9: vec3<f32>,
+  @location(1) f10: i32,
+  @location(7) f11: vec2<f32>,
+  @location(0) f12: vec2<f32>,
+  @builtin(vertex_index) f13: u32,
+  @location(12) f14: vec3<i32>,
+  @location(13) f15: vec2<u32>,
+  @location(10) f16: f32,
+  @location(14) f17: f32
+}
+struct VertexOutput0 {
+  @location(104) f34: f16,
+  @location(81) f35: vec2<u32>,
+  @location(68) f36: vec2<f32>,
+  @location(96) f37: vec2<i32>,
+  @location(56) f38: i32,
+  @location(109) f39: vec3<f16>,
+  @builtin(position) f40: vec4<f32>,
+  @location(66) f41: f32,
+  @location(3) f42: i32,
+  @location(73) f43: vec3<u32>,
+  @location(69) f44: vec2<i32>,
+  @location(50) f45: u32,
+  @location(42) f46: vec2<f16>,
+  @location(8) f47: vec4<i32>,
+  @location(10) f48: f16,
+  @location(24) f49: vec4<i32>,
+  @location(64) f50: f32,
+  @location(55) f51: f16,
+  @location(107) f52: vec4<i32>,
+  @location(116) f53: vec2<u32>,
+  @location(18) f54: vec2<i32>,
+  @location(89) f55: vec3<i32>,
+  @location(71) f56: vec3<f32>,
+  @location(52) f57: vec4<u32>,
+  @location(53) f58: vec4<f16>,
+  @location(77) f59: vec3<f32>,
+  @location(9) f60: f32,
+  @location(6) f61: vec4<f32>,
+  @location(39) f62: vec4<i32>,
+  @location(117) f63: vec3<f16>,
+  @location(80) f64: vec2<f32>,
+  @location(27) f65: vec2<i32>,
+  @location(15) f66: f32,
+  @location(114) f67: vec2<f16>,
+  @location(99) f68: vec4<i32>,
+  @location(103) f69: vec4<i32>,
+  @location(25) f70: vec4<i32>,
+  @location(36) f71: u32,
+  @location(47) f72: f16,
+  @location(16) f73: vec3<f32>,
+  @location(115) f74: vec3<f16>,
+  @location(49) f75: vec2<f32>,
+  @location(31) f76: vec2<i32>,
+  @location(46) f77: vec3<f16>,
+  @location(65) f78: vec2<f16>,
+  @location(48) f79: u32,
+  @location(40) f80: u32,
+  @location(63) f81: vec4<u32>,
+  @location(67) f82: i32,
+  @location(41) f83: vec3<f16>
+}
+
+@vertex
+fn vertex0(a0: S2, @location(5) a1: vec2<u32>, @builtin(instance_index) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout7 = device1.createPipelineLayout({label: '\u04a4\u0228\u0b36\u19bf\u0170\ue06d', bindGroupLayouts: [bindGroupLayout10]});
+let querySet23 = device1.createQuerySet({label: '\u0695\ud65b\u{1fb45}', type: 'occlusion', count: 2505});
+let textureView56 = texture25.createView({label: '\u{1f8c3}\ub89a\u08b5', format: 'etc2-rgba8unorm', mipLevelCount: 2, baseArrayLayer: 0});
+let renderBundle26 = renderBundleEncoder15.finish({label: '\u0214\u09a0\ubfea\u01b2\uce9a\u8fde'});
+let bindGroup17 = device0.createBindGroup({label: '\u2f36\ub0f9\uaadf\u68cf\u0400\u077e\u{1f6c7}\u03f8', layout: bindGroupLayout1, entries: []});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u023e\u{1f725}'});
+let querySet24 = device0.createQuerySet({label: '\u0262\uade1\u7e9c\u0b46\u{1f970}\u{1f678}\u0627\u262c', type: 'occlusion', count: 2821});
+let textureView57 = texture16.createView({});
+let renderBundle27 = renderBundleEncoder5.finish();
+try {
+computePassEncoder5.setBindGroup(4, bindGroup3, new Uint32Array(9716), 930, 0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(9, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(5, bindGroup2, new Uint32Array(8440), 3979, 0);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer12, 4664, buffer6, 33820, 36556);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 116, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer6, commandBuffer0]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 5}
+*/
+{
+  source: canvas1,
+  origin: { x: 12, y: 88 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 5, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 79, height: 28, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = textureView55.label;
+} catch {}
+let texture34 = device0.createTexture({
+  label: '\ud7e1\ud556\ua356\u6266\u6d11',
+  size: {width: 192, height: 240, depthOrArrayLayers: 10},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float'],
+});
+try {
+renderBundleEncoder11.setBindGroup(6, bindGroup8, new Uint32Array(6056), 194, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer3, 352, 9668);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet0, 114, 21, buffer15, 92928);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  label: '\u0c4d\u8866\u5dc7\u6a13\u2ea7\u{1faf6}\u2596\u071f\u{1fcb6}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler3}],
+});
+let querySet25 = device0.createQuerySet({label: '\ub929\u12f8\u{1f611}\u8bb4\ud87c', type: 'occlusion', count: 214});
+let texture35 = device0.createTexture({
+  label: '\u{1f8b5}\u05a1\u1b6f',
+  size: {width: 2580, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let renderBundle28 = renderBundleEncoder7.finish({label: '\ub83e\u9898\u6aa0'});
+try {
+renderBundleEncoder6.setVertexBuffer(2401, undefined, 1654856037, 173703843);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10108 */
+  offset: 10108,
+  bytesPerRow: 0,
+  rowsPerImage: 282,
+  buffer: buffer10,
+}, {
+  texture: texture4,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 25});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 101648, new BigUint64Array(45031), 17566);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout8 = device2.createPipelineLayout({
+  label: '\uc849\ufe2a\ud57c\u0333\u0111',
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout12, bindGroupLayout12],
+});
+let computePassEncoder14 = commandEncoder43.beginComputePass({label: '\u0565\u5ff1\u{1f7a2}\u{1f83b}\u00c9\u6ecb\u089a\u0c2a\u006a'});
+let externalTexture17 = device2.importExternalTexture({label: '\u{1ffce}\u4a39\uee62\u06de\u6c24\u97fd\ub261\u0135', source: videoFrame7, colorSpace: 'srgb'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let textureView58 = texture15.createView({
+  label: '\u{1fd44}\u003e\u{1f84d}\u{1ff36}\u2e8a\u{1fecf}\u{1fb91}\u83d7\uca3e\u{1f8c6}',
+  baseMipLevel: 6,
+  mipLevelCount: 2,
+  baseArrayLayer: 73,
+  arrayLayerCount: 10,
+});
+let sampler24 = device0.createSampler({
+  label: '\u0bad\u667a',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 92.96,
+  lodMaxClamp: 99.74,
+  compare: 'greater',
+});
+try {
+commandEncoder22.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\u58c1');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let bindGroup19 = device1.createBindGroup({
+  label: '\u0f40\u09b4\u{1f7bd}\ud993\ud221\ua72c\udda9\ua241\ucc65\u7bb5',
+  layout: bindGroupLayout10,
+  entries: [{binding: 1552, resource: sampler21}],
+});
+let buffer18 = device1.createBuffer({
+  label: '\u{1fbb7}\u38bb\u0db9',
+  size: 49656,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let textureView59 = texture27.createView({dimension: '2d-array'});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler25 = device1.createSampler({
+  label: '\u4548\u{1fdcb}\u083b\ub744\u0d40\u{1f923}\ua1bd\u81ae\u{1faf2}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.648,
+  lodMaxClamp: 15.01,
+});
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer17, 201820, 36720);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline1 = await device1.createComputePipelineAsync({
+  label: '\u{1fb14}\u{1fedd}\ud8bf\u650b\u05d9\u{1fb0f}\u{1fb4d}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let renderBundleEncoder19 = device2.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle29 = renderBundleEncoder19.finish();
+let sampler26 = device2.createSampler({addressModeU: 'clamp-to-edge', mipmapFilter: 'nearest', lodMinClamp: 42.74, lodMaxClamp: 92.62});
+let externalTexture18 = device2.importExternalTexture({
+  label: '\u0152\ud8b7\u1a27\ub2d2\u9753\u6c12\u076e\u{1ff1e}\u65aa\uc4d9',
+  source: videoFrame3,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(1631), 613, 0);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(buffer10, 14252, buffer4, 5816, 600);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet5, 3451, 154, buffer0, 71168);
+} catch {}
+try {
+commandEncoder25.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 199136, new BigUint64Array(58182), 2773, 484);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 3, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video0);
+let img7 = await imageWithData(149, 155, '#bdbc310e', '#24ad49a9');
+let querySet26 = device1.createQuerySet({label: '\udb48\ucd58\ua5bb\u7deb\uc556', type: 'occlusion', count: 784});
+let texture36 = device1.createTexture({
+  label: '\u0a4d\u03b5\u{1f656}',
+  size: {width: 273, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView60 = texture32.createView({
+  label: '\ua058\u0b3b\u0bba\u6282\ub0b8\u{1fb03}\u{1f8a8}\u0de7',
+  format: 'rg16sint',
+  baseArrayLayer: 71,
+  arrayLayerCount: 451,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(5, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer17, 156908);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise10 = device1.createComputePipelineAsync({
+  label: '\u{1fa19}\u06ea\u250a\u0233\u5a59\u041f\u4fcb\ue120\ufe4a',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let texture37 = device2.createTexture({
+  label: '\u5fdd\u6bd8\uaaab\u00f4\u97d4\u0945\uea8d\uaa20\u45de',
+  size: {width: 183, height: 1, depthOrArrayLayers: 86},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+try {
+renderBundleEncoder17.pushDebugGroup('\u{1fd2c}');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 1},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 792_272 */
+{offset: 410, bytesPerRow: 99, rowsPerImage: 129}, {width: 30, height: 1, depthOrArrayLayers: 63});
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder45 = device1.createCommandEncoder({label: '\u9829\u047b\u85f9'});
+let querySet27 = device1.createQuerySet({label: '\u4314\uf604\ub87f\u83f6\u6234\u{1ffa4}\u4c43', type: 'occlusion', count: 3804});
+let texture38 = gpuCanvasContext0.getCurrentTexture();
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline2 = await device1.createComputePipelineAsync({
+  label: '\u3fd3\u310f\u91b6',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let canvas2 = document.createElement('canvas');
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 969 */
+{offset: 969}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder46 = device2.createCommandEncoder({label: '\u644f\u0e9c\u{1fa9a}\u0c4c\u{1fd9c}\u18c0\u0091\u0d11\u{1fee5}'});
+let textureView61 = texture37.createView({});
+let bindGroupLayout13 = device1.createBindGroupLayout({
+  label: '\u{1ff76}\u{1fddb}\u{1f715}\u093f\u568a\u7a7e\u{1f972}\u9c2d\u{1f679}',
+  entries: [
+    {
+      binding: 2548,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 2591,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer19 = device1.createBuffer({
+  label: '\u08f4\uf4c2\u{1fe7f}\ud2c7\uf239\u5ac2\u589b\u0894\u2bee\ue119\ud569',
+  size: 136868,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet28 = device1.createQuerySet({
+  label: '\u5846\u{1ff15}\u2a7e\u2686\u6124\u034f\u8eb0\uda69\uc5c6\u{1f9f0}\u{1f93a}',
+  type: 'occlusion',
+  count: 910,
+});
+let texture39 = device1.createTexture({
+  label: '\uacc6\u0994\u622f\ue77d\u{1f65b}\uf98f\u09ca\u0722\ubb04',
+  size: [72],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(6, bindGroup15, new Uint32Array(3936), 704, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer17, 171492, 46813);
+} catch {}
+let arrayBuffer3 = buffer16.getMappedRange(0, 31184);
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8664 */
+  offset: 8120,
+  bytesPerRow: 256,
+  buffer: buffer19,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 12, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 33},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 6_989_192 */
+{offset: 242, bytesPerRow: 334, rowsPerImage: 155}, {width: 34, height: 0, depthOrArrayLayers: 136});
+} catch {}
+let pipeline3 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0x26fb7575},
+  fragment: {module: shaderModule1, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16sint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 1951613473,
+    stencilWriteMask: 781721036,
+    depthBias: 1619638005,
+    depthBiasClamp: 33.7322356591514,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3412,
+        attributes: [
+          {format: 'sint16x4', offset: 228, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 42, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 612, shaderLocation: 9},
+          {format: 'uint8x4', offset: 52, shaderLocation: 13},
+          {format: 'float16x4', offset: 272, shaderLocation: 10},
+          {format: 'float16x2', offset: 888, shaderLocation: 14},
+          {format: 'uint32x2', offset: 484, shaderLocation: 15},
+          {format: 'uint16x2', offset: 92, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 986, shaderLocation: 6},
+          {format: 'uint32x3', offset: 76, shaderLocation: 17},
+          {format: 'sint32', offset: 1700, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 72, shaderLocation: 11},
+          {format: 'sint16x4', offset: 96, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 152, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1548,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 128, shaderLocation: 7},
+          {format: 'float32x2', offset: 16, shaderLocation: 3},
+          {format: 'float32x2', offset: 180, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 5116,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 512, shaderLocation: 16}],
+      },
+    ],
+  },
+});
+video1.width = 204;
+let canvas4 = document.createElement('canvas');
+let img8 = await imageWithData(199, 60, '#2300b6f0', '#b40079d5');
+try {
+canvas4.getContext('webgl2');
+} catch {}
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u{1fe0f}\u93fc\uc666\u05e8\u5f85\uadab\u3efa\uddf4',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer13, 'uint16', 10244, 60161);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(4, buffer6, 0, 18952);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet8, 2099, 136, buffer0, 55808);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1632, new Int16Array(25264), 17478, 904);
+} catch {}
+document.body.prepend(video1);
+let imageBitmap5 = await createImageBitmap(imageBitmap4);
+let commandEncoder47 = device2.createCommandEncoder({label: '\u03f6\u{1fb2d}\u04c2\u29d4\u8ed6\u{1fa83}\u47ac\u5c95'});
+try {
+renderBundleEncoder17.setVertexBuffer(2026, undefined, 556696827, 3258575670);
+} catch {}
+gc();
+let offscreenCanvas1 = new OffscreenCanvas(657, 121);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder48 = device2.createCommandEncoder({label: '\u0c15\u067c\u{1f66b}\u124f\u7530\u0f9d\u05f9'});
+let textureView62 = texture35.createView({label: '\u0f30\u28c7\u1b2f\u7f99\u02a5\u0c13\u8389\u71e5', baseMipLevel: 5});
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 4792 widthInBlocks: 1198 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12552 */
+  offset: 12552,
+  bytesPerRow: 4864,
+  rowsPerImage: 229,
+  buffer: buffer12,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1198, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 5}
+*/
+{
+  source: video0,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 27, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.createComputePipelineAsync({
+  label: '\u01aa\u703a\u4a02\u00eb\ue090\u04a2\u3860\u{1f691}\u7931\u11bf',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule2 = device2.createShaderModule({
+  label: '\u{1fd64}\ua2a1\u4686\u{1fe1d}\u4548\u4da9\u06b0\u08a5\u06e3\u2493\u03ad',
+  code: `@group(1) @binding(6715)
+var<storage, read_write> parameter4: array<u32>;
+@group(0) @binding(6715)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(31) f0: f16
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(75) a0: vec4<u32>, @location(43) a1: vec2<i32>, @location(24) a2: i32, @location(37) a3: f32, @builtin(position) a4: vec4<f32>, @location(30) a5: u32, @location(77) a6: vec4<i32>, @location(35) a7: f32, @location(0) a8: vec2<f16>, @location(79) a9: vec2<f16>, @location(1) a10: vec4<f16>, a11: S5, @location(64) a12: i32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @builtin(instance_index) f0: u32,
+  @location(18) f1: vec4<f32>,
+  @location(9) f2: f32,
+  @builtin(vertex_index) f3: u32,
+  @location(5) f4: vec4<f32>,
+  @location(13) f5: u32,
+  @location(3) f6: f32,
+  @location(11) f7: f16,
+  @location(20) f8: vec4<f32>,
+  @location(0) f9: vec2<u32>,
+  @location(7) f10: vec2<u32>,
+  @location(4) f11: f16,
+  @location(14) f12: f16,
+  @location(24) f13: vec3<f16>,
+  @location(21) f14: vec2<u32>,
+  @location(8) f15: f32,
+  @location(16) f16: vec3<u32>,
+  @location(15) f17: vec2<u32>,
+  @location(19) f18: vec3<u32>,
+  @location(23) f19: vec4<f16>,
+  @location(10) f20: vec4<u32>,
+  @location(26) f21: vec2<f32>,
+  @location(12) f22: vec2<i32>,
+  @location(1) f23: vec4<f16>,
+  @location(6) f24: f32,
+  @location(2) f25: vec4<u32>,
+  @location(22) f26: vec3<u32>,
+  @location(27) f27: vec3<f32>,
+  @location(17) f28: vec2<i32>,
+  @location(25) f29: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(64) f84: i32,
+  @location(0) f85: vec2<f16>,
+  @location(79) f86: vec2<f16>,
+  @location(87) f87: f32,
+  @location(109) f88: vec3<u32>,
+  @location(83) f89: f16,
+  @location(46) f90: vec3<f16>,
+  @location(96) f91: vec2<i32>,
+  @location(100) f92: vec3<i32>,
+  @location(43) f93: vec2<i32>,
+  @location(77) f94: vec4<i32>,
+  @location(90) f95: vec4<f16>,
+  @location(44) f96: f32,
+  @location(1) f97: vec4<f16>,
+  @location(66) f98: vec3<i32>,
+  @location(86) f99: f16,
+  @location(7) f100: vec4<i32>,
+  @builtin(position) f101: vec4<f32>,
+  @location(37) f102: f32,
+  @location(31) f103: f16,
+  @location(62) f104: vec4<u32>,
+  @location(24) f105: i32,
+  @location(114) f106: vec2<u32>,
+  @location(8) f107: f16,
+  @location(45) f108: f32,
+  @location(35) f109: f32,
+  @location(26) f110: u32,
+  @location(30) f111: u32,
+  @location(113) f112: vec4<f32>,
+  @location(5) f113: vec2<i32>,
+  @location(75) f114: vec4<u32>
+}
+
+@vertex
+fn vertex0(a0: S4) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder49 = device2.createCommandEncoder();
+let texture40 = device2.createTexture({
+  label: '\u{1ffea}\u6bc3\u09c7\uc996\u7d2b\ubfa0',
+  size: {width: 183, height: 1, depthOrArrayLayers: 194},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let textureView63 = texture40.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder21 = device2.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'], stencilReadOnly: true});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder50 = device1.createCommandEncoder();
+let querySet29 = device1.createQuerySet({label: '\u{1fede}\ucf4e', type: 'occlusion', count: 1825});
+let texture41 = device1.createTexture({
+  label: '\u4355\u{1fa1c}\ued59\u0e61',
+  size: [72],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer17, 0, 114800);
+} catch {}
+try {
+device1.queue.submit([commandBuffer8]);
+} catch {}
+let bindGroup20 = device2.createBindGroup({
+  label: '\u4ae5\u{1fca1}\u3211\u43e9\u0ee3',
+  layout: bindGroupLayout12,
+  entries: [{binding: 6715, resource: externalTexture18}],
+});
+let commandEncoder51 = device2.createCommandEncoder();
+let sampler27 = device2.createSampler({
+  label: '\uf222\ue8ee\u7d0f\u01c0\ud802',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.97,
+  lodMaxClamp: 38.84,
+  maxAnisotropy: 7,
+});
+let externalTexture19 = device2.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder17.setVertexBuffer(6040, undefined);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(936, 570);
+let bindGroup21 = device2.createBindGroup({
+  label: '\u159c\u0913\u{1fb7a}\u3d50\u067c\u0d98\u2deb\ucc31\u{1fefd}\uf0a9',
+  layout: bindGroupLayout12,
+  entries: [{binding: 6715, resource: externalTexture17}],
+});
+let querySet30 = device2.createQuerySet({
+  label: '\uce6f\u{1f6d4}\ua113\u89d6\u376d\udeb7\u{1faaf}\u01fb\u066e\u{1f80c}\u8e9c',
+  type: 'occlusion',
+  count: 531,
+});
+let externalTexture20 = device2.importExternalTexture({source: video0, colorSpace: 'srgb'});
+let computePassEncoder15 = commandEncoder44.beginComputePass({label: '\u04b2\u{1f6c5}\ub828\u09d6\u745b'});
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer6);
+} catch {}
+let arrayBuffer4 = buffer9.getMappedRange();
+try {
+buffer2.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 167, y: 2 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img9 = await imageWithData(116, 139, '#f550f1e3', '#f0965347');
+let commandBuffer10 = commandEncoder32.finish({label: '\u9c98\u{1fa8a}\ueef0\u9616\u{1fc14}\u1b97\uc5f7\u0ad8\u0d48\ubc56\u8e7c'});
+let textureView64 = texture41.createView({label: '\ubf7a\ue279\u7a5d', aspect: 'all'});
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup19, new Uint32Array(6537), 3014, 0);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer5 = buffer16.getMappedRange(31184, 8968);
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3984 */
+  offset: 2152,
+  bytesPerRow: 256,
+  buffer: buffer19,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 32, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+device1.queue.submit([commandBuffer9]);
+} catch {}
+let promise12 = device1.queue.onSubmittedWorkDone();
+try {
+canvas2.getContext('2d');
+} catch {}
+let textureView65 = texture40.createView({label: '\u0365\ub276\u3af2\u387c\u{1fee6}', format: 'bgra8unorm', mipLevelCount: 2, arrayLayerCount: 1});
+let renderBundle30 = renderBundleEncoder21.finish();
+let sampler28 = device2.createSampler({
+  label: '\u0a01\ud721\uea6e\u7da9\u{1faf0}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.16,
+  lodMaxClamp: 46.30,
+});
+try {
+computePassEncoder14.setBindGroup(4, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup21, new Uint32Array(4455), 1676, 0);
+} catch {}
+let gpuCanvasContext1 = canvas3.getContext('webgpu');
+offscreenCanvas2.width = 111;
+gc();
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u0d68\u{1fd0a}\u40ed\u0f00\u0bc0\u9286',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout11, bindGroupLayout6, bindGroupLayout0, bindGroupLayout11, bindGroupLayout7, bindGroupLayout4],
+});
+let commandBuffer11 = commandEncoder28.finish({label: '\u119e\u69d0\u{1fc40}\ub5ff\uaa1c\uc580\u0fb7\u{1fea5}\u06ed'});
+let sampler29 = device0.createSampler({
+  label: '\u{1fef1}\u015a\u06c6\u0927\u13fe\ucde9',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 91.74,
+  lodMaxClamp: 94.49,
+});
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 141, y: 192, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 117, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 481 */
+{offset: 481, bytesPerRow: 286}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise13 = device0.createComputePipelineAsync({
+  label: '\u{1fc06}\ue5ed\u{1f760}\u302f\u08cd\u{1f89b}\u0d78\u897c\ueabc',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise12;
+} catch {}
+let img10 = await imageWithData(162, 94, '#f40728d4', '#7e88158b');
+let videoFrame10 = new VideoFrame(videoFrame7, {timestamp: 0});
+let computePassEncoder16 = commandEncoder23.beginComputePass({label: '\uc166\u{1fba9}\u850b\ud18b'});
+try {
+renderBundleEncoder11.setBindGroup(5, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer6, 0, 19777);
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  label: '\ua122\u7a05\u4623\u775f\u1242\u047d\u{1fee4}\u0ae6\u08cb\u{1fa16}\u0307',
+  layout: pipelineLayout2,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst'},
+  },
+}, {format: 'r32float'}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 26644,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 1688, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 3904, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 240, shaderLocation: 14},
+          {format: 'uint32x2', offset: 4688, shaderLocation: 7},
+          {format: 'float32x4', offset: 14176, shaderLocation: 13},
+          {format: 'sint16x4', offset: 556, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 944, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 5316, shaderLocation: 16},
+          {format: 'float32', offset: 2208, shaderLocation: 1},
+          {format: 'sint16x2', offset: 1124, shaderLocation: 2},
+          {format: 'float16x2', offset: 916, shaderLocation: 18},
+          {format: 'sint32x2', offset: 1152, shaderLocation: 12},
+          {format: 'sint32', offset: 3900, shaderLocation: 17},
+          {format: 'uint32x2', offset: 1184, shaderLocation: 5},
+          {format: 'float32x3', offset: 1876, shaderLocation: 15},
+          {format: 'uint8x2', offset: 12364, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm8x2', offset: 8776, shaderLocation: 9},
+          {format: 'float32x3', offset: 4040, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 3728, shaderLocation: 11},
+          {format: 'float32', offset: 5144, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder52 = device0.createCommandEncoder({label: '\u090d\u38d1\u{1fa70}\u0706\u3326\u30a4\u06d0\u{1f98b}\u67c1'});
+let textureView66 = texture4.createView({dimension: '2d', baseMipLevel: 3, mipLevelCount: 4, baseArrayLayer: 22});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.66,
+  lodMaxClamp: 63.59,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder15.setBindGroup(4, bindGroup16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 693 */
+{offset: 693}, {width: 79, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData0,
+  origin: { x: 10, y: 8 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let textureView67 = texture18.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle31 = renderBundleEncoder13.finish({label: '\u{1f6c6}\u07d2\uc930\u6119'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(6, bindGroup10, new Uint32Array(2369), 2200, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 2840 widthInBlocks: 710 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16796 */
+  offset: 16796,
+  buffer: buffer10,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 710, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet2, 2143, 1, buffer15, 33280);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  label: '\u2fe4\u0353\u2d87\uf0a8\ufda8\u0f07\u{1fcee}\u{1fe0e}\u98c2\u59a4\u{1fde0}',
+  layout: pipelineLayout4,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: 0,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater', failOp: 'replace', depthFailOp: 'replace', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilReadMask: 1566374320,
+    stencilWriteMask: 1306651284,
+    depthBiasSlopeScale: -77.67112893486032,
+    depthBiasClamp: 409.46004791122107,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1292,
+        attributes: [
+          {format: 'float16x2', offset: 524, shaderLocation: 0},
+          {format: 'uint16x2', offset: 288, shaderLocation: 6},
+          {format: 'sint8x2', offset: 464, shaderLocation: 10},
+          {format: 'uint32x3', offset: 172, shaderLocation: 3},
+          {format: 'float16x4', offset: 44, shaderLocation: 18},
+          {format: 'uint16x4', offset: 8, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 148, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 274, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 104, shaderLocation: 16},
+          {format: 'uint16x2', offset: 52, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 180, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 24, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 318, shaderLocation: 1},
+          {format: 'float32x2', offset: 212, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 112, shaderLocation: 19},
+          {format: 'sint32', offset: 32, shaderLocation: 2},
+          {format: 'float32', offset: 240, shaderLocation: 9},
+          {format: 'sint8x4', offset: 476, shaderLocation: 12},
+          {format: 'sint32x3', offset: 112, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+document.body.prepend(video0);
+let querySet31 = device0.createQuerySet({label: '\u0802\u091d\u1429\u0e8d\u063d\ud194', type: 'occlusion', count: 1635});
+let textureView68 = texture22.createView({arrayLayerCount: 1});
+try {
+renderBundleEncoder2.setVertexBuffer(2, buffer6, 0, 25192);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2156 widthInBlocks: 539 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27376 */
+  offset: 27376,
+  buffer: buffer14,
+}, {width: 539, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 3_446 */
+{offset: 782}, {width: 666, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u044e\ufec6\u777c\u0074\u7b25'});
+let commandBuffer12 = commandEncoder5.finish({label: '\u935d\uf8f9\u628b\u9ea4\u0e21\u00b5'});
+let textureView69 = texture9.createView({
+  label: '\u0aa6\u{1f647}\u4b7a\u{1f649}\ub503\u4818\u7287',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder12.setIndexBuffer(buffer5, 'uint32', 8112, 20782);
+} catch {}
+let arrayBuffer6 = buffer8.getMappedRange(0, 2424);
+let querySet32 = device2.createQuerySet({label: '\ud4db\ue595\u185a\u78c6\u{1f8e1}\u07e1\u04ae\u{1f702}\u0f72', type: 'occlusion', count: 3021});
+let texture42 = device2.createTexture({
+  size: [1506, 1, 152],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let textureView70 = texture40.createView({label: '\u0b17\u8d71\u9d95\u{1f941}', baseMipLevel: 2});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 32, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 254, height: 1, depthOrArrayLayers: 11});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+gc();
+let videoFrame11 = new VideoFrame(videoFrame2, {timestamp: 0});
+let querySet33 = device2.createQuerySet({label: '\u0232\u02ac\u{1fdb4}\u0da1', type: 'occlusion', count: 3403});
+let textureView71 = texture42.createView({
+  label: '\u{1fbff}\ubbcd\ud35e\u{1fbe1}\uce3c\u87ce\u0d3d\u4570\u0a88\u{1ff4a}\u6592',
+  dimension: '3d',
+  format: 'bgra8unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 196, y: 0, z: 7},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 11_369_136 */
+{offset: 246, bytesPerRow: 3239, rowsPerImage: 39}, {width: 769, height: 0, depthOrArrayLayers: 91});
+} catch {}
+let bindGroup22 = device2.createBindGroup({
+  label: '\u05fb\u{1fe29}\udd27\u0644\u6dec\u9077\u03d8\u{1f6d1}',
+  layout: bindGroupLayout12,
+  entries: [{binding: 6715, resource: externalTexture19}],
+});
+let commandBuffer13 = commandEncoder43.finish({label: '\ue8eb\ue9b6\u85c2\u256c\u0e76\uc051\u0298\u046d\u98d6\ub86b'});
+let textureView72 = texture37.createView({label: '\ua45d\u{1f7b7}\u9ce6\u3dcc\uf919\u{1f9f6}\uc9b3\u0740\u0bc7\u07d2', dimension: '3d'});
+let renderBundleEncoder22 = device2.createRenderBundleEncoder({
+  label: '\u0d6b\u9998\u8a40\u0977\u049c',
+  colorFormats: [undefined, 'rgba8uint', 'r8sint', 'rg8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture21 = device2.importExternalTexture({
+  label: '\u{1fe30}\u5230\u073d\u0007\uf11d\u{1f71d}\u0670',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 91_894 */
+{offset: 712, bytesPerRow: 167, rowsPerImage: 39}, {width: 56, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let pipeline6 = device2.createRenderPipeline({
+  label: '\u1045\udf8f\u{1f8e4}\u{1fa45}\uf701\u{1fdb1}\uab69\u084e\u{1fb70}',
+  layout: 'auto',
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 5348,
+        attributes: [
+          {format: 'float16x4', offset: 508, shaderLocation: 18},
+          {format: 'float16x2', offset: 780, shaderLocation: 27},
+          {format: 'uint32x3', offset: 120, shaderLocation: 13},
+          {format: 'uint32x2', offset: 40, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 1404, shaderLocation: 5},
+          {format: 'float16x2', offset: 712, shaderLocation: 20},
+          {format: 'float16x2', offset: 1820, shaderLocation: 3},
+          {format: 'uint16x4', offset: 2908, shaderLocation: 7},
+          {format: 'uint16x4', offset: 540, shaderLocation: 15},
+          {format: 'sint32x3', offset: 1072, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 1},
+          {format: 'float16x4', offset: 40, shaderLocation: 6},
+          {format: 'uint8x4', offset: 8, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 4480, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 1636, shaderLocation: 24},
+          {format: 'float32', offset: 864, shaderLocation: 4},
+          {format: 'uint32', offset: 596, shaderLocation: 16},
+          {format: 'uint32x2', offset: 188, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 3568, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint16x2', offset: 1144, shaderLocation: 12},
+          {format: 'uint32x3', offset: 11284, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 46148,
+        attributes: [
+          {format: 'snorm8x4', offset: 14384, shaderLocation: 9},
+          {format: 'uint32x4', offset: 25232, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 528, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 5736, shaderLocation: 26},
+          {format: 'uint32x4', offset: 1648, shaderLocation: 25},
+          {format: 'uint8x2', offset: 5124, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 4752, shaderLocation: 11},
+          {format: 'float32x4', offset: 8168, shaderLocation: 23},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let buffer20 = device1.createBuffer({
+  label: '\u092d\uc54e\u0f61\u29e4',
+  size: 114472,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+});
+let commandBuffer14 = commandEncoder34.finish({label: '\u33a8\u{1fbe9}\u0a01\u00a5\ub0bc\ufbda'});
+let texture43 = device1.createTexture({
+  label: '\u0309\ueb7a\u{1ff96}\ub92e\uf829\u0056\uf63f\u3b6e\u{1f68a}\u0a33\u1835',
+  size: {width: 546, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView73 = texture38.createView({dimension: '2d-array'});
+let renderBundle32 = renderBundleEncoder14.finish({label: '\u7811\ua615\ufd05\u094b\u0dd4\u0da3\udeb3\u0121'});
+try {
+commandEncoder45.insertDebugMarker('\u05d3');
+} catch {}
+try {
+renderBundleEncoder18.insertDebugMarker('\u0822');
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let texture44 = device0.createTexture({
+  label: '\u4689\u{1f873}\u2a62\u3013\u6e52\u02d6\ub61d\u2ccb\u{1f745}\u05af\u5d90',
+  size: [31],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+let textureView74 = texture26.createView({label: '\u{1fb07}\u0f95\u9024', mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u1a22\u9c52\uf982\ue84a\u0c13\u064a\u4d98\u7209',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler31 = device0.createSampler({
+  label: '\u0f01\u0526\u031a\u8bc3\uda2b\ueaf5\u05c1\u{1f7be}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 79.93,
+});
+try {
+commandEncoder31.clearBuffer(buffer11, 96816, 56640);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 427, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 274 */
+{offset: 274}, {width: 388, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet34 = device1.createQuerySet({label: '\u03c4\uee62\u068f\u09b1\u34e8\u00f9\u0f9e\u6a75', type: 'occlusion', count: 1250});
+let texture45 = device1.createTexture({
+  label: '\u0872\u9310\u{1fa7f}\u0e16',
+  size: {width: 36},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint'],
+});
+try {
+commandEncoder42.copyBufferToBuffer(buffer16, 31316, buffer20, 91680, 12004);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 20404, new DataView(new ArrayBuffer(63523)), 635);
+} catch {}
+let video2 = await videoWithData();
+try {
+adapter1.label = '\u{1f78f}\uc840\u7044\u9af3\u33af';
+} catch {}
+let commandEncoder54 = device1.createCommandEncoder();
+let textureView75 = texture29.createView({label: '\u0ace\u0880\u3d08\u4670\u0641\u0446\u230d\u{1fc8f}\u{1fdad}\u0d3d\u1175'});
+try {
+computePassEncoder13.setBindGroup(6, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer17, 0);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer16, 15468, buffer20, 75908, 19320);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9892 */
+  offset: 9876,
+  buffer: buffer20,
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+let bindGroupLayout14 = device1.createBindGroupLayout({
+  label: '\u1208\u82ae\u6b2d\u9541\u54d0\u2958\u5693\u{1fe81}\u{1fb38}',
+  entries: [
+    {binding: 3157, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true }},
+  ],
+});
+let pipelineLayout10 = device1.createPipelineLayout({
+  label: '\uad05\u01d0\u4f1d\uce20',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout10, bindGroupLayout10, bindGroupLayout14, bindGroupLayout10],
+});
+let commandEncoder55 = device1.createCommandEncoder({label: '\u{1fd16}\u2ffb\u81a6\u{1fbe6}\u0191\uf79d'});
+let texture46 = device1.createTexture({
+  label: '\u{1fe3c}\u4fbc\uf73e\u31c9\uc1fd\u{1fa9f}',
+  size: {width: 750, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'astc-10x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView76 = texture46.createView({label: '\u{1f714}\u536d\u0413\u0d3f\u{1f81e}\u0a62\u0630', dimension: '2d-array', mipLevelCount: 6});
+try {
+commandEncoder42.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+});
+} catch {}
+let pipeline7 = await device1.createRenderPipelineAsync({
+  label: '\u{1f8f9}\u0fe4',
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0x36cc55e6},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 3317870551,
+    stencilWriteMask: 352395066,
+    depthBias: -1539203501,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 764,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 20, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 76, shaderLocation: 10},
+          {format: 'uint32x2', offset: 124, shaderLocation: 5},
+          {format: 'uint32x3', offset: 64, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 132, shaderLocation: 14},
+          {format: 'float32x3', offset: 68, shaderLocation: 4},
+          {format: 'sint32x2', offset: 60, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 23592,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 2136, shaderLocation: 7},
+          {format: 'uint32x3', offset: 10188, shaderLocation: 15},
+          {format: 'sint32x4', offset: 3220, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 528, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 2204, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 1888, shaderLocation: 2},
+          {format: 'float32x4', offset: 4436, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 4552, attributes: [{format: 'snorm16x4', offset: 792, shaderLocation: 3}]},
+      {
+        arrayStride: 6852,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 1846, shaderLocation: 1},
+          {format: 'uint8x4', offset: 36, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 3256,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 532, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let bindGroup23 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 1922, resource: sampler4}]});
+let commandEncoder56 = device0.createCommandEncoder();
+let textureView77 = texture18.createView({
+  label: '\u0e77\uddc5\u0ed2\u6c83\u02b1\u963c\uaf85\u8560',
+  aspect: 'all',
+  format: 'rgb10a2uint',
+  baseMipLevel: 5,
+  baseArrayLayer: 0,
+});
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 275, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 180, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer11, 71496, 75892);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet20, 101, 83, buffer0, 51200);
+} catch {}
+let pipelineLayout11 = device2.createPipelineLayout({label: '\uca28\u{1f9ef}\u05f6\u1e81\u0c13\u0f0a\u0e3d\u02c4', bindGroupLayouts: [bindGroupLayout12]});
+let buffer21 = device2.createBuffer({
+  label: '\u09b6\ue8c5\u781b\u{1fdb4}\u{1fd5e}\u0592\u251e\u05b2\u{1fc84}\u0349',
+  size: 603980,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder57 = device2.createCommandEncoder({});
+let renderBundle33 = renderBundleEncoder22.finish({label: '\u08ff\u48d4\u{1fdd3}\u24e8\u{1fabc}\u{1f6f2}\u0410\u1a93\u3265\u{1fa45}'});
+try {
+buffer21.unmap();
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 15},
+  aspect: 'all',
+}, new ArrayBuffer(1_185_155), /* required buffer size: 1_185_155 */
+{offset: 815, bytesPerRow: 326, rowsPerImage: 227}, {width: 154, height: 1, depthOrArrayLayers: 17});
+} catch {}
+let commandEncoder58 = device1.createCommandEncoder({label: '\u{1fb82}\u0e63\u{1f76e}'});
+let textureView78 = texture29.createView({});
+let sampler32 = device1.createSampler({
+  label: '\u1d30\u01cd\u007c\u2244\ue900\u2e1d\u00ea\u0638\u0e04\u0b53',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.61,
+  lodMaxClamp: 82.27,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup13, []);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder55.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 13, y: 0, z: 15},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8848 */
+  offset: 8848,
+  bytesPerRow: 0,
+  rowsPerImage: 283,
+  buffer: buffer20,
+}, {width: 0, height: 1, depthOrArrayLayers: 189});
+dissociateBuffer(device1, buffer20);
+} catch {}
+document.body.prepend(video1);
+gc();
+let querySet35 = device2.createQuerySet({type: 'occlusion', count: 2310});
+let commandBuffer15 = commandEncoder51.finish({label: '\u{1ffd6}\u{1f666}\u7b5c\u3d84\uf99b\u1df7\ud57e\udc68\ueb14\u0b83'});
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 30, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 293, height: 1, depthOrArrayLayers: 23});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 42, y: 20 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 93, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(74, 661);
+let commandEncoder59 = device2.createCommandEncoder({label: '\u22f7\u0f71\u{1f703}\ud3e1\u0932\u{1f9d2}\uf235\ub0df\u0693\u0caf'});
+let querySet36 = device2.createQuerySet({
+  label: '\udc14\u5d18\u{1ff08}\u29d1\u{1fda2}\u7f03\u8aa5\u1a4e\u0cb1\u0c6a\ufd87',
+  type: 'occlusion',
+  count: 4039,
+});
+let textureView79 = texture40.createView({baseMipLevel: 0, mipLevelCount: 3});
+let externalTexture22 = device2.importExternalTexture({
+  label: '\u061a\u8ab8\u{1fc70}\u{1fa4c}\u0ed7\u912c\u05a8\ue1c6\u6e2e\u0f83',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup21, new Uint32Array(4649), 784, 0);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 7},
+  aspect: 'all',
+},
+{width: 323, height: 0, depthOrArrayLayers: 34});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: img5,
+  origin: { x: 37, y: 1 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 255, y: 0, z: 82},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle34 = renderBundleEncoder22.finish({});
+try {
+renderBundleEncoder17.setBindGroup(7, bindGroup22, []);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2482, undefined, 2940959116);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: imageData2,
+  origin: { x: 6, y: 2 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({label: '\ub851\u8163\ub8a1\u003f\u0e21'});
+let textureView80 = texture12.createView({label: '\u{1f87e}\u0de2\uaf2f\u97f9\ue936\u0ffd\u70a3', dimension: '2d-array', baseMipLevel: 4});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\ucfa9\u0c23\u04db\u98f2\u312f\u0dd7\uf5e9\u7808\uce3d',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder31.copyBufferToBuffer(buffer4, 30252, buffer14, 116248, 33252);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 313, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 150, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 7},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(40)), /* required buffer size: 1_237_131 */
+{offset: 567, bytesPerRow: 701, rowsPerImage: 49}, {width: 109, height: 0, depthOrArrayLayers: 37});
+} catch {}
+let videoFrame12 = new VideoFrame(img3, {timestamp: 0});
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 243, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let pipeline8 = await device1.createRenderPipelineAsync({
+  label: '\uac71\u09e7\u{1ff6d}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 25548,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 8904, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 9668, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 5252, shaderLocation: 2},
+          {format: 'uint32', offset: 732, shaderLocation: 17},
+          {format: 'uint32x4', offset: 2128, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 2532, shaderLocation: 14},
+          {format: 'uint16x4', offset: 4004, shaderLocation: 15},
+          {format: 'sint16x2', offset: 9220, shaderLocation: 12},
+          {format: 'sint32', offset: 328, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 2564, shaderLocation: 7},
+          {format: 'float32x3', offset: 12960, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 4752,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 184, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 180, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 1688,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 444, shaderLocation: 4},
+          {format: 'float32x3', offset: 92, shaderLocation: 3},
+          {format: 'sint16x2', offset: 168, shaderLocation: 1},
+          {format: 'uint8x2', offset: 34, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 28, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+adapter0.label = '\u4e92\u00e1\ud806\u0778\uec6e\u0744\u2e0d\ubc6b\u5508\u3f34';
+} catch {}
+let shaderModule3 = device1.createShaderModule({
+  label: '\u{1fb81}\u0393\u3571\u{1fe31}\u51aa\ub1ba\u92a6\u6a74\u07a3\uce6d\ucca7',
+  code: `@group(0) @binding(1552)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(65) a0: vec3<i32>, @location(85) a1: vec4<f32>, @location(95) a2: i32, @builtin(sample_index) a3: u32, @builtin(front_facing) a4: bool, @builtin(position) a5: vec4<f32>, @builtin(sample_mask) a6: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(13) f0: vec2<f32>,
+  @location(4) f1: vec4<f32>,
+  @location(16) f2: vec2<f16>,
+  @builtin(instance_index) f3: u32,
+  @location(12) f4: vec2<f16>,
+  @location(0) f5: vec2<f16>,
+  @location(11) f6: f16,
+  @location(17) f7: vec4<i32>,
+  @builtin(vertex_index) f8: u32,
+  @location(2) f9: vec3<f32>,
+  @location(8) f10: vec2<f16>,
+  @location(6) f11: f16,
+  @location(9) f12: vec4<u32>,
+  @location(10) f13: i32
+}
+struct VertexOutput0 {
+  @builtin(position) f115: vec4<f32>,
+  @location(65) f116: vec3<i32>,
+  @location(95) f117: i32,
+  @location(85) f118: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<u32>, @location(15) a1: vec2<i32>, @location(3) a2: vec3<f32>, @location(1) a3: vec3<i32>, a4: S6) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder61 = device1.createCommandEncoder();
+let computePassEncoder17 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+buffer16.destroy();
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer14]);
+} catch {}
+let promise14 = device1.createRenderPipelineAsync({
+  label: '\u1cb2\u8c22\u{1f966}\u0df0\u0e8b\u51a4\uf0de\ud219\u0493',
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0x9d175888},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3608,
+        attributes: [
+          {format: 'sint16x2', offset: 2392, shaderLocation: 15},
+          {format: 'uint32x2', offset: 216, shaderLocation: 9},
+          {format: 'sint32x2', offset: 1200, shaderLocation: 1},
+          {format: 'uint32x2', offset: 872, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 408, shaderLocation: 12},
+          {format: 'sint32x3', offset: 268, shaderLocation: 10},
+          {format: 'sint32', offset: 352, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 520, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 224, shaderLocation: 3},
+          {format: 'float16x4', offset: 544, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 1080, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 1024, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 2024, attributes: []},
+      {
+        arrayStride: 4792,
+        attributes: [
+          {format: 'float32x2', offset: 32, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 780, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 680, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 10228, stepMode: 'instance', attributes: []},
+      {arrayStride: 2788, stepMode: 'instance', attributes: []},
+      {arrayStride: 2524, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6632,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 2524, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let shaderModule4 = device1.createShaderModule({
+  label: '\u0c8f\u063f\u{1fd65}\u{1ff3c}\u197f\uc176\ud3db\u0b84\u6a30\u{1ffdf}',
+  code: `@group(0) @binding(2548)
+var<storage, read_write> parameter5: array<u32>;
+@group(0) @binding(2591)
+var<storage, read_write> type1: array<u32>;
+@group(4) @binding(1552)
+var<storage, read_write> global2: array<u32>;
+@group(1) @binding(1552)
+var<storage, read_write> function4: array<u32>;
+@group(2) @binding(1552)
+var<storage, read_write> parameter6: array<u32>;
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f32>, @location(2) a1: u32, @location(5) a2: vec2<f32>, @location(7) a3: vec2<u32>, @location(16) a4: f32, @location(1) a5: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder18 = commandEncoder39.beginComputePass({label: '\u0584\u5571\u24ba\ua71e\u01ce\ua755\ue556\u{1fcaf}\ub4da'});
+let renderBundle35 = renderBundleEncoder18.finish({});
+try {
+commandEncoder42.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\ud2c8');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend(video2);
+let computePassEncoder19 = commandEncoder49.beginComputePass({label: '\uf726\u9015\u90e3'});
+let renderBundle36 = renderBundleEncoder19.finish({});
+let externalTexture23 = device2.importExternalTexture({
+  label: '\u1548\uab3e\u4d72\u0101\u343c\ued63\u3fd0\u80f9\u{1f8c7}\u{1ff45}',
+  source: videoFrame10,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup21, new Uint32Array(4556), 2203, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 33, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 267_327 */
+{offset: 991, bytesPerRow: 328, rowsPerImage: 116}, {width: 14, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let pipeline9 = device2.createComputePipeline({
+  label: '\u08f2\u{1fed0}\u0da7\u7637\u{1feaf}\u07e1\ue707',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame13 = new VideoFrame(videoFrame11, {timestamp: 0});
+try {
+offscreenCanvas3.getContext('webgpu');
+} catch {}
+let pipelineLayout12 = device2.createPipelineLayout({label: '\u8dfc\u0bf2\u0550\u{1f86b}\u07b3\u05ba\u8071\uab87\uff8e', bindGroupLayouts: []});
+let textureView81 = texture40.createView({
+  label: '\u9be6\u028e\u8f29\u0f13\u{1ffa7}\u2e1f\u6ced\u{1f793}\u0b2b\u2321\u17bf',
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder25 = device2.createRenderBundleEncoder({
+  label: '\u83fa\u0e63\ube7d',
+  colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'],
+  depthReadOnly: true,
+});
+let externalTexture24 = device2.importExternalTexture({label: '\u0fbd\u06e0\u0b9f\uefd1', source: videoFrame6, colorSpace: 'display-p3'});
+try {
+computePassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(6, bindGroup20);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\uf9e1');
+} catch {}
+let commandEncoder62 = device1.createCommandEncoder({label: '\u0172\u0d23\u1337\u9a03\u{1feb7}\u0b3d\u0544'});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer18, 6724, buffer20, 46524, 30916);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 987 */
+{offset: 987}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView82 = texture30.createView({label: '\u088e\uaba5\u{1fe44}\u{1fdfa}\u{1f650}\u100c\u5180\u{1f94d}\u117e\ud68a'});
+let computePassEncoder20 = commandEncoder61.beginComputePass({label: '\udaeb\u5b65\u2b86\u5ffd\u4a5e\ub28b\u0033\u076d\ucba4\u2ca7'});
+let sampler33 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.63,
+});
+let externalTexture25 = device1.importExternalTexture({label: '\u7371\u{1fbdb}\u3cff\u46fc', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 520 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27028 */
+  offset: 27028,
+  bytesPerRow: 768,
+  buffer: buffer19,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let sampler34 = device0.createSampler({
+  label: '\u2f9c\ue18a\u9d22\u6745\u197e\u0b19\ude1a\ucb64\u17bb\u1c31\u{1f6b6}',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 31.68,
+  lodMaxClamp: 39.88,
+});
+try {
+computePassEncoder12.setBindGroup(9, bindGroup11, new Uint32Array(6900), 885, 0);
+} catch {}
+try {
+commandEncoder6.insertDebugMarker('\udfb3');
+} catch {}
+let video3 = await videoWithData();
+let texture47 = device1.createTexture({
+  label: '\u0a6b\u0454\u06f9\u{1f9ef}\u0df1\u0aa6\u{1fc54}\u{1f6f9}',
+  size: {width: 144},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView83 = texture30.createView({});
+try {
+computePassEncoder18.setBindGroup(7, bindGroup19);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 132 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15964 */
+  offset: 15964,
+  buffer: buffer20,
+}, {width: 33, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 64, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder64 = device2.createCommandEncoder({label: '\u04d0\ufecc\u042d\ubd60\u{1f963}\u4d29'});
+let textureView84 = texture40.createView({
+  label: '\u{1f83a}\u{1f9ac}\udfa7\u{1fef1}\ucdcd\u621b\u0960\u08ac\u{1f7f0}',
+  baseMipLevel: 2,
+  arrayLayerCount: 1,
+});
+let sampler35 = device2.createSampler({
+  label: '\uc4ba\u06c5\u51bf\u{1fab5}\u{1f9e5}\u{1fd16}\uf443\ubc7b\u62c3\uc78e',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.43,
+  lodMaxClamp: 94.37,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 1142, y: 0, z: 21},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 83, y: 0, z: 7},
+  aspect: 'all',
+},
+{width: 187, height: 0, depthOrArrayLayers: 54});
+} catch {}
+let pipelineLayout13 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12]});
+let computePassEncoder21 = commandEncoder47.beginComputePass({});
+try {
+computePassEncoder19.setPipeline(pipeline9);
+} catch {}
+let promise15 = buffer21.mapAsync(GPUMapMode.READ, 296, 476256);
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 72, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 237, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let pipeline10 = await device2.createComputePipelineAsync({
+  label: '\u322b\u0e14',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let pipeline11 = device2.createRenderPipeline({
+  label: '\u0f95\u075c\u6aad\uc97d\u38ba\u9dbb\u4c66\u0a7f',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x2', offset: 11532, shaderLocation: 1},
+          {format: 'uint32x3', offset: 5268, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 12304, shaderLocation: 26},
+          {format: 'uint8x4', offset: 31144, shaderLocation: 22},
+          {format: 'sint16x4', offset: 15208, shaderLocation: 17},
+          {format: 'uint8x2', offset: 3280, shaderLocation: 10},
+          {format: 'uint32x4', offset: 2260, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 5800, shaderLocation: 4},
+          {format: 'sint32x2', offset: 480, shaderLocation: 12},
+          {format: 'float32x3', offset: 332, shaderLocation: 27},
+          {format: 'float16x4', offset: 1668, shaderLocation: 23},
+          {format: 'uint32', offset: 12508, shaderLocation: 16},
+          {format: 'uint16x4', offset: 224, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 11974, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 2708, shaderLocation: 18},
+          {format: 'float16x4', offset: 13788, shaderLocation: 24},
+          {format: 'uint32x2', offset: 7672, shaderLocation: 13},
+          {format: 'uint8x4', offset: 536, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 1604,
+        attributes: [
+          {format: 'snorm8x4', offset: 744, shaderLocation: 8},
+          {format: 'float16x2', offset: 432, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 8480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 880, shaderLocation: 21},
+          {format: 'float32x3', offset: 740, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 936, shaderLocation: 5},
+          {format: 'float16x2', offset: 4316, shaderLocation: 9},
+          {format: 'uint32x4', offset: 768, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 264, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'snorm16x4', offset: 8800, shaderLocation: 20}]},
+      {
+        arrayStride: 16836,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 1388, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+video0.height = 113;
+let textureView85 = texture32.createView({
+  label: '\u073b\u77cd\ub643\u{1f7df}\u{1f73f}\u{1fef9}\uf276\u{1f8af}\u8276',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 414,
+});
+let renderPassEncoder0 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -327.7, g: -814.1, b: -789.1, a: 914.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+});
+let renderBundle37 = renderBundleEncoder18.finish({label: '\u051c\u0ebf'});
+try {
+renderPassEncoder0.beginOcclusionQuery(419);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1176);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8, buffer17, 46736, 82130);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer4), /* required buffer size: 1_265 */
+{offset: 905, rowsPerImage: 161}, {width: 90, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture48 = device0.createTexture({
+  label: '\u48d7\u5bb7\u0466\u4a78\u02db\u1f39\u433a',
+  size: {width: 192, height: 240, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView86 = texture28.createView({
+  label: '\u0e2f\ue035\u855b\u067a\u{1fbbb}\u9f3a',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 3,
+  baseArrayLayer: 189,
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer6, 15872, 28317);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer6, 36548, 13164);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+let renderPassEncoder1 = commandEncoder54.beginRenderPass({
+  colorAttachments: [{view: textureView85, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet23,
+});
+try {
+renderPassEncoder1.setViewport(20.99, 0.4945, 42.82, 0.1560, 0.2304, 0.3628);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer17, 0, 247921);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 962 */
+{offset: 962}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline12 = device1.createComputePipeline({
+  label: '\uae03\u0c1e\u04da\u0114\u96ac\ue67c',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline13 = await device1.createRenderPipelineAsync({
+  label: '\u00fa\u{1fe30}\u7f86\ub03e\u{1fb7a}\u{1fe6a}\u7264\u{1facf}\ue2ea\u0ec5',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 516025950,
+    stencilWriteMask: 1258891988,
+    depthBias: 2092171908,
+    depthBiasClamp: 131.29227280024972,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 208,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 16, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 16},
+          {format: 'sint8x2', offset: 86, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 36, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 44, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 14},
+          {format: 'sint8x4', offset: 4, shaderLocation: 1},
+          {format: 'uint32x4', offset: 64, shaderLocation: 5},
+          {format: 'uint16x4', offset: 16, shaderLocation: 17},
+          {format: 'float16x4', offset: 12, shaderLocation: 4},
+          {format: 'uint8x4', offset: 16, shaderLocation: 15},
+          {format: 'float16x4', offset: 0, shaderLocation: 2},
+          {format: 'float32x4', offset: 4, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 26, shaderLocation: 3},
+          {format: 'uint32x2', offset: 44, shaderLocation: 13},
+          {format: 'sint32x3', offset: 40, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let canvas5 = document.createElement('canvas');
+let buffer22 = device0.createBuffer({
+  label: '\u1639\ub4b9\u3417\u366b\u{1fe0c}\u01ca',
+  size: 130108,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let commandBuffer16 = commandEncoder56.finish({label: '\u0014\u0157\ue348\u3b25\ubae8\u015f\u0004\u{1fbed}\u0a81\ub0cb'});
+let texture49 = device0.createTexture({
+  label: '\ucc3b\ub604\u6b85',
+  size: {width: 125},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder22 = commandEncoder19.beginComputePass({label: '\ua00d\u009b\u{1fa1e}\u{1f7e5}\u{1ff5e}\u8bbf'});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let renderBundle38 = renderBundleEncoder9.finish({label: '\u1192\u{1ff3c}\u3e0b\u{1fbaf}\ub407\ud371\u{1fd09}\u{1fbee}\u33b4'});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup2);
+} catch {}
+let arrayBuffer7 = buffer11.getMappedRange(19368, 308);
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 2432 widthInBlocks: 304 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10208 */
+  offset: 10208,
+  bytesPerRow: 2560,
+  buffer: buffer10,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 304, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 2, y: 93 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder();
+let textureView87 = texture16.createView({format: 'rgb10a2uint', arrayLayerCount: 1});
+try {
+renderBundleEncoder12.setVertexBuffer(8, buffer6, 71172, 233);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7412 */
+  offset: 7412,
+  buffer: buffer1,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet25, 83, 120, buffer15, 57088);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+  label: '\u{1f94f}\uf4c7',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 345100112,
+    stencilWriteMask: 1174850029,
+    depthBias: -562163495,
+    depthBiasSlopeScale: 474.5962832078354,
+    depthBiasClamp: 930.7761713396415,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 16768, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 15200,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 3820, shaderLocation: 9},
+          {format: 'sint16x2', offset: 3892, shaderLocation: 10},
+          {format: 'float32', offset: 464, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 2060, shaderLocation: 0},
+          {format: 'float32', offset: 2616, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 6304, shaderLocation: 14},
+          {format: 'uint8x4', offset: 904, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 11696, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 2022, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 2752, shaderLocation: 4},
+          {format: 'sint16x2', offset: 4020, shaderLocation: 2},
+          {format: 'float16x2', offset: 372, shaderLocation: 11},
+          {format: 'uint8x2', offset: 5850, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 1468, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 452, shaderLocation: 13},
+          {format: 'uint32x2', offset: 616, shaderLocation: 7},
+          {format: 'uint32', offset: 3752, shaderLocation: 6},
+          {format: 'sint32', offset: 1440, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 5488,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32', offset: 32, shaderLocation: 12}],
+      },
+      {arrayStride: 15828, attributes: []},
+      {arrayStride: 8676, stepMode: 'instance', attributes: []},
+      {arrayStride: 17884, attributes: [{format: 'unorm10-10-10-2', offset: 892, shaderLocation: 19}]},
+    ],
+  },
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 364, y: 1, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer15, 73896);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(querySet4, 2942, 75, buffer0, 97280);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer6), /* required buffer size: 202 */
+{offset: 202, bytesPerRow: 2235}, {width: 266, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 5}
+*/
+{
+  source: canvas1,
+  origin: { x: 82, y: 4 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise16 = device0.createComputePipelineAsync({layout: pipelineLayout9, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise15;
+} catch {}
+let bindGroup24 = device1.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 1552, resource: sampler21}]});
+let textureView88 = texture39.createView({label: '\ub0f9\ub893\u01ae\u0ee1\ud972\u26ad\u0073\u238a\u4ed4\ua953', baseArrayLayer: 0});
+let renderPassEncoder2 = commandEncoder55.beginRenderPass({
+  label: '\u076f\u{1fd47}\u4f0b\u{1f75e}\u09bf',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 361.3, g: 113.7, b: -799.4, a: 580.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 84998358,
+});
+let sampler36 = device1.createSampler({
+  label: '\u{1fa70}\u9aec\u3d32\uef2e\u6260\u4fa0\u42fa\u{1ff0a}\u{1f9f7}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 99.66,
+  lodMaxClamp: 99.95,
+  maxAnisotropy: 1,
+});
+let externalTexture26 = device1.importExternalTexture({label: '\u246e\u0c41\u{1fa9e}\udf5a\u52a0\u3bb8\u92d9', source: video1});
+try {
+renderPassEncoder0.setViewport(66.40, 0.4696, 0.6310, 0.2582, 0.04054, 0.3602);
+} catch {}
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE, 1152, 42188);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 252 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7392 */
+  offset: 7392,
+  buffer: buffer19,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 63, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 33080, new DataView(new ArrayBuffer(9190)), 521, 244);
+} catch {}
+let pipeline15 = device1.createRenderPipeline({
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0xf24d301c},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8852,
+        attributes: [
+          {format: 'snorm8x2', offset: 1956, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 1144, shaderLocation: 3},
+          {format: 'sint32', offset: 84, shaderLocation: 1},
+          {format: 'sint32', offset: 604, shaderLocation: 10},
+          {format: 'float32', offset: 4896, shaderLocation: 6},
+          {format: 'uint32x2', offset: 736, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 172, shaderLocation: 0},
+          {format: 'float16x4', offset: 1080, shaderLocation: 13},
+          {format: 'float16x2', offset: 2608, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 3812, shaderLocation: 2},
+          {format: 'sint32x2', offset: 604, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 7832, shaderLocation: 11},
+          {format: 'sint8x4', offset: 460, shaderLocation: 15},
+          {format: 'uint8x2', offset: 1576, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 4252,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 368, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 320, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+commandEncoder35.label = '\ua192\u833b';
+} catch {}
+let shaderModule5 = device1.createShaderModule({
+  label: '\u0f3e\u6ee6\u5bd7',
+  code: `@group(0) @binding(1552)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> @location(200) vec4<i32> {
+return vec4<i32>();
+}
+
+struct S7 {
+  @builtin(instance_index) f0: u32,
+  @location(12) f1: vec2<f32>,
+  @location(14) f2: f16,
+  @location(7) f3: f16,
+  @location(4) f4: vec4<u32>,
+  @location(10) f5: vec4<u32>,
+  @location(0) f6: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<f16>, @location(2) a1: vec3<f16>, @builtin(vertex_index) a2: u32, @location(17) a3: vec3<f32>, @location(11) a4: vec3<i32>, @location(5) a5: vec2<f16>, @location(8) a6: vec4<i32>, @location(6) a7: vec3<f16>, a8: S7, @location(9) a9: vec2<i32>, @location(3) a10: vec3<i32>, @location(1) a11: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let querySet37 = device1.createQuerySet({
+  label: '\u99a1\u9655\u0d56\u69f3\ue264\u0135\u{1fd45}\u{1fed1}\u0b56\u2fbf\u0ee6',
+  type: 'occlusion',
+  count: 2122,
+});
+let textureView89 = texture27.createView({label: '\u99bc\u092f\u07ed\u8df9\u08ad', baseMipLevel: 1, arrayLayerCount: 1});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({
+  label: '\u{1f9ea}\u041f\u3355\ubd3a\u5ac9\u{1f953}\u8d02\uf7da\u{1fc74}\u0b0c',
+  colorFormats: ['rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle39 = renderBundleEncoder14.finish();
+let sampler37 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.16,
+  lodMaxClamp: 40.35,
+  maxAnisotropy: 19,
+});
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 6092, new Int16Array(50148));
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let buffer23 = device1.createBuffer({
+  label: '\u{1f679}\u0cd3\u0094\u0db3\u00b3\ua544\u{1fa91}',
+  size: 107851,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder67 = device1.createCommandEncoder();
+let textureView90 = texture30.createView({baseMipLevel: 0});
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(4, bindGroup15, new Uint32Array(5030), 2235, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 49.61, g: 991.5, b: -36.52, a: -432.0, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer23, 'uint32', 66848, 18350);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(7, bindGroup15);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 57752 */
+  offset: 57752,
+  rowsPerImage: 290,
+  buffer: buffer19,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20012 */
+  offset: 20008,
+  bytesPerRow: 256,
+  buffer: buffer20,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker('\uc5ce');
+} catch {}
+let video4 = await videoWithData();
+let bindGroupLayout15 = device0.createBindGroupLayout({entries: []});
+let buffer24 = device0.createBuffer({label: '\u{1f7e8}\u3e1c', size: 101276, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let texture50 = device0.createTexture({
+  size: [31, 1, 649],
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup9, new Uint32Array(3657), 730, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer1, 6636, buffer15, 55852, 25452);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let imageBitmap6 = await createImageBitmap(videoFrame5);
+let commandEncoder68 = device1.createCommandEncoder({label: '\u21cb\u{1fb60}\u0422\u0715\u78d1\u9012\u{1fe61}\ufe6c\u{1fb60}\u030c\ue32d'});
+let querySet38 = device1.createQuerySet({label: '\u00e8\u1b5b\ub599\u0e0d\ua621\u{1fb33}\u011d\u053d\u9633', type: 'occlusion', count: 1481});
+try {
+computePassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer19, 88192, buffer20, 54728, 31452);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer20, 102588, 5408);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u2de3');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 7336, new Int16Array(39404));
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer5), /* required buffer size: 929 */
+{offset: 729, bytesPerRow: 476, rowsPerImage: 296}, {width: 50, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap7 = await createImageBitmap(offscreenCanvas3);
+let externalTexture27 = device2.importExternalTexture({label: '\u0584\u{1fc7c}\u0bf1\u{1fc48}', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder17.setPipeline(pipeline11);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup25 = device0.createBindGroup({label: '\u{1f9e1}\u29bd\u{1ff82}\u094d\u{1f6f7}\u0794', layout: bindGroupLayout1, entries: []});
+let commandEncoder69 = device0.createCommandEncoder({label: '\ub83e\u155a\u2ebc\u0f56\u{1f647}\u4982'});
+let textureView91 = texture6.createView({label: '\ud130\ud172\u{1faaf}\u0fdb\u{1f9b7}\ub1b0\uc715\u0ed1\uab18\u36e1', aspect: 'all'});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer7, 39860, buffer11, 51880, 55976);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20156 */
+  offset: 20156,
+  buffer: buffer6,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet10, 926, 733, buffer0, 34048);
+} catch {}
+let commandEncoder70 = device2.createCommandEncoder({label: '\uf4c6\u3254\u6ea8\u01b0\u{1fd38}\u33ae'});
+let querySet39 = device2.createQuerySet({label: '\u0a69\u{1f688}', type: 'occlusion', count: 1383});
+try {
+computePassEncoder19.setBindGroup(9, bindGroup22, new Uint32Array(9095), 6718, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer5), /* required buffer size: 2_863_037 */
+{offset: 831, bytesPerRow: 232, rowsPerImage: 169}, {width: 11, height: 1, depthOrArrayLayers: 74});
+} catch {}
+let promise17 = device2.queue.onSubmittedWorkDone();
+let video5 = await videoWithData();
+try {
+offscreenCanvas2.getContext('webgl2');
+} catch {}
+let querySet40 = device0.createQuerySet({label: '\ue121\u0335\u65f0\u{1fdac}\u5eb9\ua785\ubd91\u454a', type: 'occlusion', count: 2546});
+let texture51 = device0.createTexture({
+  label: '\ue998\u0f5c\u46e1\u042f\u5c60\u7384\u{1f794}\ubc96\u{1fc29}\u{1f7b8}\u550d',
+  size: [1440],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView92 = texture48.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({label: '\uba02\u7f1e', colorFormats: ['rgba16float', 'r32float'], sampleCount: 1, depthReadOnly: true});
+try {
+renderBundleEncoder20.setBindGroup(4, bindGroup18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 954 */
+{offset: 954}, {width: 76, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(776, 820);
+let img11 = await imageWithData(2, 155, '#cf9ae039', '#74de9f55');
+let shaderModule6 = device1.createShaderModule({
+  label: '\u{1fa7e}\u0701\uc3fd\uac28\u43cf\u389c\u3d5e\u0128',
+  code: `@group(0) @binding(1552)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(3, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(14) f0: f16,
+  @location(9) f1: vec4<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(17) f3: f16,
+  @location(12) f4: vec4<f16>,
+  @location(10) f5: u32,
+  @location(5) f6: vec2<f16>,
+  @location(13) f7: f16,
+  @builtin(vertex_index) f8: u32
+}
+
+@vertex
+fn vertex0(a0: S8, @location(15) a1: u32, @location(0) a2: vec4<u32>, @location(4) a3: vec2<f32>, @location(1) a4: vec2<u32>, @location(16) a5: vec3<f32>, @location(6) a6: vec3<u32>, @location(2) a7: vec2<i32>, @location(7) a8: vec4<f16>, @location(11) a9: vec2<i32>, @location(3) a10: vec3<f16>, @location(8) a11: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let computePassEncoder23 = commandEncoder45.beginComputePass({label: '\u0982\u7cad\u{1fc82}\u{1fc32}\u22a3\uecf5\u{1fa48}\u389c\u{1f6b6}'});
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint'], sampleCount: 1});
+let externalTexture28 = device1.importExternalTexture({
+  label: '\u09f3\uee1d\u8b18\u{1fcd8}\u082d\ueb30\u0f1c\ucad9\u065e\u0750\u2e49',
+  source: video2,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder0.setScissorRect(48, 0, 2, 1);
+} catch {}
+try {
+renderPassEncoder2.setViewport(41.94, 0.3955, 6.314, 0.1575, 0.5868, 0.6062);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5841, undefined);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 284 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6516 */
+  offset: 6516,
+  buffer: buffer16,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 71, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 659 */
+{offset: 659}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder71 = device1.createCommandEncoder({label: '\u954e\u04c8\uddd3\uc55c'});
+let textureView93 = texture29.createView({label: '\u8cfc\u0415\u{1f78f}\u{1f956}\u{1fb04}\u778c\u2a4a\u{1ff9c}\ud021', baseMipLevel: 0});
+let computePassEncoder24 = commandEncoder35.beginComputePass({label: '\u8f5d\u0efe\u{1f6d0}'});
+let renderPassEncoder3 = commandEncoder42.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -297.0, g: -37.31, b: -502.3, a: 11.96, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 302604214,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup13, new Uint32Array(8019), 4255, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 54.37, g: -366.9, b: -794.1, a: -337.6, });
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(6, bindGroup19, new Uint32Array(621), 604, 0);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 60700, 38860);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer23, 98084);
+} catch {}
+let arrayBuffer8 = buffer18.getMappedRange(38400, 3252);
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer19, 119216, buffer20, 18900, 16760);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl2');
+} catch {}
+let commandEncoder72 = device1.createCommandEncoder({label: '\ua4e7\uce59\u7b39\u9738\u37af'});
+let texture52 = device1.createTexture({
+  label: '\u{1f762}\u0ee9\u07fe\u{1f7f1}\u{1ffbe}\u0000\u0b4a\u0d32\u0bf0\uc3fd\u42ea',
+  size: {width: 546, height: 4, depthOrArrayLayers: 1423},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint'],
+});
+let renderPassEncoder4 = commandEncoder67.beginRenderPass({
+  label: '\u7184\ubb23\u0e40\u799b\u0bf0',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 735.2, g: 296.2, b: 597.4, a: -975.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 863600625,
+});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  label: '\u4376\u{1fb53}\u0185',
+  colorFormats: ['rg16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder1.setScissorRect(57, 1, 7, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup19);
+} catch {}
+let arrayBuffer9 = buffer18.getMappedRange(42432, 740);
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23896 */
+  offset: 23896,
+  buffer: buffer19,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\ubc48');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1336, new Float32Array(58044), 15571, 21888);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer7), /* required buffer size: 30 */
+{offset: 30}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext3 = canvas5.getContext('webgpu');
+let commandEncoder73 = device1.createCommandEncoder();
+let textureView94 = texture36.createView({
+  label: '\u9805\u2986\u0643\u01fa\u3994\u{1fc54}\u{1ff62}\u09f5\u{1f674}',
+  dimension: '2d-array',
+  baseMipLevel: 8,
+});
+let computePassEncoder25 = commandEncoder72.beginComputePass({label: '\u65b8\u{1fc0f}\u305c\u{1fb35}\u{1fa4e}\ub59d\uc083\u9edc\u{1fd7c}\ua0e5'});
+let externalTexture29 = device1.importExternalTexture({label: '\ud673\u6e11\u{1fd03}', source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(16, 1, 35, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(46.27, 0.9747, 19.74, 0.02486, 0.1819, 0.9314);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer23, 'uint32', 63096, 30259);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer17);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 42, z: 658},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder68.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\ud9db\u0eb5\u0895\uc4d5\uf138\u6280'});
+let commandBuffer17 = commandEncoder60.finish({label: '\ucf4c\u{1fe21}\ua4bd'});
+let textureView95 = texture8.createView({label: '\u0d16\u7c3f\uea19\u0f1f\u0e1d\u0961\u0758'});
+try {
+commandEncoder63.copyBufferToBuffer(buffer24, 95072, buffer6, 70516, 4240);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline16 = device0.createRenderPipeline({
+  label: '\ue458\ue61f\u236c\u000b\u{1fc86}\uac89\u98e8\u{1f84f}\u{1fa91}\u{1fad4}\u2cdb',
+  layout: pipelineLayout2,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'r32float'}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x4', offset: 19288, shaderLocation: 10},
+          {format: 'float16x4', offset: 680, shaderLocation: 16},
+          {format: 'float32', offset: 5248, shaderLocation: 4},
+          {format: 'sint32', offset: 12556, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 3132, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 1092, shaderLocation: 1},
+          {format: 'float16x4', offset: 2868, shaderLocation: 14},
+          {format: 'float16x2', offset: 7224, shaderLocation: 8},
+          {format: 'sint32x2', offset: 2988, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 6376, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 16832, shaderLocation: 15},
+          {format: 'float16x2', offset: 4220, shaderLocation: 0},
+          {format: 'sint8x4', offset: 188, shaderLocation: 12},
+          {format: 'uint32x4', offset: 4220, shaderLocation: 3},
+          {format: 'uint8x2', offset: 1730, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 6376, shaderLocation: 9},
+          {format: 'uint32', offset: 3676, shaderLocation: 7},
+          {format: 'uint8x4', offset: 4136, shaderLocation: 5},
+          {format: 'float32x3', offset: 8340, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6392,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 364, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+gc();
+let img12 = await imageWithData(137, 129, '#8a06b4c0', '#0d2871cc');
+let bindGroup26 = device1.createBindGroup({
+  label: '\u2cf2\u0c25\u2732\u611e\u0353\u{1ff05}\uc1d1\u{1f874}\u6bca\u007e',
+  layout: bindGroupLayout10,
+  entries: [{binding: 1552, resource: sampler21}],
+});
+let sampler38 = device1.createSampler({
+  label: '\u429a\u622a\u{1f8db}\u77b7\u05c0\u{1f8c6}\u5dbd\uc5c2',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.79,
+  lodMaxClamp: 31.19,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder2.setScissorRect(25, 0, 14, 1);
+} catch {}
+try {
+renderBundleEncoder30.insertDebugMarker('\u239e');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 622 */
+{offset: 622, bytesPerRow: 57}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = await promise14;
+let img13 = await imageWithData(139, 125, '#e53a28ba', '#71df6788');
+let bindGroup27 = device2.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 6715, resource: externalTexture19}]});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup21, new Uint32Array(3446), 3014, 0);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2995, undefined, 2168536959, 1619122752);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+renderBundleEncoder17.popDebugGroup();
+} catch {}
+let promise18 = device2.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let imageBitmap8 = await createImageBitmap(imageBitmap7);
+try {
+computePassEncoder19.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(5, bindGroup22);
+} catch {}
+canvas5.height = 524;
+let video6 = await videoWithData();
+let shaderModule7 = device2.createShaderModule({
+  label: '\ub395\u0d80\u2cee\u2794\u0a87\u680d\u2c96\u0e0f\u{1f9bc}\u{1feea}',
+  code: `@group(0) @binding(6715)
+var<storage, read_write> global3: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(96) f0: vec4<f32>,
+  @location(41) f1: vec4<i32>,
+  @location(106) f2: vec4<u32>,
+  @location(103) f3: f16,
+  @location(44) f4: vec4<f32>,
+  @builtin(sample_index) f5: u32,
+  @location(58) f6: vec4<f32>,
+  @builtin(sample_mask) f7: u32,
+  @builtin(front_facing) f8: bool,
+  @location(20) f9: vec4<i32>,
+  @location(79) f10: vec4<i32>,
+  @location(90) f11: vec2<f16>,
+  @location(4) f12: u32,
+  @location(83) f13: vec3<i32>,
+  @location(68) f14: vec2<i32>,
+  @location(67) f15: u32,
+  @location(14) f16: vec3<f32>,
+  @location(104) f17: f32,
+  @location(95) f18: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: i32,
+  @location(0) f1: vec3<u32>,
+  @location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(101) a0: vec4<f32>, @location(13) a1: f16, @location(84) a2: f16, @location(114) a3: vec4<u32>, a4: S10, @builtin(position) a5: vec4<f32>, @location(19) a6: vec2<f16>, @location(2) a7: vec4<u32>, @location(77) a8: u32, @location(8) a9: vec2<u32>, @location(100) a10: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(2) f0: vec2<u32>,
+  @location(0) f1: vec4<f32>,
+  @location(20) f2: vec3<f32>,
+  @location(10) f3: vec4<f32>,
+  @location(6) f4: vec3<f32>,
+  @location(15) f5: vec3<f32>,
+  @location(11) f6: vec2<f16>,
+  @location(8) f7: f32,
+  @location(1) f8: vec2<f32>,
+  @location(18) f9: f16,
+  @location(12) f10: vec4<i32>,
+  @location(16) f11: vec4<f32>,
+  @location(24) f12: vec4<u32>,
+  @location(19) f13: f32,
+  @location(21) f14: f16,
+  @location(9) f15: vec4<f16>,
+  @location(14) f16: vec4<f32>,
+  @location(22) f17: f32,
+  @location(23) f18: vec2<u32>,
+  @builtin(vertex_index) f19: u32,
+  @location(5) f20: vec2<f32>,
+  @location(17) f21: u32
+}
+struct VertexOutput0 {
+  @location(2) f119: vec4<u32>,
+  @location(19) f120: vec2<f16>,
+  @location(84) f121: f16,
+  @location(77) f122: u32,
+  @location(101) f123: vec4<f32>,
+  @location(95) f124: vec4<u32>,
+  @location(58) f125: vec4<f32>,
+  @location(96) f126: vec4<f32>,
+  @location(103) f127: f16,
+  @location(90) f128: vec2<f16>,
+  @location(79) f129: vec4<i32>,
+  @location(106) f130: vec4<u32>,
+  @location(41) f131: vec4<i32>,
+  @location(44) f132: vec4<f32>,
+  @location(14) f133: vec3<f32>,
+  @location(20) f134: vec4<i32>,
+  @location(104) f135: f32,
+  @location(100) f136: vec4<i32>,
+  @location(67) f137: u32,
+  @location(83) f138: vec3<i32>,
+  @location(13) f139: f16,
+  @builtin(position) f140: vec4<f32>,
+  @location(68) f141: vec2<i32>,
+  @location(4) f142: u32,
+  @location(114) f143: vec4<u32>,
+  @location(8) f144: vec2<u32>
+}
+
+@vertex
+fn vertex0(a0: S9, @location(7) a1: vec2<f16>, @location(13) a2: f16, @location(26) a3: f32, @location(25) a4: f32, @location(3) a5: vec2<i32>, @location(27) a6: f32, @location(4) a7: vec4<u32>, @builtin(instance_index) a8: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder75 = device2.createCommandEncoder({label: '\u{1fa21}\u3d90\u5ea4\u9806\u09e9\u8966\u{1fe63}\u{1f8ba}\u{1fdd3}'});
+let querySet41 = device2.createQuerySet({label: '\u52cb\u0a77', type: 'occlusion', count: 2757});
+let commandBuffer18 = commandEncoder64.finish({label: '\u{1fd82}\u{1f726}'});
+let textureView96 = texture40.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder26 = commandEncoder75.beginComputePass({label: '\ub682\u30c9\u0824\u{1fc83}\ud1f1\u0d32\ue3bb\u3384'});
+let renderBundleEncoder32 = device2.createRenderBundleEncoder({
+  label: '\u{1f7d4}\u033e\u26c6\u3472\u79ff\u19c7\ufb80\u308c\u0c08\u{1fc08}',
+  colorFormats: [undefined, 'rgba8uint', 'r8sint', 'rg8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle40 = renderBundleEncoder25.finish({});
+let externalTexture30 = device2.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder21.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let pipeline18 = await device2.createComputePipelineAsync({
+  label: '\ub1bf\u0d53\u66ad\u0cb3\u{1f886}\uf7e0\u21ad\u0d0b\u5037',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap9 = await createImageBitmap(video5);
+let commandEncoder76 = device0.createCommandEncoder({label: '\u2c37\u14b5\u4234\u0c8c\udb53\ucc5a'});
+let renderBundle41 = renderBundleEncoder4.finish();
+let sampler39 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.77,
+  lodMaxClamp: 92.14,
+});
+let externalTexture31 = device0.importExternalTexture({label: '\uc5ec\uc70f\ub252\u4f82\u18dd', source: video5, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder11.setBindGroup(8, bindGroup10, new Uint32Array(2475), 938, 0);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 7128 widthInBlocks: 1782 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4268 */
+  offset: 4268,
+  buffer: buffer24,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1782, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18848 */
+  offset: 18848,
+  buffer: buffer14,
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+let shaderModule8 = device1.createShaderModule({
+  label: '\uaded\u9475\uf19b\u5969\u4eb8\u0324\u0d04\u0017\u{1feb0}',
+  code: `@group(4) @binding(1552)
+var<storage, read_write> parameter8: array<u32>;
+@group(0) @binding(2548)
+var<storage, read_write> n3: array<u32>;
+@group(2) @binding(1552)
+var<storage, read_write> type2: array<u32>;
+@group(1) @binding(1552)
+var<storage, read_write> type3: array<u32>;
+@group(3) @binding(3157)
+var<storage, read_write> global4: array<u32>;
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(36) f0: vec2<f32>,
+  @location(6) f1: u32,
+  @location(8) f2: vec2<f32>,
+  @location(118) f3: vec4<u32>,
+  @location(52) f4: vec2<f32>,
+  @location(74) f5: vec2<f16>,
+  @location(20) f6: vec4<u32>,
+  @location(113) f7: vec4<u32>,
+  @location(67) f8: vec3<f32>,
+  @builtin(front_facing) f9: bool,
+  @location(44) f10: vec2<f32>,
+  @location(1) f11: u32,
+  @location(86) f12: f16,
+  @location(73) f13: vec3<f32>,
+  @location(102) f14: vec3<i32>,
+  @builtin(sample_index) f15: u32,
+  @location(110) f16: vec4<u32>,
+  @location(43) f17: vec2<f32>,
+  @location(79) f18: vec4<f16>,
+  @location(116) f19: f16,
+  @location(94) f20: vec2<i32>,
+  @location(7) f21: vec3<f16>,
+  @location(71) f22: vec2<i32>,
+  @location(59) f23: vec3<f16>,
+  @location(10) f24: vec4<f32>,
+  @location(98) f25: vec3<f16>,
+  @location(75) f26: vec3<u32>,
+  @location(76) f27: vec2<u32>,
+  @location(12) f28: vec3<i32>,
+  @location(22) f29: vec4<i32>,
+  @location(99) f30: vec4<f32>,
+  @location(101) f31: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(6) f1: i32
+}
+
+@fragment
+fn fragment0(@location(88) a0: vec2<f32>, @builtin(position) a1: vec4<f32>, @location(106) a2: vec3<u32>, @location(39) a3: vec2<i32>, @location(56) a4: vec2<u32>, @location(72) a5: vec4<f16>, a6: S11, @builtin(sample_mask) a7: u32, @location(91) a8: vec2<f32>, @location(70) a9: f32, @location(64) a10: f32, @location(97) a11: vec4<u32>, @location(37) a12: vec3<f32>, @location(68) a13: vec3<f16>, @location(62) a14: vec4<f32>, @location(3) a15: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(75) f145: vec3<u32>,
+  @location(36) f146: vec2<f32>,
+  @location(110) f147: vec4<u32>,
+  @location(10) f148: vec4<f32>,
+  @location(12) f149: vec3<i32>,
+  @location(91) f150: vec2<f32>,
+  @location(22) f151: vec4<i32>,
+  @location(88) f152: vec2<f32>,
+  @location(64) f153: f32,
+  @location(68) f154: vec3<f16>,
+  @location(70) f155: f32,
+  @location(3) f156: vec4<f32>,
+  @location(44) f157: vec2<f32>,
+  @location(56) f158: vec2<u32>,
+  @location(116) f159: f16,
+  @location(62) f160: vec4<f32>,
+  @location(67) f161: vec3<f32>,
+  @location(76) f162: vec2<u32>,
+  @location(1) f163: u32,
+  @location(59) f164: vec3<f16>,
+  @location(106) f165: vec3<u32>,
+  @location(7) f166: vec3<f16>,
+  @location(94) f167: vec2<i32>,
+  @location(101) f168: vec2<i32>,
+  @builtin(position) f169: vec4<f32>,
+  @location(72) f170: vec4<f16>,
+  @location(73) f171: vec3<f32>,
+  @location(20) f172: vec4<u32>,
+  @location(74) f173: vec2<f16>,
+  @location(52) f174: vec2<f32>,
+  @location(102) f175: vec3<i32>,
+  @location(39) f176: vec2<i32>,
+  @location(71) f177: vec2<i32>,
+  @location(8) f178: vec2<f32>,
+  @location(43) f179: vec2<f32>,
+  @location(86) f180: f16,
+  @location(99) f181: vec4<f32>,
+  @location(113) f182: vec4<u32>,
+  @location(79) f183: vec4<f16>,
+  @location(118) f184: vec4<u32>,
+  @location(98) f185: vec3<f16>,
+  @location(6) f186: u32,
+  @location(97) f187: vec4<u32>,
+  @location(37) f188: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f32>, @location(10) a1: vec3<f16>, @location(15) a2: f32, @location(5) a3: f16, @location(7) a4: i32, @location(1) a5: f32, @location(16) a6: vec2<f16>, @location(4) a7: vec3<i32>, @location(9) a8: i32, @location(17) a9: vec3<u32>, @location(12) a10: vec3<u32>, @location(2) a11: vec4<f32>, @location(0) a12: f16, @location(8) a13: i32, @location(3) a14: vec2<i32>, @location(11) a15: vec2<f32>, @location(6) a16: f16, @location(13) a17: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\u0a31\ua29f\uc343\u027f',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout14, bindGroupLayout13, bindGroupLayout10, bindGroupLayout10, bindGroupLayout14, bindGroupLayout10],
+});
+let commandEncoder77 = device1.createCommandEncoder();
+let textureView97 = texture32.createView({
+  label: '\u{1f9b6}\u{1fbe6}\u{1f6d2}\uab58\u8846\u0492\ueb27\u{1f993}\u0c4c\u53a4\u{1f792}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  baseArrayLayer: 271,
+});
+try {
+renderPassEncoder0.setScissorRect(45, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(5, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup24, new Uint32Array(6324), 5757, 0);
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder();
+let commandBuffer19 = commandEncoder12.finish({label: '\u{1f88f}\u97fe\u34b3\u{1fdff}\u66aa\u{1fb7e}\uff29\u0922\uad63'});
+let texture53 = device0.createTexture({
+  label: '\u0119\uf732\u{1fd0f}\u0192',
+  size: [192],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView98 = texture4.createView({dimension: '2d', baseMipLevel: 7, baseArrayLayer: 5});
+let renderBundle42 = renderBundleEncoder24.finish({label: '\u0e74\u32db\u{1fed0}\u{1fd08}\u0723\ub9d5'});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+querySet22.destroy();
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer4, 7920, buffer15, 57688, 12192);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let commandEncoder79 = device2.createCommandEncoder();
+let textureView99 = texture42.createView({label: '\ud252\ud4a8\ueb4b\u0d05\ue139\u066d', dimension: '3d', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder27 = commandEncoder46.beginComputePass();
+try {
+commandEncoder79.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 207, y: 0, z: 18},
+  aspect: 'all',
+},
+{width: 355, height: 0, depthOrArrayLayers: 22});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 744, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 46, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({
+  label: '\u08ce\u{1f9dc}',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout8, bindGroupLayout9, bindGroupLayout1],
+});
+let buffer25 = device0.createBuffer({
+  label: '\u{1fcd5}\u{1fbba}\u4131\ubdc8\uc2d2\ub18e\u1dfb\u0e20',
+  size: 262453,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder29.setVertexBuffer(7, buffer6, 0, 4962);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 15936, new DataView(new ArrayBuffer(57625)), 1836, 9696);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video2);
+let commandEncoder81 = device2.createCommandEncoder();
+let querySet42 = device2.createQuerySet({label: '\u6a73\ua866\ud8d6\u0688\u57e2', type: 'occlusion', count: 1623});
+let texture54 = device2.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+let externalTexture32 = device2.importExternalTexture({label: '\u{1fa2a}\u{1f9ef}\uc8d8\u8bd0\uc94f\u7933\u570b', source: video3, colorSpace: 'srgb'});
+try {
+renderBundleEncoder17.setPipeline(pipeline11);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1_228_959 */
+{offset: 472, bytesPerRow: 477, rowsPerImage: 103}, {width: 106, height: 1, depthOrArrayLayers: 26});
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  label: '\u6400\u{1fea6}\u{1fd0d}\u0b24',
+  layout: bindGroupLayout6,
+  entries: [{binding: 3682, resource: sampler0}, {binding: 1191, resource: sampler16}],
+});
+let commandBuffer20 = commandEncoder7.finish({label: '\u1e6a\u13ee'});
+let computePassEncoder28 = commandEncoder22.beginComputePass({});
+let renderBundle43 = renderBundleEncoder24.finish({label: '\u0049\u7c11\u{1f60e}\u8176\u7024\u7f64\u92e6\u00f8\u5565\u0ddf\ubfd3'});
+let externalTexture33 = device0.importExternalTexture({label: '\u16b0\u0e0b\u{1fbdf}', source: videoFrame7, colorSpace: 'srgb'});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup17, new Uint32Array(6152), 288, 0);
+} catch {}
+let querySet43 = device1.createQuerySet({type: 'occlusion', count: 3059});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({label: '\ua8d8\uf4d0\u4b61', colorFormats: ['rg16sint'], stencilReadOnly: true});
+let renderBundle44 = renderBundleEncoder27.finish({label: '\u{1f742}\u01b8\u2c30\u63e1\u{1fb04}\u{1f701}\u7b60\u{1fdd9}'});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer23, 'uint16');
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup13, new Uint32Array(7670), 862, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5, buffer23);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15684 */
+  offset: 15684,
+  buffer: buffer19,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+let commandEncoder82 = device1.createCommandEncoder({});
+let renderPassEncoder5 = commandEncoder68.beginRenderPass({
+  label: '\u080e\u{1fe6a}\uc0ac\u3a53\ufa88\ud929\u02ce\u{1fc23}',
+  colorAttachments: [{view: textureView85, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 667101107,
+});
+try {
+renderPassEncoder0.setStencilReference(2409);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer23, 'uint32', 84004);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer23, 'uint16', 61744, 5469);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer16, 23708, buffer20, 12024, 29076);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder82.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 23552 */
+  offset: 23552,
+  buffer: buffer19,
+}, {
+  texture: texture46,
+  mipLevel: 5,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 1922, resource: sampler3}]});
+let commandEncoder83 = device0.createCommandEncoder();
+let texture55 = gpuCanvasContext0.getCurrentTexture();
+let textureView100 = texture7.createView({});
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer6, 0, 55478);
+} catch {}
+try {
+commandEncoder78.insertDebugMarker('\u{1fefd}');
+} catch {}
+document.body.prepend(video0);
+let bindGroupLayout16 = device1.createBindGroupLayout({
+  label: '\u5244\u035d',
+  entries: [
+    {
+      binding: 3076,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 3101,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout16 = device1.createPipelineLayout({
+  label: '\u4b66\uc4e8\u09e1\u5f59\ub2be\u{1f63a}\u3e5f\ue1a8\u{1fcaf}\u{1f8e0}\u{1fe02}',
+  bindGroupLayouts: [bindGroupLayout16, bindGroupLayout13, bindGroupLayout16, bindGroupLayout10, bindGroupLayout13, bindGroupLayout16, bindGroupLayout10],
+});
+let commandEncoder84 = device1.createCommandEncoder({label: '\u0081\u{1fd8a}\u05aa'});
+let querySet44 = device1.createQuerySet({type: 'occlusion', count: 2718});
+let textureView101 = texture39.createView({aspect: 'all'});
+let renderBundleEncoder34 = device1.createRenderBundleEncoder({label: '\u086f\udc1c\u1789\ub95a\u046d', colorFormats: ['rg16sint'], depthReadOnly: true});
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(1, buffer23, 82520, 8894);
+} catch {}
+try {
+commandEncoder71.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 552 widthInBlocks: 138 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 43608 */
+  offset: 43056,
+  buffer: buffer20,
+}, {width: 138, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+renderBundleEncoder30.insertDebugMarker('\ueddb');
+} catch {}
+let video7 = await videoWithData();
+let bindGroupLayout17 = device1.createBindGroupLayout({
+  label: '\u9067\u8c3d\u3812\u9908\u0d7d\u030a',
+  entries: [
+    {
+      binding: 4694,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 8797, visibility: 0, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder85 = device1.createCommandEncoder({});
+let texture56 = device1.createTexture({
+  size: [68, 1, 176],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture34 = device1.importExternalTexture({source: videoFrame13});
+try {
+renderPassEncoder2.setBindGroup(4, bindGroup19, new Uint32Array(6308), 5326, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(919);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle22, renderBundle32, renderBundle39, renderBundle26, renderBundle26, renderBundle32, renderBundle44, renderBundle35]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer23, 0, 23651);
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 46},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+document.body.prepend(img2);
+let commandEncoder86 = device2.createCommandEncoder();
+let texture57 = device2.createTexture({
+  label: '\u28d7\u0962\u0bac\u0bfe\ua464',
+  size: [6024, 1, 7],
+  mipLevelCount: 8,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let externalTexture35 = device2.importExternalTexture({
+  label: '\u2542\u0862\u0373\u{1ff08}\u0ba7\u{1f8c2}\u0407\u731d',
+  source: videoFrame12,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder19.setPipeline(pipeline18);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 7, y: 42 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 73, y: 0, z: 38},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup30 = device2.createBindGroup({
+  label: '\u0ad2\u950a',
+  layout: bindGroupLayout12,
+  entries: [{binding: 6715, resource: externalTexture30}],
+});
+let commandEncoder87 = device2.createCommandEncoder({});
+let commandBuffer21 = commandEncoder59.finish({label: '\u01dc\u08b8\uad89\u43af\u8d6d\u{1fce5}\u6a7b\u58bc\u0bd8\uadd6\u{1f7e4}'});
+let textureView102 = texture42.createView({dimension: '3d', format: 'bgra8unorm', baseMipLevel: 2, baseArrayLayer: 0});
+let externalTexture36 = device2.importExternalTexture({
+  label: '\u9a83\u0476\u0332\u854c\u0757\u0eb0\u0730\u{1fbc9}\u{1fa78}\u5a00',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline11);
+} catch {}
+let shaderModule9 = device1.createShaderModule({
+  code: `@group(7) @binding(1552)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(1552)
+var<storage, read_write> global5: array<u32>;
+@group(6) @binding(1552)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(1552)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(1552)
+var<storage, read_write> function5: array<u32>;
+@group(4) @binding(1552)
+var<storage, read_write> local3: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(19) f0: vec2<i32>,
+  @location(11) f1: u32,
+  @builtin(sample_mask) f2: u32,
+  @location(93) f3: u32,
+  @location(107) f4: vec2<u32>,
+  @location(12) f5: f32,
+  @builtin(front_facing) f6: bool,
+  @location(34) f7: vec3<f16>,
+  @location(17) f8: vec3<u32>,
+  @builtin(sample_index) f9: u32,
+  @location(27) f10: vec3<i32>,
+  @location(39) f11: vec3<f16>,
+  @location(53) f12: vec2<u32>,
+  @location(94) f13: f16,
+  @location(90) f14: vec3<i32>,
+  @location(98) f15: vec3<i32>,
+  @location(50) f16: vec4<f32>,
+  @location(83) f17: vec2<u32>,
+  @location(102) f18: f32,
+  @location(85) f19: vec4<i32>,
+  @location(111) f20: u32,
+  @location(77) f21: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(2) f1: f32
+}
+
+@fragment
+fn fragment0(@location(113) a0: vec4<i32>, @location(103) a1: vec2<f16>, @location(52) a2: vec4<u32>, @location(117) a3: vec2<f32>, @builtin(position) a4: vec4<f32>, @location(15) a5: vec4<f32>, @location(64) a6: vec3<f32>, @location(78) a7: vec3<u32>, @location(24) a8: vec3<u32>, @location(118) a9: vec2<f32>, @location(35) a10: vec4<f16>, @location(30) a11: vec2<i32>, @location(54) a12: f32, a13: S13, @location(20) a14: vec4<u32>, @location(8) a15: vec3<i32>, @location(59) a16: f32, @location(60) a17: vec2<f16>, @location(29) a18: vec4<f32>, @location(82) a19: u32, @location(40) a20: i32, @location(109) a21: vec4<u32>, @location(32) a22: vec3<f32>, @location(112) a23: vec2<f16>, @location(38) a24: vec3<f16>, @location(56) a25: vec4<f16>, @location(67) a26: vec3<i32>, @location(75) a27: vec2<f32>, @location(44) a28: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(1) f0: vec3<u32>,
+  @location(13) f1: vec4<f16>,
+  @location(16) f2: u32
+}
+struct VertexOutput0 {
+  @location(19) f189: vec2<i32>,
+  @location(59) f190: f32,
+  @location(35) f191: vec4<f16>,
+  @location(64) f192: vec3<f32>,
+  @location(60) f193: vec2<f16>,
+  @location(94) f194: f16,
+  @location(53) f195: vec2<u32>,
+  @location(78) f196: vec3<u32>,
+  @location(82) f197: u32,
+  @location(109) f198: vec4<u32>,
+  @location(56) f199: vec4<f16>,
+  @location(102) f200: f32,
+  @location(40) f201: i32,
+  @location(112) f202: vec2<f16>,
+  @location(93) f203: u32,
+  @location(11) f204: u32,
+  @location(12) f205: f32,
+  @location(34) f206: vec3<f16>,
+  @location(77) f207: u32,
+  @builtin(position) f208: vec4<f32>,
+  @location(39) f209: vec3<f16>,
+  @location(52) f210: vec4<u32>,
+  @location(103) f211: vec2<f16>,
+  @location(50) f212: vec4<f32>,
+  @location(20) f213: vec4<u32>,
+  @location(8) f214: vec3<i32>,
+  @location(75) f215: vec2<f32>,
+  @location(107) f216: vec2<u32>,
+  @location(113) f217: vec4<i32>,
+  @location(83) f218: vec2<u32>,
+  @location(17) f219: vec3<u32>,
+  @location(118) f220: vec2<f32>,
+  @location(27) f221: vec3<i32>,
+  @location(98) f222: vec3<i32>,
+  @location(67) f223: vec3<i32>,
+  @location(32) f224: vec3<f32>,
+  @location(85) f225: vec4<i32>,
+  @location(38) f226: vec3<f16>,
+  @location(29) f227: vec4<f32>,
+  @location(54) f228: f32,
+  @location(44) f229: vec3<i32>,
+  @location(15) f230: vec4<f32>,
+  @location(117) f231: vec2<f32>,
+  @location(111) f232: u32,
+  @location(24) f233: vec3<u32>,
+  @location(30) f234: vec2<i32>,
+  @location(90) f235: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<i32>, @location(0) a1: f32, @location(17) a2: vec4<f32>, @location(7) a3: vec4<i32>, @location(2) a4: vec2<u32>, @builtin(vertex_index) a5: u32, @location(5) a6: vec2<i32>, a7: S12, @location(12) a8: f32, @location(4) a9: vec3<f16>, @location(8) a10: vec2<i32>, @location(15) a11: vec3<u32>, @location(9) a12: vec3<u32>, @location(14) a13: vec4<f32>, @location(10) a14: i32, @location(3) a15: vec3<u32>, @location(11) a16: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder88 = device1.createCommandEncoder({label: '\u3c33\u{1fa34}\uf22b\ue9b6'});
+let commandBuffer22 = commandEncoder61.finish({label: '\u014b\u{1f919}\u035e\uf64d\u{1fad5}\ufc12\u0a49\u{1f73e}\u0722\u03b5\ufb9e'});
+let renderPassEncoder6 = commandEncoder85.beginRenderPass({
+  label: '\u826d\u{1f96f}\u0db9\u{1ff26}\u{1ff24}',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -841.4, g: 253.4, b: -604.1, a: 384.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 168808035,
+});
+let sampler40 = device1.createSampler({
+  label: '\uf1f4\u3098\u0810\ubd8a\u2ee0\u35ed\u{1ffe4}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.67,
+  lodMaxClamp: 95.03,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder6.setBindGroup(5, bindGroup19, new Uint32Array(8394), 385, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1102);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer17, 0);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 19720 */
+  offset: 19720,
+  bytesPerRow: 256,
+  buffer: buffer16,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 12, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1456, new Int16Array(59201), 58244, 56);
+} catch {}
+let pipeline19 = device1.createComputePipeline({
+  label: '\u{1f7e1}\u{1fde1}\ud790\u5026\ue2a1',
+  layout: 'auto',
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let imageData4 = new ImageData(256, 88);
+let querySet45 = device0.createQuerySet({label: '\u{1f9f8}\u0f4d', type: 'occlusion', count: 1798});
+let renderBundle45 = renderBundleEncoder5.finish({});
+let externalTexture37 = device0.importExternalTexture({
+  label: '\u065b\u0061\u{1fc2b}\u0bed\u0b14\ued4d\u92ec\u{1fdac}\ubaad\u833b\u3f07',
+  source: video5,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder9.setBindGroup(7, bindGroup17, []);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup6, new Uint32Array(8764), 4554, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer6, 0, 59363);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer4, 71732, buffer3, 32648, 2460);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1227, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+  label: '\u0b1d\u8a95\u7c5a\u7d95\u044f\u0230\u817d',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x9a702521},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8016,
+        attributes: [
+          {format: 'unorm16x2', offset: 3904, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 2438, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 508, shaderLocation: 11},
+          {format: 'float32', offset: 1828, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 384, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 68, shaderLocation: 4},
+          {format: 'float16x2', offset: 1588, shaderLocation: 15},
+          {format: 'sint32', offset: 5128, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 672, shaderLocation: 1},
+          {format: 'uint8x4', offset: 5396, shaderLocation: 3},
+          {format: 'sint8x4', offset: 1956, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 2310, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 1320, shaderLocation: 0},
+          {format: 'float32', offset: 632, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 184,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 4, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 7492,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 284, shaderLocation: 17},
+          {format: 'sint8x4', offset: 1004, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 6296,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 452, shaderLocation: 8},
+          {format: 'uint8x4', offset: 148, shaderLocation: 5},
+          {format: 'uint8x2', offset: 334, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+gc();
+let bindGroupLayout18 = device2.createBindGroupLayout({
+  label: '\u{1f9b9}\u091c\uf758\u{1f93d}\u{1fc6d}\uf284\u93ab\u3c77\u0e9e\ue354\u3f16',
+  entries: [
+    {binding: 6334, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 8121,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 6182, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let commandEncoder89 = device2.createCommandEncoder({label: '\u0813\u2cf2\u0d3d\u{1feb7}\u26ab\ue568\uc3c7\uc161'});
+let renderBundle46 = renderBundleEncoder22.finish({label: '\u0e92\u2859\u638f\uc1ba'});
+try {
+computePassEncoder26.setBindGroup(9, bindGroup27, new Uint32Array(9249), 7582, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 21, y: 72 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 28, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(652, 902);
+let commandEncoder90 = device0.createCommandEncoder({label: '\u{1f8c2}\u79af\u77ea'});
+let renderBundle47 = renderBundleEncoder24.finish();
+let arrayBuffer10 = buffer3.getMappedRange(125128, 132);
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 7840 widthInBlocks: 1960 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2984 */
+  offset: 2984,
+  buffer: buffer24,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1960, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet3, 1551, 199, buffer0, 141568);
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({});
+let pipelineLayout17 = device0.createPipelineLayout({
+  label: '\u0273\u9375\u5d91\ueb8e\uecd7\u{1fc4d}\u52b2\ua422\ua487\u8d07',
+  bindGroupLayouts: [bindGroupLayout7],
+});
+let textureView103 = texture49.createView({label: '\u3191\ua50f\uac28\u060d\ua3c0\u7f7f\u08eb\u{1f927}\u71cc\uec67\u4ec3', arrayLayerCount: 1});
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+  await buffer14.mapAsync(GPUMapMode.READ, 185840);
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 9412, shaderLocation: 14},
+          {format: 'float32', offset: 776, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 3342, shaderLocation: 4},
+          {format: 'float16x4', offset: 12284, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 5468, shaderLocation: 11},
+          {format: 'sint8x4', offset: 3796, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 5440, shaderLocation: 9},
+          {format: 'uint8x4', offset: 5256, shaderLocation: 7},
+          {format: 'sint16x4', offset: 1116, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 170, shaderLocation: 1},
+          {format: 'uint8x2', offset: 26448, shaderLocation: 5},
+          {format: 'uint16x2', offset: 1372, shaderLocation: 3},
+          {format: 'sint32x2', offset: 2128, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 884, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 4108, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 4412, shaderLocation: 13},
+          {format: 'uint8x2', offset: 6484, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 18692, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5996,
+        attributes: [
+          {format: 'float16x4', offset: 452, shaderLocation: 19},
+          {format: 'sint16x4', offset: 1732, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw'},
+});
+try {
+offscreenCanvas5.getContext('2d');
+} catch {}
+let querySet46 = device2.createQuerySet({
+  label: '\u4028\ud4e2\u0a2f\u54f1\u{1f9d9}\u45aa\u{1fabc}\u0d90\u6b7b\udc31',
+  type: 'occlusion',
+  count: 3973,
+});
+let offscreenCanvas6 = new OffscreenCanvas(296, 884);
+try {
+offscreenCanvas6.getContext('webgl');
+} catch {}
+let textureView104 = texture5.createView({aspect: 'all', format: 'rgb10a2uint', mipLevelCount: 1});
+let computePassEncoder29 = commandEncoder25.beginComputePass({label: '\u06b2\u0024\u8071\u{1fa15}\u95c8\ue085\u75fa\u37e6'});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({label: '\u0875\u5b69\u0baa\u1de1\ua6ca\u91a0\u0974', colorFormats: ['rgba16float', 'r32float']});
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 105, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 203, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(querySet12, 547, 233, buffer15, 3584);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 88024, new DataView(new ArrayBuffer(36991)), 34845, 212);
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\ua87d\u07d2\u0a84\u{1faf2}\ub58a',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let offscreenCanvas7 = new OffscreenCanvas(830, 95);
+let bindGroup31 = device2.createBindGroup({
+  label: '\u{1fdb3}\u1d57\u2d0e\u0d94\ud27e\u6276\u{1f88c}\u975a\u{1fa95}\u{1f8ff}\u830d',
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 6334, resource: externalTexture24},
+    {binding: 6182, resource: externalTexture18},
+    {binding: 8121, resource: sampler26},
+  ],
+});
+let commandEncoder91 = device2.createCommandEncoder({label: '\uf3e1\u5d7b\uc94c\u442b\ufb3c\u7647\u0167\u91f0'});
+let texture58 = device2.createTexture({
+  size: [6024, 1, 1845],
+  mipLevelCount: 10,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let textureView105 = texture57.createView({
+  label: '\u4dc9\u4176\ue676\u{1feaf}\uf32d\ua4a5\u145f\u6b2e',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 4,
+  arrayLayerCount: 2,
+});
+let renderBundleEncoder36 = device2.createRenderBundleEncoder({colorFormats: [undefined, 'rgba8uint', 'r8sint', 'rg8sint', 'rgba32float'], stencilReadOnly: true});
+let sampler41 = device2.createSampler({
+  label: '\u6491\ud369\u6d5f\u05ee',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.51,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2982, undefined, 0, 2650570095);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: imageData2,
+  origin: { x: 11, y: 81 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 29, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView106 = texture6.createView({label: '\u{1ffbc}\uc285\u0095\u2f1d\u7802\u0c0e'});
+let renderBundle48 = renderBundleEncoder28.finish({label: '\u662b\u9a52\ufa72\ucf60\u{1fc27}\u{1fd69}'});
+let externalTexture38 = device0.importExternalTexture({label: '\u8c62\udb0c\ucb48\u5b06\u02ca\uc029', source: video3, colorSpace: 'display-p3'});
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 117, y: 157, z: 4},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 281_034 */
+{offset: 186, bytesPerRow: 312, rowsPerImage: 297}, {width: 12, height: 10, depthOrArrayLayers: 4});
+} catch {}
+let textureView107 = texture54.createView({label: '\uc01e\u{1fcaf}\u097a\u9564\ucdcf\u0e73\ufe63\uc58e\u04d0'});
+let sampler42 = device2.createSampler({
+  label: '\u2011\u4630\u21d6\u0838\u7679',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 72.63,
+  compare: 'less',
+});
+let externalTexture39 = device2.importExternalTexture({
+  label: '\ubd11\udb5d\u0cc5\u{1fa4c}\u0ac6\u{1f9ea}\u1b20\u05f7\ud2a4\ue5b2',
+  source: video6,
+  colorSpace: 'srgb',
+});
+let arrayBuffer11 = buffer21.getMappedRange(157656, 62056);
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: img4,
+  origin: { x: 33, y: 23 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 35, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device2.createComputePipeline({
+  label: '\u8260\ua384\uf0e8\u1d26\ue217\u0058\u38a6\u021c\u1171\u9ed0\u0069',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+document.body.prepend(img9);
+let commandEncoder92 = device1.createCommandEncoder();
+let commandBuffer23 = commandEncoder73.finish();
+let textureView108 = texture45.createView({mipLevelCount: 1});
+let computePassEncoder30 = commandEncoder71.beginComputePass({});
+let externalTexture40 = device1.importExternalTexture({label: '\u{1ff06}\uefc4\u0403\u2401\u0bb8\u0876\u5322\u07a5', source: videoFrame6});
+try {
+renderPassEncoder1.setBindGroup(5, bindGroup13);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(34, 1, 31, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(594);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout19 = pipeline6.getBindGroupLayout(2);
+let bindGroup32 = device2.createBindGroup({
+  label: '\u020a\u00c4\u04af\u5a47\u0c95\u{1fca3}\u{1fd34}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 6715, resource: externalTexture20}],
+});
+let commandEncoder93 = device2.createCommandEncoder({label: '\u00f2\ud32f\u6316\u02c8\u0760\ub30c\u2142\u099c\ud9a7'});
+let renderBundle49 = renderBundleEncoder17.finish({label: '\ua442\u0f36\u5a81\u{1fb3f}\u0d75\u0c13\u0fed\u49d7\u1755'});
+try {
+renderBundleEncoder32.setBindGroup(8, bindGroup22, new Uint32Array(5908), 104, 0);
+} catch {}
+try {
+commandEncoder81.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: canvas3,
+  origin: { x: 19, y: 26 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 36, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 43, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap10 = await createImageBitmap(video6);
+let commandEncoder94 = device0.createCommandEncoder();
+let texture59 = device0.createTexture({
+  size: {width: 720, height: 6, depthOrArrayLayers: 61},
+  mipLevelCount: 10,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint'],
+});
+let computePassEncoder31 = commandEncoder14.beginComputePass({label: '\uf760\ud718\u{1fa19}'});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float', 'r32float'], stencilReadOnly: true});
+let renderBundle50 = renderBundleEncoder13.finish({label: '\u1133\u{1fcd3}\u8489'});
+let externalTexture41 = device0.importExternalTexture({source: video5});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet25, 78, 112, buffer15, 24832);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 459_082 */
+{offset: 534, bytesPerRow: 236, rowsPerImage: 67}, {width: 6, height: 0, depthOrArrayLayers: 30});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 129, y: 260 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas7.getContext('2d');
+} catch {}
+let commandEncoder95 = device2.createCommandEncoder({label: '\u0b61\u2541\u6c29\u014d\uad0c\u{1fe1f}\u{1f94d}\u7fda'});
+let arrayBuffer12 = buffer21.getMappedRange(315400, 154800);
+try {
+commandEncoder86.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 8_317_405 */
+{offset: 53, bytesPerRow: 2659, rowsPerImage: 184}, {width: 619, height: 0, depthOrArrayLayers: 18});
+} catch {}
+let textureView109 = texture37.createView({label: '\u{1fe30}\u{1fcf8}\u07e3\u0990\u055e', mipLevelCount: 1});
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline24 = await device2.createRenderPipelineAsync({
+  label: '\u0c85\u0d7d\u09b0\u01b7',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint'}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 7496, shaderLocation: 18},
+          {format: 'float32', offset: 28, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 8402, shaderLocation: 22},
+          {format: 'unorm16x4', offset: 13616, shaderLocation: 15},
+          {format: 'float32', offset: 22648, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 26356, shaderLocation: 25},
+          {format: 'uint8x2', offset: 246, shaderLocation: 24},
+          {format: 'float32', offset: 9316, shaderLocation: 21},
+          {format: 'uint16x4', offset: 1036, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 7548, shaderLocation: 9},
+          {format: 'float32x2', offset: 1064, shaderLocation: 7},
+          {format: 'float32x4', offset: 2520, shaderLocation: 6},
+          {format: 'uint8x2', offset: 5772, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 12744, shaderLocation: 20},
+          {format: 'float32', offset: 5412, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 14328, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 4952, shaderLocation: 26},
+          {format: 'float32x4', offset: 2864, shaderLocation: 27},
+          {format: 'uint32x4', offset: 3444, shaderLocation: 2},
+          {format: 'uint16x4', offset: 864, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 23080,
+        attributes: [
+          {format: 'sint32x3', offset: 108, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 6500, shaderLocation: 13},
+          {format: 'float32', offset: 2780, shaderLocation: 10},
+          {format: 'sint16x4', offset: 5740, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 676,
+        attributes: [
+          {format: 'snorm16x2', offset: 44, shaderLocation: 19},
+          {format: 'float16x2', offset: 120, shaderLocation: 1},
+          {format: 'float32x3', offset: 16, shaderLocation: 5},
+          {format: 'float32', offset: 72, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let texture60 = gpuCanvasContext1.getCurrentTexture();
+let textureView110 = texture30.createView({label: '\u117f\u0df3\ue385\u{1fc68}\u{1f82d}', format: 'rg16sint'});
+let computePassEncoder32 = commandEncoder62.beginComputePass({label: '\u0c87\uc143\u0a03\u{1f935}\u{1f644}\u0592\u6035\u{1f950}'});
+let renderPassEncoder7 = commandEncoder77.beginRenderPass({
+  label: '\u390d\u55d5\u1ee8\u054f',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 512.3, g: 914.1, b: 384.4, a: -618.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 1187583873,
+});
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderPassEncoder3.setIndexBuffer(buffer23, 'uint16', 99024, 7259);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline8);
+} catch {}
+try {
+device1.queue.submit([commandBuffer23]);
+} catch {}
+let imageBitmap11 = await createImageBitmap(img11);
+let textureView111 = texture4.createView({
+  label: '\uf7df\uacad\u0754\ud352\u{1ff46}\u005e\uc264\u05c7\u0cde\u0056',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 6,
+  baseArrayLayer: 10,
+});
+let externalTexture42 = device0.importExternalTexture({label: '\u1251\ua4df\u{1fd8e}', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder29.setBindGroup(5, bindGroup6, new Uint32Array(9868), 8333, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline22);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 15, y: 0 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = await device0.createComputePipelineAsync({
+  label: '\u99ba\u0681',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline26 = device0.createRenderPipeline({
+  label: '\u30d6\u01d8\u32e8\u{1f75e}\u{1fdf3}\uba92\u0a75\u{1fdeb}\u0ce1',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1364,
+        attributes: [
+          {format: 'uint32x2', offset: 272, shaderLocation: 7},
+          {format: 'float32x2', offset: 760, shaderLocation: 18},
+          {format: 'sint32x4', offset: 8, shaderLocation: 10},
+          {format: 'uint8x4', offset: 240, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 4444,
+        attributes: [
+          {format: 'sint16x2', offset: 948, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 476, shaderLocation: 4},
+          {format: 'sint16x4', offset: 900, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 5064,
+        attributes: [
+          {format: 'snorm16x2', offset: 604, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 356, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 380, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 184, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 1664, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 3460,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 412, shaderLocation: 16}],
+      },
+      {
+        arrayStride: 6404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 100, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 1680, shaderLocation: 0},
+          {format: 'uint16x4', offset: 32, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 344, shaderLocation: 13},
+          {format: 'uint32x2', offset: 780, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 11},
+          {format: 'sint32x4', offset: 1360, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let querySet47 = device0.createQuerySet({type: 'occlusion', count: 3559});
+let textureView112 = texture21.createView({
+  label: '\u35b5\u3c9d\u5b32\u337a\u5215\ue270\u{1fef5}\u0b92',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+  baseArrayLayer: 59,
+  arrayLayerCount: 11,
+});
+let computePassEncoder33 = commandEncoder74.beginComputePass({label: '\u0efb\ufb85\u0deb\u8692\uc70f\u{1f68a}\u0ed5\u0c93\u3599\u0a31'});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u59c2\udc0b\u{1ff21}\u061f\u09e1\u{1f9a1}\u{1fa64}\u067e\u8088',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let sampler43 = device0.createSampler({
+  label: '\u0a33\u1d19\u2872',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.91,
+  lodMaxClamp: 47.70,
+  maxAnisotropy: 18,
+});
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 960, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 119, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer3, 123272, 10376);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1292, new Float32Array(43876), 7094, 492);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer7), /* required buffer size: 157 */
+{offset: 157}, {width: 1376, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 0, y: 57 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 51},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView113 = texture1.createView({
+  label: '\u02ae\uf9d4\u{1fe23}\u{1f605}\u{1fd07}\uca23\u{1fe00}\u709e',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+});
+let sampler44 = device0.createSampler({
+  label: '\u{1f87b}\ud592\u{1fc52}\ua753\u0d8a\u{1fbe8}\u{1f716}\ucb4e\u0bf6',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 74.76,
+});
+let promise19 = buffer10.mapAsync(GPUMapMode.WRITE, 0, 6304);
+try {
+commandEncoder63.copyBufferToBuffer(buffer12, 33856, buffer15, 15864, 5048);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 552, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 572, new Float32Array(2651), 1738, 324);
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 1641807661,
+    depthBiasSlopeScale: 589.5489745061597,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5936,
+        attributes: [
+          {format: 'sint8x2', offset: 688, shaderLocation: 2},
+          {format: 'uint8x4', offset: 2156, shaderLocation: 5},
+          {format: 'sint32x4', offset: 840, shaderLocation: 10},
+          {format: 'float32', offset: 280, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 228, shaderLocation: 14},
+          {format: 'uint32x2', offset: 36, shaderLocation: 3},
+          {format: 'float32', offset: 1916, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 1456, shaderLocation: 11},
+          {format: 'sint32x3', offset: 208, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 632, shaderLocation: 19},
+          {format: 'uint16x4', offset: 328, shaderLocation: 6},
+          {format: 'float16x4', offset: 280, shaderLocation: 9},
+          {format: 'sint32x3', offset: 440, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 6576,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 104, shaderLocation: 13},
+          {format: 'uint32x4', offset: 408, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 26904,
+        attributes: [
+          {format: 'float32x4', offset: 1136, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 10682, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 2560, shaderLocation: 4},
+          {format: 'float32x2', offset: 72, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 3084, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+gc();
+let texture61 = device1.createTexture({
+  size: [150, 155, 1],
+  mipLevelCount: 3,
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['astc-10x5-unorm', 'astc-10x5-unorm-srgb'],
+});
+try {
+renderPassEncoder5.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(46, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer23, 'uint16', 42176, 38774);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup13, new Uint32Array(8940), 6645, 0);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let img14 = await imageWithData(280, 36, '#25de7b44', '#1312c84d');
+let commandEncoder96 = device0.createCommandEncoder({label: '\u0f5b\u0c26\ua844\u0f01\u194e\u{1fa8c}\u0732\u{1f69c}\u0f18\u05c7'});
+let commandBuffer24 = commandEncoder83.finish({label: '\u{1fcc7}\u{1faaf}\u{1f7a3}\u2be4\u7d26\u530e\u0e40\u69e2\uebd4'});
+let texture62 = device0.createTexture({
+  label: '\u0f2e\u5d6b\u{1f870}\u061e\u0e80\uecbd\u02ba\u{1f9be}\ue7b0\u60ed',
+  size: [2880, 24, 61],
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer5, 20684);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(0)), /* required buffer size: 58 */
+{offset: 58}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let commandBuffer25 = commandEncoder16.finish();
+let texture63 = device0.createTexture({
+  size: [62],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder10.dispatchWorkgroupsIndirect(buffer5, 15460);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(4, bindGroup6, new Uint32Array(3873), 2610, 0);
+} catch {}
+let promise21 = buffer7.mapAsync(GPUMapMode.WRITE, 0, 87468);
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 229, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet14, 1570, 108, buffer15, 45568);
+} catch {}
+let pipeline28 = device0.createComputePipeline({
+  label: '\u98b9\u{1fff9}\u03d7\u04bf\u0a58\u36c1\u0611\u{1f92b}\u{1fe03}\u16fe\u0412',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline29 = device0.createRenderPipeline({
+  label: '\u224f\u1cb0\uce29\u71b8\ua134',
+  layout: pipelineLayout17,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2773451586,
+    stencilWriteMask: 430509378,
+    depthBias: 1552610944,
+    depthBiasSlopeScale: -9.57878373488468,
+    depthBiasClamp: 693.1564449850528,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11600,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 524, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 292, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 1500, shaderLocation: 1},
+          {format: 'uint32x2', offset: 2152, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 820, shaderLocation: 13},
+          {format: 'sint8x2', offset: 302, shaderLocation: 10},
+          {format: 'uint8x2', offset: 1510, shaderLocation: 7},
+          {format: 'uint8x4', offset: 664, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 5404, shaderLocation: 14},
+          {format: 'float32x2', offset: 508, shaderLocation: 11},
+          {format: 'float32x2', offset: 412, shaderLocation: 18},
+          {format: 'float32', offset: 4496, shaderLocation: 15},
+          {format: 'sint32x3', offset: 876, shaderLocation: 2},
+          {format: 'uint8x4', offset: 3292, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 460, shaderLocation: 16},
+          {format: 'sint32x2', offset: 200, shaderLocation: 12},
+          {format: 'sint32x2', offset: 2824, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 1572, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 922, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 836, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let pipelineLayout18 = device0.createPipelineLayout({
+  label: '\u{1fc55}\u52e9\u6c97\u5666\u{1f74a}\uef9c',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout1, bindGroupLayout5, bindGroupLayout0, bindGroupLayout0, bindGroupLayout7],
+});
+let commandBuffer26 = commandEncoder6.finish({});
+let texture64 = device0.createTexture({
+  label: '\u{1fc51}\u5e42\u6ce5\uf2c8\u0e19\u6f9e\u6dfd',
+  size: {width: 322},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView114 = texture24.createView({
+  label: '\u{1f8d5}\u{1f65f}\u0d77\u{1ffad}\u0b46\u8c42\ucb52\u0c61\u99e3\u0d6b\u6126',
+  format: 'r16float',
+  baseMipLevel: 4,
+  baseArrayLayer: 102,
+  arrayLayerCount: 162,
+});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u01e9\u00fe\ub8ea\ua129\ua9f7\u0ddc',
+  colorFormats: ['rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle51 = renderBundleEncoder39.finish();
+try {
+computePassEncoder29.setBindGroup(6, bindGroup9, new Uint32Array(5995), 5304, 0);
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(3);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 582, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 3,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 65, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet2, 1829, 13, buffer15, 36096);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 274, y: 0, z: 5},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 3_140_471 */
+{offset: 256, bytesPerRow: 501, rowsPerImage: 232}, {width: 56, height: 4, depthOrArrayLayers: 28});
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+  label: '\u{1f75f}\u{1fcfe}\u0f93\u0945\u621d\u084d\u{1ffb3}\u1aab',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater', failOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 1164505936,
+    depthBias: 760166751,
+    depthBiasSlopeScale: 273.967572967681,
+    depthBiasClamp: 335.9178915970895,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 10848,
+        attributes: [
+          {format: 'unorm8x2', offset: 1164, shaderLocation: 8},
+          {format: 'uint8x2', offset: 36, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 32, shaderLocation: 15},
+          {format: 'uint8x4', offset: 1276, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 1172, shaderLocation: 16},
+          {format: 'float32', offset: 2772, shaderLocation: 0},
+          {format: 'sint8x2', offset: 402, shaderLocation: 10},
+          {format: 'float32x4', offset: 308, shaderLocation: 1},
+          {format: 'uint32x3', offset: 2432, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 3050, shaderLocation: 18},
+          {format: 'sint16x4', offset: 3540, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 8576, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 5992, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 2712,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 112, shaderLocation: 19},
+          {format: 'sint16x4', offset: 340, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 9488, attributes: []},
+      {
+        arrayStride: 1756,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 204, shaderLocation: 13},
+          {format: 'uint16x4', offset: 336, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 756, shaderLocation: 14},
+          {format: 'sint16x2', offset: 292, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 4788, attributes: [{format: 'float32', offset: 1156, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder97 = device1.createCommandEncoder({label: '\ub7c1\u1fae\u0e76\u{1fbe2}\u{1f959}\u0a1d\u0464\u6ee7'});
+let renderBundleEncoder41 = device1.createRenderBundleEncoder({label: '\u007b\u395a\u2768\uf8d8\u691b', colorFormats: ['rg16sint'], depthReadOnly: true});
+try {
+renderPassEncoder0.setBindGroup(4, bindGroup15);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 680.9, g: -462.5, b: -721.3, a: -579.5, });
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(6, bindGroup13);
+} catch {}
+let promise22 = device1.queue.onSubmittedWorkDone();
+let pipeline31 = await promise10;
+let pipeline32 = await device1.createRenderPipelineAsync({
+  label: '\u6154\ua75e\uece5\u2388\u{1fc2f}\u4cd3\u21e8\u041f\uc4f0\u785c',
+  layout: pipelineLayout14,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 3577194139,
+    depthBias: -714979998,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: -59.551915587268624,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 5960, shaderLocation: 11},
+          {format: 'uint16x4', offset: 8912, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 208, shaderLocation: 7},
+          {format: 'float32', offset: 9088, shaderLocation: 5},
+          {format: 'float32x3', offset: 2272, shaderLocation: 14},
+          {format: 'float16x2', offset: 2776, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 14074, shaderLocation: 1},
+          {format: 'uint32x4', offset: 2480, shaderLocation: 4},
+          {format: 'sint8x2', offset: 2920, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 8824, shaderLocation: 12},
+          {format: 'sint32x3', offset: 5588, shaderLocation: 8},
+          {format: 'float32x3', offset: 18064, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 5592,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 32, shaderLocation: 16},
+          {format: 'uint32', offset: 1192, shaderLocation: 10},
+          {format: 'sint8x2', offset: 1282, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 948, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 268,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x2', offset: 122, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+offscreenCanvas3.width = 560;
+let computePassEncoder34 = commandEncoder57.beginComputePass({});
+let sampler45 = device2.createSampler({
+  label: '\u87ca\u{1fbc7}\u0f3f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.29,
+  maxAnisotropy: 7,
+});
+try {
+commandEncoder70.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline33 = device2.createRenderPipeline({
+  label: '\u7909\u{1f90c}\u6a47\u5ade\u{1fa37}\u450e\u{1fc28}\u7f49\u399a',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 3357763041,
+    stencilWriteMask: 3042846331,
+    depthBias: -1169609951,
+    depthBiasClamp: 373.51670323336066,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14844,
+        attributes: [
+          {format: 'unorm8x4', offset: 3224, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 396, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 11312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 704, shaderLocation: 18},
+          {format: 'uint16x4', offset: 2704, shaderLocation: 13},
+          {format: 'float16x2', offset: 552, shaderLocation: 14},
+          {format: 'sint8x2', offset: 924, shaderLocation: 17},
+          {format: 'uint8x4', offset: 1532, shaderLocation: 22},
+          {format: 'uint8x4', offset: 4004, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 656, shaderLocation: 4},
+          {format: 'uint16x2', offset: 1880, shaderLocation: 2},
+          {format: 'float32x3', offset: 916, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 7944,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x2', offset: 2488, shaderLocation: 27},
+          {format: 'unorm16x4', offset: 628, shaderLocation: 11},
+          {format: 'uint32x2', offset: 248, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 968, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 712, shaderLocation: 1},
+          {format: 'float32x3', offset: 524, shaderLocation: 9},
+          {format: 'uint32x2', offset: 1112, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 412, shaderLocation: 23},
+          {format: 'float32x4', offset: 720, shaderLocation: 24},
+          {format: 'unorm10-10-10-2', offset: 412, shaderLocation: 20},
+          {format: 'uint32x4', offset: 324, shaderLocation: 19},
+          {format: 'float32x3', offset: 1156, shaderLocation: 26},
+          {format: 'uint32x3', offset: 4788, shaderLocation: 0},
+          {format: 'uint16x4', offset: 1052, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 22188,
+        attributes: [
+          {format: 'sint16x4', offset: 100, shaderLocation: 12},
+          {format: 'uint32', offset: 3960, shaderLocation: 7},
+          {format: 'uint32x4', offset: 2080, shaderLocation: 25},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+  await promise20;
+} catch {}
+let commandEncoder98 = device2.createCommandEncoder({label: '\uae44\u0cdf\uc178\u0136\ubcd9\u{1fc4e}'});
+let textureView115 = texture42.createView({label: '\u072b\ub221\u{1ff2d}', dimension: '3d', baseMipLevel: 2, baseArrayLayer: 0});
+let sampler46 = device2.createSampler({
+  label: '\ud711\u0e78\ua4dc\u0f73\u{1ff8a}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 16.30,
+  lodMaxClamp: 69.21,
+});
+try {
+computePassEncoder26.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup21, new Uint32Array(3657), 3562, 0);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 127},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 5,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder19.insertDebugMarker('\ue0b3');
+} catch {}
+let pipeline34 = device2.createComputePipeline({
+  label: '\u049b\u0228\ue5be\u0f0c\ufa1d\u05ae\u{1fea3}\ub2ce\udd30',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder99 = device1.createCommandEncoder();
+let textureView116 = texture36.createView({
+  label: '\u0f4b\u{1f7c0}\u{1fcdd}\udb72\u2ca0\u0faf\ua06a\ucfb1\u459e\ufe80\u{1f628}',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let externalTexture43 = device1.importExternalTexture({label: '\udff1\ua91d\ua408\udc26\u5384', source: videoFrame7, colorSpace: 'display-p3'});
+try {
+computePassEncoder23.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(1300);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -187.9, g: -673.3, b: 387.9, a: -48.08, });
+} catch {}
+try {
+renderPassEncoder7.setViewport(51.29, 0.6725, 9.771, 0.01381, 0.1253, 0.1812);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer17, 0, 46624);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let pipeline35 = await device1.createRenderPipelineAsync({
+  label: '\u4ac9\u{1fc63}\u0033\u1ec3',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 2231309198,
+    stencilWriteMask: 2393701696,
+    depthBiasClamp: 23.041060461487533,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 248,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 20, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 16},
+          {format: 'sint8x2', offset: 62, shaderLocation: 17},
+          {format: 'uint8x2', offset: 26, shaderLocation: 9},
+          {format: 'uint32', offset: 20, shaderLocation: 5},
+          {format: 'sint32', offset: 88, shaderLocation: 1},
+          {format: 'float16x4', offset: 0, shaderLocation: 6},
+          {format: 'sint16x4', offset: 0, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 2572,
+        attributes: [
+          {format: 'sint32', offset: 288, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 0},
+          {format: 'float32x4', offset: 104, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 884, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 10776, stepMode: 'vertex', attributes: []},
+      {arrayStride: 920, stepMode: 'instance', attributes: []},
+      {arrayStride: 3496, stepMode: 'instance', attributes: []},
+      {arrayStride: 7428, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 23884,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 252, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 1556, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let shaderModule10 = device2.createShaderModule({
+  code: `@group(0) @binding(6715)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(8) f0: vec4<u32>,
+  @location(24) f1: vec3<u32>,
+  @location(10) f2: vec3<f32>,
+  @location(13) f3: vec3<f32>,
+  @location(21) f4: vec2<f32>,
+  @location(11) f5: vec2<u32>,
+  @location(23) f6: u32,
+  @location(15) f7: f16,
+  @location(5) f8: vec2<u32>,
+  @location(18) f9: vec4<f16>,
+  @location(9) f10: vec4<f32>,
+  @location(7) f11: vec4<f32>,
+  @location(12) f12: i32,
+  @location(1) f13: i32
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<u32>, @location(6) a1: vec3<f32>, @location(26) a2: vec2<f32>, @location(20) a3: f32, @location(4) a4: u32, @location(0) a5: i32, @location(25) a6: vec4<f16>, a7: S14, @location(22) a8: vec3<u32>, @location(27) a9: vec3<i32>, @location(17) a10: vec4<f32>, @location(14) a11: vec3<f16>, @location(2) a12: vec4<i32>, @location(3) a13: f16, @location(19) a14: vec2<f16>, @builtin(vertex_index) a15: u32, @builtin(instance_index) a16: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup33 = device2.createBindGroup({
+  label: '\u0ea1\u7b18\u85c2\u0a52',
+  layout: bindGroupLayout19,
+  entries: [{binding: 6715, resource: externalTexture24}],
+});
+let commandEncoder100 = device2.createCommandEncoder({label: '\u0a5f\u773b\u{1feb7}\u8128\ub128\u54a5\ufe44\u9bed\ua4e9'});
+let texture65 = device2.createTexture({
+  label: '\u08ec\u8d1c\ua84b\uaa2a\u2650',
+  size: {width: 1506, height: 1, depthOrArrayLayers: 1114},
+  mipLevelCount: 10,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler47 = device2.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.37,
+  lodMaxClamp: 98.45,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder36.setBindGroup(7, bindGroup20, new Uint32Array(3493), 944, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(5406, undefined, 4130883358);
+} catch {}
+let promise23 = adapter3.requestAdapterInfo();
+let computePassEncoder35 = commandEncoder94.beginComputePass({label: '\ud615\u1200\u0fa2\u{1ff9a}\u{1fb32}\ub4ae'});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\u3b68\u{1fd89}',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler48 = device0.createSampler({
+  label: '\u20e9\u{1f701}\u{1fa38}\u{1ff6b}\u{1fac8}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.07,
+  lodMaxClamp: 92.48,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(7, bindGroup29, new Uint32Array(3552), 211, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer5, 'uint32', 16928, 10635);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 12932, new BigUint64Array(63772), 57309, 1880);
+} catch {}
+let img15 = await imageWithData(127, 138, '#ff486901', '#f95cb30e');
+let texture66 = device0.createTexture({
+  label: '\u3846\ua052\ube1e\u24cd\u{1fd10}\u{1f871}\ucd5c\u5d3e',
+  size: {width: 360, height: 3, depthOrArrayLayers: 61},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(7, bindGroup16, new Uint32Array(2033), 293, 0);
+} catch {}
+try {
+querySet25.destroy();
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer4, 11276, buffer3, 35072, 20916);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 784 */
+  offset: 784,
+  rowsPerImage: 61,
+  buffer: buffer3,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let commandEncoder101 = device0.createCommandEncoder({label: '\u{1f94b}\ufaca\u7075'});
+let textureView117 = texture11.createView({label: '\u0437\ue8b6\u965c\u3acf\ufc4b\u7810\u339f\u02ca\ud808\u{1f87d}'});
+let computePassEncoder36 = commandEncoder26.beginComputePass({label: '\u821d\ud81a\u7884\u9f4e\u0171\uc09d\ua578'});
+let externalTexture44 = device0.importExternalTexture({
+  label: '\u0eb0\u0d56\u0228\u0277\u0ce7\u{1f8be}\u2699\u17b1',
+  source: videoFrame12,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder29.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer6, 39976, 1577);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 621, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 90, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet13, 171, 13, buffer15, 15360);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 24, depthOrArrayLayers: 61}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 517, y: 2, z: 41},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({
+  label: '\u{1fd56}\u1cf4\u0029\u{1fbb1}\u1cde\u2998\u7d34\u{1f622}\u4227\ud8c8\u{1fa5d}',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout15, bindGroupLayout4, bindGroupLayout7, bindGroupLayout0, bindGroupLayout15],
+});
+let commandEncoder102 = device0.createCommandEncoder();
+let querySet48 = device0.createQuerySet({type: 'occlusion', count: 2818});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({label: '\u4b8d\u0060\uac45\u0383', colorFormats: ['rgba8unorm'], depthReadOnly: true});
+let externalTexture45 = device0.importExternalTexture({source: video4});
+try {
+computePassEncoder9.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(8, buffer6);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 15792 widthInBlocks: 1974 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 6024 */
+  offset: 6024,
+  buffer: buffer12,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 419, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1974, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 141 */
+{offset: 141}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img16 = await imageWithData(253, 267, '#85052976', '#6e092cd5');
+let bindGroupLayout20 = device2.createBindGroupLayout({
+  label: '\u{1fbaf}\ub6f7\ue52f\u0677\u{1fc3d}\u3011\u{1fe1b}\u026d\u3444\u8347\u{1ff33}',
+  entries: [
+    {
+      binding: 1496,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder103 = device2.createCommandEncoder({});
+let texture67 = gpuCanvasContext3.getCurrentTexture();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 11, y: 50 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 26, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = device2.createComputePipeline({
+  label: '\ubfbd\ube8c\u99d6\u4afe',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+let querySet49 = device1.createQuerySet({label: '\u{1fa14}\u2160', type: 'occlusion', count: 2335});
+let textureView118 = texture43.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 4});
+let sampler49 = device1.createSampler({
+  label: '\u0373\u6048\u09b2\u0760\u2a64\u4ed2\ue903\u61d8\u75db',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.24,
+  lodMaxClamp: 81.03,
+});
+try {
+renderPassEncoder2.setBlendConstant({ r: 269.5, g: 746.5, b: -367.2, a: 360.6, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(8, 0, 13, 1);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 14496 */
+  offset: 14496,
+  bytesPerRow: 512,
+  buffer: buffer19,
+}, {
+  texture: texture61,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 75, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+renderBundleEncoder41.pushDebugGroup('\u3ad7');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline37 = await device1.createRenderPipelineAsync({
+  label: '\ucecf\udc12',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1888,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 260, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 32, shaderLocation: 4},
+          {format: 'float32', offset: 544, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 140, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 1056, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 182, shaderLocation: 3},
+          {format: 'uint8x4', offset: 352, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 528, shaderLocation: 17},
+          {format: 'uint32x2', offset: 748, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 1192, shaderLocation: 8},
+          {format: 'sint32x3', offset: 200, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 16},
+          {format: 'float32x4', offset: 236, shaderLocation: 13},
+          {format: 'uint8x2', offset: 712, shaderLocation: 6},
+          {format: 'uint8x2', offset: 402, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 352, shaderLocation: 12},
+          {format: 'float16x2', offset: 76, shaderLocation: 9},
+          {format: 'uint16x2', offset: 156, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+let texture68 = device2.createTexture({
+  label: '\u0045\u19c6\u04f1\u79ea\ua2eb\u0326\u{1fe13}\u0a60',
+  size: [16, 1, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView119 = texture58.createView({label: '\u{1f675}\ud301\u0e11', baseMipLevel: 8, baseArrayLayer: 425, arrayLayerCount: 824});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 150, y: 55 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 19, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas1.width = 1486;
+let querySet50 = device1.createQuerySet({type: 'occlusion', count: 3526});
+let textureView120 = texture47.createView({});
+let renderBundleEncoder44 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle52 = renderBundleEncoder33.finish({label: '\ucd69\ua51d\u5029\ud39f\u0f2b\u{1f62b}\u0e23\u4d24'});
+let externalTexture46 = device1.importExternalTexture({label: '\u07d5\ue9ce\u7d7b\u0210\u008c\ud02a\u0336\u{1fdce}', source: video1});
+try {
+renderPassEncoder1.beginOcclusionQuery(1015);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(8, buffer23, 0, 38234);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(6, bindGroup13);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7424 */
+  offset: 5856,
+  bytesPerRow: 512,
+  buffer: buffer19,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 16, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 16, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23204 */
+  offset: 23020,
+  buffer: buffer20,
+}, {width: 46, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle53 = renderBundleEncoder30.finish({});
+let externalTexture47 = device1.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(16, 0, 7, 1);
+} catch {}
+try {
+renderPassEncoder7.setViewport(57.34, 0.5248, 2.395, 0.2338, 0.4803, 0.8430);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(5, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline37);
+} catch {}
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 11552 */
+  offset: 11032,
+  bytesPerRow: 256,
+  rowsPerImage: 62,
+  buffer: buffer19,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 12, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+let textureView121 = texture39.createView({
+  label: '\uad10\ub069\ua54c\u0f7c\u{1fd68}\uaf48\u{1fb20}\u{1fe94}\u{1fe71}\uf123\u{1fb7c}',
+  aspect: 'all',
+});
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({
+  label: '\u{1f9f8}\ud125\u8eae\ucad2\u{1f9ec}\ufe93',
+  colorFormats: ['rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture48 = device1.importExternalTexture({source: videoFrame11, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup15, new Uint32Array(3464), 2235, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(8, buffer23, 86836, 480);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(1, buffer23, 0);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  label: '\u9581\u{1ff77}\u0cae\u{1fee9}\u029f',
+  layout: bindGroupLayout2,
+  entries: [{binding: 1922, resource: sampler1}],
+});
+let buffer26 = device0.createBuffer({
+  label: '\u{1f8d0}\u0946\u98cd\u{1fc46}\u70af\uc483\u0e11\ud84e\u{1fda4}\u701f\u27f9',
+  size: 21364,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet51 = device0.createQuerySet({type: 'occlusion', count: 93});
+let commandBuffer27 = commandEncoder8.finish({label: '\u859b\u{1f850}\u{1fcaa}\u0716\u1bed\u{1fea9}'});
+try {
+computePassEncoder5.setBindGroup(7, bindGroup18);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline25);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 616, 69792);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer10, 704, buffer6, 5184, 14012);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 1304 widthInBlocks: 163 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10088 */
+  offset: 10088,
+  buffer: buffer24,
+}, {
+  texture: texture35,
+  mipLevel: 3,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 163, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 5,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 39304, new Int16Array(64762), 27913, 116);
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+  label: '\ua795\u9900\ue412\u5fe4\u05aa\ufe14\ud8be',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x8131232b},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-wrap'},
+    stencilReadMask: 2339635422,
+    stencilWriteMask: 1134897478,
+    depthBiasSlopeScale: 628.7748367427919,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2560, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1168,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 96, shaderLocation: 18},
+          {format: 'uint8x4', offset: 24, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 60, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 16, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 388, shaderLocation: 19},
+          {format: 'float16x4', offset: 0, shaderLocation: 0},
+          {format: 'sint32x2', offset: 532, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 216, shaderLocation: 15},
+          {format: 'sint8x2', offset: 700, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 376, shaderLocation: 11},
+          {format: 'uint16x4', offset: 20, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 200, shaderLocation: 14},
+          {format: 'sint8x2', offset: 260, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 17724,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 488, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 1220, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 1136,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 344, shaderLocation: 1},
+          {format: 'uint16x4', offset: 220, shaderLocation: 5},
+          {format: 'sint8x2', offset: 22, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 6612, attributes: [{format: 'uint8x4', offset: 1880, shaderLocation: 3}]},
+    ],
+  },
+});
+let renderBundle54 = renderBundleEncoder6.finish({});
+let externalTexture49 = device0.importExternalTexture({source: video6, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+commandEncoder102.copyBufferToBuffer(buffer24, 45356, buffer14, 359220, 43204);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 123, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 230, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1840, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer11, 153344, 23220);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2732, new DataView(new ArrayBuffer(51405)), 20851, 3624);
+} catch {}
+let img17 = await imageWithData(183, 145, '#cd723571', '#2be97261');
+let shaderModule11 = device2.createShaderModule({
+  label: '\uc6ee\ua7f0\uaa04\uc101\u994b\uce24\u{1fcc0}\ub0d5\ue2c1\u787d',
+  code: `@group(0) @binding(6715)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec4<u32>,
+  @location(0) f1: u32,
+  @location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, a2: S15, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let texture69 = device2.createTexture({
+  size: {width: 3264},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+commandEncoder100.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+gc();
+let videoFrame14 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let commandEncoder104 = device2.createCommandEncoder();
+let texture70 = device2.createTexture({
+  label: '\u05a3\u2c0b\u6b40\u{1feec}\uaa88\u677a\u9b09\u1631\u0839\ud2dd',
+  size: {width: 33, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint'],
+});
+let sampler50 = device2.createSampler({
+  label: '\u0fa7\ub34d\ua4c2\u0324',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 15.81,
+});
+try {
+buffer21.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer4), /* required buffer size: 642 */
+{offset: 634}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule12 = device1.createShaderModule({
+  label: '\u0751\u0b69\u064b\u0ba2\ud6ed\u78fe\u308d\u4eba\u440b\u0ba0',
+  code: `@group(1) @binding(1552)
+var<storage, read_write> field3: array<u32>;
+@group(2) @binding(1552)
+var<storage, read_write> function6: array<u32>;
+@group(3) @binding(3157)
+var<storage, read_write> field4: array<u32>;
+@group(4) @binding(1552)
+var<storage, read_write> function7: array<u32>;
+@group(0) @binding(2591)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(7) f0: vec2<f32>,
+  @location(5) f1: vec3<f32>,
+  @location(17) f2: vec3<f16>,
+  @location(6) f3: u32,
+  @builtin(vertex_index) f4: u32,
+  @location(3) f5: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: f32, @location(13) a1: vec3<f32>, @location(4) a2: u32, @location(10) a3: u32, @location(16) a4: vec2<f16>, a5: S16, @location(9) a6: vec3<u32>, @location(2) a7: vec2<i32>, @location(0) a8: vec2<u32>, @location(12) a9: i32, @location(14) a10: i32, @location(15) a11: vec4<f16>, @location(11) a12: vec4<u32>, @location(1) a13: vec2<f16>, @builtin(instance_index) a14: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let texture71 = device1.createTexture({
+  label: '\ufa1d\ufbc0\u4138\u0a67\ud792\u0e97\u4041',
+  size: [72, 160, 132],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView122 = texture25.createView({
+  label: '\ub17b\u0b37\u1b17\u3872\ud942\u{1ffbe}\u89f5\u0955\u14c5',
+  dimension: '2d-array',
+  baseArrayLayer: 0,
+});
+let renderPassEncoder8 = commandEncoder58.beginRenderPass({
+  label: '\u0bf5\u990d\u4865\uffc0\u0e08\u0306\u{1fbbf}\u2492',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 331.6, g: 801.9, b: 522.1, a: 469.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 344003140,
+});
+let renderBundle55 = renderBundleEncoder44.finish();
+try {
+computePassEncoder24.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(8, bindGroup19);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 943.3, g: 240.6, b: -647.8, a: 248.5, });
+} catch {}
+try {
+renderPassEncoder7.setViewport(50.85, 0.9448, 12.84, 0.05378, 0.1712, 0.5396);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer23, 20528, 4112);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(8, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(6, buffer23, 63412, 735);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8448 */
+  offset: 8448,
+  bytesPerRow: 512,
+  buffer: buffer20,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline39 = device1.createRenderPipeline({
+  label: '\u075d\u2dcc\u21c0\u0534',
+  layout: pipelineLayout10,
+  fragment: {module: shaderModule9, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16sint'}]},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5632,
+        attributes: [
+          {format: 'uint8x2', offset: 94, shaderLocation: 9},
+          {format: 'uint16x2', offset: 212, shaderLocation: 15},
+          {format: 'uint32x2', offset: 856, shaderLocation: 11},
+          {format: 'float32x4', offset: 624, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 2040, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 1532,
+        attributes: [
+          {format: 'float32x2', offset: 152, shaderLocation: 0},
+          {format: 'sint32x2', offset: 532, shaderLocation: 5},
+          {format: 'sint16x4', offset: 348, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 200, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 11992,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1432, shaderLocation: 3},
+          {format: 'sint8x4', offset: 192, shaderLocation: 10},
+          {format: 'uint16x4', offset: 1680, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 1684, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 2352, shaderLocation: 2},
+          {format: 'sint32x2', offset: 16144, shaderLocation: 7},
+          {format: 'uint32x2', offset: 3800, shaderLocation: 16},
+          {format: 'sint32x3', offset: 7700, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 220, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 632,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 252, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder105 = device1.createCommandEncoder({});
+let texture72 = device1.createTexture({
+  size: {width: 144},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView123 = texture27.createView({
+  label: '\u0b36\uc4a6\ub09f\u9f28\u0c93\uf6d0\u17fb\u9b35\u77b6',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'etc2-rgb8a1unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+let externalTexture50 = device1.importExternalTexture({source: videoFrame11, colorSpace: 'srgb'});
+try {
+computePassEncoder25.setBindGroup(8, bindGroup13);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 759.1, g: -544.1, b: -979.1, a: -779.1, });
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer23, 20188, 31797);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer4, 59636, buffer3, 16956, 5680);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder80.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11812 */
+  offset: 11812,
+  buffer: buffer6,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder90.resolveQuerySet(querySet0, 68, 87, buffer15, 24320);
+} catch {}
+let commandEncoder106 = device1.createCommandEncoder({label: '\u0d59\ubc2a\ufb6e\u3ed3\u{1ff7b}'});
+let texture73 = device1.createTexture({
+  label: '\ue3fd\u{1f8dc}\u{1f678}\u23af\u088d',
+  size: {width: 36, height: 80, depthOrArrayLayers: 1120},
+  mipLevelCount: 7,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView124 = texture47.createView({dimension: '1d'});
+let renderPassEncoder9 = commandEncoder106.beginRenderPass({
+  label: '\u3fb4\ub6da\u0ffe\u0ddc\u1397\u0caf\u{1fcc9}',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 530.0, g: -886.7, b: 919.9, a: -202.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet21,
+});
+let renderBundle56 = renderBundleEncoder33.finish({label: '\u1b32\u014e\u8f18\u{1fb73}\u89bd\uaa5f'});
+let sampler51 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.81,
+  lodMaxClamp: 76.02,
+  maxAnisotropy: 5,
+});
+try {
+commandEncoder84.copyBufferToBuffer(buffer16, 52348, buffer20, 80508, 9064);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let imageBitmap12 = await createImageBitmap(img17);
+let commandEncoder107 = device2.createCommandEncoder({label: '\u8ed4\u{1fdb7}\u0d37'});
+let commandBuffer28 = commandEncoder100.finish({label: '\ue2be\u7675\u01f9'});
+let textureView125 = texture69.createView({label: '\u08fc\u9d19\u006f\u129c\u50bc\ub3f1\u0396\u0793\u{1fe5f}', format: 'rg8uint'});
+let renderBundleEncoder46 = device2.createRenderBundleEncoder({
+  label: '\u0ffc\u0ef3\u042a\u0211\ubb41',
+  colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle57 = renderBundleEncoder21.finish({});
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView126 = texture38.createView({label: '\u0fc8\u06dd\u{1fc47}\u1e51\uaef1\u070e\u0acf'});
+let sampler52 = device1.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 83.14});
+let externalTexture51 = device1.importExternalTexture({label: '\u9b62\u0a9e\u0e83\udbb2', source: video2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setBlendConstant({ r: -754.2, g: 402.6, b: 810.9, a: -781.2, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(65, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer17, 180084, 32378);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(8, bindGroup15);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer16, 1180, buffer20, 50776, 20208);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout21 = device2.createBindGroupLayout({
+  label: '\u005d\u3490\u7101\ua56b\u1f75\u2662\ue53a',
+  entries: [
+    {
+      binding: 8080,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let buffer27 = device2.createBuffer({size: 144638, usage: GPUBufferUsage.COPY_SRC});
+let textureView127 = texture40.createView({aspect: 'all', format: 'bgra8unorm', baseMipLevel: 0, mipLevelCount: 2});
+let renderBundle58 = renderBundleEncoder17.finish();
+let sampler53 = device2.createSampler({
+  label: '\u{1f60e}\u08f7\u{1f779}\u187d\u33a8\u8d77\u5386\u{1ff94}\u{1ffbb}\u7f2a\uf0cb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.81,
+  maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder46.setBindGroup(7, bindGroup20, new Uint32Array(1146), 31, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 3,
+  origin: {x: 17, y: 0, z: 112},
+  aspect: 'all',
+}, new ArrayBuffer(22_528_910), /* required buffer size: 22_528_910 */
+{offset: 384, bytesPerRow: 328, rowsPerImage: 154}, {width: 87, height: 1, depthOrArrayLayers: 447});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: imageBitmap12,
+  origin: { x: 5, y: 56 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 21, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = await device2.createRenderPipelineAsync({
+  label: '\u04dc\u0cd6\u{1f9ce}\u{1fbe7}\u{1fc15}\u{1fcf7}\u0a1c\u{1f732}\u7067',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 1829492719,
+    stencilWriteMask: 1521164478,
+    depthBiasSlopeScale: 566.8713841255262,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2824,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 252, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 188, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 464, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 682, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 1116, shaderLocation: 27},
+          {format: 'float16x4', offset: 188, shaderLocation: 4},
+          {format: 'float16x4', offset: 116, shaderLocation: 20},
+          {format: 'uint32x4', offset: 124, shaderLocation: 7},
+          {format: 'uint32x4', offset: 228, shaderLocation: 16},
+          {format: 'uint8x2', offset: 106, shaderLocation: 15},
+          {format: 'uint32x2', offset: 2144, shaderLocation: 25},
+          {format: 'sint8x2', offset: 246, shaderLocation: 12},
+          {format: 'float16x2', offset: 216, shaderLocation: 6},
+          {format: 'sint32', offset: 556, shaderLocation: 17},
+          {format: 'uint16x2', offset: 92, shaderLocation: 2},
+          {format: 'uint32x4', offset: 404, shaderLocation: 19},
+          {format: 'uint32x4', offset: 240, shaderLocation: 22},
+          {format: 'snorm16x4', offset: 460, shaderLocation: 8},
+          {format: 'float32x4', offset: 772, shaderLocation: 26},
+        ],
+      },
+      {
+        arrayStride: 8520,
+        attributes: [
+          {format: 'uint32x2', offset: 1932, shaderLocation: 13},
+          {format: 'uint8x2', offset: 2832, shaderLocation: 21},
+          {format: 'float16x4', offset: 936, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 968, shaderLocation: 5},
+          {format: 'uint32', offset: 1076, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 3356, shaderLocation: 23},
+          {format: 'float32x3', offset: 148, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 17728, stepMode: 'instance', attributes: []},
+      {arrayStride: 17128, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 18856,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 1748, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 1152,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 40, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder108 = device2.createCommandEncoder({label: '\u0db1\udd1e\ue396\uc5df\u0ac7\ued92\ue25e\u0616\ufbc4\u16cc'});
+let computePassEncoder37 = commandEncoder70.beginComputePass();
+let renderBundle59 = renderBundleEncoder17.finish({label: '\u{1f71e}\uc64f\u{1fd0d}\u0216\u5c9b\u99ba\u9110'});
+let promise25 = buffer21.mapAsync(GPUMapMode.READ);
+try {
+commandEncoder103.copyBufferToBuffer(buffer27, 95348, buffer21, 107400, 8452);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: img13,
+  origin: { x: 6, y: 12 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 78, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline41 = await device2.createComputePipelineAsync({
+  label: '\u0277\u0b46\u0a4d\u{1fb3e}',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise25;
+} catch {}
+document.body.prepend(canvas2);
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let renderBundle60 = renderBundleEncoder23.finish({label: '\u{1fa4c}\u6aa3\u8a8e\u{1fbe3}\uf234\ucbc9\u{1f927}\u08b2'});
+let externalTexture52 = device0.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer13, 'uint32', 43616, 7831);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2, buffer6, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 13028, new BigUint64Array(3568), 2125, 80);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 240, depthOrArrayLayers: 10}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 40, y: 89, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 58, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(96, 228);
+let texture74 = device2.createTexture({
+  label: '\u0652\u0261\u2db5\ufd49',
+  size: [816],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView128 = texture42.createView({label: '\u{1f986}\u9828\ubfa7', baseMipLevel: 2});
+let sampler54 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.65,
+  lodMaxClamp: 71.20,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder37.setBindGroup(9, bindGroup22, new Uint32Array(2720), 42, 0);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6980 */
+  offset: 6980,
+  buffer: buffer27,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+let img18 = await imageWithData(12, 36, '#cf0daf67', '#2d8582dd');
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\u029f\u05ec\u63f1',
+  entries: [
+    {
+      binding: 3877,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 459,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 171204875, hasDynamicOffset: true },
+    },
+    {binding: 607, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder109 = device0.createCommandEncoder();
+let renderBundle61 = renderBundleEncoder26.finish({});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(2, 4, 5);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(7, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 13, y: 29, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 5_324 */
+{offset: 724, bytesPerRow: 372}, {width: 17, height: 13, depthOrArrayLayers: 1});
+} catch {}
+let pipeline42 = await device0.createRenderPipelineAsync({
+  label: '\u027a\u{1fa82}\uc12f\u{1fc70}\uc9e5',
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'keep'},
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilWriteMask: 837946605,
+    depthBias: 767223761,
+    depthBiasSlopeScale: -47.92963917607784,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10516,
+        attributes: [
+          {format: 'unorm8x4', offset: 924, shaderLocation: 19},
+          {format: 'uint32x4', offset: 596, shaderLocation: 6},
+          {format: 'sint32x2', offset: 3608, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 7860, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 16652, shaderLocation: 8},
+          {format: 'float32x4', offset: 8384, shaderLocation: 9},
+          {format: 'sint32x4', offset: 880, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 3748, shaderLocation: 15},
+          {format: 'float32x2', offset: 920, shaderLocation: 18},
+          {format: 'sint8x2', offset: 218, shaderLocation: 17},
+          {format: 'float32x4', offset: 12408, shaderLocation: 11},
+          {format: 'sint32', offset: 1364, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 3260,
+        attributes: [
+          {format: 'uint16x2', offset: 416, shaderLocation: 3},
+          {format: 'float16x4', offset: 208, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 680, shaderLocation: 16},
+          {format: 'float32x2', offset: 468, shaderLocation: 0},
+          {format: 'float16x4', offset: 204, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 558, shaderLocation: 14},
+          {format: 'uint32x3', offset: 140, shaderLocation: 7},
+          {format: 'uint16x2', offset: 88, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let imageBitmap13 = await createImageBitmap(videoFrame4);
+let textureView129 = texture12.createView({
+  label: '\u02a2\u2a82\u{1fd35}\u7d14\u7d09\u94d6\u{1fe5b}',
+  dimension: '2d-array',
+  format: 'rgb10a2unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let sampler55 = device0.createSampler({
+  label: '\u05df\u0afa\u1143\u1289',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.741,
+  lodMaxClamp: 65.24,
+  compare: 'less',
+  maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder37.setVertexBuffer(1, buffer6, 0);
+} catch {}
+let promise26 = buffer12.mapAsync(GPUMapMode.WRITE, 0, 3488);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: img4,
+  origin: { x: 115, y: 46 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 37},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder38 = commandEncoder105.beginComputePass();
+let sampler56 = device1.createSampler({
+  label: '\u0006\u{1fd17}\u68a9\uef3c\u{1fb06}\u{1f9d6}\u{1ff17}\u982c\u0845\u9cf6',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.94,
+  lodMaxClamp: 98.36,
+  maxAnisotropy: 12,
+});
+let externalTexture53 = device1.importExternalTexture({label: '\u086c\u{1f650}', source: videoFrame11, colorSpace: 'srgb'});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer23, 'uint16');
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline39);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(8, buffer23, 57296, 30983);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer16, 17712, buffer20, 77588, 21108);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12420 */
+  offset: 12420,
+  buffer: buffer19,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 7308, new BigUint64Array(63347), 62200);
+} catch {}
+let commandEncoder110 = device1.createCommandEncoder({label: '\u64ae\u7bef\u231c\u{1f94d}\u{1fc98}\u5fb3\ue801\u00e3\u0fdb\udad6\u32fc'});
+let querySet52 = device1.createQuerySet({
+  label: '\u603c\uf775\u3b93\u4a8d\u0ef6\u{1f9f6}\u0b75\uf9c2\u{1f84f}\u0c34',
+  type: 'occlusion',
+  count: 1031,
+});
+let computePassEncoder39 = commandEncoder110.beginComputePass({label: '\u1df5\u01da\u6698\u0726\uf5e3\u551e\u{1f86b}\u0350'});
+let externalTexture54 = device1.importExternalTexture({label: '\u002a\u040d\u02d4\u00d5', source: video6, colorSpace: 'display-p3'});
+try {
+computePassEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(1224);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle39, renderBundle25, renderBundle39, renderBundle26, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(51.56, 0.3215, 12.37, 0.6647, 0.1555, 0.6490);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(8, buffer17, 111200, 53939);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 20248 */
+  offset: 20248,
+  buffer: buffer20,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 36564, new Float32Array(42425), 28903);
+} catch {}
+let commandEncoder111 = device2.createCommandEncoder({label: '\u7670\u{1fce5}'});
+let querySet53 = device2.createQuerySet({
+  label: '\u0cbe\u3fc1\u586d\u05dc\u4aa9\u{1f74c}\ua388\u{1f6f4}\u{1f633}',
+  type: 'occlusion',
+  count: 2669,
+});
+try {
+device2.queue.submit([commandBuffer13]);
+} catch {}
+let pipeline43 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'increment-clamp'},
+    depthBiasClamp: 290.177346071434,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 6496, attributes: [{format: 'uint8x2', offset: 364, shaderLocation: 1}]}],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+document.body.prepend(video4);
+let texture75 = device2.createTexture({
+  label: '\u8bda\u06af\u4811\ua169\u{1ff2f}\u9f01\u0fb7\u{1fcdc}\u0435\u{1fdd4}\u339f',
+  size: [816],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture76 = gpuCanvasContext3.getCurrentTexture();
+let textureView130 = texture58.createView({
+  label: '\u049c\uf823\u{1f7c5}\u269d\u{1fceb}\u0c15\u0c73\u76dc\u{1ff92}',
+  baseMipLevel: 7,
+  mipLevelCount: 2,
+  baseArrayLayer: 1619,
+  arrayLayerCount: 62,
+});
+let sampler57 = device2.createSampler({
+  label: '\uca80\ua00d\udd6d\u0c34\u{1f91e}\u22dc\u0005\ue57d\ub50c\u0d04',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.16,
+  lodMaxClamp: 87.96,
+  maxAnisotropy: 13,
+});
+try {
+commandEncoder107.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let pipeline44 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9104,
+        attributes: [
+          {format: 'sint32x3', offset: 204, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 4272, shaderLocation: 18},
+          {format: 'uint32', offset: 1572, shaderLocation: 24},
+          {format: 'uint32x3', offset: 3964, shaderLocation: 5},
+          {format: 'uint32x3', offset: 3316, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 1092, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 6920,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 28, shaderLocation: 22},
+          {format: 'uint8x4', offset: 2008, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 316, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 302, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 1200, shaderLocation: 26},
+          {format: 'uint32x4', offset: 156, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 258, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 2852,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 848, shaderLocation: 7},
+          {format: 'sint8x4', offset: 560, shaderLocation: 12},
+          {format: 'uint32', offset: 244, shaderLocation: 8},
+          {format: 'float32x2', offset: 336, shaderLocation: 20},
+          {format: 'float32', offset: 156, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 864, shaderLocation: 3},
+          {format: 'sint32x2', offset: 240, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 300, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 3144,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 68, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 756, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 328, shaderLocation: 17},
+          {format: 'sint16x4', offset: 188, shaderLocation: 27},
+          {format: 'unorm10-10-10-2', offset: 944, shaderLocation: 14},
+          {format: 'sint32x3', offset: 1264, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 720, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 12012,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 1016, shaderLocation: 25}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+let pipelineLayout20 = device1.createPipelineLayout({
+  label: '\u3686\ue9af\u2756\ua391\u0234\u{1fc57}\u0856\u0df8\u0905\u{1fd7e}\u2e87',
+  bindGroupLayouts: [bindGroupLayout16, bindGroupLayout14],
+});
+let commandEncoder112 = device1.createCommandEncoder({label: '\u{1f673}\ub164\u204f'});
+let querySet54 = device1.createQuerySet({label: '\u0f6c\u{1fc5f}', type: 'occlusion', count: 2484});
+let textureView131 = texture72.createView({label: '\u133f\u7bb5'});
+let renderPassEncoder10 = commandEncoder92.beginRenderPass({
+  label: '\u{1f96b}\ua6ff\u21c5\u0065',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -603.4, g: -865.2, b: 756.9, a: -33.71, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet23,
+  maxDrawCount: 767503580,
+});
+let renderBundle62 = renderBundleEncoder27.finish({label: '\u{1f8b9}\u0109\u5ab9\u0bc8\u40f8\u2eff'});
+let externalTexture55 = device1.importExternalTexture({label: '\u017f\ue661\u0515\ub7e6\ud8e6\u{1f830}', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup13, new Uint32Array(9390), 2627, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(8, bindGroup13);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup24, new Uint32Array(7481), 3228, 0);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(2, bindGroup19, new Uint32Array(8218), 1959, 0);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder41.popDebugGroup();
+} catch {}
+document.body.prepend(img11);
+let canvas6 = document.createElement('canvas');
+let commandEncoder113 = device1.createCommandEncoder({label: '\u{1f692}\u74a9\u0c51\u{1fd62}\u0ddf'});
+try {
+renderPassEncoder6.setIndexBuffer(buffer23, 'uint32', 32016, 20184);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer17);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer23, 'uint32', 93160, 5246);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(canvas5);
+let textureView132 = texture40.createView({label: '\ueac2\ua228\u{1fc0e}', mipLevelCount: 2});
+let renderBundle63 = renderBundleEncoder46.finish({});
+try {
+renderBundleEncoder32.setVertexBuffer(825, undefined, 0, 3531367468);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer27, 129404, buffer21, 103672, 15168);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let pipeline45 = device2.createRenderPipeline({
+  label: '\u0c41\u6253\u09ee\u185b\u052e\u1b76\u{1f969}',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0xdee2401e},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1592, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 18136,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x4', offset: 384, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise23;
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({entries: []});
+let textureView133 = texture59.createView({
+  label: '\u{1f808}\ub6ee\u4398\u0b83\u05bb',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 6,
+  baseArrayLayer: 37,
+  arrayLayerCount: 6,
+});
+let computePassEncoder40 = commandEncoder80.beginComputePass({label: '\uc6ee\u00d3\ub87b\u0f72\ud7d9\ufb44\u0830\u8675\u4352'});
+try {
+computePassEncoder5.setBindGroup(6, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint16', 27734, 6159);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer6, 0, 4389);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4592 */
+  offset: 4584,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 959 */
+{offset: 959}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: canvas2,
+  origin: { x: 12, y: 86 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 4,
+  origin: {x: 32, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas6.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder({label: '\u41d7\uf502\u0f2d\u86df\u05d3\u{1fe29}\u0af2\u0354\u4b42'});
+let textureView134 = texture55.createView({label: '\ue40d\u{1ff0f}', dimension: '2d-array', format: 'bgra8unorm-srgb', baseArrayLayer: 0});
+let computePassEncoder41 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder5.dispatchWorkgroups(3);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 23272 */
+  offset: 23272,
+  bytesPerRow: 0,
+  rowsPerImage: 155,
+  buffer: buffer24,
+}, {
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 15});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline46 = device0.createRenderPipeline({
+  label: '\ub056\u01ae\u8ef7\u{1ff73}\u{1fc46}\u0a66\u0cc0',
+  layout: pipelineLayout4,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 116, shaderLocation: 2},
+          {format: 'sint32x2', offset: 28, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 1},
+          {format: 'uint32x3', offset: 80, shaderLocation: 5},
+          {format: 'sint32', offset: 44, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 142, shaderLocation: 18},
+          {format: 'uint8x2', offset: 26, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 6740,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x2', offset: 874, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 616, shaderLocation: 15},
+          {format: 'float16x4', offset: 156, shaderLocation: 8},
+          {format: 'float32x4', offset: 580, shaderLocation: 9},
+          {format: 'uint16x4', offset: 792, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 1796, shaderLocation: 0},
+          {format: 'uint8x2', offset: 3278, shaderLocation: 3},
+          {format: 'float32', offset: 208, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 388, attributes: [{format: 'float32x2', offset: 52, shaderLocation: 4}]},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32x2', offset: 6244, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 1960, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 1924, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 240,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm16x2', offset: 28, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+canvas3.height = 77;
+let commandEncoder115 = device1.createCommandEncoder({label: '\u0256\u{1f9d6}\uad7e\ub978'});
+let textureView135 = texture29.createView({label: '\ud198\u{1f8dd}\u6247\u871e\uc8e4\u{1fd7f}\u{1fc33}\u0b28\ud0e2\u8b88', mipLevelCount: 1});
+let renderPassEncoder11 = commandEncoder84.beginRenderPass({
+  label: '\u2960\u650b\u73b8\u{1fd6e}\u0a31\u2553\u02ae\u0949\u4403',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -383.3, g: -324.2, b: -135.9, a: -209.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 700103705,
+});
+try {
+computePassEncoder25.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(6, bindGroup26, new Uint32Array(8033), 6435, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle53, renderBundle55, renderBundle39, renderBundle55, renderBundle56, renderBundle32, renderBundle19, renderBundle56, renderBundle26, renderBundle35]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(2389);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(8, buffer23, 0, 26815);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer19, 86212, buffer20, 3136, 2456);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 26004, new Int16Array(53657), 27379);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({label: '\u0e12\u{1f8da}\u0271\u0aff\ua223\u{1f9f7}\u9424\u0b6f\u{1f630}'});
+let querySet55 = device0.createQuerySet({label: '\u{1f9d8}\u{1f6e8}\u0383', type: 'occlusion', count: 3642});
+let texture77 = device0.createTexture({
+  label: '\u01bc\u85a4\ub4c2',
+  size: [1290, 1, 128],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView136 = texture21.createView({
+  label: '\u8a45\u{1fd0d}\u4d44\u01f5\u239c\u066d\u{1f750}\u0aee',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 70,
+});
+let computePassEncoder42 = commandEncoder52.beginComputePass({label: '\u{1fefd}\u0939\uef59\uef14\u1d52\u1a72\uefd5'});
+try {
+computePassEncoder16.dispatchWorkgroups(2, 3);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 3424 widthInBlocks: 428 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 36832 */
+  offset: 33408,
+  buffer: buffer25,
+}, {
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 428, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1_509 */
+{offset: 417}, {width: 273, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+  label: '\u{1fd27}\u62e8\u9d26\u8071\uc2a8\u{1f75f}',
+  layout: pipelineLayout1,
+  multisample: {mask: 0x28d86d3b},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11936,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 1830, shaderLocation: 14},
+          {format: 'sint16x2', offset: 44, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 852,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 56, shaderLocation: 11},
+          {format: 'uint8x2', offset: 110, shaderLocation: 5},
+          {format: 'uint32x2', offset: 104, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 48, shaderLocation: 16},
+          {format: 'float16x2', offset: 248, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 70, shaderLocation: 1},
+          {format: 'sint16x4', offset: 84, shaderLocation: 10},
+          {format: 'float16x4', offset: 104, shaderLocation: 13},
+          {format: 'uint16x4', offset: 0, shaderLocation: 3},
+          {format: 'sint16x4', offset: 392, shaderLocation: 17},
+          {format: 'float16x2', offset: 168, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 98, shaderLocation: 9},
+          {format: 'uint16x4', offset: 68, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 80, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 10324,
+        attributes: [
+          {format: 'float32x4', offset: 120, shaderLocation: 18},
+          {format: 'sint32', offset: 136, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 516,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 88, shaderLocation: 8}],
+      },
+      {arrayStride: 14284, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x2', offset: 12704, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+gc();
+let video8 = await videoWithData();
+let computePassEncoder43 = commandEncoder88.beginComputePass();
+let sampler58 = device1.createSampler({
+  label: '\uf672\ud268\ubbc0\u0714\u{1fad4}\ue10b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 17.79,
+  compare: 'greater',
+});
+try {
+computePassEncoder38.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -114.4, g: -538.0, b: -884.0, a: -102.8, });
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(38, 0, 17, 1);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1333);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer23, 'uint16', 87944, 3039);
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer19, 12288, buffer20, 33576, 13908);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 26, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder82.insertDebugMarker('\u8a92');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 9208, new Float32Array(43117), 17759);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline48 = await device1.createComputePipelineAsync({
+  label: '\u5d5b\u22f9\u0eb9',
+  layout: 'auto',
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer29 = commandEncoder27.finish({label: '\u7719\u{1fec8}\u6c6a\ufa58'});
+let textureView137 = texture63.createView({label: '\u32ab\ue560\u0f4d'});
+try {
+computePassEncoder29.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(buffer12, 13916, buffer3, 108388, 19748);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let bindGroup35 = device1.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 1552, resource: sampler25}]});
+let textureView138 = texture29.createView({label: '\u{1ffbc}\u03e7\u0ddd\u9b00\ue609\u{1f921}', baseArrayLayer: 0});
+let renderBundle64 = renderBundleEncoder18.finish({label: '\u0d02\u9b15\udbff\u0e15\ufa67'});
+let externalTexture56 = device1.importExternalTexture({source: video2});
+try {
+renderPassEncoder4.beginOcclusionQuery(1986);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -593.9, g: 771.1, b: -895.8, a: 343.0, });
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer17, 153536, 81018);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup35);
+} catch {}
+let pipeline49 = await device1.createRenderPipelineAsync({
+  label: '\ua03b\u4168\u47ca\ub327\u0431\u0977\u99e5\u328c',
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule3, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16sint'}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'zero'},
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 4584, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 2948, shaderLocation: 6},
+          {format: 'float16x2', offset: 2636, shaderLocation: 16},
+          {format: 'uint32x2', offset: 34896, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 8256, shaderLocation: 11},
+          {format: 'sint16x4', offset: 3836, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 5724, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 6000,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 732, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 12},
+          {format: 'float16x2', offset: 1952, shaderLocation: 13},
+          {format: 'sint16x2', offset: 1384, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 80, shaderLocation: 8},
+          {format: 'sint8x4', offset: 584, shaderLocation: 15},
+          {format: 'uint32x3', offset: 1584, shaderLocation: 9},
+          {format: 'float32x4', offset: 892, shaderLocation: 4},
+          {format: 'sint32x3', offset: 2080, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 448, attributes: [{format: 'float16x2', offset: 4, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let img19 = await imageWithData(151, 12, '#371be2fb', '#04f7711a');
+let shaderModule13 = device2.createShaderModule({
+  label: '\u{1f7b1}\u{1f8b3}\u0d83\u08fa\u{1fc45}\u{1f732}\u4935\u4ac5\u8cf9',
+  code: `@group(0) @binding(6715)
+var<storage, read_write> global6: array<u32>;
+
+@compute @workgroup_size(1, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec2<i32>,
+  @location(2) f2: vec3<i32>,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(63) a0: f16, @location(20) a1: vec3<f16>, @location(59) a2: vec2<f16>, @builtin(front_facing) a3: bool, @location(80) a4: vec4<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(90) f236: vec4<f16>,
+  @location(114) f237: vec4<i32>,
+  @location(37) f238: vec2<u32>,
+  @location(44) f239: vec2<i32>,
+  @location(108) f240: f16,
+  @location(20) f241: vec3<f16>,
+  @location(63) f242: f16,
+  @location(23) f243: vec2<i32>,
+  @location(9) f244: vec3<f16>,
+  @location(36) f245: vec2<f32>,
+  @location(14) f246: vec2<f32>,
+  @location(21) f247: vec2<u32>,
+  @location(27) f248: vec4<f16>,
+  @location(38) f249: vec2<f32>,
+  @location(59) f250: vec2<f16>,
+  @location(100) f251: vec3<u32>,
+  @builtin(position) f252: vec4<f32>,
+  @location(104) f253: vec2<f32>,
+  @location(68) f254: vec2<f16>,
+  @location(80) f255: vec4<u32>,
+  @location(11) f256: vec3<i32>,
+  @location(5) f257: vec2<i32>,
+  @location(64) f258: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec4<i32>, @builtin(instance_index) a1: u32, @location(11) a2: i32, @location(25) a3: vec2<f16>, @location(0) a4: vec2<u32>, @builtin(vertex_index) a5: u32, @location(5) a6: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup36 = device2.createBindGroup({
+  label: '\u4fd1\uace6\u61a3',
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 8121, resource: sampler47},
+    {binding: 6182, resource: externalTexture36},
+    {binding: 6334, resource: externalTexture39},
+  ],
+});
+let commandEncoder117 = device2.createCommandEncoder({label: '\u3926\uc4a0\u01fa'});
+let textureView139 = texture68.createView({label: '\u0f79\u{1fa29}', dimension: '2d-array', mipLevelCount: 2});
+let renderBundle65 = renderBundleEncoder36.finish();
+let pipeline50 = device2.createRenderPipeline({
+  label: '\uabdc\u30b6\u02ba\uf538\ued71\u5e21\u{1ff76}\ue12a',
+  layout: pipelineLayout13,
+  multisample: {mask: 0x9e335916},
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  targets: [undefined, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 1958178592,
+    stencilWriteMask: 502175714,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3904,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 28, shaderLocation: 25},
+          {format: 'sint16x4', offset: 640, shaderLocation: 18},
+          {format: 'sint16x2', offset: 256, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 11796,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 6384, shaderLocation: 5}],
+      },
+      {arrayStride: 10096, stepMode: 'instance', attributes: []},
+      {arrayStride: 1636, attributes: [{format: 'uint16x2', offset: 556, shaderLocation: 0}]},
+    ],
+  },
+});
+try {
+  await promise21;
+} catch {}
+let texture78 = gpuCanvasContext3.getCurrentTexture();
+let renderBundle66 = renderBundleEncoder25.finish({label: '\u4939\uf9e2\u84b8\ue5ee'});
+let sampler59 = device2.createSampler({
+  label: '\u{1f9fa}\ud7a1\u9c05\u658e\u0b35\u026a\u31b0\u{1f8a5}',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.65,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder26.setBindGroup(8, bindGroup20);
+} catch {}
+let arrayBuffer13 = buffer21.getMappedRange(0, 85500);
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 51, y: 0, z: 326},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer1), /* required buffer size: 30_247_164 */
+{offset: 36, bytesPerRow: 1033, rowsPerImage: 244}, {width: 111, height: 1, depthOrArrayLayers: 121});
+} catch {}
+let pipeline51 = await device2.createRenderPipelineAsync({
+  label: '\u0377\u08ea\u0907\u002b\u{1f92c}\u0a0b\u5531\ubd6e\u2246',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 15376,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 3112, shaderLocation: 22},
+          {format: 'sint16x4', offset: 56, shaderLocation: 3},
+          {format: 'uint32', offset: 2644, shaderLocation: 24},
+          {format: 'uint16x2', offset: 9016, shaderLocation: 4},
+          {format: 'float32', offset: 2720, shaderLocation: 25},
+          {format: 'float16x2', offset: 2152, shaderLocation: 14},
+          {format: 'float16x2', offset: 1020, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 2116, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 1278, shaderLocation: 11},
+          {format: 'float32x2', offset: 1424, shaderLocation: 6},
+          {format: 'float32x3', offset: 932, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 2920,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 328, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 48, shaderLocation: 21},
+          {format: 'float32x2', offset: 68, shaderLocation: 9},
+          {format: 'uint32', offset: 172, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 568, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 1696, shaderLocation: 27},
+        ],
+      },
+      {
+        arrayStride: 9840,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 400, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 648, shaderLocation: 26},
+          {format: 'snorm8x2', offset: 294, shaderLocation: 20},
+          {format: 'float16x4', offset: 180, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 5174, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 12972,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 92, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint8x4', offset: 16172, shaderLocation: 23},
+          {format: 'unorm10-10-10-2', offset: 32404, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 2264, shaderLocation: 7},
+          {format: 'uint32x4', offset: 24492, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup37 = device0.createBindGroup({
+  label: '\ubca1\ub7fa\u1542\u8759\u08b8\u01ed\u{1fb3e}\u0d55\u052a\u9471\u{1fc45}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 1191, resource: sampler8}, {binding: 3682, resource: sampler22}],
+});
+let querySet56 = device0.createQuerySet({label: '\u0e42\u011b\uf413\ua8bc\u059b\u{1f951}\u0ed5\u{1ff23}', type: 'occlusion', count: 1928});
+let commandBuffer30 = commandEncoder90.finish();
+let textureView140 = texture10.createView({
+  label: '\u0a93\u3189\u11a8\ued92\u{1f6fd}\u{1fdbc}\u{1f922}',
+  baseMipLevel: 1,
+  baseArrayLayer: 52,
+  arrayLayerCount: 8,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(5, buffer6, 0, 29244);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer11, 130936, 9116);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 54},
+  aspect: 'all',
+}, new ArrayBuffer(4_395_073), /* required buffer size: 4_395_073 */
+{offset: 715, bytesPerRow: 89, rowsPerImage: 234}, {width: 9, height: 1, depthOrArrayLayers: 212});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(163, 30);
+let imageData6 = new ImageData(180, 216);
+let commandBuffer31 = commandEncoder99.finish({});
+let textureView141 = texture31.createView({label: '\ue7ae\u86a6\u{1f9de}\u{1f748}\u0dde\u4d5a\u2b6f', dimension: '2d', baseArrayLayer: 921});
+let computePassEncoder44 = commandEncoder115.beginComputePass({label: '\u331e\u0ff6\u{1fd43}\u0b4d\u847e\uf18b\u6a92\u{1fe73}'});
+let renderPassEncoder12 = commandEncoder112.beginRenderPass({
+  label: '\ua8a9\u076a\u0c90\u{1f76e}\u0b94\u8eb3\ud6db\u8b55',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 12.85, g: 854.0, b: -451.5, a: 336.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet49,
+  maxDrawCount: 111619017,
+});
+let renderBundle67 = renderBundleEncoder30.finish({});
+try {
+renderPassEncoder2.setBindGroup(8, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(6, bindGroup26, new Uint32Array(2314), 1810, 0);
+} catch {}
+try {
+commandEncoder113.copyBufferToBuffer(buffer19, 42904, buffer20, 68540, 16280);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder82.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let querySet57 = device0.createQuerySet({
+  label: '\u0221\u3b87\u6e36\u6ac1\u6aec\u{1f86a}\ufa51\u724c\ue669\u{1fc45}',
+  type: 'occlusion',
+  count: 3913,
+});
+let texture79 = device0.createTexture({
+  label: '\u{1f800}\u7067\u{1fce0}\u9b37\ub484\u3a39',
+  size: [1440, 12, 61],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView142 = texture3.createView({label: '\u27eb\u048a\u073e\u467c\u0497\u044a\u{1fecf}\udc1a\u7521\u6319', dimension: '1d'});
+let externalTexture57 = device0.importExternalTexture({label: '\u8a73\u01f6\u{1ff03}\u{1faff}\u{1fd2e}\u{1f889}\u6e3d', source: video5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder40.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 14, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline52 = await promise16;
+let textureView143 = texture58.createView({
+  label: '\u0475\u4b33\u271d',
+  baseMipLevel: 1,
+  mipLevelCount: 7,
+  baseArrayLayer: 1830,
+  arrayLayerCount: 2,
+});
+let renderBundleEncoder48 = device2.createRenderBundleEncoder({label: '\u4b68\ue25e', colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'], stencilReadOnly: true});
+let renderBundle68 = renderBundleEncoder25.finish();
+try {
+renderBundleEncoder48.setVertexBuffer(9384, undefined, 0, 2086419532);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 36192 */
+  offset: 36192,
+  bytesPerRow: 256,
+  buffer: buffer27,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer27);
+} catch {}
+let video9 = await videoWithData();
+try {
+offscreenCanvas8.getContext('webgl');
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  label: '\u{1f610}\ua889\u02ec\u070a\u6935\u00ed\u23d2\u8182\u15d7\u{1fe07}',
+  layout: bindGroupLayout7,
+  entries: [{binding: 3198, resource: sampler15}],
+});
+let commandEncoder118 = device0.createCommandEncoder({label: '\u09d3\u033d\u0d11\u4e75'});
+let textureView144 = texture23.createView({label: '\u0450\u0a0b\u0489\u0ac4\uf728', baseMipLevel: 1});
+let computePassEncoder45 = commandEncoder38.beginComputePass();
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(buffer12, 33648, buffer11, 133380, 6512);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let texture80 = device1.createTexture({
+  label: '\u{1f6aa}\u08c2\u{1fdaa}\ua2c9\uaa32\u95d7',
+  size: {width: 68, height: 1, depthOrArrayLayers: 176},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint'],
+});
+let textureView145 = texture52.createView({label: '\u{1fff1}\u081e\u{1f815}', dimension: '2d', mipLevelCount: 2, baseArrayLayer: 193});
+let renderBundle69 = renderBundleEncoder41.finish({label: '\ufde0\ub5a1\u0969\u6233\u0c31\u22a4'});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(973);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1779, undefined, 0, 375296359);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 2, y: 31, z: 327},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({label: '\uc370\u03d5'});
+let textureView146 = texture50.createView({label: '\u6529\u96bd\u8bf9\ubc40\ue3ee', baseArrayLayer: 164, arrayLayerCount: 15});
+try {
+renderBundleEncoder11.setBindGroup(5, bindGroup8);
+} catch {}
+try {
+buffer7.destroy();
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 3, y: 30, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 168 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10624 */
+  offset: 10624,
+  buffer: buffer6,
+}, {width: 21, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 34, y: 26 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 91},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img20 = await imageWithData(131, 4, '#76b247d5', '#5089c3f9');
+let shaderModule14 = device1.createShaderModule({
+  code: `@group(3) @binding(1552)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(3101)
+var<storage, read_write> local5: array<u32>;
+@group(4) @binding(2591)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(2591)
+var<storage, read_write> global7: array<u32>;
+@group(6) @binding(1552)
+var<storage, read_write> parameter9: array<u32>;
+@group(0) @binding(3076)
+var<storage, read_write> local6: array<u32>;
+@group(5) @binding(3101)
+var<storage, read_write> local7: array<u32>;
+@group(2) @binding(3076)
+var<storage, read_write> n5: array<u32>;
+@group(4) @binding(2548)
+var<storage, read_write> local8: array<u32>;
+@group(1) @binding(2548)
+var<storage, read_write> function9: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(14) f0: u32,
+  @location(12) f1: vec2<f16>,
+  @location(3) f2: vec2<u32>,
+  @location(4) f3: f32,
+  @location(13) f4: i32
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<f16>, @location(2) a1: vec2<u32>, a2: S17, @location(7) a3: vec2<f32>, @location(8) a4: i32, @location(17) a5: f32, @builtin(vertex_index) a6: u32, @builtin(instance_index) a7: u32, @location(15) a8: vec3<u32>, @location(6) a9: vec3<f32>, @location(5) a10: vec2<f32>, @location(11) a11: vec2<f16>, @location(1) a12: vec2<i32>, @location(10) a13: vec4<f32>, @location(0) a14: vec3<i32>, @location(16) a15: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder120 = device1.createCommandEncoder();
+let textureView147 = texture27.createView({label: '\u7c7e\u715a\u694c', dimension: '2d-array', mipLevelCount: 2});
+try {
+computePassEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -902.0, g: -944.9, b: 585.8, a: -696.2, });
+} catch {}
+try {
+renderPassEncoder11.setViewport(41.81, 0.8171, 10.11, 0.1071, 0.08476, 0.4444);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline39);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer23, 'uint32', 96232, 3188);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(4, buffer17, 0, 135888);
+} catch {}
+let arrayBuffer14 = buffer18.getMappedRange(42168, 124);
+try {
+commandEncoder97.copyBufferToBuffer(buffer16, 33152, buffer20, 25076, 26232);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 217},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video1.height = 34;
+let texture81 = device0.createTexture({
+  label: '\ua4fe\u024a\ub7cf\u7ad8\uec5e',
+  size: [192, 240, 10],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView148 = texture77.createView({
+  label: '\ueebd\ua8c6\u94db\u83ad\u{1fdd9}\u1960\ua98b\u2ca5',
+  dimension: '3d',
+  aspect: 'all',
+  baseMipLevel: 1,
+});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u{1fcc8}\ub1fb\u057b\u7201\u6f71\u{1f8b5}\ua325\u7e4c\u3614\u2ebe\ue0d4',
+  colorFormats: ['rgba16float', 'r32float'],
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup14, new Uint32Array(6059), 3300, 0);
+} catch {}
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(4, buffer22, 91240, 26381);
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas5.width = 130;
+let bindGroup39 = device2.createBindGroup({
+  label: '\u4fa3\u{1f6b2}\u03af\udf46\u03e6\u{1fe7f}\ub97c\u4db7\u4e57',
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 6182, resource: externalTexture35},
+    {binding: 8121, resource: sampler28},
+    {binding: 6334, resource: externalTexture30},
+  ],
+});
+let commandBuffer32 = commandEncoder91.finish({label: '\u0e65\u0f22\u98c8\u{1f66c}\ud724\u0dbf\u822d\u8a00\ue438'});
+let renderBundleEncoder50 = device2.createRenderBundleEncoder({label: '\udc59\u0272', colorFormats: [undefined, 'rgba8uint', 'r8sint', 'rg8sint', 'rgba32float']});
+try {
+commandEncoder117.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter1.label = '\uf3e9\ua173\ude4f\u3f4c\u{1fe4b}\ufceb\ub0a1\u0f85';
+} catch {}
+let commandEncoder121 = device1.createCommandEncoder({});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.submit([commandBuffer22]);
+} catch {}
+let shaderModule15 = device2.createShaderModule({
+  label: '\u0927\u9e21\u0237\u8043',
+  code: `@group(1) @binding(6715)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(6715)
+var<storage, read_write> parameter11: array<u32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec2<u32>,
+  @location(1) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(6) f0: vec2<f16>,
+  @location(16) f1: vec4<f16>,
+  @location(12) f2: f32,
+  @location(17) f3: vec3<f32>,
+  @location(27) f4: i32,
+  @location(5) f5: vec2<f16>,
+  @location(15) f6: u32,
+  @location(26) f7: vec2<i32>,
+  @location(19) f8: vec2<u32>,
+  @location(24) f9: vec2<i32>,
+  @location(9) f10: i32,
+  @location(23) f11: vec4<f32>,
+  @location(4) f12: vec4<u32>,
+  @location(21) f13: vec2<u32>,
+  @location(2) f14: vec3<f32>,
+  @location(20) f15: vec3<f16>,
+  @location(3) f16: vec4<u32>,
+  @builtin(vertex_index) f17: u32,
+  @location(7) f18: i32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, a1: S18, @location(10) a2: vec4<f32>, @location(8) a3: f16, @location(11) a4: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder122 = device2.createCommandEncoder({label: '\u066b\u844a\u77db\u0552\uca7a\u{1f649}'});
+let texture82 = device2.createTexture({
+  label: '\u0cc1\u7fd2\u509e',
+  size: [1632, 192, 852],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let externalTexture58 = device2.importExternalTexture({label: '\ub8e3\u0cfb\u9291\u04b3\u723a', source: video0, colorSpace: 'srgb'});
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4456 */
+  offset: 4444,
+  buffer: buffer27,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer6), /* required buffer size: 201 */
+{offset: 201}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView149 = texture75.createView({label: '\u{1fb65}\ub555\ua70b\u0002\u26c9\u03d6\ua08d\u7285', aspect: 'all'});
+try {
+renderBundleEncoder32.setVertexBuffer(3506, undefined, 4215826974, 23102371);
+} catch {}
+try {
+commandEncoder111.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture83 = device0.createTexture({
+  label: '\ude05\u3732',
+  size: {width: 720, height: 6, depthOrArrayLayers: 61},
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView150 = texture2.createView({label: '\u00d1\u{1ffc1}\u069a\u31be\u{1fafc}'});
+let computePassEncoder46 = commandEncoder20.beginComputePass();
+let renderBundle70 = renderBundleEncoder8.finish({label: '\ue854\u013e\u8044\u{1fb62}\u9aae\u9e25\u27a3\u21da'});
+try {
+computePassEncoder35.setBindGroup(8, bindGroup29);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(1, bindGroup37, new Uint32Array(9184), 4093, 0);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer24, 93260, buffer15, 32872, 6456);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer6, 4076, 48380);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 13244, new DataView(new ArrayBuffer(13838)), 8908, 1636);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 24, depthOrArrayLayers: 61}
+*/
+{
+  source: imageData1,
+  origin: { x: 7, y: 35 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 340, y: 3, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 34, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipeline53 = await promise11;
+let buffer28 = device2.createBuffer({label: '\u0e45\u0b11', size: 139120, usage: GPUBufferUsage.VERTEX});
+let commandEncoder123 = device2.createCommandEncoder({label: '\u{1fc30}\ucad8\u{1f7b5}\u0ab4\u{1f752}\uafbd\u8383\u024c\u0547\u{1ff84}'});
+let textureView151 = texture76.createView({});
+let computePassEncoder47 = commandEncoder93.beginComputePass();
+let renderBundle71 = renderBundleEncoder36.finish();
+try {
+renderBundleEncoder48.setBindGroup(8, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(6, bindGroup39, new Uint32Array(6341), 2684, 0);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({});
+let bindGroup40 = device0.createBindGroup({label: '\u1fd1\u9090\u0bfa\ubf29\u0820\u{1fe41}', layout: bindGroupLayout1, entries: []});
+let commandEncoder124 = device0.createCommandEncoder();
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u05e4\u{1fa06}\u01b7\uf06f\uf81f\u0af7\ue641\u5d5a\ufbf9\uc810',
+  colorFormats: ['rgba8unorm'],
+  depthReadOnly: true,
+});
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4372 */
+  offset: 4336,
+  buffer: buffer26,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img10,
+  origin: { x: 36, y: 41 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  label: '\u82f9\u{1fc49}\u9d42\u0240\u{1f7ce}\u3d9e\ue6e0',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7980,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x3', offset: 1324, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 888, shaderLocation: 19},
+          {format: 'float32x2', offset: 2632, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 100, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 1552, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 1768, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 516, shaderLocation: 4},
+          {format: 'uint32x3', offset: 720, shaderLocation: 5},
+          {format: 'sint16x2', offset: 4844, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 2616, shaderLocation: 9},
+          {format: 'sint32x2', offset: 592, shaderLocation: 2},
+          {format: 'float16x2', offset: 400, shaderLocation: 0},
+          {format: 'uint32x4', offset: 708, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 1952, shaderLocation: 16},
+          {format: 'sint8x4', offset: 2404, shaderLocation: 17},
+          {format: 'uint32x4', offset: 656, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 1244, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 16016, attributes: [{format: 'sint8x2', offset: 4046, shaderLocation: 10}]},
+      {
+        arrayStride: 1096,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 0, shaderLocation: 3}],
+      },
+      {arrayStride: 10208, attributes: [{format: 'float32', offset: 10204, shaderLocation: 18}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+gc();
+let textureView152 = texture32.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 484});
+let computePassEncoder48 = commandEncoder97.beginComputePass({});
+let renderPassEncoder13 = commandEncoder113.beginRenderPass({
+  label: '\ud145\uad46\u262c\u0fbd\u5948\u652e',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -671.8, g: 597.8, b: -558.4, a: -858.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet52,
+  maxDrawCount: 1176880314,
+});
+let renderBundle72 = renderBundleEncoder27.finish({label: '\uf351\uc44c\uc47e\u0b43\u4d84\u06a3\u{1f7ba}\u0e87\u{1fef4}'});
+try {
+renderPassEncoder11.setBlendConstant({ r: -349.1, g: 968.4, b: -38.06, a: 310.3, });
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(766);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(6901, undefined, 2744247923);
+} catch {}
+try {
+commandEncoder120.copyBufferToTexture({
+  /* bytesInLastRow: 712 widthInBlocks: 178 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3184 */
+  offset: 2472,
+  buffer: buffer19,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 178, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 6,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(501, 833);
+try {
+adapter1.label = '\u3fb4\u0c6a\u{1fc9a}\u{1fbce}\uf95b\u{1fd43}';
+} catch {}
+let renderBundle73 = renderBundleEncoder21.finish();
+try {
+computePassEncoder21.setBindGroup(5, bindGroup27, new Uint32Array(8846), 1762, 0);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer9), /* required buffer size: 470 */
+{offset: 470, bytesPerRow: 149, rowsPerImage: 247}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 67, y: 3 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 313, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline55 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0xd7cbdc37},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 3789441518,
+    stencilWriteMask: 3405765191,
+    depthBiasClamp: 758.3121246925319,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4316,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 1192, shaderLocation: 5},
+          {format: 'float32x4', offset: 64, shaderLocation: 10},
+          {format: 'float32x4', offset: 900, shaderLocation: 13},
+          {format: 'sint32x4', offset: 104, shaderLocation: 27},
+          {format: 'unorm8x4', offset: 1048, shaderLocation: 17},
+          {format: 'float32x3', offset: 1552, shaderLocation: 9},
+          {format: 'float32x4', offset: 952, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 1028, shaderLocation: 18},
+          {format: 'uint32x4', offset: 352, shaderLocation: 24},
+          {format: 'sint32x3', offset: 552, shaderLocation: 0},
+          {format: 'float32x3', offset: 360, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 1776, shaderLocation: 6},
+          {format: 'uint16x4', offset: 692, shaderLocation: 16},
+          {format: 'sint32x4', offset: 1136, shaderLocation: 12},
+          {format: 'float16x2', offset: 2408, shaderLocation: 19},
+          {format: 'uint16x4', offset: 308, shaderLocation: 4},
+          {format: 'uint32', offset: 172, shaderLocation: 22},
+          {format: 'float16x4', offset: 220, shaderLocation: 26},
+          {format: 'uint16x4', offset: 16, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 20184,
+        attributes: [
+          {format: 'float16x4', offset: 1280, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 454, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 9952,
+        attributes: [
+          {format: 'uint32x3', offset: 1644, shaderLocation: 23},
+          {format: 'sint32', offset: 408, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 2188, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 2364, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 8724, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 620,
+        attributes: [
+          {format: 'uint16x4', offset: 80, shaderLocation: 11},
+          {format: 'float32', offset: 44, shaderLocation: 25},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let bindGroup41 = device2.createBindGroup({
+  label: '\u0244\u8944\ud235\u5049\u0a83\u0682\u0326\u0b92',
+  layout: bindGroupLayout21,
+  entries: [{binding: 8080, resource: sampler47}],
+});
+let commandEncoder125 = device2.createCommandEncoder({label: '\u{1fdc6}\uc624\uafcc\u0a3f\ue854\u7aa2\u5920\u517e\u{1fe68}\u{1fdd3}'});
+let computePassEncoder49 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder19.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(9, bindGroup39);
+} catch {}
+let renderBundleEncoder52 = device2.createRenderBundleEncoder({
+  label: '\u0d46\uf7de\u{1fffd}',
+  colorFormats: ['r8uint', 'rg32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder47.setPipeline(pipeline18);
+} catch {}
+try {
+querySet46.destroy();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(365), /* required buffer size: 365 */
+{offset: 365}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline56 = await device2.createRenderPipelineAsync({
+  label: '\ua55a\u0eb0\u36ac\uf47e\u{1fa02}\u097d\u0d2b\u0189\u20bf',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0xf4491b94},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rgba16sint'}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 1992918898,
+    stencilWriteMask: 1819871974,
+    depthBiasSlopeScale: 75.92801663711276,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15328,
+        attributes: [
+          {format: 'snorm16x4', offset: 772, shaderLocation: 3},
+          {format: 'uint32', offset: 6828, shaderLocation: 25},
+          {format: 'uint8x4', offset: 2124, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 1256, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 7492, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 4516, shaderLocation: 14},
+          {format: 'uint32x4', offset: 980, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 688, shaderLocation: 26},
+          {format: 'uint8x2', offset: 1122, shaderLocation: 22},
+          {format: 'float16x2', offset: 456, shaderLocation: 8},
+          {format: 'float32', offset: 5080, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 744,
+        attributes: [
+          {format: 'uint8x2', offset: 248, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 23},
+          {format: 'uint8x4', offset: 412, shaderLocation: 21},
+          {format: 'float16x2', offset: 16, shaderLocation: 5},
+          {format: 'sint32x4', offset: 44, shaderLocation: 12},
+          {format: 'sint8x2', offset: 52, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 36, shaderLocation: 18},
+          {format: 'uint8x4', offset: 268, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 56, shaderLocation: 27},
+        ],
+      },
+      {
+        arrayStride: 24784,
+        attributes: [
+          {format: 'uint16x4', offset: 1752, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 14660, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 36, shaderLocation: 24},
+          {format: 'unorm16x4', offset: 3096, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 7440, stepMode: 'instance', attributes: []},
+      {arrayStride: 6200, attributes: []},
+      {
+        arrayStride: 5056,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 48, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 616,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 440, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 7200,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 1088, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+  await promise19;
+} catch {}
+let commandEncoder126 = device1.createCommandEncoder({label: '\u7fef\u645e\u{1fb6d}\u003c'});
+let renderPassEncoder14 = commandEncoder121.beginRenderPass({
+  label: '\u0ab8\u4536\u{1fc05}\u0739\u{1f85e}\u8627\u{1f67e}\u{1fdad}\u75a3\u{1f6ec}\u36b6',
+  colorAttachments: [{
+  view: textureView152,
+  clearValue: { r: 169.7, g: 47.41, b: -285.1, a: 117.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 658449882,
+});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(4, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer17, 0, 164437);
+} catch {}
+try {
+commandEncoder120.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 25372 */
+  offset: 25372,
+  bytesPerRow: 512,
+  rowsPerImage: 15,
+  buffer: buffer20,
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 88},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let video10 = await videoWithData();
+let bindGroupLayout24 = device1.createBindGroupLayout({
+  label: '\ud475\ua157\uf159\u{1f85d}',
+  entries: [{binding: 133, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let bindGroup42 = device1.createBindGroup({
+  label: '\u{1f9c4}\u0692\uab19\u08c7\u0f76\u27e7\u631c\u027f\u4204\u0aa8\u6944',
+  layout: bindGroupLayout24,
+  entries: [{binding: 133, resource: externalTexture43}],
+});
+let commandEncoder127 = device1.createCommandEncoder({label: '\u{1fdd1}\u{1f6b2}\ua224\uccce\u{1fa3c}\u0376\u{1fd7a}'});
+let querySet58 = device1.createQuerySet({
+  label: '\u{1fe79}\u{1ff22}\u{1fc77}\u{1f6bf}\u6f36\u4ff5\u0120\u1e00\u3359',
+  type: 'occlusion',
+  count: 2865,
+});
+let texture84 = device1.createTexture({
+  label: '\u244e\u9d13\ubff1\u{1f899}\u0ae4\u9336\u4c3e\uced9',
+  size: [68],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint'],
+});
+let renderPassEncoder15 = commandEncoder72.beginRenderPass({
+  label: '\ue87a\uad8f\uc0df\uc1af\ue80c\u05f0',
+  colorAttachments: [{
+  view: textureView152,
+  clearValue: { r: 769.4, g: 426.9, b: 114.5, a: -14.65, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet50,
+  maxDrawCount: 678873964,
+});
+let sampler60 = device1.createSampler({
+  label: '\u0c40\u19ed\u{1f6d1}\u{1f6c8}\u46f2\udf97\u5230\u0b99\u0a64',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.46,
+  lodMaxClamp: 91.04,
+  maxAnisotropy: 9,
+});
+let externalTexture59 = device1.importExternalTexture({label: '\u1e76\u0918\ub672\u7043\u5adf\u1987\uc7f3\u8d8c', source: videoFrame4});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(4, bindGroup35, new Uint32Array(3868), 975, 0);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer23, 107360, 213);
+} catch {}
+try {
+commandEncoder82.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5328 */
+  offset: 5216,
+  buffer: buffer20,
+}, {width: 28, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+let commandEncoder128 = device2.createCommandEncoder({label: '\u{1fef6}\u0d1e\uac3d\ufedf\u05ae\u0735'});
+let textureView153 = texture75.createView({label: '\uabd5\u422a\ub9db\u{1fa0c}', format: 'rgba16sint', baseMipLevel: 0, baseArrayLayer: 0});
+let sampler61 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 76.94,
+  lodMaxClamp: 96.70,
+});
+try {
+renderBundleEncoder32.setVertexBuffer(2, buffer28, 51672, 50865);
+} catch {}
+let pipeline57 = await device2.createComputePipelineAsync({
+  label: '\ue17e\u32fe',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule11, entryPoint: 'compute0'},
+});
+video7.height = 99;
+canvas4.height = 814;
+let pipelineLayout21 = device0.createPipelineLayout({label: '\u9751\u{1f9f6}\u1a2f\u9127', bindGroupLayouts: [bindGroupLayout4]});
+let commandEncoder129 = device0.createCommandEncoder({});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\ueba6\u{1f7cb}\u{1fc08}\u01d9\u0c64\u8a10\u4455\ua55c\u331b\ucc53',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder42.setBindGroup(6, bindGroup12, []);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(4, bindGroup0, new Uint32Array(3227), 2049, 0);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let promise27 = buffer25.mapAsync(GPUMapMode.WRITE, 252184, 9820);
+try {
+commandEncoder37.copyBufferToBuffer(buffer12, 30772, buffer6, 49332, 716);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer3, 101368, 672);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+  label: '\u509e\u3ec4\u9ded\u06e4\u6481\u6f8c\u7112',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'replace'},
+    stencilBack: {depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 176217946,
+    stencilWriteMask: 858259868,
+    depthBiasSlopeScale: 421.3186197606634,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7544,
+        attributes: [
+          {format: 'float32', offset: 80, shaderLocation: 0},
+          {format: 'uint8x4', offset: 3452, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 1180, shaderLocation: 11},
+          {format: 'float32', offset: 276, shaderLocation: 1},
+          {format: 'float32x2', offset: 560, shaderLocation: 4},
+          {format: 'float16x2', offset: 928, shaderLocation: 8},
+          {format: 'sint32x4', offset: 1128, shaderLocation: 17},
+          {format: 'uint32x4', offset: 1824, shaderLocation: 7},
+          {format: 'float32x2', offset: 1264, shaderLocation: 15},
+          {format: 'uint16x4', offset: 972, shaderLocation: 6},
+          {format: 'sint32x4', offset: 256, shaderLocation: 2},
+          {format: 'sint32x4', offset: 3204, shaderLocation: 10},
+          {format: 'float32', offset: 412, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 1782, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 1004, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 872, shaderLocation: 9},
+          {format: 'uint32x3', offset: 3316, shaderLocation: 5},
+          {format: 'sint32x2', offset: 2452, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 456, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 4232, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+});
+let img21 = await imageWithData(210, 21, '#399a4e50', '#2b3c63c8');
+try {
+adapter2.label = '\u02bb\u0014\ud3db\uc45d\u1928';
+} catch {}
+let textureView154 = texture71.createView({label: '\u26a3\uc738\u97e6\u0ed3\ufa74', baseMipLevel: 6});
+let renderPassEncoder16 = commandEncoder127.beginRenderPass({
+  label: '\u{1f70d}\ua8a9\uc5bc\u{1f6e1}\u{1fc23}\u6bf9\u7b2a',
+  colorAttachments: [{
+  view: textureView154,
+  depthSlice: 0,
+  clearValue: { r: 37.53, g: 741.9, b: -471.1, a: -89.81, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 100041487,
+});
+let externalTexture60 = device1.importExternalTexture({label: '\u5ac5\u050c\u835d', source: video10, colorSpace: 'srgb'});
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(6, buffer23);
+} catch {}
+try {
+buffer19.destroy();
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.submit([commandBuffer10]);
+} catch {}
+let img22 = await imageWithData(148, 255, '#06e16dbe', '#538c6b5f');
+let textureView155 = texture3.createView({label: '\u{1f907}\ua81d\u0f2e\ufd22'});
+let computePassEncoder50 = commandEncoder96.beginComputePass();
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({
+  label: '\ua773\u6aba\u{1f688}\u{1fb7e}\u{1f82a}\u0828\u{1ffc0}\u9b50\u962b\u5b0a\u0638',
+  colorFormats: ['rgba16float', 'r32float'],
+  stencilReadOnly: true,
+});
+let sampler62 = device0.createSampler({
+  label: '\u0a09\u0862\u43fd\u0bff\ucf7f\uc431\u4a23\u79a0\u0aac\u{1f902}\u3088',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.88,
+  lodMaxClamp: 65.08,
+});
+try {
+renderBundleEncoder20.setVertexBuffer(6, buffer22, 0, 122330);
+} catch {}
+let arrayBuffer15 = buffer14.getMappedRange(324840, 24032);
+try {
+device0.queue.writeBuffer(buffer6, 10116, new DataView(new ArrayBuffer(35145)), 20991, 1144);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(64)), /* required buffer size: 21_185_766 */
+{offset: 486, bytesPerRow: 2452, rowsPerImage: 270}, {width: 538, height: 0, depthOrArrayLayers: 33});
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(944, 977);
+let renderBundleEncoder55 = device2.createRenderBundleEncoder({
+  label: '\u27e6\u541c\u1649\ue4ca\u0943\u9362\u{1f612}\u02b5\u03f4\udae8',
+  colorFormats: ['r8uint', 'rg32uint'],
+});
+try {
+commandEncoder111.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 222, y: 0, z: 78},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 470, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: img4,
+  origin: { x: 16, y: 24 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 17, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 71, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView156 = texture78.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundle74 = renderBundleEncoder48.finish({label: '\u5fe2\u0fb9\u{1f633}\u9c59\u1e74\u8ff3'});
+try {
+renderBundleEncoder52.setBindGroup(8, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(5, bindGroup39, new Uint32Array(5755), 5067, 0);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(8, buffer28, 29076, 93548);
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.submit([commandBuffer21, commandBuffer28]);
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  label: '\u48a4\u{1f8c9}\u2baa\u9ded\ufa72\u0353\u{1fdf7}\uea99\u03c9',
+  layout: bindGroupLayout5,
+  entries: [],
+});
+let pipelineLayout22 = device0.createPipelineLayout({
+  label: '\u{1fc2b}\u9786\ua19c\u9a8e\u{1fb0a}\u55bf',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout4, bindGroupLayout15, bindGroupLayout7, bindGroupLayout15, bindGroupLayout5, bindGroupLayout4],
+});
+let commandEncoder130 = device0.createCommandEncoder({label: '\u01ea\ua4ee\uc839\u00c4\u0b85\u03a8\u0c38\u0c3b'});
+let texture85 = device0.createTexture({
+  label: '\u3443\ue4ca\u0502\u{1fdac}',
+  size: {width: 384, height: 480, depthOrArrayLayers: 21},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+let textureView157 = texture12.createView({dimension: '2d-array', baseMipLevel: 4});
+try {
+commandEncoder119.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 73},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 79, y: 32, z: 1},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 3676, new DataView(new ArrayBuffer(47013)), 3634, 7432);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 250, y: 21 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 52},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video4.width = 207;
+let commandEncoder131 = device1.createCommandEncoder({});
+let querySet59 = device1.createQuerySet({label: '\ucf0e\u8838', type: 'occlusion', count: 487});
+let texture86 = device1.createTexture({
+  label: '\u0bc2\u48b9\u5bf2\u5618\ufaec\u0668',
+  size: [144],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let renderBundle75 = renderBundleEncoder41.finish({});
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(8, buffer17, 91096, 117143);
+} catch {}
+try {
+commandEncoder120.copyTextureToBuffer({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14760 */
+  offset: 14760,
+  rowsPerImage: 64,
+  buffer: buffer20,
+}, {width: 56, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 14932, new DataView(new ArrayBuffer(15442)), 15357, 36);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 431 */
+{offset: 431, rowsPerImage: 68}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder132 = device0.createCommandEncoder({label: '\u04b2\uec20\u4728\u0faa'});
+let commandBuffer33 = commandEncoder14.finish({label: '\u32a0\u6219\u443f\u{1f9ea}\u{1ffe2}\ue5da\ubc5f\u{1fe03}\u86c0'});
+let texture87 = device0.createTexture({
+  label: '\uf15b\ubbe9\u2fbb\u633a\uc005\u0caf\u61f6\u793f',
+  size: [720, 6, 427],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderBundle76 = renderBundleEncoder35.finish({label: '\u0de3\u{1fb34}\u{1f6fd}\u860f'});
+try {
+renderBundleEncoder2.setBindGroup(7, bindGroup11, new Uint32Array(1893), 549, 0);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(0, buffer22, 0);
+} catch {}
+gc();
+let videoFrame15 = new VideoFrame(videoFrame8, {timestamp: 0});
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+let buffer29 = device1.createBuffer({
+  label: '\u5694\u706c\u{1f6f1}\u{1f877}\ub6d7\ufd76\u02b9\u9aec\u173d',
+  size: 232692,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder133 = device1.createCommandEncoder({label: '\u{1feb1}\uefc8\u5d53\u0e4c'});
+let textureView158 = texture52.createView({label: '\u{1f7e1}\u5103\u{1fb9f}', baseArrayLayer: 1355, arrayLayerCount: 5});
+let renderBundle77 = renderBundleEncoder33.finish({label: '\ue71a\u0f02\u{1fbdf}\u71d1\u{1fdf7}'});
+try {
+renderPassEncoder15.beginOcclusionQuery(1735);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle35, renderBundle56, renderBundle44, renderBundle26, renderBundle52, renderBundle62, renderBundle39, renderBundle19, renderBundle26, renderBundle67]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer17);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer16, 42272, buffer29, 48260, 5664);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video11 = await videoWithData();
+let bindGroup44 = device2.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 6715, resource: externalTexture36}]});
+let commandEncoder134 = device2.createCommandEncoder();
+let querySet60 = device2.createQuerySet({type: 'occlusion', count: 3489});
+let textureView159 = texture58.createView({
+  label: '\ub1b6\u810f\u071c\u0df6\ue121\u{1fabe}',
+  mipLevelCount: 2,
+  baseArrayLayer: 850,
+  arrayLayerCount: 749,
+});
+let computePassEncoder51 = commandEncoder111.beginComputePass();
+try {
+computePassEncoder27.setBindGroup(0, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(3, buffer28, 76128, 13200);
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u0ba9\u0809\ufb36\u046a\u{1ff30}\u05ed\uc068\u1383\ub43d\u02f0\u0325',
+  code: `@group(0) @binding(3198)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @location(6) f0: vec4<u32>,
+  @location(53) f1: vec2<i32>,
+  @location(13) f2: i32,
+  @location(74) f3: vec4<u32>,
+  @location(41) f4: u32,
+  @location(68) f5: vec2<u32>,
+  @location(56) f6: vec4<f16>,
+  @location(51) f7: vec4<f32>,
+  @location(49) f8: vec4<f32>,
+  @location(12) f9: vec2<i32>,
+  @location(50) f10: vec4<f32>,
+  @location(59) f11: vec2<i32>,
+  @builtin(sample_mask) f12: u32,
+  @location(18) f13: vec4<i32>,
+  @location(14) f14: vec4<i32>,
+  @location(30) f15: vec3<u32>,
+  @location(33) f16: vec4<i32>,
+  @location(4) f17: vec3<u32>,
+  @location(23) f18: vec2<i32>,
+  @location(37) f19: f32,
+  @location(66) f20: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: f32
+}
+
+@fragment
+fn fragment0(@location(19) a0: vec4<f16>, @location(27) a1: vec3<f16>, @location(40) a2: vec4<f16>, @location(3) a3: vec2<u32>, @location(34) a4: vec2<i32>, @location(16) a5: vec3<f16>, @location(70) a6: u32, a7: S20, @location(38) a8: vec2<i32>, @location(65) a9: vec2<i32>, @location(55) a10: vec3<f32>, @location(29) a11: f16, @location(48) a12: f16, @location(7) a13: vec4<i32>, @location(10) a14: u32, @builtin(sample_index) a15: u32, @builtin(position) a16: vec4<f32>, @builtin(front_facing) a17: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(16) f0: vec3<f32>,
+  @location(17) f1: vec2<f16>,
+  @location(18) f2: vec4<i32>,
+  @location(13) f3: i32,
+  @location(4) f4: vec3<f32>,
+  @location(0) f5: vec3<i32>,
+  @location(19) f6: vec3<i32>,
+  @location(3) f7: vec2<i32>,
+  @location(2) f8: vec2<u32>,
+  @location(10) f9: f32
+}
+struct VertexOutput0 {
+  @location(53) f259: vec2<i32>,
+  @location(40) f260: vec4<f16>,
+  @location(59) f261: vec2<i32>,
+  @location(66) f262: vec4<f16>,
+  @location(55) f263: vec3<f32>,
+  @location(4) f264: vec3<u32>,
+  @location(3) f265: vec2<u32>,
+  @location(68) f266: vec2<u32>,
+  @location(51) f267: vec4<f32>,
+  @location(49) f268: vec4<f32>,
+  @location(65) f269: vec2<i32>,
+  @location(56) f270: vec4<f16>,
+  @location(10) f271: u32,
+  @location(16) f272: vec3<f16>,
+  @location(12) f273: vec2<i32>,
+  @location(37) f274: f32,
+  @location(29) f275: f16,
+  @location(33) f276: vec4<i32>,
+  @location(14) f277: vec4<i32>,
+  @location(38) f278: vec2<i32>,
+  @builtin(position) f279: vec4<f32>,
+  @location(34) f280: vec2<i32>,
+  @location(50) f281: vec4<f32>,
+  @location(70) f282: u32,
+  @location(18) f283: vec4<i32>,
+  @location(13) f284: i32,
+  @location(74) f285: vec4<u32>,
+  @location(27) f286: vec3<f16>,
+  @location(23) f287: vec2<i32>,
+  @location(19) f288: vec4<f16>,
+  @location(41) f289: u32,
+  @location(30) f290: vec3<u32>,
+  @location(6) f291: vec4<u32>,
+  @location(48) f292: f16,
+  @location(7) f293: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f16>, @location(14) a1: vec3<f32>, @location(8) a2: vec3<u32>, @location(5) a3: vec3<u32>, @location(15) a4: vec3<f16>, @location(11) a5: f32, a6: S19, @location(1) a7: vec4<f32>, @location(12) a8: vec3<i32>, @location(7) a9: vec4<f16>, @location(6) a10: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let sampler63 = device0.createSampler({
+  label: '\ube68\u002b\u0f33\u{1fb1d}\u20c8\uccb9\u1070\u{1fc95}\u{1fd4c}\u2d13',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.87,
+  lodMaxClamp: 38.91,
+});
+try {
+renderBundleEncoder40.setBindGroup(5, bindGroup14, new Uint32Array(5413), 4896, 0);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(6, buffer22, 0);
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(buffer1, 9540, buffer11, 115936, 11648);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(querySet5, 1848, 1029, buffer15, 89344);
+} catch {}
+let pipeline59 = device0.createRenderPipeline({
+  label: '\u{1fcaf}\ud975',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3068,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 776, shaderLocation: 18},
+          {format: 'float32x4', offset: 332, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 208, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 744, shaderLocation: 9},
+          {format: 'float32x4', offset: 628, shaderLocation: 4},
+          {format: 'sint32x3', offset: 680, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 104, shaderLocation: 13},
+          {format: 'float16x2', offset: 148, shaderLocation: 0},
+          {format: 'uint16x4', offset: 328, shaderLocation: 7},
+          {format: 'uint16x4', offset: 96, shaderLocation: 5},
+          {format: 'float16x2', offset: 1188, shaderLocation: 11},
+          {format: 'sint32x4', offset: 1044, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 12716,
+        attributes: [
+          {format: 'uint16x4', offset: 4036, shaderLocation: 3},
+          {format: 'sint32x2', offset: 0, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 700, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 708, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 5088, attributes: []},
+      {
+        arrayStride: 4204,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 980, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 512, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 1948, shaderLocation: 19},
+          {format: 'sint16x2', offset: 2028, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder135 = device1.createCommandEncoder({label: '\u09b8\u00c0\u0819\u{1fa20}\u7e15\u01f9\u73d6'});
+let commandBuffer34 = commandEncoder126.finish({});
+let texture88 = device1.createTexture({
+  size: {width: 273, height: 2, depthOrArrayLayers: 705},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView160 = texture56.createView({label: '\u0932\u{1fee9}\u{1f7ef}\u3854'});
+let computePassEncoder52 = commandEncoder131.beginComputePass({});
+let externalTexture61 = device1.importExternalTexture({source: videoFrame8});
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(6, 0, 15, 0);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1960);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder120.copyBufferToTexture({
+  /* bytesInLastRow: 408 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6468 */
+  offset: 6468,
+  buffer: buffer19,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 102, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 11088, new Int16Array(49055), 26489);
+} catch {}
+try {
+  await promise27;
+} catch {}
+let imageBitmap14 = await createImageBitmap(offscreenCanvas9);
+let commandEncoder136 = device2.createCommandEncoder({label: '\ub507\u{1f7da}\u0dc7'});
+let texture89 = device2.createTexture({
+  label: '\ucb84\ue69c\u1056\u9541\u5176\u{1fd55}\u3d96\ufbea\u01b2\uef97',
+  size: {width: 753, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder50.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer27, 90340, buffer21, 588812, 2256);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 790 widthInBlocks: 395 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25492 */
+  offset: 25492,
+  buffer: buffer27,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 395, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 205, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 149, height: 1, depthOrArrayLayers: 8});
+} catch {}
+let texture90 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder17 = commandEncoder135.beginRenderPass({
+  label: '\u{1f7d3}\u{1f90f}\u638a\u87dc\u027e\u064f\u0ff5',
+  colorAttachments: [{
+  view: textureView152,
+  clearValue: { r: -627.0, g: 76.16, b: -874.7, a: 363.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet58,
+  maxDrawCount: 656643152,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup35, new Uint32Array(2199), 58, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(7, bindGroup13);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(333);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer23, 'uint16');
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline8);
+} catch {}
+let textureView161 = texture62.createView({
+  label: '\u06ca\uea7f\u0847\ud3d9\u14e5\u7f2f\u0fad\u76e4\u0ace',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 16,
+});
+let computePassEncoder53 = commandEncoder130.beginComputePass({label: '\u08d1\u{1f7cf}\u1e4e\u{1ff36}\u{1f7e7}\uc6f6\uc083'});
+let arrayBuffer16 = buffer4.getMappedRange(28656, 45164);
+try {
+commandEncoder36.copyBufferToBuffer(buffer12, 21064, buffer4, 18640, 4692);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img12,
+  origin: { x: 21, y: 24 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise22;
+} catch {}
+canvas5.height = 129;
+let video12 = await videoWithData();
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let commandEncoder137 = device2.createCommandEncoder({label: '\u0cf2\u9663\u{1ff07}\uf113\u6663\u3766\u0c34\u4022'});
+let computePassEncoder54 = commandEncoder98.beginComputePass({});
+let renderBundle78 = renderBundleEncoder52.finish({});
+try {
+computePassEncoder26.insertDebugMarker('\ucd73');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: video11,
+  origin: { x: 4, y: 2 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 67},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+try {
+offscreenCanvas10.getContext('webgpu');
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({label: '\ue19d\u0be6\u00ae\u1151'});
+let textureView162 = texture5.createView({label: '\u05d7\u939b\u{1f748}', baseMipLevel: 1});
+let computePassEncoder55 = commandEncoder30.beginComputePass({label: '\ua253\u0485\u02ea\ue7e6'});
+let renderBundle79 = renderBundleEncoder7.finish();
+try {
+computePassEncoder45.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer6);
+} catch {}
+try {
+commandEncoder129.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 21},
+  aspect: 'all',
+},
+{width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer14, 165328);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder109.resolveQuerySet(querySet18, 2478, 559, buffer0, 64000);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer14), /* required buffer size: 469 */
+{offset: 469}, {width: 303, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap15 = await createImageBitmap(video8);
+let commandEncoder139 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: [720, 6, 1684],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView163 = texture53.createView({label: '\u5d5a\u03be\u0453', baseArrayLayer: 0});
+let computePassEncoder56 = commandEncoder129.beginComputePass({label: '\u7f93\u96ae\u7cee\u2641\u0f02\u{1f69f}\u{1fdd1}\u{1fc2f}\u229d'});
+let sampler64 = device0.createSampler({
+  label: '\uad47\ufcf1\u0361\u34b4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 51.59,
+  lodMaxClamp: 74.02,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder51.setBindGroup(5, bindGroup8, new Uint32Array(4065), 1243, 0);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer5, 'uint32');
+} catch {}
+try {
+commandEncoder139.resolveQuerySet(querySet56, 1010, 541, buffer15, 59136);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 205, y: 0, z: 56},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 77_962_630 */
+{offset: 902, bytesPerRow: 1378, rowsPerImage: 272}, {width: 319, height: 0, depthOrArrayLayers: 209});
+} catch {}
+let pipeline60 = await promise13;
+let textureView164 = texture37.createView({label: '\uc786\u9032\uc667\ub253\ue1ab\u0c9c\u68ae\u{1f730}\u0900\u0e20'});
+let computePassEncoder57 = commandEncoder107.beginComputePass({label: '\u0258\uc9fe\u8f70\uf07b'});
+let renderBundle80 = renderBundleEncoder19.finish({label: '\ue2cb\uc057\u0ba0\u{1fb20}\u{1fd40}\u{1fb60}\u43c5\u67ee\ue899\u215e\u3cf1'});
+try {
+renderBundleEncoder55.setBindGroup(4, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline51);
+} catch {}
+try {
+commandEncoder128.copyBufferToTexture({
+  /* bytesInLastRow: 62 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3702 */
+  offset: 3702,
+  bytesPerRow: 256,
+  buffer: buffer27,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder123.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 9,
+  origin: {x: 1, y: 0, z: 111},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(16)), /* required buffer size: 5_662_054 */
+{offset: 554, bytesPerRow: 67, rowsPerImage: 130}, {width: 8, height: 0, depthOrArrayLayers: 651});
+} catch {}
+let bindGroup45 = device0.createBindGroup({label: '\u02ca\u1222', layout: bindGroupLayout15, entries: []});
+let querySet61 = device0.createQuerySet({
+  label: '\u{1fd35}\u{1f781}\u{1ff5e}\u{1facf}\uaefc\u0644\u3f80\u024b\u2d47\u0956',
+  type: 'occlusion',
+  count: 2899,
+});
+let renderBundle81 = renderBundleEncoder1.finish({label: '\u1b2a\u{1f855}\u95bf\u078e\u0a2f\u4a8f\u13ce\u0133\u8259'});
+try {
+renderBundleEncoder53.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer5, 'uint16', 4788, 18806);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder124.clearBuffer(buffer3, 113708, 7888);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder36.insertDebugMarker('\u732d');
+} catch {}
+try {
+  await promise24;
+} catch {}
+let canvas7 = document.createElement('canvas');
+try {
+renderBundleEncoder37.setVertexBuffer(2, buffer22, 66020, 16845);
+} catch {}
+let promise28 = buffer26.mapAsync(GPUMapMode.WRITE, 14280);
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 4,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 5,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 9, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 6700, new Float32Array(48457), 32233, 7068);
+} catch {}
+let commandEncoder140 = device1.createCommandEncoder();
+let computePassEncoder58 = commandEncoder82.beginComputePass({label: '\u0794\u61a6\u382f\u357d\u0e34\u038c\u033d\udd14\u7cce\uf3b1\u0d5c'});
+let renderPassEncoder18 = commandEncoder120.beginRenderPass({
+  label: '\u{1fe8c}\u{1fe03}\u65be\u1c08\u22f2\u0786\u463d',
+  colorAttachments: [{
+  view: textureView152,
+  clearValue: { r: 837.3, g: -939.8, b: -2.064, a: 705.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 864983848,
+});
+let renderBundle82 = renderBundleEncoder18.finish({label: '\uf38a\u855d\u24b6\ucf72\u{1fe3d}'});
+try {
+renderPassEncoder9.setBindGroup(5, bindGroup24);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(0, buffer17, 0, 14983);
+} catch {}
+try {
+commandEncoder133.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 2,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline61 = device1.createComputePipeline({
+  label: '\u04f6\u{1ffd6}\uc373\u828b\u0b65\uc340\u669f',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+try {
+window.someLabel = externalTexture35.label;
+} catch {}
+let bindGroup46 = device2.createBindGroup({
+  label: '\uda01\u{1fd3d}\u7616',
+  layout: bindGroupLayout21,
+  entries: [{binding: 8080, resource: sampler28}],
+});
+let querySet62 = device2.createQuerySet({label: '\u734b\uefee\u{1fb3d}\u3cf0\u{1f722}\ud617', type: 'occlusion', count: 3852});
+let textureView165 = texture89.createView({label: '\u92de\u02ff\u0188', dimension: '2d-array', baseMipLevel: 3, arrayLayerCount: 1});
+let externalTexture62 = device2.importExternalTexture({source: video7, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder55.setPipeline(pipeline51);
+} catch {}
+let texture92 = device0.createTexture({
+  label: '\u0407\ua127\u06ac\u6498\u{1ffe0}\ue416\u0604\u{1f685}\ue9ed',
+  size: [645],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\ub25b\u04e1\u63ab\u7753\u{1fd69}\u{1fe79}\u46c1\u3c9e\u71bf',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let sampler65 = device0.createSampler({
+  label: '\u44b3\u020d\u9cc7\u70f8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.55,
+  lodMaxClamp: 94.10,
+  compare: 'always',
+});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup18, []);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(7, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(6, bindGroup7, new Uint32Array(8920), 2133, 0);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 39},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 256, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 86, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer9, 21516);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline62 = await device0.createComputePipelineAsync({
+  label: '\u{1fd7e}\u714a\u{1fb36}\ufc1f\u9398\u0ca7\u38ea\u24ad\u{1f94d}\u09fc\u{1f8a1}',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let video13 = await videoWithData();
+let videoFrame16 = new VideoFrame(img8, {timestamp: 0});
+let shaderModule17 = device2.createShaderModule({
+  label: '\u{1fe3f}\udfcf\u{1f64b}\uf851\u56f6\u1add\u{1f69c}',
+  code: `@group(0) @binding(6715)
+var<storage, read_write> global8: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(4) f1: vec4<f32>,
+  @location(3) f2: vec2<i32>,
+  @location(2) f3: vec2<i32>,
+  @location(6) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(26) a0: i32, @location(14) a1: vec4<f16>, @location(18) a2: vec3<i32>, @location(24) a3: u32, @location(25) a4: vec4<u32>, @location(5) a5: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout25 = device2.createBindGroupLayout({label: '\u265d\udaf1\u{1f7c6}\u0e46\ufd5a\u018a', entries: []});
+let commandEncoder141 = device2.createCommandEncoder({label: '\uef12\u025b\u{1fd03}\uf474\u{1fa5e}\u0ca4\u15fb'});
+let textureView166 = texture42.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder59 = commandEncoder104.beginComputePass({label: '\u0108\u20a2'});
+try {
+computePassEncoder34.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(4, buffer28, 0);
+} catch {}
+try {
+commandEncoder136.copyBufferToBuffer(buffer27, 15948, buffer21, 601508, 1096);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2200 */
+  offset: 2200,
+  bytesPerRow: 256,
+  buffer: buffer27,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroupLayout26 = device2.createBindGroupLayout({
+  label: '\u05a4\u3f21\u0df4\u70f3\u084c\uf25c\u05e9\u0fd2',
+  entries: [
+    {
+      binding: 7893,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder142 = device2.createCommandEncoder();
+let texture93 = device2.createTexture({
+  label: '\u471a\uf076\ud425\u08ec\u00b8\u905d\u80c7',
+  size: [1464],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let renderBundle83 = renderBundleEncoder17.finish({label: '\u2ec0\u0536\u03ad\u{1fec3}\u267d\u0f5d\uc39d\u2231'});
+let arrayBuffer17 = buffer21.getMappedRange(85504, 1800);
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 124 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7068 */
+  offset: 7068,
+  bytesPerRow: 512,
+  buffer: buffer27,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 62, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: img19,
+  origin: { x: 21, y: 4 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise29 = device2.createRenderPipelineAsync({
+  label: '\u{1f746}\ub10f\u0f23\u01b2\u6349\ue87b\u048c\uf8dd\ub30f\u{1fef8}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 2747243726,
+    stencilWriteMask: 3479477688,
+    depthBiasClamp: 474.6600117961964,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 6200, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let gpuCanvasContext4 = canvas7.getContext('webgpu');
+let offscreenCanvas11 = new OffscreenCanvas(548, 880);
+let videoFrame17 = new VideoFrame(video5, {timestamp: 0});
+let bindGroupLayout27 = pipeline62.getBindGroupLayout(0);
+let pipelineLayout23 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout27, bindGroupLayout5, bindGroupLayout15, bindGroupLayout0, bindGroupLayout4],
+});
+let querySet63 = device0.createQuerySet({type: 'occlusion', count: 740});
+let textureView167 = texture5.createView({label: '\u1fc1\u3185\u{1f6ad}\uac62', dimension: '2d-array', baseMipLevel: 1});
+let sampler66 = device0.createSampler({
+  label: '\u01f3\u0bb2\u9660\u0ce9\u2cf5\u0b80',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 80.23,
+  lodMaxClamp: 87.97,
+});
+try {
+computePassEncoder29.dispatchWorkgroups(4, 4, 1);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder47.setIndexBuffer(buffer5, 'uint16', 21080, 13793);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer18 = buffer15.getMappedRange();
+try {
+commandEncoder118.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 33464, new BigUint64Array(39075), 38079, 264);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer11), /* required buffer size: 85 */
+{offset: 85}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 240, depthOrArrayLayers: 10}
+*/
+{
+  source: video6,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 12, y: 77, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture94 = device0.createTexture({
+  label: '\u{1fc26}\u1cae\u0342\udfad\u{1fe8a}\u0517\ue6f9\u0633\u0e67',
+  size: {width: 645, height: 1, depthOrArrayLayers: 33},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float'],
+});
+try {
+renderBundleEncoder20.setVertexBuffer(8, buffer22, 68184);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas11.getContext('webgpu');
+let canvas8 = document.createElement('canvas');
+let commandEncoder143 = device1.createCommandEncoder({label: '\u{1f8c4}\u2460\u06d4\u04a1'});
+let texture95 = device1.createTexture({
+  label: '\u0701\u{1f683}',
+  size: [288, 640, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'astc-12x12-unorm-srgb'],
+});
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer23, 0, 48014);
+} catch {}
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({});
+let commandBuffer35 = commandEncoder66.finish({label: '\u0082\u50aa\uf947\u0908\u66dc\u072f\ue340'});
+let textureView168 = texture20.createView({label: '\u0351\u6b26\ud4b3\u0dac', aspect: 'all'});
+let renderBundleEncoder57 = device0.createRenderBundleEncoder({
+  label: '\uff4a\ud071\u37bc\u0571\ud820\u{1fc06}\u{1f77c}\u80a6\u38e7\u0618\u9a98',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder55.setPipeline(pipeline25);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 512 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 21264 */
+  offset: 21264,
+  bytesPerRow: 768,
+  buffer: buffer1,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 1, y: 4, z: 1},
+  aspect: 'all',
+}, {width: 64, height: 52, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder56.insertDebugMarker('\u66ce');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer16, commandBuffer7, commandBuffer19, commandBuffer33, commandBuffer24]);
+} catch {}
+let pipeline63 = device0.createComputePipeline({layout: pipelineLayout22, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let pipeline64 = await device0.createRenderPipelineAsync({
+  label: '\uc021\ub15c\u1cb7\u{1f72d}\ue08a\uc0e7\u8e54\u8a2a',
+  layout: pipelineLayout21,
+  multisample: {mask: 0x572fe408},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 104895961,
+    stencilWriteMask: 928480595,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7920,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 486, shaderLocation: 5},
+          {format: 'uint32', offset: 412, shaderLocation: 8},
+          {format: 'sint16x4', offset: 172, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 172, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 4476, shaderLocation: 4},
+          {format: 'sint32x3', offset: 808, shaderLocation: 13},
+          {format: 'uint32x3', offset: 176, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 3696, shaderLocation: 1},
+          {format: 'sint32x3', offset: 2392, shaderLocation: 12},
+          {format: 'float32x4', offset: 1452, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 300, shaderLocation: 9},
+          {format: 'float32x3', offset: 872, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 1064, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 484, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 1428, shaderLocation: 10},
+          {format: 'float32x4', offset: 132, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 3044, shaderLocation: 7},
+          {format: 'sint32x2', offset: 44, shaderLocation: 3},
+          {format: 'sint8x4', offset: 688, shaderLocation: 19},
+          {format: 'sint8x2', offset: 2590, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: false,
+},
+});
+let commandEncoder145 = device2.createCommandEncoder();
+let textureView169 = texture82.createView({baseMipLevel: 0, mipLevelCount: 6});
+let renderBundle84 = renderBundleEncoder21.finish();
+let sampler67 = device2.createSampler({
+  label: '\u0af5\ucd0d\u{1ffe7}\uedff',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.84,
+  lodMaxClamp: 60.16,
+  compare: 'equal',
+  maxAnisotropy: 16,
+});
+try {
+commandEncoder117.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 76544 */
+  offset: 76544,
+  buffer: buffer27,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder103.clearBuffer(buffer21, 416172, 125716);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let commandEncoder146 = device1.createCommandEncoder({label: '\ue61a\u015c\u003a\uc321\u3171\u1ad1\u{1f9ab}\u01bc'});
+let texture96 = device1.createTexture({
+  size: [136, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView170 = texture52.createView({
+  label: '\u954b\u97f3\u{1f8cf}\uc9b1\u{1f8e5}\u0402\u05d5\ub27e\u77a4',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 332,
+  arrayLayerCount: 326,
+});
+try {
+computePassEncoder58.setBindGroup(5, bindGroup42, new Uint32Array(9979), 2117, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(7, bindGroup35);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle39, renderBundle82, renderBundle67, renderBundle67]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer23, 'uint16', 82182, 23061);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(1, buffer23, 0, 72235);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder133.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 14624 */
+  offset: 14624,
+  bytesPerRow: 0,
+  buffer: buffer16,
+}, {
+  texture: texture46,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup47 = device2.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 6715, resource: externalTexture23}]});
+let buffer30 = device2.createBuffer({
+  label: '\u0b5e\u0408\u{1f6ba}\u59f1\u0c4d\u7321\u9f30\u1f1c\u0753\u9b3a',
+  size: 132060,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer36 = commandEncoder81.finish({label: '\u0383\u30aa\ud956\u005d\u{1fb8e}\u027f\u{1f8db}\u0494\ud7c7\u{1ffe3}\u7809'});
+let renderBundle85 = renderBundleEncoder25.finish();
+let sampler68 = device2.createSampler({
+  label: '\u0b6f\u5b22\u{1f684}\u00eb\u{1f878}\u0f80\u42da\u{1f679}\uab32\u9197',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.67,
+  lodMaxClamp: 83.04,
+});
+try {
+device2.queue.submit([commandBuffer18, commandBuffer15]);
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(870, 895);
+let commandEncoder147 = device2.createCommandEncoder({label: '\u0f7b\udf4e\u0f4a\u{1fb19}\u08f8'});
+let renderBundle86 = renderBundleEncoder36.finish({});
+try {
+computePassEncoder49.insertDebugMarker('\u175a');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(80)), /* required buffer size: 247 */
+{offset: 247}, {width: 2928, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let img23 = await imageWithData(300, 249, '#1339f738', '#81ad35ab');
+let videoFrame18 = new VideoFrame(video13, {timestamp: 0});
+try {
+canvas8.getContext('bitmaprenderer');
+} catch {}
+let textureView171 = texture20.createView({label: '\u2227\u18cb\u0cc4\u5b4a\ub3d2\ucd84\u9950\uf460\u2cff'});
+try {
+computePassEncoder29.dispatchWorkgroupsIndirect(buffer5, 10508);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer1, 19780, buffer6, 63488, 6136);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer11, 123896, 22172);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let commandEncoder148 = device2.createCommandEncoder({label: '\u{1fcc5}\u02fc\u4e0f\u7fa5\u029d\u{1fc4e}\u{1f7cc}\u0281'});
+let querySet64 = device2.createQuerySet({label: '\u868c\u344d', type: 'occlusion', count: 2683});
+let commandBuffer37 = commandEncoder123.finish();
+let texture97 = device2.createTexture({
+  label: '\u20a9\u{1f76c}\u0240\u{1fd1e}\u0903\u0f01\u0101\u{1f983}',
+  size: [816, 96, 220],
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup41, new Uint32Array(4550), 3752, 0);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder55.setIndexBuffer(buffer30, 'uint32', 17748);
+} catch {}
+let arrayBuffer19 = buffer21.getMappedRange(87304, 63216);
+try {
+commandEncoder128.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet36, 2022, 1618, buffer30, 19456);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let video14 = await videoWithData();
+let imageData7 = new ImageData(248, 20);
+let shaderModule18 = device2.createShaderModule({
+  label: '\u0c5a\ue4d9',
+  code: `
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(sample_index) f1: u32,
+  @builtin(front_facing) f2: bool
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(1) f1: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(104) a0: u32, @location(48) a1: u32, @location(45) a2: i32, @location(40) a3: vec3<i32>, @location(46) a4: vec2<i32>, @location(30) a5: vec4<f16>, @location(58) a6: vec3<f16>, @location(26) a7: f32, @location(36) a8: i32, a9: S22, @builtin(sample_mask) a10: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(15) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(26) f2: vec3<i32>,
+  @location(25) f3: vec2<u32>,
+  @location(27) f4: vec3<i32>,
+  @location(5) f5: f16,
+  @location(9) f6: vec2<f16>,
+  @builtin(vertex_index) f7: u32,
+  @location(22) f8: vec4<i32>,
+  @location(19) f9: vec3<f32>,
+  @location(10) f10: vec3<f16>,
+  @location(6) f11: f16,
+  @location(14) f12: vec3<i32>,
+  @location(7) f13: i32,
+  @builtin(instance_index) f14: u32
+}
+struct VertexOutput0 {
+  @location(30) f294: vec4<f16>,
+  @location(46) f295: vec2<i32>,
+  @location(36) f296: i32,
+  @builtin(position) f297: vec4<f32>,
+  @location(40) f298: vec3<i32>,
+  @location(104) f299: u32,
+  @location(45) f300: i32,
+  @location(26) f301: f32,
+  @location(48) f302: u32,
+  @location(58) f303: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(21) a0: u32, @location(18) a1: vec2<i32>, @location(1) a2: vec3<u32>, @location(20) a3: vec2<f16>, @location(3) a4: vec3<i32>, @location(4) a5: vec4<f32>, @location(13) a6: f32, @location(16) a7: vec2<u32>, @location(11) a8: vec2<f32>, @location(24) a9: vec4<f32>, @location(23) a10: vec4<u32>, @location(8) a11: u32, @location(2) a12: vec2<u32>, @location(12) a13: vec2<i32>, @location(17) a14: vec4<f16>, a15: S21) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder149 = device2.createCommandEncoder({label: '\u97a9\ub3ba\udfaa\u0064\u{1ff82}\u0969\u5117'});
+let querySet65 = device2.createQuerySet({label: '\u{1fc65}\u0e10\u0867\u496e\u0df0\u1819\ud1ad\u{1f74c}\u0191', type: 'occlusion', count: 1693});
+try {
+renderBundleEncoder50.setVertexBuffer(6, buffer28, 86476);
+} catch {}
+let arrayBuffer20 = buffer21.getMappedRange(150520, 5416);
+try {
+device2.queue.writeBuffer(buffer30, 2704, new DataView(new ArrayBuffer(2048)), 891, 380);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let buffer31 = device0.createBuffer({
+  label: '\u6818\u3055',
+  size: 13642,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder150 = device0.createCommandEncoder({label: '\u2447\u7f86\u{1fc9f}\u{1f82d}\uc6b5\u08d3\u070d'});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup43, new Uint32Array(5422), 2178, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView172 = texture93.createView({label: '\u06d7\u0415\uc5b5\u{1fe88}\u{1f79e}\u0837\u56f4\u{1f70b}', dimension: '1d', aspect: 'all'});
+let computePassEncoder60 = commandEncoder141.beginComputePass();
+try {
+querySet32.destroy();
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24416 */
+  offset: 24416,
+  bytesPerRow: 0,
+  buffer: buffer30,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: img17,
+  origin: { x: 9, y: 12 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 451, y: 0, z: 21},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline65 = device2.createComputePipeline({
+  label: '\u0ac3\uc5e0\u0518',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video15 = await videoWithData();
+try {
+offscreenCanvas12.getContext('2d');
+} catch {}
+let pipelineLayout24 = device1.createPipelineLayout({
+  label: '\u357d\ue1bd\u67aa\u01de',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout16, bindGroupLayout24, bindGroupLayout14, bindGroupLayout17, bindGroupLayout13, bindGroupLayout17],
+});
+let texture98 = device1.createTexture({
+  size: [2412, 6, 1],
+  mipLevelCount: 3,
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-6x6-unorm-srgb', 'astc-6x6-unorm', 'astc-6x6-unorm'],
+});
+let renderPassEncoder19 = commandEncoder143.beginRenderPass({
+  label: '\u8ad6\u{1febc}\u2dc3\u4342\u{1f702}',
+  colorAttachments: [{
+  view: textureView154,
+  depthSlice: 0,
+  clearValue: { r: 327.0, g: 519.4, b: -11.10, a: 847.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 568889406,
+});
+let renderBundleEncoder58 = device1.createRenderBundleEncoder({
+  label: '\u1daa\uf8b8\u0517\u0cf9\u1e01\u0d03\u073a\ub0e8\u0625',
+  colorFormats: ['rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture63 = device1.importExternalTexture({label: '\u4f7f\u{1f91d}\u0595\ub0ae\u{1f658}\u6be6\uc16b', source: video12, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setBindGroup(6, bindGroup24, new Uint32Array(410), 175, 0);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(3773);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer23, 0, 19019);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(4, bindGroup42);
+} catch {}
+let pipeline66 = device1.createRenderPipeline({
+  label: '\u{1ffe8}\u1230\u0bac\u06cb\u1ae6\u00ee',
+  layout: pipelineLayout20,
+  multisample: {mask: 0xc2e35682},
+  fragment: {module: shaderModule6, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16sint'}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 70706178,
+    stencilWriteMask: 4049991191,
+    depthBias: -1120222471,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15772,
+        attributes: [
+          {format: 'unorm8x4', offset: 476, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 810, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 4874, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 5860, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 220,
+        attributes: [
+          {format: 'uint16x4', offset: 4, shaderLocation: 1},
+          {format: 'float32', offset: 52, shaderLocation: 16},
+          {format: 'sint8x4', offset: 64, shaderLocation: 2},
+          {format: 'uint8x4', offset: 48, shaderLocation: 10},
+          {format: 'uint32x4', offset: 4, shaderLocation: 0},
+          {format: 'float32x3', offset: 8, shaderLocation: 4},
+          {format: 'float32x3', offset: 16, shaderLocation: 3},
+          {format: 'uint8x4', offset: 0, shaderLocation: 6},
+          {format: 'uint8x2', offset: 18, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 24, shaderLocation: 7},
+          {format: 'sint32x2', offset: 80, shaderLocation: 11},
+          {format: 'float32x2', offset: 0, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 24, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 26, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw'},
+});
+try {
+  await promise30;
+} catch {}
+let promise31 = adapter3.requestDevice({
+  label: '\u062e\uaa35\u1a51',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxColorAttachmentBytesPerSample: 35,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 40834,
+    maxStorageTexturesPerShaderStage: 35,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 8519,
+    maxDynamicUniformBuffersPerPipelineLayout: 44886,
+    maxBindingsPerBindGroup: 5094,
+    maxTextureArrayLayers: 1110,
+    maxTextureDimension1D: 13411,
+    maxTextureDimension2D: 8428,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 120135971,
+    maxStorageBufferBindingSize: 149241176,
+    maxUniformBuffersPerShaderStage: 20,
+    maxSampledTexturesPerShaderStage: 43,
+    maxInterStageShaderVariables: 113,
+    maxInterStageShaderComponents: 87,
+  },
+});
+let commandEncoder151 = device1.createCommandEncoder({label: '\u1d70\u58e9\u1832\u{1fc3a}\u{1fb55}\u02ea\u7d04'});
+let textureView173 = texture86.createView({label: '\u07f2\u0c04\uc12c', mipLevelCount: 1});
+let computePassEncoder61 = commandEncoder151.beginComputePass({label: '\u{1fe73}\u312d'});
+let renderBundle87 = renderBundleEncoder30.finish({});
+try {
+renderPassEncoder6.setBlendConstant({ r: -439.3, g: -597.2, b: -622.2, a: -276.2, });
+} catch {}
+try {
+commandEncoder133.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 2,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 816 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 10288 */
+  offset: 10288,
+  buffer: buffer29,
+}, {width: 306, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer29);
+} catch {}
+let gpuCanvasContext6 = canvas9.getContext('webgpu');
+let buffer32 = device0.createBuffer({
+  label: '\u0385\u72b4\u{1fe64}\uaac3\u0ff7\u4a57',
+  size: 224424,
+  usage: GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet66 = device0.createQuerySet({label: '\u03a1\u{1f867}\u{1f9e9}\u6a64\udf52', type: 'occlusion', count: 1748});
+let textureView174 = texture0.createView({label: '\u03a5\u{1f8e6}\u{1fb52}\u0cd2\u0f24\u4f59\u{1f7f5}', baseMipLevel: 0});
+let computePassEncoder62 = commandEncoder124.beginComputePass({label: '\u06c2\u0057\u7a82'});
+let renderBundle88 = renderBundleEncoder42.finish({label: '\u0002\u{1fd5d}\u3c73\u7a71\u{1f90a}\u0c74\u{1ff33}\u0c89\u0bf5\u2cea\u03e4'});
+try {
+computePassEncoder10.dispatchWorkgroupsIndirect(buffer5, 14072);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(4, bindGroup14, new Uint32Array(690), 225, 0);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(3, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 432, new Float32Array(18440), 13221, 892);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let commandEncoder152 = device1.createCommandEncoder({label: '\u495f\u0ca7\u0911\ue754\u0c2c\u3d38\u0949'});
+let renderPassEncoder20 = commandEncoder146.beginRenderPass({
+  label: '\u{1fe36}\u0e89',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -905.7, g: 153.2, b: -835.2, a: 592.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 191826481,
+});
+try {
+renderPassEncoder13.setBindGroup(6, bindGroup24);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(8, buffer17);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+commandEncoder140.clearBuffer(buffer29);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 1,
+  origin: {x: 10, y: 5, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 71 */
+{offset: 71}, {width: 10, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline67 = device1.createRenderPipeline({
+  label: '\u825f\uaade',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x8cbe42af},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'increment-wrap',
+    },
+    stencilBack: {failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 2247123970,
+    depthBias: -106334292,
+    depthBiasSlopeScale: 236.9618340789126,
+    depthBiasClamp: 135.27287665922583,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 4602, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 14396, shaderLocation: 11},
+          {format: 'uint8x4', offset: 2920, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 4516, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 3258, shaderLocation: 16},
+          {format: 'uint32x2', offset: 1452, shaderLocation: 15},
+          {format: 'sint16x4', offset: 760, shaderLocation: 0},
+          {format: 'float16x4', offset: 532, shaderLocation: 12},
+          {format: 'float16x4', offset: 1444, shaderLocation: 17},
+          {format: 'sint32x4', offset: 9244, shaderLocation: 1},
+          {format: 'uint16x4', offset: 5464, shaderLocation: 14},
+          {format: 'float32x3', offset: 13516, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 6992,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 550, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 16424,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 620, shaderLocation: 10},
+          {format: 'sint32', offset: 380, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 14592, attributes: [{format: 'sint8x2', offset: 4932, shaderLocation: 13}]},
+      {arrayStride: 7312, stepMode: 'instance', attributes: []},
+      {arrayStride: 3124, stepMode: 'instance', attributes: []},
+      {arrayStride: 11544, stepMode: 'vertex', attributes: []},
+      {arrayStride: 18476, stepMode: 'instance', attributes: []},
+      {arrayStride: 8208, attributes: [{format: 'snorm8x2', offset: 298, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\u8e9b\u1674\u074f\u4232\u0062\u0b08',
+  entries: [
+    {
+      binding: 1382,
+      visibility: 0,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 2425,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let renderBundleEncoder59 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder44.copyBufferToBuffer(buffer7, 51780, buffer15, 73172, 18372);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 1, y: 29, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 23},
+  aspect: 'all',
+},
+{width: 117, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet1, 325, 224, buffer31, 6656);
+} catch {}
+let querySet67 = device2.createQuerySet({label: '\ub099\u09fa\u{1f752}\u{1fe53}\u040e\uac92\u{1f73b}\u087b', type: 'occlusion', count: 3516});
+let renderBundleEncoder60 = device2.createRenderBundleEncoder({
+  label: '\u04e2\u2c84\u0e68\u4db9\ua8aa\u{1f9c0}\u14b4\ube6a\u{1f6d4}',
+  colorFormats: ['r8uint', 'rg32uint'],
+  depthReadOnly: true,
+});
+let renderBundle89 = renderBundleEncoder32.finish({label: '\u0510\u0507\u6767\u09d0\ub2db\u4a20\u{1fdbb}\u{1f9ed}\u{1ff2f}\u5281\u{1ff9d}'});
+try {
+computePassEncoder34.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(8, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(3096, undefined, 627574929, 1266721336);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 33436, new Float32Array(58316), 21924, 5296);
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(733, 474);
+let bindGroupLayout29 = pipeline64.getBindGroupLayout(0);
+let bindGroup48 = device0.createBindGroup({layout: bindGroupLayout23, entries: []});
+let texture99 = device0.createTexture({
+  size: [15, 1, 1],
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView175 = texture12.createView({
+  label: '\u0b13\u6a25\u73d8\u6b3d\u9193\u27d9\uf6e4\u5ba0\u{1f627}\ub5cd',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundle90 = renderBundleEncoder56.finish({label: '\u7c17\u40a3\u070a'});
+let sampler69 = device0.createSampler({
+  label: '\u62f4\u0bbe',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.78,
+  lodMaxClamp: 59.60,
+});
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 45},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 27892 */
+  offset: 27892,
+  bytesPerRow: 0,
+  rowsPerImage: 232,
+  buffer: buffer6,
+}, {width: 0, height: 7, depthOrArrayLayers: 397});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet18, 1867, 1046, buffer0, 99584);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 24896, new BigUint64Array(41641), 3459, 3532);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer7), /* required buffer size: 17_004_527 */
+{offset: 567, bytesPerRow: 1248, rowsPerImage: 262}, {width: 302, height: 1, depthOrArrayLayers: 53});
+} catch {}
+document.body.prepend(img19);
+let canvas10 = document.createElement('canvas');
+let imageBitmap16 = await createImageBitmap(img12);
+let buffer33 = device0.createBuffer({
+  label: '\u7487\u5b4a\u5a5b\u12f1\u0cbc\u{1f7cf}\u{1fa34}\u01a8\u0907',
+  size: 577768,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder153 = device0.createCommandEncoder({label: '\uf29c\u{1fecb}\ua106\u8ed3\u{1fadf}\u0339\u{1f657}'});
+let textureView176 = texture4.createView({
+  label: '\ud45d\u{1fb3a}\u8df9\u{1fa01}\uac04\u{1fc43}\u0c82',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+let renderBundle91 = renderBundleEncoder3.finish({label: '\u944f\u384c\u0875'});
+let sampler70 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.62,
+  lodMaxClamp: 64.31,
+});
+try {
+computePassEncoder10.setPipeline(pipeline63);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer7, 111004, buffer14, 31700, 1452);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer14);
+} catch {}
+let pipeline68 = device0.createComputePipeline({layout: pipelineLayout19, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let shaderModule19 = device0.createShaderModule({
+  label: '\u{1ffd8}\u6402\u0d44\u414b\u05cd',
+  code: `@group(0) @binding(1922)
+var<storage, read_write> n7: array<u32>;
+@group(1) @binding(37)
+var<storage, read_write> function10: array<u32>;
+@group(1) @binding(550)
+var<storage, read_write> parameter12: array<u32>;
+@group(6) @binding(550)
+var<storage, read_write> field6: array<u32>;
+@group(3) @binding(3198)
+var<storage, read_write> parameter13: array<u32>;
+@group(6) @binding(37)
+var<storage, read_write> function11: array<u32>;
+
+@compute @workgroup_size(2, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec3<f32>,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S24, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(11) f0: vec4<f16>,
+  @location(7) f1: f32,
+  @location(13) f2: u32,
+  @location(4) f3: u32,
+  @location(0) f4: vec2<i32>,
+  @location(18) f5: i32,
+  @location(9) f6: vec4<u32>
+}
+
+@vertex
+fn vertex0(a0: S23, @location(19) a1: vec3<i32>, @builtin(instance_index) a2: u32, @location(3) a3: vec2<i32>, @location(6) a4: vec3<f16>, @location(2) a5: vec4<i32>, @location(10) a6: vec4<f16>, @location(1) a7: vec3<f16>, @location(12) a8: vec3<i32>, @location(8) a9: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder154 = device0.createCommandEncoder({label: '\u0fec\u0f93\ud300\u6714\u5168'});
+let renderBundle92 = renderBundleEncoder42.finish();
+let sampler71 = device0.createSampler({
+  label: '\u940e\ue123\u7447\u205c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 88.50,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer5, 'uint16', 24914, 4243);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 12768, 20092);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 1,
+  origin: {x: 73, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 99, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 330, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer11, commandBuffer17, commandBuffer2, commandBuffer35]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(793), /* required buffer size: 793 */
+{offset: 397, bytesPerRow: 432}, {width: 99, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise32 = adapter0.requestAdapterInfo();
+let commandEncoder155 = device2.createCommandEncoder({label: '\u7f70\u6e22\u06b0'});
+let querySet68 = device2.createQuerySet({label: '\ucb5e\u{1fd21}\u43c6', type: 'occlusion', count: 3000});
+try {
+device2.queue.writeBuffer(buffer30, 15320, new BigUint64Array(30243), 20820);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let shaderModule20 = device1.createShaderModule({
+  label: '\ucee5\u{1f8d3}\u5c78\uf9da\u{1f7e6}\uaa2f\ud031\u{1f7a2}\u0ac9',
+  code: `@group(4) @binding(2591)
+var<storage, read_write> function12: array<u32>;
+@group(4) @binding(2548)
+var<storage, read_write> global9: array<u32>;
+@group(6) @binding(1552)
+var<storage, read_write> type6: array<u32>;
+@group(1) @binding(2591)
+var<storage, read_write> n8: array<u32>;
+@group(5) @binding(3076)
+var<storage, read_write> type7: array<u32>;
+@group(0) @binding(3076)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(3101)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @builtin(front_facing) f0: bool
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, a3: S26) -> @location(200) vec3<i32> {
+return vec3<i32>();
+}
+
+struct S25 {
+  @location(6) f0: u32,
+  @location(17) f1: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec3<f16>, @builtin(instance_index) a1: u32, @builtin(vertex_index) a2: u32, @location(14) a3: vec3<f32>, @location(11) a4: i32, @location(12) a5: vec3<f16>, @location(10) a6: vec3<u32>, @location(15) a7: vec4<u32>, @location(3) a8: vec4<f32>, a9: S25, @location(7) a10: vec4<f16>, @location(2) a11: vec3<u32>, @location(16) a12: vec4<i32>, @location(8) a13: i32, @location(5) a14: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let renderBundleEncoder61 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint'], depthReadOnly: true});
+try {
+renderPassEncoder19.setBindGroup(5, bindGroup35);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle35, renderBundle82, renderBundle62, renderBundle56, renderBundle44, renderBundle56, renderBundle82, renderBundle69, renderBundle87]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(0.4916, 0.1007, 0.1707, 1.898, 0.4041, 0.4755);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(2, bindGroup24, new Uint32Array(499), 82, 0);
+} catch {}
+try {
+commandEncoder133.copyBufferToBuffer(buffer18, 15816, buffer29, 67220, 9504);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+offscreenCanvas13.getContext('2d');
+} catch {}
+let bindGroupLayout30 = device1.createBindGroupLayout({
+  label: '\u5a3d\u09ec\u{1fb48}\u8a1e\u04d2\u0b7c\u{1fdf9}\u2b18\u377d\u0fd1',
+  entries: [
+    {
+      binding: 6964,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 6239,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 1001,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderPassEncoder21 = commandEncoder88.beginRenderPass({
+  label: '\u3944\ua171\u{1fdb0}\u{1f76b}\u{1ff81}\u4496\u0e3a\uf313',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 614.5, g: 219.5, b: 758.5, a: 606.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet50,
+  maxDrawCount: 1149726562,
+});
+let externalTexture64 = device1.importExternalTexture({
+  label: '\u045f\u{1fd18}\u{1f796}\ufb5a\u9003\u{1fd33}\u0867\u06af\u6065\u{1fe4e}\u7212',
+  source: videoFrame7,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle77, renderBundle72, renderBundle56, renderBundle37, renderBundle19, renderBundle22, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -213.4, g: -976.2, b: -762.9, a: 794.6, });
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(814);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline39);
+} catch {}
+try {
+  await buffer29.mapAsync(GPUMapMode.READ, 0, 38280);
+} catch {}
+try {
+commandEncoder140.copyBufferToBuffer(buffer18, 20152, buffer20, 22640, 284);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let pipeline69 = await device1.createComputePipelineAsync({
+  label: '\ub53c\u091e\u039d\u91fa\u3e94',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let pipeline70 = device1.createRenderPipeline({
+  label: '\u4e4a\ub49e\u068b\u0e98\u026d\u37b9\u{1fedd}',
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', targets: [{format: 'rg16sint'}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilWriteMask: 1994394128,
+    depthBias: 757386511,
+    depthBiasSlopeScale: 910.0359897868617,
+    depthBiasClamp: 311.8937692649021,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5916,
+        attributes: [
+          {format: 'float32x3', offset: 156, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 1484, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 716, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 1664,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 228, shaderLocation: 7},
+          {format: 'uint16x4', offset: 36, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 11216, attributes: [{format: 'uint8x4', offset: 4292, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw'},
+});
+let bindGroup49 = device1.createBindGroup({
+  label: '\u6153\u688e\ua9dd\u5d3c\u0de7\u1a1c',
+  layout: bindGroupLayout10,
+  entries: [{binding: 1552, resource: sampler60}],
+});
+let buffer34 = device1.createBuffer({
+  label: '\u5cb7\u1781\u0bbf\u0b40\u85bc\uaef0\u9568\u02f1',
+  size: 43844,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder156 = device1.createCommandEncoder({label: '\u0caf\u10e3\u8e73\ua698'});
+let texture100 = device1.createTexture({
+  label: '\u5b5b\u{1fae5}\ud63c\u{1f620}\u06a2\u0080\u2b35',
+  size: {width: 288},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView177 = texture41.createView({label: '\u{1fc5d}\uf172\u7248\u{1fe30}', dimension: '1d', baseArrayLayer: 0});
+let renderBundleEncoder62 = device1.createRenderBundleEncoder({
+  label: '\u4163\u4344\u2eaa\u0981\ud628\u{1f659}\u{1f7fa}\u{1fd2f}\u0a95\u0aba\ue85a',
+  colorFormats: ['rg16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler72 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.06,
+  lodMaxClamp: 92.91,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder16.beginOcclusionQuery(492);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer34, 'uint32', 39732, 3692);
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer29);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder133.resolveQuerySet(querySet17, 236, 6, buffer34, 36608);
+} catch {}
+try {
+  await promise32;
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout5, bindGroupLayout22, bindGroupLayout1, bindGroupLayout15],
+});
+let querySet69 = device0.createQuerySet({label: '\uf6c3\u0cd8\u{1fade}\ue86f', type: 'occlusion', count: 1341});
+let textureView178 = texture92.createView({label: '\u129b\u{1fd9d}\u3e2b\ue664\u{1f616}'});
+let sampler73 = device0.createSampler({
+  label: '\ufd97\ud683\u0527\u{1f80e}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.79,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder5.dispatchWorkgroups(5, 1, 5);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 200 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8800 */
+  offset: 8800,
+  buffer: buffer24,
+}, {
+  texture: texture35,
+  mipLevel: 5,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 25, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 31, y: 9 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 107, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas5);
+let pipelineLayout26 = device2.createPipelineLayout({
+  label: '\u5495\u{1fe2a}\u07bb\u{1f7c5}\u0068\u{1fb61}\u{1f717}\u{1f858}',
+  bindGroupLayouts: [bindGroupLayout19],
+});
+let querySet70 = device2.createQuerySet({label: '\u13e3\ue9f6', type: 'occlusion', count: 3370});
+let textureView179 = texture76.createView({dimension: '2d-array'});
+let renderBundleEncoder63 = device2.createRenderBundleEncoder({
+  label: '\u{1fa1e}\u{1fcbc}\u6223\u008b\u0567\ue960',
+  colorFormats: ['r8uint', 'rg32uint'],
+  depthReadOnly: true,
+});
+let externalTexture65 = device2.importExternalTexture({
+  label: '\u{1f813}\u8701\u{1fb4f}\u7494\u5341\u6fad\u5e73\u0200\ubd21',
+  source: videoFrame13,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder55.setVertexBuffer(4, buffer28);
+} catch {}
+try {
+commandEncoder137.copyBufferToBuffer(buffer27, 90564, buffer30, 11928, 32592);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 58 */
+{offset: 58, bytesPerRow: 420}, {width: 174, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 34, y: 3 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 177, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet71 = device1.createQuerySet({
+  label: '\u{1fee8}\u9ed0\ua7f5\u7a85\ua54e\ufd2a\u0fdd\u93ce\uf52c\u883d\uda72',
+  type: 'occlusion',
+  count: 1772,
+});
+let computePassEncoder63 = commandEncoder156.beginComputePass({label: '\u0782\u08ae\uf7d4\u39cc\u9d94\u{1fafb}\u03df\u0b30\u6168\u0ffb\u{1fb5c}'});
+let renderPassEncoder22 = commandEncoder133.beginRenderPass({
+  label: '\u5b96\u07dc\u{1fcf4}\u2bce\u8d78\u0cbb\u1667\u0700\u852d\u6719',
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -585.7, g: 927.7, b: 93.98, a: -147.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet71,
+  maxDrawCount: 546219429,
+});
+let renderBundle93 = renderBundleEncoder30.finish({});
+try {
+renderPassEncoder1.setViewport(37.52, 0.5588, 3.234, 0.3580, 0.1350, 0.9614);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer34, 0, 1185);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(1, bindGroup15, []);
+} catch {}
+try {
+commandEncoder152.copyBufferToBuffer(buffer16, 20532, buffer20, 87700, 15472);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder152.resolveQuerySet(querySet49, 934, 456, buffer34, 256);
+} catch {}
+let gpuCanvasContext7 = canvas10.getContext('webgpu');
+let bindGroup50 = device1.createBindGroup({
+  label: '\u0a45\u2e8f\u0815\ubc75\u0f17\u{1ffed}\uc813\u0b8c\uae8c\u0644',
+  layout: bindGroupLayout24,
+  entries: [{binding: 133, resource: externalTexture61}],
+});
+let commandBuffer38 = commandEncoder140.finish({label: '\u7b89\u403a\u597a\u0ca0\u3c33\u7c9a\u1a75'});
+let texture101 = device1.createTexture({
+  size: {width: 72, height: 160, depthOrArrayLayers: 1343},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView180 = texture47.createView({label: '\u2a56\u8cc3\u0ea7\u1c4e'});
+let computePassEncoder64 = commandEncoder152.beginComputePass({label: '\u6d33\u{1f6c0}\uf55a\ub3e0\u{1ff04}\uad2c\u07f2\u0686\u{1f6a6}\u0737'});
+let sampler74 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.24,
+  lodMaxClamp: 73.97,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder23.setPipeline(pipeline61);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(8, bindGroup13);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer23, 46100, 12313);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(8, bindGroup35, new Uint32Array(1706), 1345, 0);
+} catch {}
+let pipelineLayout27 = device1.createPipelineLayout({
+  label: '\uee8d\u0389\u093a\u385e',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout16, bindGroupLayout14, bindGroupLayout14],
+});
+let commandEncoder157 = device1.createCommandEncoder({});
+let renderPassEncoder23 = commandEncoder157.beginRenderPass({
+  label: '\u3690\u0eac\udcc1\u0a28\u{1fd64}\u{1f6a4}\u0389\u08c8\uf80f',
+  colorAttachments: [{view: textureView152, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 452127077,
+});
+try {
+renderPassEncoder10.beginOcclusionQuery(2087);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle37, renderBundle37, renderBundle64, renderBundle53]);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline37);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 604 */
+{offset: 604}, {width: 57, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap17 = await createImageBitmap(img13);
+let texture102 = device0.createTexture({
+  label: '\u19ee\u073a\ud909\u{1f905}\u1545\u{1f6e7}',
+  size: [31],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32float'],
+});
+let externalTexture66 = device0.importExternalTexture({label: '\u{1fd72}\u0ef1\u{1f8b5}\u3f9c\u0d0e\u2762\u8cfb\u860e\ubb9d\u{1f840}', source: videoFrame10});
+try {
+commandEncoder31.resolveQuerySet(querySet12, 282, 519, buffer15, 40448);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 812, new BigUint64Array(20779), 7584, 620);
+} catch {}
+let pipeline71 = await device0.createComputePipelineAsync({layout: pipelineLayout15, compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}}});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroupLayout31 = pipeline3.getBindGroupLayout(4);
+let texture103 = device1.createTexture({
+  label: '\u0d67\u{1fd2c}\u59bb\u{1f97d}\u0d87\u020c\u{1f88a}\ua77e\ua255',
+  size: {width: 72},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let externalTexture67 = device1.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setStencilReference(2610);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer23, 'uint32');
+} catch {}
+let pipeline72 = device1.createRenderPipeline({
+  label: '\u0193\u048d\u{1fc8e}\u91a2\u0214\ubc01\u{1f9b3}\u2a27\ua22a\u04c4\u0684',
+  layout: pipelineLayout24,
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 1004743257,
+    stencilWriteMask: 4008796855,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9784,
+        attributes: [
+          {format: 'snorm16x2', offset: 2056, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 916, shaderLocation: 12},
+          {format: 'uint8x2', offset: 1436, shaderLocation: 6},
+          {format: 'float32x2', offset: 1512, shaderLocation: 14},
+          {format: 'uint32x3', offset: 852, shaderLocation: 1},
+          {format: 'uint32x3', offset: 408, shaderLocation: 10},
+          {format: 'uint8x2', offset: 2712, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 24,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 6104,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 3468, shaderLocation: 11},
+          {format: 'float32', offset: 2312, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 388, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 500, shaderLocation: 9},
+          {format: 'float32', offset: 2000, shaderLocation: 7},
+          {format: 'uint8x4', offset: 464, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 7276, stepMode: 'instance', attributes: []},
+      {arrayStride: 80, attributes: []},
+      {arrayStride: 1128, attributes: [{format: 'float32', offset: 64, shaderLocation: 17}]},
+      {arrayStride: 10148, attributes: [{format: 'sint32x4', offset: 240, shaderLocation: 2}]},
+      {
+        arrayStride: 14780,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 268, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let computePassEncoder65 = commandEncoder63.beginComputePass();
+let renderBundleEncoder64 = device0.createRenderBundleEncoder({
+  label: '\u0646\udc3a\ud6db\ucf33\u030c',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder40.setPipeline(pipeline62);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(9, bindGroup48);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+window.someLabel = shaderModule1.label;
+} catch {}
+let bindGroupLayout32 = pipeline49.getBindGroupLayout(1);
+let texture104 = gpuCanvasContext3.getCurrentTexture();
+let textureView181 = texture71.createView({label: '\u{1fdcd}\u349a\u{1ffe4}\u{1fe86}\u0462', mipLevelCount: 1});
+let renderBundleEncoder65 = device1.createRenderBundleEncoder({label: '\u3be4\ucadf', colorFormats: ['rg16sint'], depthReadOnly: false, stencilReadOnly: true});
+try {
+computePassEncoder44.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 311.1, g: 687.1, b: 207.9, a: -81.71, });
+} catch {}
+try {
+renderBundleEncoder65.setPipeline(pipeline37);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout33 = device2.createBindGroupLayout({
+  label: '\u372f\u0c8a\u0406',
+  entries: [
+    {binding: 784, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 5469,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 3240,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup51 = device2.createBindGroup({label: '\u7bb9\u82ea', layout: bindGroupLayout25, entries: []});
+let commandEncoder159 = device2.createCommandEncoder({label: '\uf6f3\ufd10\u542e\u9306\u0f32'});
+let textureView182 = texture57.createView({baseMipLevel: 6, mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 1});
+try {
+commandEncoder136.copyBufferToBuffer(buffer27, 85212, buffer21, 137240, 8440);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 136 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 14440 */
+  offset: 14304,
+  buffer: buffer30,
+}, {width: 68, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder148.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 262, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline73 = device2.createComputePipeline({
+  label: '\ub393\u5706\u797a\u08b2\uad03\u0818\u03d6\u{1f6f9}\u08cd',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let textureView183 = texture58.createView({
+  label: '\u7520\ue12a\u5a63\u{1fa7b}\u2588\uf46f\u0555\u072a\u06c2',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 1762,
+});
+let computePassEncoder66 = commandEncoder103.beginComputePass({label: '\u786f\ud392\u{1fc06}\u9c84\u6114\u0a5b'});
+let sampler75 = device2.createSampler({
+  label: '\u4ef9\u{1f929}\ud31d\uc129',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 37.62,
+});
+try {
+computePassEncoder57.setPipeline(pipeline73);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline44);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 7292, new Int16Array(35562));
+} catch {}
+let shaderModule21 = device1.createShaderModule({
+  label: '\ua660\uf44a\u0d2d\u2be6\u{1f7df}',
+  code: `@group(0) @binding(1552)
+var<storage, read_write> parameter14: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @builtin(instance_index) f0: u32,
+  @location(8) f1: f16
+}
+
+@vertex
+fn vertex0(a0: S27, @builtin(vertex_index) a1: u32, @location(17) a2: f32, @location(11) a3: vec2<f32>, @location(1) a4: vec3<u32>, @location(9) a5: vec3<f16>, @location(15) a6: vec4<i32>, @location(3) a7: vec2<u32>, @location(4) a8: vec4<f16>, @location(14) a9: f32, @location(7) a10: vec2<f16>, @location(6) a11: vec3<u32>, @location(13) a12: f32, @location(2) a13: vec4<f32>, @location(10) a14: f32, @location(0) a15: vec3<u32>, @location(12) a16: f16, @location(16) a17: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup52 = device1.createBindGroup({
+  label: '\u{1f716}\u{1ffd5}\u6a79\u0ceb\u{1f952}\u39ae\u6c57\u0f29\u0800\u0d46',
+  layout: bindGroupLayout31,
+  entries: [{binding: 1552, resource: sampler36}],
+});
+let buffer35 = device1.createBuffer({
+  label: '\u0eaf\u5ef2\u{1ffa2}\u0a13\u0299\uaa62\u{1f763}\u5b91\u9e00',
+  size: 105440,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let querySet72 = device1.createQuerySet({type: 'occlusion', count: 1443});
+let externalTexture68 = device1.importExternalTexture({label: '\u43bd\u3a5c\ub8e3\u058b', source: video6, colorSpace: 'srgb'});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup50, new Uint32Array(1177), 553, 0);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(43, 1, 15, 0);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 21136, new Int16Array(57552), 38208);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline74 = await device1.createRenderPipelineAsync({
+  label: '\u0782\u0c46',
+  layout: 'auto',
+  multisample: {mask: 0xf2a064f0},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 3291052688,
+    stencilWriteMask: 916378824,
+    depthBiasClamp: 590.4057749318613,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14008,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 60, shaderLocation: 0},
+          {format: 'uint16x2', offset: 500, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 6200, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 756, shaderLocation: 10},
+          {format: 'float32x3', offset: 2004, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 2556,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 492, shaderLocation: 5},
+          {format: 'uint16x4', offset: 348, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 324, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 16, shaderLocation: 11},
+          {format: 'sint8x2', offset: 268, shaderLocation: 9},
+          {format: 'sint32x2', offset: 368, shaderLocation: 7},
+          {format: 'sint16x4', offset: 40, shaderLocation: 3},
+          {format: 'float32', offset: 252, shaderLocation: 16},
+          {format: 'sint16x4', offset: 44, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 148, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 19192, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 9392,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 896, shaderLocation: 13},
+          {format: 'sint32x3', offset: 612, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 280, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'front'},
+});
+let img24 = await imageWithData(210, 181, '#6fb285f8', '#1fabad88');
+let texture105 = device0.createTexture({
+  label: '\u0fda\u0fc1\u{1ffa5}',
+  size: {width: 31, height: 1, depthOrArrayLayers: 121},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let computePassEncoder67 = commandEncoder37.beginComputePass({label: '\u4193\u0c5e\u072f\u{1fcd9}\u{1fe22}\ufafb\u0728'});
+let renderBundle94 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup0, new Uint32Array(8002), 6731, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(8, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer33, 'uint32', 537016);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(5, buffer32, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 8008, new Int16Array(25640), 20253, 1540);
+} catch {}
+let shaderModule22 = device2.createShaderModule({
+  label: '\u2bd1\ub1ed\u33ba',
+  code: `@group(0) @binding(6715)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(29) f0: vec4<i32>,
+  @location(110) f1: i32,
+  @location(3) f2: vec2<f16>,
+  @location(69) f3: vec2<i32>,
+  @location(94) f4: f32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec3<u32>,
+  @location(1) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(22) a0: vec4<i32>, @location(82) a1: vec2<f16>, @location(9) a2: vec4<f16>, @location(97) a3: vec3<u32>, @location(96) a4: i32, @location(90) a5: vec2<u32>, @location(104) a6: vec3<i32>, @location(39) a7: vec3<u32>, @location(63) a8: f16, @location(0) a9: vec3<f16>, @location(99) a10: vec4<f32>, @builtin(sample_mask) a11: u32, @location(30) a12: vec3<f16>, @builtin(sample_index) a13: u32, @location(21) a14: vec4<u32>, @location(79) a15: i32, @location(68) a16: vec2<u32>, @builtin(front_facing) a17: bool, @location(116) a18: u32, @location(28) a19: vec3<u32>, @builtin(position) a20: vec4<f32>, @location(36) a21: vec2<u32>, @location(75) a22: f32, @location(65) a23: vec4<i32>, a24: S28, @location(73) a25: vec3<f16>, @location(57) a26: vec3<u32>, @location(81) a27: u32, @location(45) a28: f16, @location(84) a29: i32, @location(77) a30: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(22) f304: vec4<i32>,
+  @location(116) f305: u32,
+  @location(97) f306: vec3<u32>,
+  @location(39) f307: vec3<u32>,
+  @location(77) f308: u32,
+  @builtin(position) f309: vec4<f32>,
+  @location(81) f310: u32,
+  @location(9) f311: vec4<f16>,
+  @location(113) f312: vec2<i32>,
+  @location(26) f313: vec3<f32>,
+  @location(87) f314: vec3<f16>,
+  @location(45) f315: f16,
+  @location(64) f316: vec3<f16>,
+  @location(36) f317: vec2<u32>,
+  @location(110) f318: i32,
+  @location(104) f319: vec3<i32>,
+  @location(63) f320: f16,
+  @location(90) f321: vec2<u32>,
+  @location(30) f322: vec3<f16>,
+  @location(0) f323: vec3<f16>,
+  @location(84) f324: i32,
+  @location(76) f325: vec2<f16>,
+  @location(79) f326: i32,
+  @location(73) f327: vec3<f16>,
+  @location(75) f328: f32,
+  @location(31) f329: vec2<f32>,
+  @location(99) f330: vec4<f32>,
+  @location(68) f331: vec2<u32>,
+  @location(103) f332: vec3<f16>,
+  @location(94) f333: f32,
+  @location(21) f334: vec4<u32>,
+  @location(29) f335: vec4<i32>,
+  @location(65) f336: vec4<i32>,
+  @location(57) f337: vec3<u32>,
+  @location(28) f338: vec3<u32>,
+  @location(71) f339: vec2<f16>,
+  @location(82) f340: vec2<f16>,
+  @location(96) f341: i32,
+  @location(69) f342: vec2<i32>,
+  @location(3) f343: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec4<u32>, @location(12) a1: vec3<f32>, @location(20) a2: f16, @location(24) a3: vec4<f16>, @location(14) a4: vec3<i32>, @builtin(vertex_index) a5: u32, @location(6) a6: vec2<u32>, @location(0) a7: vec2<i32>, @location(13) a8: vec3<i32>, @location(1) a9: f16, @location(19) a10: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder160 = device2.createCommandEncoder({});
+let externalTexture69 = device2.importExternalTexture({label: '\u05c7\ueab0\u015f\u8aa9\uba87\u0e06', source: videoFrame13, colorSpace: 'srgb'});
+try {
+renderBundleEncoder55.setPipeline(pipeline44);
+} catch {}
+let pipeline75 = await device2.createComputePipelineAsync({
+  label: '\u2149\u{1f994}\uc0b2',
+  layout: 'auto',
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder161 = device2.createCommandEncoder({});
+let texture106 = device2.createTexture({
+  label: '\u9d85\u2c47',
+  size: [816],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder21.setBindGroup(7, bindGroup20, new Uint32Array(963), 398, 0);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(4, buffer28, 0);
+} catch {}
+let arrayBuffer21 = buffer21.getMappedRange(155936, 26448);
+try {
+commandEncoder95.copyBufferToBuffer(buffer27, 140520, buffer30, 40624, 2240);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder160.copyTextureToBuffer({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 26 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 18812 */
+  offset: 18812,
+  buffer: buffer30,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer16), /* required buffer size: 1_242 */
+{offset: 874}, {width: 184, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 10, y: 64 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 222, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let querySet73 = device0.createQuerySet({label: '\u{1fc88}\uecd5\u{1f9dd}\u3e0d\u23ce\u06c8\ua024', type: 'occlusion', count: 1310});
+let computePassEncoder68 = commandEncoder41.beginComputePass({label: '\u061c\u{1fdfa}'});
+try {
+commandEncoder69.copyBufferToBuffer(buffer7, 102188, buffer11, 42752, 5104);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video15,
+  origin: { x: 9, y: 9 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet74 = device2.createQuerySet({
+  label: '\u0a70\uf234\u0b41\u9d09\u043f\ue319\ue9f2\u01a5\u0af7\u02b8\u0f9d',
+  type: 'occlusion',
+  count: 292,
+});
+try {
+renderBundleEncoder60.setPipeline(pipeline44);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(5, buffer28, 73104, 49318);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 2144, new Float32Array(49889), 41281);
+} catch {}
+let shaderModule23 = device0.createShaderModule({
+  label: '\u079f\ub1c4\u8001\u5362\ufa04\u531e\u65cb\u{1fc24}\u09db\u05c6',
+  code: `@group(4) @binding(1221)
+var<storage, read_write> field8: array<u32>;
+@group(3) @binding(1221)
+var<storage, read_write> n9: array<u32>;
+@group(5) @binding(3198)
+var<storage, read_write> field9: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(4) f3: vec3<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(1) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(8) f0: vec2<f32>,
+  @location(16) f1: vec2<f32>,
+  @location(10) f2: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, @builtin(instance_index) a1: u32, @location(14) a2: vec4<u32>, @location(7) a3: vec2<u32>, @location(19) a4: vec2<u32>, @location(9) a5: vec3<f16>, @builtin(vertex_index) a6: u32, @location(12) a7: vec2<f16>, @location(2) a8: i32, @location(1) a9: vec4<u32>, @location(13) a10: f16, a11: S29, @location(3) a12: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let pipelineLayout28 = device0.createPipelineLayout({label: '\u{1f87f}\u6e16\ue010\u0ed5\u0713\u5cbf\u191a\u{1fb70}\u0789', bindGroupLayouts: []});
+let commandEncoder162 = device0.createCommandEncoder({label: '\uecf6\u96f4'});
+let textureView184 = texture15.createView({label: '\u{1f846}\u7f9f', dimension: '2d', baseMipLevel: 8, baseArrayLayer: 252});
+let sampler76 = device0.createSampler({
+  label: '\uddaa\u01ad\uacea\u0eef\u{1fb0c}\u09c9',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.2475,
+  lodMaxClamp: 32.33,
+});
+try {
+commandEncoder53.copyBufferToBuffer(buffer24, 21248, buffer4, 24084, 27956);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder144.clearBuffer(buffer15, 13028);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 30524, new DataView(new ArrayBuffer(36967)), 4854, 10240);
+} catch {}
+let imageBitmap18 = await createImageBitmap(canvas3);
+let commandEncoder163 = device1.createCommandEncoder({label: '\u8281\udb0e\u0d0c\u{1fe1c}\udd61\u2a34'});
+let textureView185 = texture88.createView({label: '\u4161\ue6ce\u03d1\ud3bd\u0cb9\uaf24', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder18.setBindGroup(7, bindGroup24);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup52, new Uint32Array(9053), 6623, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(638);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(167);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(7, bindGroup19, new Uint32Array(6981), 6364, 0);
+} catch {}
+let pipeline76 = device1.createComputePipeline({
+  label: '\u3d99\u0e5a\u4aee\u{1fc5b}\u7ff1\u{1fdd4}\u08eb',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline77 = device1.createRenderPipeline({
+  label: '\u96e8\uc041\u0a53\u0fba\u0eaf\u{1fa7b}',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1072,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 480, shaderLocation: 12},
+          {format: 'uint32x2', offset: 308, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 696, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 312, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 144, shaderLocation: 16},
+          {format: 'uint32x3', offset: 148, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 126, shaderLocation: 2},
+          {format: 'float16x4', offset: 112, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 140, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 116, shaderLocation: 6},
+          {format: 'float32x3', offset: 124, shaderLocation: 4},
+          {format: 'uint32x4', offset: 4, shaderLocation: 17},
+          {format: 'uint32', offset: 104, shaderLocation: 15},
+          {format: 'sint32x3', offset: 180, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 4512,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 252, shaderLocation: 8}],
+      },
+      {arrayStride: 6532, attributes: [{format: 'float32x2', offset: 848, shaderLocation: 3}]},
+    ],
+  },
+});
+let commandEncoder164 = device1.createCommandEncoder();
+let querySet75 = device1.createQuerySet({label: '\ud21a\ub43d\u948c\u{1f837}\u6d36', type: 'occlusion', count: 2872});
+let commandBuffer39 = commandEncoder163.finish({});
+let textureView186 = texture71.createView({label: '\ue8ff\u1ad5\u382f\uf8c7\u0ba8\u22cd', baseMipLevel: 2});
+let renderPassEncoder24 = commandEncoder164.beginRenderPass({
+  label: '\u{1ffd1}\u0f94\ub54f\u046d\u693e\u6d98\u8500\u015b\u029c',
+  colorAttachments: [{
+  view: textureView185,
+  depthSlice: 30,
+  clearValue: { r: -546.6, g: 136.8, b: -707.6, a: 271.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet38,
+  maxDrawCount: 1047593451,
+});
+try {
+computePassEncoder58.setBindGroup(7, bindGroup42, new Uint32Array(7690), 5763, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(6, bindGroup42);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer34, 'uint32', 30832, 4534);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer23, 22456);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline37);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer18), /* required buffer size: 531 */
+{offset: 23}, {width: 127, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img25 = await imageWithData(108, 79, '#ca776b81', '#a0ca09d4');
+let bindGroup53 = device0.createBindGroup({layout: bindGroupLayout3, entries: []});
+let textureView187 = texture24.createView({label: '\u{1fe50}\u824f\u{1feec}\u9003', dimension: '2d', baseMipLevel: 5, baseArrayLayer: 265});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+commandEncoder129.copyBufferToBuffer(buffer10, 15008, buffer14, 174100, 3564);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.submit([commandBuffer26]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 100, y: 8 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline78 = device0.createRenderPipeline({
+  label: '\u014a\uf49a\u1a95\u317e\u7e1d\u693a',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x28d18461},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint'}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'decrement-wrap', depthFailOp: 'invert'},
+    stencilReadMask: 3164845459,
+    stencilWriteMask: 167620218,
+    depthBiasSlopeScale: 620.0258126720242,
+    depthBiasClamp: 478.72773147860426,
+  },
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4404,
+        attributes: [
+          {format: 'sint32x3', offset: 356, shaderLocation: 2},
+          {format: 'sint8x2', offset: 1098, shaderLocation: 5},
+          {format: 'float32x3', offset: 2204, shaderLocation: 13},
+          {format: 'float16x2', offset: 440, shaderLocation: 9},
+          {format: 'uint32x3', offset: 224, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 1224, shaderLocation: 8},
+          {format: 'float32x3', offset: 320, shaderLocation: 16},
+          {format: 'sint8x4', offset: 416, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 18376, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 11432,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1144, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 3130, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 7924, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 2516,
+        attributes: [
+          {format: 'uint8x4', offset: 860, shaderLocation: 1},
+          {format: 'uint32', offset: 16, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+offscreenCanvas3.height = 1729;
+let videoFrame19 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+let pipelineLayout29 = device0.createPipelineLayout({label: '\u27b9\u5b0e\u0c6a', bindGroupLayouts: []});
+let commandEncoder165 = device0.createCommandEncoder({label: '\u0b77\u0ff3\u0eca\ud0a5\u9ad3\ud519\uf5d4'});
+let querySet76 = device0.createQuerySet({
+  label: '\u042d\u322a\u06f3\uc6f0\u{1fa5f}\u413b\u{1f6f7}\u001f\ue3b4\u{1ff47}',
+  type: 'occlusion',
+  count: 3473,
+});
+let renderBundleEncoder66 = device0.createRenderBundleEncoder({label: '\u{1fe24}\u{1f9a4}\u0508', colorFormats: ['rgba8unorm']});
+try {
+commandEncoder132.insertDebugMarker('\u1f0d');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 175, y: 389 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 4,
+  origin: {x: 15, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(704, 924);
+let video16 = await videoWithData();
+let commandEncoder166 = device0.createCommandEncoder({label: '\u5319\uc6a1\u0ad4'});
+let texture107 = device0.createTexture({
+  label: '\ued57\u06aa\u{1f612}',
+  size: {width: 1440, height: 12, depthOrArrayLayers: 61},
+  mipLevelCount: 7,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+let textureView188 = texture3.createView({format: 'r32uint'});
+try {
+computePassEncoder28.setBindGroup(6, bindGroup9, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData8 = new ImageData(256, 164);
+try {
+externalTexture45.label = '\u5403\u09d9\u0274\u{1fe2c}\u{1fcff}\u55ba\u5918\u2be6\u21b1\u{1f7e2}\u657e';
+} catch {}
+let pipelineLayout30 = device0.createPipelineLayout({
+  label: '\u11aa\u157a',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout3, bindGroupLayout5, bindGroupLayout2, bindGroupLayout22, bindGroupLayout0, bindGroupLayout23, bindGroupLayout2, bindGroupLayout9],
+});
+let buffer36 = device0.createBuffer({size: 99500, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderBundleEncoder29.setVertexBuffer(4, buffer31, 0, 10506);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 89, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(24_795), /* required buffer size: 24_795 */
+{offset: 99, bytesPerRow: 294, rowsPerImage: 7}, {width: 57, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let promise33 = device0.createComputePipelineAsync({
+  label: '\u{1fa15}\ud4de\u099c\u{1feca}\u1a5a\ub76a\uc45d\u0169',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule16, entryPoint: 'compute0'},
+});
+let pipeline79 = device0.createRenderPipeline({
+  label: '\u0a9c\ub74e\u{1fd4b}\ud675\udccd\ucc02',
+  layout: pipelineLayout30,
+  multisample: {count: 4, mask: 0x77016d29},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2unorm'}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8124,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 164, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 410, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 364, shaderLocation: 3},
+          {format: 'uint32', offset: 968, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 892, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 232, attributes: [{format: 'snorm16x4', offset: 44, shaderLocation: 8}]},
+      {arrayStride: 6416, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4192,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 612, shaderLocation: 7},
+          {format: 'sint16x4', offset: 696, shaderLocation: 10},
+          {format: 'uint32x3', offset: 412, shaderLocation: 1},
+          {format: 'float32x3', offset: 616, shaderLocation: 16},
+          {format: 'uint8x2', offset: 28, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 884, attributes: []},
+      {arrayStride: 2772, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3432,
+        attributes: [
+          {format: 'sint32x4', offset: 1420, shaderLocation: 2},
+          {format: 'sint16x4', offset: 388, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', cullMode: 'front'},
+});
+let commandEncoder167 = device1.createCommandEncoder({label: '\u2278\u96d8\u7696\uf144\ufc86\u{1fa0a}'});
+let texture108 = device1.createTexture({
+  label: '\u0240\u{1f6a8}\u0a04\u0972\u0201\ub6e8\u{1f7e8}\u02f7\u0fdc',
+  size: [36],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView189 = texture27.createView({
+  label: '\u0ef6\u08e5\u{1f875}\u3134\ua55a\u3c2c\u706e\u0a89',
+  format: 'etc2-rgb8a1unorm',
+  mipLevelCount: 1,
+});
+let renderPassEncoder25 = commandEncoder167.beginRenderPass({
+  colorAttachments: [{
+  view: textureView154,
+  depthSlice: 0,
+  clearValue: { r: -268.8, g: -61.24, b: 206.3, a: -626.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 249618977,
+});
+try {
+computePassEncoder44.setPipeline(pipeline48);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(7, bindGroup15, new Uint32Array(7928), 6998, 0);
+} catch {}
+try {
+renderPassEncoder23.setViewport(30.96, 0.08538, 1.818, 0.3897, 0.7846, 0.9775);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(6, bindGroup49, new Uint32Array(6829), 5894, 0);
+} catch {}
+let arrayBuffer22 = buffer29.getMappedRange(0, 10212);
+try {
+device1.queue.submit([commandBuffer38, commandBuffer39]);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+document.body.prepend(canvas7);
+let videoFrame20 = new VideoFrame(imageBitmap11, {timestamp: 0});
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({label: '\u00a6\u0927', colorFormats: ['rg16sint'], stencilReadOnly: true});
+try {
+computePassEncoder24.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(129);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer17, 98028, 88357);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\ue1f9');
+} catch {}
+try {
+renderBundleEncoder62.insertDebugMarker('\u07b1');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 4, y: 72, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(10_485), /* required buffer size: 10_485 */
+{offset: 165, bytesPerRow: 952}, {width: 200, height: 44, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout31 = device0.createPipelineLayout({
+  label: '\u{1f88e}\u0e71\u0ce0',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout8, bindGroupLayout5, bindGroupLayout2, bindGroupLayout7, bindGroupLayout29],
+});
+let commandEncoder168 = device0.createCommandEncoder();
+let texture109 = device0.createTexture({
+  label: '\ufb19\ucc6c\u339f\u{1fa05}\u5cd2',
+  size: {width: 125, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView190 = texture33.createView({label: '\u{1f67a}\ubee8\u0e01\u{1f802}'});
+let computePassEncoder69 = commandEncoder132.beginComputePass();
+let renderBundleEncoder68 = device0.createRenderBundleEncoder({
+  label: '\u005b\u0b2a\u1004',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+});
+try {
+computePassEncoder65.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(1, buffer31, 7756, 1763);
+} catch {}
+try {
+commandEncoder139.copyBufferToBuffer(buffer25, 107928, buffer4, 53432, 512);
+dissociateBuffer(device0, buffer25);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas14.getContext('webgpu');
+let querySet77 = device1.createQuerySet({label: '\ue433\u02f5\u2fb7\u47f7\u{1fbf2}\u0151', type: 'occlusion', count: 2469});
+let texture110 = device1.createTexture({
+  size: [288, 640, 530],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+try {
+renderPassEncoder11.beginOcclusionQuery(651);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(3568);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer34, 'uint32', 16928, 23047);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(8, buffer34, 0, 6235);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer34]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 8360, new Int16Array(17764));
+} catch {}
+gc();
+let texture111 = device0.createTexture({
+  size: [62, 1, 242],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder45.dispatchWorkgroups(1, 5, 4);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(9, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer3, 45588, 69436);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27, commandBuffer29]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 54436, new Int16Array(46684), 27274, 348);
+} catch {}
+gc();
+let offscreenCanvas15 = new OffscreenCanvas(772, 207);
+let bindGroupLayout34 = device2.createBindGroupLayout({
+  label: '\u{1fd41}\ucf7e\u3018\ueb03\u{1fb86}\u{1fe87}\u035d\u{1f6a5}\u02b8',
+  entries: [
+    {
+      binding: 1866,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 2608,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet78 = device2.createQuerySet({type: 'occlusion', count: 1021});
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8580 */
+  offset: 8580,
+  bytesPerRow: 512,
+  buffer: buffer30,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet62, 1438, 1983, buffer30, 100096);
+} catch {}
+try {
+offscreenCanvas15.getContext('webgl2');
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(7, bindGroup36);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline44);
+} catch {}
+try {
+buffer30.destroy();
+} catch {}
+let commandEncoder169 = device1.createCommandEncoder({label: '\ud15f\u3284\u0c15\u0605\u04b0\u{1fd5e}\u{1f8ff}\u2742\u{1fdf8}\u0ca6'});
+let querySet79 = device1.createQuerySet({
+  label: '\u0e98\u0a7f\u3edd\u30fb\u06a7\u0482\uf152\u0a3b\u00b1\u0b65\u0cc6',
+  type: 'occlusion',
+  count: 1371,
+});
+try {
+computePassEncoder63.setBindGroup(6, bindGroup19, new Uint32Array(7793), 1917, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline69);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(4, bindGroup13, new Uint32Array(6811), 4901, 0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(1119);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer23, 105656, 1464);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(3, buffer17, 153484, 92780);
+} catch {}
+try {
+commandEncoder169.resolveQuerySet(querySet50, 2368, 408, buffer34, 21248);
+} catch {}
+let shaderModule24 = device1.createShaderModule({
+  label: '\u6d8d\u059d\u0914\u6c82\ucd2a\ud7d5\u0eed\ub8b7',
+  code: `@group(6) @binding(1552)
+var<storage, read_write> parameter16: array<u32>;
+@group(5) @binding(3157)
+var<storage, read_write> function13: array<u32>;
+@group(1) @binding(3157)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(2548)
+var<storage, read_write> local10: array<u32>;
+@group(4) @binding(1552)
+var<storage, read_write> function14: array<u32>;
+@group(0) @binding(2548)
+var<storage, read_write> function15: array<u32>;
+@group(0) @binding(2591)
+var<storage, read_write> local11: array<u32>;
+@group(2) @binding(2591)
+var<storage, read_write> parameter17: array<u32>;
+@group(3) @binding(1552)
+var<storage, read_write> field10: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @location(2) f0: vec4<f32>,
+  @builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(2) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(27) a0: vec2<i32>, @location(8) a1: vec4<u32>, @location(74) a2: u32, @location(60) a3: u32, @location(95) a4: vec3<u32>, @builtin(sample_index) a5: u32, @builtin(sample_mask) a6: u32, a7: S31, @location(43) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @location(16) f0: f16,
+  @location(0) f1: vec2<f16>,
+  @location(4) f2: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(60) f344: u32,
+  @location(74) f345: u32,
+  @location(27) f346: vec2<i32>,
+  @builtin(position) f347: vec4<f32>,
+  @location(8) f348: vec4<u32>,
+  @location(95) f349: vec3<u32>,
+  @location(43) f350: u32,
+  @location(2) f351: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: i32, @location(10) a1: vec3<i32>, @location(5) a2: vec2<u32>, @location(13) a3: vec2<f32>, @location(15) a4: u32, @builtin(vertex_index) a5: u32, @builtin(instance_index) a6: u32, @location(3) a7: vec4<f32>, @location(2) a8: vec2<u32>, a9: S30, @location(6) a10: vec4<u32>, @location(12) a11: vec2<f32>, @location(7) a12: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView191 = texture100.createView({label: '\u4f56\u{1fce9}\u5af0\ua86d\u0ee5\u08c9\u86ad\u5adb\ua124\u379a\u8848', baseArrayLayer: 0});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(265);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setViewport(14.86, 0.2802, 3.065, 0.3239, 0.3593, 0.7589);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer23, 'uint16', 59910, 15401);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup42, new Uint32Array(5848), 4343, 0);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer35, 25992, buffer34, 22964, 12740);
+dissociateBuffer(device1, buffer35);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16584 */
+  offset: 16580,
+  buffer: buffer34,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer34);
+} catch {}
+gc();
+let adapter5 = await navigator.gpu.requestAdapter({});
+let video17 = await videoWithData();
+let shaderModule25 = device0.createShaderModule({
+  label: '\u0a61\u97c4\u06af\u{1fbcd}\u1af3\ud091\ub098',
+  code: `@group(2) @binding(3682)
+var<storage, read_write> n10: array<u32>;
+@group(5) @binding(3198)
+var<storage, read_write> field11: array<u32>;
+@group(6) @binding(37)
+var<storage, read_write> n11: array<u32>;
+@group(3) @binding(1221)
+var<storage, read_write> function16: array<u32>;
+@group(4) @binding(1904)
+var<storage, read_write> field12: array<u32>;
+@group(2) @binding(1191)
+var<storage, read_write> field13: array<u32>;
+@group(1) @binding(1904)
+var<storage, read_write> n12: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @location(13) f0: vec2<u32>,
+  @location(12) f1: vec3<f32>,
+  @location(4) f2: f32,
+  @location(10) f3: vec4<u32>,
+  @location(8) f4: vec2<u32>,
+  @location(1) f5: vec3<u32>,
+  @location(18) f6: f32,
+  @location(9) f7: vec3<i32>
+}
+
+@vertex
+fn vertex0(a0: S32, @builtin(vertex_index) a1: u32, @location(0) a2: vec4<u32>, @location(3) a3: f32, @builtin(instance_index) a4: u32, @location(5) a5: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder170 = device0.createCommandEncoder({});
+try {
+computePassEncoder36.setBindGroup(8, bindGroup5);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer36, 18684);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+device0.queue.submit([commandBuffer30]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder171 = device2.createCommandEncoder({label: '\u06b2\uba27\uced4\u0aeb\u78a2\ubad6\u{1fe9c}\ua272\u{1f892}\u0362'});
+let commandBuffer40 = commandEncoder117.finish();
+let renderBundle95 = renderBundleEncoder63.finish({});
+let externalTexture70 = device2.importExternalTexture({
+  label: '\u20b5\ua7a8\u2677\u79dc\u0a48\u0a32\u189c\u{1f68b}\u01e7\u8efb\u00e1',
+  source: videoFrame7,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder27.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(0, bindGroup32, new Uint32Array(8820), 841, 0);
+} catch {}
+try {
+renderBundleEncoder55.setIndexBuffer(buffer30, 'uint16', 36850);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(2, buffer28, 126356);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 623},
+  aspect: 'all',
+}, arrayBuffer22, /* required buffer size: 23_964_762 */
+{offset: 690, bytesPerRow: 2111, rowsPerImage: 264}, {width: 249, height: 0, depthOrArrayLayers: 44});
+} catch {}
+let pipeline80 = await promise29;
+let buffer37 = device1.createBuffer({label: '\uf02b\u5d6c\u080d\u18bd\u0e5e\u18ec\uddb8', size: 455996, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder172 = device1.createCommandEncoder({label: '\u7ccd\u{1fbd3}\u{1ff40}\u{1fcb3}\ueeb2\u0995\u8fc9\u5c8e\u{1fe7d}\u{1f94e}\uac99'});
+let texture112 = device1.createTexture({
+  label: '\uf0d1\u1a27\u{1fa2b}\u0aed\uce48\u7145',
+  size: {width: 72, height: 160, depthOrArrayLayers: 132},
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView192 = texture52.createView({label: '\u9846\ud6ea\u5c48\u4d9c\u{1ffe8}', dimension: '2d', baseMipLevel: 5, baseArrayLayer: 1347});
+let renderBundle96 = renderBundleEncoder61.finish({});
+try {
+computePassEncoder48.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(6, bindGroup50);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer23, 0, 34736);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(5, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder169.copyTextureToBuffer({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 26, y: 1, z: 8},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38932 */
+  offset: 38932,
+  bytesPerRow: 0,
+  rowsPerImage: 229,
+  buffer: buffer20,
+}, {width: 0, height: 137, depthOrArrayLayers: 6});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder172.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({});
+let bindGroup54 = device2.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 8080, resource: sampler68}]});
+let texture113 = device2.createTexture({
+  label: '\u04d2\uaa24\u{1f7cf}\u04a3\u099f\ua74d\u505a\u0cb7\u{1ff09}\u5c65\u13e9',
+  size: [3012, 1, 1],
+  mipLevelCount: 5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView193 = texture74.createView({label: '\ub2bb\u{1ffc0}', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup30, new Uint32Array(8288), 4158, 0);
+} catch {}
+let videoFrame21 = new VideoFrame(video11, {timestamp: 0});
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture113,
+  mipLevel: 1,
+  origin: {x: 368, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 26},
+  aspect: 'all',
+},
+{width: 654, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 158968, new BigUint64Array(63431), 24147);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 125, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer11), /* required buffer size: 846 */
+{offset: 846}, {width: 429, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline81 = device2.createRenderPipeline({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 9786864,
+    depthBiasClamp: 14.07036286853112,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 3788, attributes: [{format: 'uint32x4', offset: 524, shaderLocation: 1}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas16 = new OffscreenCanvas(18, 761);
+let imageData9 = new ImageData(28, 44);
+let videoFrame22 = new VideoFrame(videoFrame21, {timestamp: 0});
+let commandEncoder173 = device1.createCommandEncoder({});
+let texture114 = device1.createTexture({
+  label: '\u{1feef}\u{1ff80}\u{1fad5}\u047c',
+  size: {width: 546, height: 4, depthOrArrayLayers: 1411},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView194 = texture100.createView({label: '\u6ca9\uc8f9\u0b03\u0b6a\u{1f7d9}\ua20a', mipLevelCount: 1});
+let computePassEncoder70 = commandEncoder172.beginComputePass({label: '\ubfb0\u{1fe32}\u0488\u0d45\uf09f\u0f87'});
+let renderPassEncoder26 = commandEncoder39.beginRenderPass({
+  label: '\u0968\u5c58\uc3f1\u0657\ub7e9\u0618\ube04\u56a7\u9d68',
+  colorAttachments: [{
+  view: textureView154,
+  depthSlice: 1,
+  clearValue: { r: -884.7, g: -58.14, b: -846.0, a: -218.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 328972432,
+});
+try {
+renderPassEncoder24.executeBundles([renderBundle87, renderBundle53]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer34, 39344, 2821);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(1, bindGroup26, new Uint32Array(5305), 3657, 0);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder169.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22548 */
+  offset: 22548,
+  buffer: buffer19,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder169.resolveQuerySet(querySet72, 1434, 6, buffer34, 24320);
+} catch {}
+try {
+commandEncoder169.insertDebugMarker('\u0cba');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(80)), /* required buffer size: 536 */
+{offset: 536, rowsPerImage: 211}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas14.width = 1947;
+let video18 = await videoWithData();
+let textureView195 = texture90.createView({
+  label: '\udefb\u{1fc53}\u4644\u{1fbab}\uc390\u{1fd9e}\u0fa7\u069a\u063f\u{1fccc}\u{1f909}',
+  dimension: '2d-array',
+});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle67, renderBundle44, renderBundle44, renderBundle19, renderBundle96]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(3610);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer34, 'uint16');
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline39);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+  await buffer37.mapAsync(GPUMapMode.READ, 351168);
+} catch {}
+try {
+device1.queue.submit([commandBuffer31]);
+} catch {}
+let promise34 = device1.queue.onSubmittedWorkDone();
+let pipeline82 = device1.createComputePipeline({layout: 'auto', compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}}});
+let shaderModule26 = device0.createShaderModule({
+  label: '\u{1fc01}\ub24e\ubd0a\u{1fd5c}\u1b1d\u7035\u306b\uba20',
+  code: `@group(8) @binding(3477)
+var<storage, read_write> type8: array<u32>;
+@group(4) @binding(459)
+var<storage, read_write> function17: array<u32>;
+@group(4) @binding(3877)
+var<storage, read_write> function18: array<u32>;
+@group(7) @binding(1922)
+var<storage, read_write> type9: array<u32>;
+@group(0) @binding(2060)
+var<storage, read_write> function19: array<u32>;
+@group(5) @binding(1221)
+var<storage, read_write> n13: array<u32>;
+@group(4) @binding(607)
+var<storage, read_write> field14: array<u32>;
+@group(8) @binding(2060)
+var<storage, read_write> function20: array<u32>;
+@group(3) @binding(1922)
+var<storage, read_write> local12: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(4) f2: u32,
+  @location(1) f3: vec4<u32>,
+  @location(0) f4: vec4<f32>,
+  @location(7) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S33 {
+  @location(1) f0: f32,
+  @location(10) f1: vec4<u32>,
+  @location(14) f2: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec3<i32>, @location(8) a1: vec2<u32>, @location(4) a2: u32, a3: S33, @location(15) a4: vec4<i32>, @location(5) a5: vec2<u32>, @location(3) a6: vec3<u32>, @location(0) a7: vec2<f32>, @builtin(vertex_index) a8: u32, @location(17) a9: vec2<i32>, @location(13) a10: f32, @location(9) a11: u32, @location(11) a12: vec3<f16>, @location(16) a13: vec2<f16>, @location(6) a14: vec3<f16>, @location(7) a15: i32, @location(12) a16: vec2<u32>, @location(2) a17: f32, @location(18) a18: vec3<i32>, @builtin(instance_index) a19: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let commandEncoder174 = device0.createCommandEncoder({label: '\udbb9\u{1f82f}\u868a\ub371\uad72\u1261\u02e1\u02d0'});
+let texture115 = device0.createTexture({
+  size: {width: 645},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let sampler77 = device0.createSampler({
+  label: '\u09fe\u7c45',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.78,
+  lodMaxClamp: 32.88,
+  maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder64.setBindGroup(5, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7728 */
+  offset: 7724,
+  buffer: buffer7,
+}, {
+  texture: texture19,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+renderBundleEncoder20.pushDebugGroup('\u{1ffce}');
+} catch {}
+try {
+renderBundleEncoder20.popDebugGroup();
+} catch {}
+let pipeline83 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0x3c863b5c},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 737202688,
+    stencilWriteMask: 2163230970,
+    depthBias: -504279577,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 524,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 8, shaderLocation: 5},
+          {format: 'sint8x2', offset: 2, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 90, shaderLocation: 13},
+          {format: 'uint8x2', offset: 16, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 56, shaderLocation: 16},
+          {format: 'uint16x4', offset: 120, shaderLocation: 7},
+          {format: 'sint16x4', offset: 8, shaderLocation: 2},
+          {format: 'float32x2', offset: 16, shaderLocation: 3},
+          {format: 'float32x4', offset: 36, shaderLocation: 12},
+          {format: 'float32x4', offset: 68, shaderLocation: 9},
+          {format: 'uint16x4', offset: 24, shaderLocation: 1},
+          {format: 'uint8x4', offset: 88, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 40, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw', cullMode: 'back'},
+});
+gc();
+let imageData10 = new ImageData(64, 48);
+let textureView196 = texture71.createView({label: '\u{1fde8}\u02b4\u{1f81b}\u8f17\ub177\u2fa1', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundle97 = renderBundleEncoder65.finish({label: '\u0ffd\u{1f8db}\ud995\u01ef\u2f1f\u0ead\u{1faee}\u{1fcf7}'});
+let sampler78 = device1.createSampler({
+  label: '\uf8be\u0810\u{1f927}\u{1ff55}\uad52\u{1f98e}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 25.89,
+  lodMaxClamp: 92.00,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle44, renderBundle37, renderBundle44, renderBundle35, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: -836.1, g: -197.7, b: -994.5, a: 29.00, });
+} catch {}
+try {
+commandEncoder173.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1184 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 39136 */
+  offset: 39136,
+  buffer: buffer34,
+}, {width: 444, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder169.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 31172, new Float32Array(11774), 6652, 800);
+} catch {}
+try {
+adapter4.label = '\uf13e\u{1f891}\u3c57\u0d37';
+} catch {}
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  label: '\u{1f8b3}\ua390',
+  entries: [
+    {
+      binding: 5167,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 4185,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 3189,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup55 = device1.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 1552, resource: sampler72}]});
+let textureView197 = texture43.createView({
+  label: '\u505f\u{1f654}\u022f\u{1f702}\u{1ff3b}\u052f\u0e09\u767c\u{1fd1d}\uc5d4\u83dd',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let externalTexture71 = device1.importExternalTexture({label: '\u{1f77b}\uaa78\u30df', source: video3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer34, 6828, 5246);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 64, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder169.resolveQuerySet(querySet34, 323, 510, buffer34, 32000);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 312, new Int16Array(42727), 18332, 7644);
+} catch {}
+let video19 = await videoWithData();
+try {
+offscreenCanvas16.getContext('webgl2');
+} catch {}
+let bindGroupLayout36 = device2.createBindGroupLayout({
+  label: '\u0a79\u031a\u05fa\u55a8\u2cf7\uf3e8\uc879\u{1f9a2}\u7047\u{1f944}',
+  entries: [
+    {
+      binding: 7045,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let querySet80 = device2.createQuerySet({label: '\u9f45\u{1fa03}\u0791\uce8e', type: 'occlusion', count: 3236});
+let textureView198 = texture89.createView({dimension: '2d-array', baseArrayLayer: 0});
+let renderBundle98 = renderBundleEncoder55.finish();
+try {
+computePassEncoder34.setBindGroup(9, bindGroup54, new Uint32Array(1750), 15, 0);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer30, 'uint16', 868, 82112);
+} catch {}
+try {
+commandEncoder161.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 188, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 23, y: 22 },
+  flipY: true,
+}, {
+  texture: texture113,
+  mipLevel: 4,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData11 = new ImageData(4, 176);
+let textureView199 = texture85.createView({label: '\u6866\u0c09\u6431\u{1fd15}\u065e\u2aa8\u03ef\u7e1a', aspect: 'all', baseMipLevel: 4});
+let renderBundleEncoder69 = device0.createRenderBundleEncoder({
+  label: '\u{1fe0c}\u0285\u0fae\u5da9\u0e11\u0258\u33fc\u{1fd2b}\u595c\u0e2e\u4342',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+try {
+commandEncoder2.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+externalTexture2.label = '\u0a2d\uec03\u2e74\ua814\u{1fc73}\u1d35';
+} catch {}
+try {
+window.someLabel = renderBundleEncoder2.label;
+} catch {}
+let buffer38 = device0.createBuffer({
+  label: '\u2601\u{1fe1a}\uc273\u2231\u0ddd\u1476\ua937',
+  size: 105969,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundleEncoder70 = device0.createRenderBundleEncoder({label: '\u6009\ub5f4\u{1ff1d}\u1469', colorFormats: ['r16uint', 'rg32uint'], stencilReadOnly: true});
+let renderBundle99 = renderBundleEncoder29.finish({label: '\u53db\u1926\u02f6'});
+try {
+computePassEncoder29.dispatchWorkgroups(1, 3, 1);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(8, bindGroup11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer11), /* required buffer size: 571 */
+{offset: 571}, {width: 586, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1440, height: 12, depthOrArrayLayers: 61}
+*/
+{
+  source: img6,
+  origin: { x: 2, y: 84 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 285, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let pipeline84 = device0.createComputePipeline({layout: pipelineLayout25, compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise34;
+} catch {}
+let texture116 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture72 = device1.importExternalTexture({label: '\u55e6\u{1ff0d}\u06eb\uf8bd', source: video1});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -947.8, g: -770.1, b: -829.1, a: 358.0, });
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer23, 'uint16', 8076);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline77);
+} catch {}
+try {
+commandEncoder169.resolveQuerySet(querySet17, 371, 9, buffer34, 1024);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView200 = texture36.createView({label: '\u02e9\u{1fd75}\u64d9\u0bce\u{1fb2d}', dimension: '2d-array', aspect: 'all', mipLevelCount: 8});
+let renderPassEncoder27 = commandEncoder173.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 446.1, g: 436.3, b: -357.9, a: 425.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet58,
+});
+try {
+computePassEncoder63.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(1327);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2597);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer34, 17992, 8167);
+} catch {}
+try {
+commandEncoder169.copyBufferToBuffer(buffer35, 81724, buffer34, 1380, 22300);
+dissociateBuffer(device1, buffer35);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\uca16');
+} catch {}
+let bindGroupLayout37 = device2.createBindGroupLayout({
+  label: '\ucc40\uaf3b\uec03\u0347\uf349\u{1ff57}\u{1f8e8}',
+  entries: [{binding: 7590, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }}],
+});
+let querySet81 = device2.createQuerySet({label: '\u3ff0\u0d7b\u{1fa42}\u085a\uce24', type: 'occlusion', count: 405});
+let textureView201 = texture42.createView({
+  label: '\ue45f\u{1fd26}\u55bc\u{1f8ad}\u0f4a\u5843\u09e9\ude88\ua0cd',
+  baseMipLevel: 2,
+  arrayLayerCount: 1,
+});
+let computePassEncoder71 = commandEncoder171.beginComputePass({label: '\uf762\u{1f9b6}\u0b25\uc866\u0561\u{1f899}\u018c\u5c55\u{1f9c5}'});
+let renderBundle100 = renderBundleEncoder21.finish({label: '\u0fdc\uc335\uf2c6\u07a8\u0dce\u014b\u07d0'});
+let sampler79 = device2.createSampler({
+  label: '\uae3b\uab29',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.85,
+  lodMaxClamp: 99.09,
+  maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder50.setBindGroup(9, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(8, buffer28, 99932, 23984);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 11, y: 8, z: 3},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(0)), /* required buffer size: 5_676_433 */
+{offset: 174, bytesPerRow: 1479, rowsPerImage: 295}, {width: 668, height: 3, depthOrArrayLayers: 14});
+} catch {}
+try {
+canvas11.getContext('bitmaprenderer');
+} catch {}
+let commandBuffer41 = commandEncoder155.finish({label: '\u40be\u051c\u080e\ufc2d\u7328'});
+let computePassEncoder72 = commandEncoder95.beginComputePass();
+try {
+renderBundleEncoder50.setBindGroup(7, bindGroup21, []);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer28, 20460, 82934);
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 2104 widthInBlocks: 526 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 848 */
+  offset: 848,
+  buffer: buffer30,
+}, {
+  texture: texture113,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 526, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder160.pushDebugGroup('\u0732');
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture117 = gpuCanvasContext7.getCurrentTexture();
+let textureView202 = texture42.createView({label: '\u091d\u{1f91b}\u7486\u{1fa79}', format: 'bgra8unorm-srgb', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder50.setBindGroup(7, bindGroup31, new Uint32Array(8870), 8167, 0);
+} catch {}
+try {
+commandEncoder136.copyBufferToBuffer(buffer27, 142760, buffer21, 563372, 320);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder142.copyTextureToBuffer({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 15824 */
+  offset: 15816,
+  rowsPerImage: 103,
+  buffer: buffer30,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet46, 2337, 530, buffer30, 81920);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer4), /* required buffer size: 949 */
+{offset: 949, rowsPerImage: 113}, {width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 3, y: 2 },
+  flipY: true,
+}, {
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet82 = device0.createQuerySet({label: '\u{1fbdd}\ud0f1\u{1ff14}\u{1f8ab}', type: 'occlusion', count: 1258});
+let textureView203 = texture0.createView({});
+let sampler80 = device0.createSampler({
+  label: '\u0226\ucd92\u{1f7c2}\u91ce\u8451\ua3c8\u0b40',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 65.85,
+  lodMaxClamp: 72.15,
+});
+try {
+renderBundleEncoder49.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(7, buffer32, 159896, 35336);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 320 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1852 */
+  offset: 1852,
+  rowsPerImage: 25,
+  buffer: buffer7,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 73, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let commandEncoder175 = device0.createCommandEncoder({});
+let textureView204 = texture79.createView({dimension: '2d', baseArrayLayer: 17});
+let computePassEncoder73 = commandEncoder144.beginComputePass({label: '\u7e91\u{1fd8e}\u0db0\u{1f9fa}\u76e3'});
+let sampler81 = device0.createSampler({
+  label: '\u08f6\u02dd\u{1feec}\u9e23',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.41,
+});
+let externalTexture73 = device0.importExternalTexture({label: '\u6c90\u{1fb92}\u03e3\u5ac2\u67af', source: video14, colorSpace: 'srgb'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer33, 'uint32', 547684);
+} catch {}
+try {
+commandEncoder138.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1084 widthInBlocks: 271 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10124 */
+  offset: 10124,
+  bytesPerRow: 1280,
+  rowsPerImage: 99,
+  buffer: buffer6,
+}, {width: 271, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder175.resolveQuerySet(querySet40, 2260, 147, buffer15, 33792);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let img26 = await imageWithData(126, 164, '#45b9652f', '#65f92f4f');
+let renderPassEncoder28 = commandEncoder169.beginRenderPass({
+  colorAttachments: [{
+  view: textureView152,
+  clearValue: { r: -810.6, g: -986.2, b: -964.8, a: 522.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 131890768,
+});
+let renderBundleEncoder71 = device1.createRenderBundleEncoder({label: '\u0a8d\u{1faa9}\u{1fc86}\u030f\u027e\u66a5', colorFormats: ['rg16sint'], depthReadOnly: true});
+let sampler82 = device1.createSampler({
+  label: '\uf054\u7cc4\ub335\u0a7a\u7395\u8416\u8382\u0558\u0b1a\u0179',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.47,
+  lodMaxClamp: 57.95,
+});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline39);
+} catch {}
+let imageBitmap19 = await createImageBitmap(video7);
+let sampler83 = device2.createSampler({
+  label: '\u4827\u{1fb9d}\u{1f606}\u07dc\ub5cf\u{1f9e2}',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.65,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder19.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder60.setPipeline(pipeline51);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(3, buffer28, 0, 130117);
+} catch {}
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+querySet32.destroy();
+} catch {}
+try {
+commandEncoder145.copyBufferToBuffer(buffer30, 87464, buffer21, 553932, 39356);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 34736 */
+  offset: 34736,
+  rowsPerImage: 217,
+  buffer: buffer27,
+}, {
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder160.popDebugGroup();
+} catch {}
+document.body.prepend(img25);
+let offscreenCanvas17 = new OffscreenCanvas(1020, 843);
+let video20 = await videoWithData();
+try {
+adapter2.label = '\u1679\udcba\uc563\u0f5f\u76f6';
+} catch {}
+try {
+offscreenCanvas17.getContext('webgpu');
+} catch {}
+let bindGroup56 = device1.createBindGroup({
+  label: '\u{1f737}\u087e\u076f\uf84d\u00f7\u{1f8cc}\u0000\u3b45\u0bef\u5436\u5fd9',
+  layout: bindGroupLayout24,
+  entries: [{binding: 133, resource: externalTexture61}],
+});
+let querySet83 = device1.createQuerySet({type: 'occlusion', count: 1349});
+let textureView205 = texture112.createView({baseArrayLayer: 0});
+let renderBundle101 = renderBundleEncoder18.finish();
+let sampler84 = device1.createSampler({
+  label: '\ud59d\u9f48\u{1ffc7}\ue74a\u1bfe',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 90.67,
+});
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle75, renderBundle35, renderBundle20, renderBundle25, renderBundle87, renderBundle22, renderBundle101, renderBundle56, renderBundle67, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder27.setBlendConstant({ r: 799.4, g: 223.7, b: 585.2, a: -253.6, });
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(1, buffer34);
+} catch {}
+let pipeline85 = device1.createComputePipeline({
+  label: '\u07d4\u20ca\u8f43\u00d4',
+  layout: 'auto',
+  compute: {module: shaderModule20, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule27 = device0.createShaderModule({
+  label: '\u01be\u61c9\ua7da\u{1fd90}\u{1ff6a}\uf190\u460f\ucdd0',
+  code: `@group(9) @binding(1191)
+var<storage, read_write> local13: array<u32>;
+@group(8) @binding(1221)
+var<storage, read_write> parameter18: array<u32>;
+@group(5) @binding(1922)
+var<storage, read_write> global11: array<u32>;
+@group(4) @binding(550)
+var<storage, read_write> type10: array<u32>;
+@group(4) @binding(37)
+var<storage, read_write> global12: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S34 {
+  @location(4) f0: vec4<i32>,
+  @location(17) f1: vec4<u32>,
+  @location(11) f2: vec4<u32>,
+  @location(6) f3: vec4<i32>,
+  @location(15) f4: i32,
+  @location(1) f5: vec3<f16>,
+  @location(16) f6: vec2<i32>,
+  @location(12) f7: vec2<f32>,
+  @location(2) f8: vec4<u32>,
+  @location(0) f9: vec4<f16>,
+  @location(18) f10: vec3<i32>,
+  @location(9) f11: vec2<f16>,
+  @location(8) f12: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: f32, @location(14) a1: vec2<i32>, @location(10) a2: vec2<f16>, @location(19) a3: vec3<u32>, @location(3) a4: f32, @location(13) a5: vec4<u32>, @location(7) a6: vec3<f32>, a7: S34, @builtin(vertex_index) a8: u32, @builtin(instance_index) a9: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup57 = device0.createBindGroup({
+  label: '\ue04c\u749c\u{1fb21}\u0c5a\u761c\uea3d\ufb2f\u61b1\u{1fa7e}\u0897\u{1fca2}',
+  layout: bindGroupLayout1,
+  entries: [],
+});
+let querySet84 = device0.createQuerySet({type: 'occlusion', count: 1365});
+let texture118 = device0.createTexture({
+  label: '\u{1f672}\u001d\u464f\u07b6\u{1f953}\u{1fbc4}\u31ca\u0864\udce4',
+  size: {width: 322, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView206 = texture34.createView({
+  label: '\ueb2e\u0748\u2ef8\u03ff\u{1fc7e}\u72e4\ua0f3\u8a6a\u9d2a\u4419',
+  baseMipLevel: 2,
+  arrayLayerCount: 1,
+});
+let computePassEncoder74 = commandEncoder166.beginComputePass({label: '\u{1f62f}\u0692\u08fc\ua95b\ud0b6'});
+let sampler85 = device0.createSampler({
+  label: '\u{1f820}\u78e4\u0ed0\u{1febb}\u6f0b\u{1fbc3}\u0d21',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.28,
+  lodMaxClamp: 92.44,
+  compare: 'never',
+});
+try {
+computePassEncoder33.setBindGroup(7, bindGroup10, new Uint32Array(8562), 7367, 0);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(8, buffer32, 213756, 6522);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+try {
+adapter2.label = '\uab31\ue8cd\u8ad8\u0ca3\ua2c4';
+} catch {}
+let commandEncoder176 = device2.createCommandEncoder({label: '\ud801\u2763\u0bfa\uc9f5\u0af5\u3e86\u547f\u0ec5\u0535\u0dc7\ucb23'});
+let texture119 = device2.createTexture({
+  label: '\u{1fdca}\u7952\u{1ff7d}\u0113\ufee2\u7266\u{1fe7c}',
+  size: [132, 1, 55],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView207 = texture89.createView({baseMipLevel: 1});
+try {
+commandEncoder134.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+video5.width = 262;
+let shaderModule28 = device1.createShaderModule({
+  label: '\u7cfd\u{1fbfd}',
+  code: `@group(6) @binding(1552)
+var<storage, read_write> global13: array<u32>;
+@group(8) @binding(1552)
+var<storage, read_write> type11: array<u32>;
+@group(7) @binding(1552)
+var<storage, read_write> local14: array<u32>;
+@group(3) @binding(1552)
+var<storage, read_write> parameter19: array<u32>;
+@group(0) @binding(1552)
+var<storage, read_write> function21: array<u32>;
+@group(4) @binding(1552)
+var<storage, read_write> function22: array<u32>;
+@group(2) @binding(1552)
+var<storage, read_write> parameter20: array<u32>;
+@group(5) @binding(1552)
+var<storage, read_write> global14: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S36 {
+  @builtin(front_facing) f0: bool,
+  @builtin(position) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(1) f1: vec2<f32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(a0: S36, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S35 {
+  @location(3) f0: f32,
+  @location(2) f1: vec2<u32>,
+  @location(17) f2: vec2<i32>,
+  @location(15) f3: vec4<i32>,
+  @location(9) f4: vec2<u32>,
+  @location(10) f5: f16,
+  @location(4) f6: i32
+}
+
+@vertex
+fn vertex0(@location(14) a0: f32, @location(1) a1: vec3<f32>, @location(11) a2: vec2<i32>, @location(16) a3: vec3<i32>, @location(7) a4: u32, @location(8) a5: vec3<i32>, @builtin(instance_index) a6: u32, @location(5) a7: vec2<i32>, @builtin(vertex_index) a8: u32, @location(0) a9: vec4<i32>, @location(13) a10: vec3<u32>, @location(12) a11: u32, a12: S35, @location(6) a13: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let pipelineLayout32 = device1.createPipelineLayout({
+  label: '\udb4b\u5d76\u852b\u6dd7\u{1fca0}\u{1f8a6}\u0241\uff35',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout17, bindGroupLayout31, bindGroupLayout24, bindGroupLayout17, bindGroupLayout32, bindGroupLayout30],
+});
+let querySet85 = device1.createQuerySet({label: '\u059b\u{1f605}\u0d07\ued57\ue0fc\u09c2', type: 'occlusion', count: 3720});
+let externalTexture74 = device1.importExternalTexture({source: videoFrame19, colorSpace: 'srgb'});
+try {
+renderPassEncoder9.setBindGroup(8, bindGroup35);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle18, renderBundle101, renderBundle52, renderBundle72, renderBundle35]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer34, 10256, 8467);
+} catch {}
+try {
+renderBundleEncoder71.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(0, buffer23);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(191), /* required buffer size: 191 */
+{offset: 191, bytesPerRow: 174}, {width: 70, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise35;
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  label: '\u12e9\u{1fc52}\u0afc\u{1fc98}\u07fa\u711c\ub680\u4e64\u5b1e\u2063\u07b5',
+  layout: bindGroupLayout5,
+  entries: [],
+});
+let pipelineLayout33 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout27, bindGroupLayout15, bindGroupLayout28, bindGroupLayout6, bindGroupLayout11, bindGroupLayout9, bindGroupLayout15],
+});
+let commandEncoder177 = device0.createCommandEncoder({label: '\u7536\u0ae7\u73cb'});
+let texture120 = device0.createTexture({
+  label: '\u{1f750}\ubc29\u{1f7c0}\uae19\u009a\ue535\u{1f91b}\u026d\u9bc8\u0cfe',
+  size: [1440],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let sampler86 = device0.createSampler({
+  label: '\u3a2a\u5eab\u1fae\u8200\u0b53',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.01,
+  lodMaxClamp: 70.48,
+  compare: 'greater',
+  maxAnisotropy: 3,
+});
+let externalTexture75 = device0.importExternalTexture({label: '\u9d9a\u{1f808}', source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(1, buffer22, 0, 29635);
+} catch {}
+let promise36 = device0.popErrorScope();
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline86 = await promise33;
+let offscreenCanvas18 = new OffscreenCanvas(153, 667);
+let pipelineLayout34 = device2.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout36, bindGroupLayout36, bindGroupLayout34, bindGroupLayout36, bindGroupLayout20],
+});
+let commandEncoder178 = device2.createCommandEncoder({label: '\u0059\u0367\u0b95'});
+let textureView208 = texture58.createView({label: '\ua955\u{1f8f1}', dimension: '2d', baseMipLevel: 7, mipLevelCount: 1, baseArrayLayer: 934});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\ubfa0\u{1f8fd}\u{1fdd1}\u{1f857}\u0501',
+  colorFormats: [undefined, 'rgba8uint', 'r8sint', 'rg8sint', 'rgba32float'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder72.setBindGroup(8, bindGroup41, []);
+} catch {}
+try {
+texture70.destroy();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 144660, new Int16Array(27198), 6877, 2504);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 376, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 6, y: 124 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 2,
+  origin: {x: 75, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 144, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder75 = commandEncoder158.beginComputePass({label: '\u{1f874}\u07d5\u{1f806}\u03e4\udcf8\uaa58\ua620'});
+let renderBundle102 = renderBundleEncoder12.finish();
+let externalTexture76 = device0.importExternalTexture({source: video18, colorSpace: 'display-p3'});
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 705 */
+{offset: 705}, {width: 549, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline87 = device0.createComputePipeline({
+  label: '\u10c3\u04c3\u{1ff21}\u80f6\u0247\u{1fa77}\u07f8',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let querySet86 = device2.createQuerySet({type: 'occlusion', count: 1862});
+let computePassEncoder76 = commandEncoder142.beginComputePass({label: '\u4f58\u0b09\u{1f8dc}\u0503\u41fa\u0c65\u0a7e\u4618\uacf9'});
+let renderBundleEncoder73 = device2.createRenderBundleEncoder({
+  label: '\uea81\u703c\u{1face}\u2367\u{1fdc8}\ucbbb\uccae\uab1e\u6c93\ud964\u8508',
+  colorFormats: ['r8uint', 'rg32uint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(6, bindGroup51, new Uint32Array(453), 294, 0);
+} catch {}
+try {
+renderBundleEncoder73.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder137.copyTextureToBuffer({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 25016 */
+  offset: 25016,
+  buffer: buffer21,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 28516, new BigUint64Array(48288));
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: img4,
+  origin: { x: 167, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline88 = device2.createComputePipeline({
+  label: '\ud231\u5888\ud770\u1e76\u94a3\u{1f7b0}\u075a\u{1f868}\ub731',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder();
+let texture121 = device0.createTexture({
+  label: '\u8f2a\u273e\u09ab\u{1f8bf}\ub22c\u{1fdd8}\u{1fa0f}\u{1f928}',
+  size: {width: 768, height: 960, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder5.setBindGroup(7, bindGroup1, new Uint32Array(6934), 590, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet2, 1644, 386, buffer31, 7680);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 236, new DataView(new ArrayBuffer(20420)));
+} catch {}
+let canvas12 = document.createElement('canvas');
+let textureView209 = texture84.createView({label: '\u0f0b\u4221\u6265'});
+let renderBundleEncoder74 = device1.createRenderBundleEncoder({
+  label: '\u5211\u0776\uaa59',
+  colorFormats: ['rg16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler87 = device1.createSampler({
+  label: '\u277c\u2fd2\ubc04\u{1fa52}\u301a\uf56f\u{1fba8}\u0298\u{1f789}\u80ef\u{1f916}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.353,
+  lodMaxClamp: 36.96,
+});
+try {
+renderPassEncoder8.setStencilReference(2902);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup26, new Uint32Array(8716), 15, 0);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline77);
+} catch {}
+try {
+texture112.destroy();
+} catch {}
+let buffer39 = device2.createBuffer({
+  label: '\u0e4b\u0e05\u04b9\uba4e\u0b04',
+  size: 21502,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder180 = device2.createCommandEncoder({label: '\ud20d\u{1f664}\u0f2c\u5ac4\ub631\ufc70\u{1faf3}\u910a'});
+let textureView210 = texture93.createView({label: '\u8219\u{1fa4f}\u{1fa84}\u008a\udff9\u8429\ue4b6\u0b3f'});
+let computePassEncoder77 = commandEncoder161.beginComputePass();
+let renderBundle103 = renderBundleEncoder25.finish();
+let externalTexture77 = device2.importExternalTexture({
+  label: '\u7f48\ub53a\u2cf2\ua4c9\udff1\u62c7\u056d\u4883\ua6d4',
+  source: video7,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder51.setPipeline(pipeline34);
+} catch {}
+let pipeline89 = await device2.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+let pipeline90 = device2.createRenderPipeline({
+  label: '\u{1feb0}\u{1f7d9}\u57ec\u393f\u03a5',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0x2db93004},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'rgba8uint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'keep'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 2051852430,
+    depthBiasClamp: 377.92105014932787,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4096,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 104, shaderLocation: 5},
+          {format: 'sint8x2', offset: 112, shaderLocation: 18},
+          {format: 'sint32x2', offset: 80, shaderLocation: 26},
+          {format: 'uint32x3', offset: 1168, shaderLocation: 24},
+          {format: 'uint8x4', offset: 0, shaderLocation: 25},
+          {format: 'float16x2', offset: 3296, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+try {
+  await promise36;
+} catch {}
+let img27 = await imageWithData(188, 153, '#5c798807', '#9cf35f6b');
+let bindGroupLayout38 = device2.createBindGroupLayout({
+  label: '\u8fbd\ud51a\u76e7\uc788\u1be6',
+  entries: [
+    {
+      binding: 1523,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 737,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 7958, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let bindGroup59 = device2.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 6715, resource: externalTexture17}]});
+let textureView211 = texture89.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder78 = commandEncoder145.beginComputePass({label: '\uf351\u7329\u401c\u06d7\ud8ee\uf4a5\u0275\ua8cf\u20db'});
+let externalTexture78 = device2.importExternalTexture({label: '\ub4f4\u61bc\u03fb\u8598\u{1f818}\uae19', source: videoFrame7, colorSpace: 'srgb'});
+try {
+renderBundleEncoder72.setBindGroup(7, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(3, bindGroup33, new Uint32Array(7216), 4168, 0);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(3, buffer28, 0, 130244);
+} catch {}
+try {
+commandEncoder137.resolveQuerySet(querySet68, 2055, 578, buffer30, 44544);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 158, y: 0, z: 565},
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 163_217_426 */
+{offset: 614, bytesPerRow: 14658, rowsPerImage: 293}, {width: 1830, height: 1, depthOrArrayLayers: 39});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3012, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img17,
+  origin: { x: 77, y: 17 },
+  flipY: true,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 206, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas16.height = 27;
+let textureView212 = texture11.createView({label: '\ua69d\u016b', baseArrayLayer: 0});
+let renderBundle104 = renderBundleEncoder42.finish({label: '\u08bf\u0771\uef73\u60a0\u042a\u{1f723}\u0261\uc13d\uc017'});
+try {
+computePassEncoder29.dispatchWorkgroups(5, 4, 1);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(2, buffer32);
+} catch {}
+try {
+commandEncoder139.clearBuffer(buffer36);
+dissociateBuffer(device0, buffer36);
+} catch {}
+let pipeline91 = await device0.createComputePipelineAsync({
+  label: '\u056d\uf105\u501d\u0a1d\ufe12\ua4ca\u73b2\u0c30\u4867',
+  layout: 'auto',
+  compute: {module: shaderModule23, entryPoint: 'compute0'},
+});
+let img28 = await imageWithData(26, 300, '#3ba2383c', '#ac92b183');
+let textureView213 = texture41.createView({label: '\u0e36\u0a89\u{1fcf5}\u0af7\u70ea\u0afa\u5ab4\u{1f87c}\uf130\u4f5a', format: 'rg16sint'});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  label: '\uc2cb\uc8c8\uc9f8\u43bf',
+  colorFormats: ['rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle105 = renderBundleEncoder62.finish({label: '\u{1fa92}\u{1ffdb}\ufa7c\u065c\ub02f\u9f6b\u03cd'});
+let externalTexture79 = device1.importExternalTexture({source: video6});
+try {
+renderPassEncoder10.setBlendConstant({ r: -385.1, g: 209.4, b: -720.8, a: 487.4, });
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(1, bindGroup24, new Uint32Array(5631), 1498, 0);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let gpuCanvasContext9 = canvas12.getContext('webgpu');
+gc();
+let querySet87 = device2.createQuerySet({label: '\ub5a0\u7342\u3804\u{1f770}\u00ee\u{1f922}\uf29d\u2a3a\u0dcc', type: 'occlusion', count: 3215});
+let texture122 = device2.createTexture({
+  size: [33, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+try {
+renderBundleEncoder73.setBindGroup(8, bindGroup39, new Uint32Array(4477), 3764, 0);
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 5792 widthInBlocks: 1448 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17288 */
+  offset: 17288,
+  buffer: buffer30,
+}, {
+  texture: texture113,
+  mipLevel: 1,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1448, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder181 = device2.createCommandEncoder({label: '\u{1fa51}\ubad9\u{1ffc4}\u5b6e\u0af0\u8f8f\u06d0\u{1f6a2}\u9727\uef54'});
+let querySet88 = device2.createQuerySet({type: 'occlusion', count: 1942});
+let texture123 = device2.createTexture({
+  label: '\u{1f8ae}\u{1fff5}',
+  size: {width: 132},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let renderBundleEncoder76 = device2.createRenderBundleEncoder({label: '\u0e98\u011f\uef52\u06b3', colorFormats: ['r8uint', 'rg32uint']});
+let sampler88 = device2.createSampler({
+  label: '\u7be3\uc2de\u5952\u{1fefe}\u134b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.97,
+});
+try {
+commandEncoder134.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5456 */
+  offset: 5448,
+  buffer: buffer21,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder178.resolveQuerySet(querySet80, 1516, 180, buffer30, 15616);
+} catch {}
+let promise37 = device2.queue.onSubmittedWorkDone();
+let pipeline92 = await device2.createComputePipelineAsync({
+  label: '\u{1fcd5}\u0ff0\u8c23\ud79e\uef0c\u1381\ueb8d\u{1f69a}',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas18.getContext('webgl2');
+} catch {}
+let pipelineLayout35 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4, bindGroupLayout15]});
+let textureView214 = texture14.createView({baseMipLevel: 1});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(8, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder47.setIndexBuffer(buffer5, 'uint16', 3058, 21459);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 276 widthInBlocks: 69 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 94868 */
+  offset: 9088,
+  bytesPerRow: 512,
+  rowsPerImage: 167,
+  buffer: buffer38,
+}, {
+  texture: texture94,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 69, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer38);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise37;
+} catch {}
+let imageBitmap20 = await createImageBitmap(video12);
+let imageData12 = new ImageData(200, 224);
+let commandEncoder182 = device2.createCommandEncoder({label: '\u325e\ua949\u92b1\u09a2\u8c4d\u32ac\u095b\u8866\u0336'});
+let texture124 = device2.createTexture({
+  label: '\u071d\u03b2\u0d72\u4636',
+  size: [33, 1, 1717],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder79 = commandEncoder134.beginComputePass({label: '\u{1fbf8}\uc98f\u03b0\u72c6\u7f0a\u{1fdcf}\u{1fc14}\u7862'});
+let renderBundleEncoder77 = device2.createRenderBundleEncoder({
+  label: '\ued24\u{1f732}\u1c17\u998c\uc319\u083a\ua2ca\u0c0e',
+  colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle106 = renderBundleEncoder52.finish();
+let externalTexture80 = device2.importExternalTexture({
+  label: '\ua2fe\u{1fa60}\u619a\ucfd6\u{1fb1f}\u{1fef9}\u0a31\u{1f7cd}\ue562\u031a',
+  source: video10,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder57.dispatchWorkgroups(1, 3, 3);
+} catch {}
+try {
+device2.queue.submit([commandBuffer40, commandBuffer36]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 45 */
+{offset: 45, rowsPerImage: 234}, {width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img29 = await imageWithData(44, 43, '#ffb7202b', '#a5dd46b5');
+let bindGroupLayout39 = device2.createBindGroupLayout({label: '\u{1ff1c}\ud9bb\u{1fcd4}\u02e2\u8e65\u0206\u{1fc19}\u{1ffff}\u0011\u0159\u6cf4', entries: []});
+let bindGroup60 = device2.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 8080, resource: sampler28}]});
+let commandEncoder183 = device2.createCommandEncoder();
+let texture125 = device2.createTexture({
+  label: '\u{1fbcc}\u6b48',
+  size: [66, 1, 1316],
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView215 = texture40.createView({baseMipLevel: 1, baseArrayLayer: 0});
+let externalTexture81 = device2.importExternalTexture({label: '\u{1f8e0}\u14d1\ucf12\u0f04\u87e6\u0d02\ud5cd', source: video4, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder60.setBindGroup(4, bindGroup32, new Uint32Array(8588), 69, 0);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder160.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 26230 */
+  offset: 26230,
+  bytesPerRow: 512,
+  buffer: buffer30,
+}, {
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder137.copyTextureToBuffer({
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2656 widthInBlocks: 332 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 63256 */
+  offset: 63256,
+  buffer: buffer30,
+}, {width: 332, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder181.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 753, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: canvas5,
+  origin: { x: 14, y: 12 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 120, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline93 = await device2.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}}});
+let commandEncoder184 = device2.createCommandEncoder({label: '\u2a2b\u025b'});
+try {
+commandEncoder183.copyBufferToBuffer(buffer39, 19048, buffer21, 526784, 1812);
+dissociateBuffer(device2, buffer39);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 30, y: 20 },
+  flipY: false,
+}, {
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder();
+let textureView216 = texture7.createView({
+  label: '\u8a28\u0008\u0d5e\u69e5\u0f22\ufc7a\u0ddf\u{1f948}\ua80c\ua1be',
+  aspect: 'all',
+  baseMipLevel: 0,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder45.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(7, bindGroup17);
+} catch {}
+let arrayBuffer23 = buffer14.getMappedRange(185840, 37716);
+try {
+commandEncoder36.copyBufferToBuffer(buffer7, 1020, buffer15, 2796, 81240);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder175.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 964 widthInBlocks: 241 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1148 */
+  offset: 1148,
+  bytesPerRow: 1024,
+  buffer: buffer6,
+}, {width: 241, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 24, depthOrArrayLayers: 61}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 565, y: 195 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 285, y: 3, z: 56},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 209, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline94 = await device0.createComputePipelineAsync({
+  label: '\u{1fb60}\u94e3\u07e4\ud638\u014d\u0f45',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\ub8dc\u00c5\u5d1c\u316c\u{1fb23}\u938b\u{1f791}\uee41\u5734\u8334',
+  entries: [{binding: 85, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let bindGroup61 = device0.createBindGroup({
+  label: '\u0644\u0c21\u44f7\u4b0e\ube2a\u0352\ub323\u{1f7db}\u06fa\u3913',
+  layout: bindGroupLayout5,
+  entries: [],
+});
+let commandEncoder186 = device0.createCommandEncoder({label: '\u0b86\u{1f605}\u8ad2'});
+let querySet89 = device0.createQuerySet({label: '\u0765\u0f3e\u{1fc23}\u{1fcf6}\u{1f8d4}\u47c6\u0473\ud165', type: 'occlusion', count: 2339});
+let texture126 = device0.createTexture({
+  label: '\u0ceb\u0a0b\u0d5f\u3360',
+  size: [768, 960, 45],
+  mipLevelCount: 8,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture127 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder78 = device0.createRenderBundleEncoder({
+  label: '\u0ca3\u{1fd3b}\ufab1\u3a8f\u45f5\u5466',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder57.setVertexBuffer(0, buffer6, 23376, 18067);
+} catch {}
+let pipeline95 = await device0.createComputePipelineAsync({
+  label: '\u03f0\u{1fda0}\ubd02\u0776\u1c74\u9f93\u0004\u70e9\u{1fb5c}\u1b3b',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}},
+});
+let pipeline96 = device0.createRenderPipeline({
+  label: '\u975d\u0f26\u7be7\u0183\u3063\u0e51',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9920,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 28, shaderLocation: 10},
+          {format: 'uint32x3', offset: 1068, shaderLocation: 0},
+          {format: 'sint32x2', offset: 344, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 3556, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 10552,
+        attributes: [
+          {format: 'snorm8x2', offset: 422, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 2932, shaderLocation: 5},
+          {format: 'uint32x3', offset: 788, shaderLocation: 13},
+          {format: 'uint8x4', offset: 1256, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 1016, attributes: []},
+      {
+        arrayStride: 3120,
+        attributes: [
+          {format: 'float32', offset: 392, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 184, shaderLocation: 4},
+          {format: 'uint32', offset: 60, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55) };
+} catch {}
+let buffer40 = device2.createBuffer({
+  label: '\u5119\ub370\u603d\u02a7',
+  size: 322400,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder187 = device2.createCommandEncoder();
+let querySet90 = device2.createQuerySet({label: '\u096b\u0321\u{1fd02}\u0d60', type: 'occlusion', count: 1349});
+let externalTexture82 = device2.importExternalTexture({
+  label: '\u{1f61e}\u{1fda4}\u0cb3\u49ce\u4b3a\u234e\u{1f79f}\u49c6\ucf5b\u927a\u095b',
+  source: videoFrame7,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder60.setBindGroup(8, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(5, bindGroup36, new Uint32Array(6938), 1005, 0);
+} catch {}
+try {
+commandEncoder149.copyBufferToBuffer(buffer40, 320908, buffer21, 137740, 200);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder181.copyTextureToBuffer({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 46856 */
+  offset: 46856,
+  bytesPerRow: 256,
+  buffer: buffer21,
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder149.resolveQuerySet(querySet65, 985, 172, buffer30, 85248);
+} catch {}
+let pipeline97 = device2.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x9acc1e5b},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 1848, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 46820,
+        attributes: [
+          {format: 'float16x2', offset: 34964, shaderLocation: 12},
+          {format: 'sint16x2', offset: 9252, shaderLocation: 14},
+          {format: 'uint8x2', offset: 2200, shaderLocation: 6},
+          {format: 'sint32', offset: 8544, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 5512, shaderLocation: 20},
+          {format: 'uint16x4', offset: 7320, shaderLocation: 18},
+          {format: 'sint8x2', offset: 16456, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 1096, attributes: []},
+      {
+        arrayStride: 11260,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 4666, shaderLocation: 1},
+          {format: 'sint8x2', offset: 3992, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 1960,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 316, shaderLocation: 24}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let video21 = await videoWithData();
+let bindGroupLayout41 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3299,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 1056,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 6161, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder188 = device2.createCommandEncoder({label: '\u3b51\u0103\ue22e\u0440\u8eb4\u0983\uba0b\u2ddc'});
+let texture128 = device2.createTexture({
+  label: '\uf78c\u{1ff36}',
+  size: [6528],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+try {
+renderBundleEncoder60.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(1, buffer28, 134396, 3672);
+} catch {}
+try {
+commandEncoder187.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder136.clearBuffer(buffer21);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let commandEncoder189 = device2.createCommandEncoder({label: '\ucc0d\ub1ff\u{1fe49}\u315a\u{1fb3e}\u{1ff96}'});
+let commandBuffer42 = commandEncoder160.finish({label: '\u{1f750}\u0a6c\u{1ff1e}\u8b70\u0bb0'});
+let texture129 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder79 = device2.createRenderBundleEncoder({
+  label: '\u0713\u9071\uafa2\uac38',
+  colorFormats: [undefined, 'rgba8uint', 'r8sint', 'rg8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder73.setBindGroup(6, bindGroup21, new Uint32Array(3604), 1457, 0);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer30, 'uint32', 10204);
+} catch {}
+try {
+commandEncoder182.copyTextureToBuffer({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 19912 */
+  offset: 19912,
+  bytesPerRow: 256,
+  buffer: buffer30,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder176.clearBuffer(buffer21, 199472, 397788);
+dissociateBuffer(device2, buffer21);
+} catch {}
+let promise38 = device2.queue.onSubmittedWorkDone();
+canvas5.width = 1063;
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  label: '\u09c6\u{1f685}\u1c5d\u40a4\u2c67\u1be2\u61ea\uac84\u067c\u0c47',
+  entries: [
+    {
+      binding: 1140,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 114541507, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView217 = texture24.createView({format: 'r16float', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 64, arrayLayerCount: 377});
+let promise39 = buffer36.mapAsync(GPUMapMode.READ, 93384);
+try {
+device0.queue.writeBuffer(buffer6, 6536, new DataView(new ArrayBuffer(40352)), 20590, 3916);
+} catch {}
+let video22 = await videoWithData();
+let textureView218 = texture81.createView({label: '\u267f\u8482\u{1f722}\u16c9', mipLevelCount: 2});
+try {
+renderBundleEncoder59.setVertexBuffer(4, buffer33, 0, 252177);
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 161, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap12,
+  origin: { x: 10, y: 8 },
+  flipY: false,
+}, {
+  texture: texture118,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture130 = device2.createTexture({
+  label: '\u7923\u0584\u7fb5\u352d\ua6bb\u683c\u02d2\u{1f9f5}\u0532',
+  size: {width: 33, height: 1, depthOrArrayLayers: 1252},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32uint'],
+});
+let renderBundleEncoder80 = device2.createRenderBundleEncoder({label: '\u0bdb\u26ec', colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm']});
+try {
+renderBundleEncoder50.setBindGroup(5, bindGroup31);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer27, 127720, buffer30, 118016, 4444);
+dissociateBuffer(device2, buffer27);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder159.copyTextureToBuffer({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13168 */
+  offset: 13168,
+  buffer: buffer21,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer21);
+} catch {}
+let shaderModule29 = device0.createShaderModule({
+  label: '\u0298\u0b7a\u2fd0\ubc71\u0ead\u93b4\u099d\ucbba\u0761',
+  code: `@group(4) @binding(1191)
+var<storage, read_write> function23: array<u32>;
+@group(3) @binding(2425)
+var<storage, read_write> function24: array<u32>;
+@group(6) @binding(2060)
+var<storage, read_write> n14: array<u32>;
+@group(1) @binding(550)
+var<storage, read_write> global15: array<u32>;
+@group(5) @binding(1904)
+var<storage, read_write> global16: array<u32>;
+@group(3) @binding(1382)
+var<storage, read_write> function25: array<u32>;
+@group(1) @binding(37)
+var<storage, read_write> local15: array<u32>;
+@group(6) @binding(3477)
+var<storage, read_write> n15: array<u32>;
+@group(4) @binding(3682)
+var<storage, read_write> field15: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S38 {
+  @builtin(sample_mask) f0: u32,
+  @location(10) f1: vec2<f32>,
+  @location(17) f2: vec2<f16>,
+  @builtin(sample_index) f3: u32,
+  @builtin(position) f4: vec4<f32>,
+  @location(20) f5: vec2<f16>,
+  @location(27) f6: f32,
+  @location(54) f7: f32,
+  @location(57) f8: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<u32>,
+  @location(2) f1: i32,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(55) a0: vec3<f16>, @location(19) a1: vec3<i32>, a2: S38, @location(31) a3: vec3<f32>, @location(5) a4: i32, @location(0) a5: f16, @builtin(front_facing) a6: bool, @location(46) a7: vec4<f32>, @location(16) a8: vec4<f16>, @location(11) a9: vec4<u32>, @location(8) a10: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S37 {
+  @location(0) f0: vec2<i32>,
+  @location(3) f1: u32,
+  @location(19) f2: f16,
+  @location(18) f3: vec3<i32>,
+  @location(11) f4: i32,
+  @builtin(vertex_index) f5: u32,
+  @location(5) f6: vec4<i32>,
+  @location(4) f7: vec2<u32>,
+  @location(1) f8: vec4<i32>,
+  @location(12) f9: vec3<f32>,
+  @location(7) f10: vec4<i32>,
+  @location(13) f11: vec4<f16>,
+  @location(8) f12: vec4<i32>,
+  @location(14) f13: vec4<f32>,
+  @location(6) f14: vec2<f16>,
+  @location(9) f15: u32,
+  @builtin(instance_index) f16: u32
+}
+struct VertexOutput0 {
+  @location(77) f352: vec4<f32>,
+  @location(35) f353: vec4<i32>,
+  @location(13) f354: vec4<u32>,
+  @location(62) f355: vec4<f32>,
+  @location(75) f356: vec3<u32>,
+  @location(61) f357: vec2<f16>,
+  @builtin(position) f358: vec4<f32>,
+  @location(10) f359: vec2<f32>,
+  @location(31) f360: vec3<f32>,
+  @location(11) f361: vec4<u32>,
+  @location(67) f362: i32,
+  @location(56) f363: vec2<i32>,
+  @location(4) f364: vec3<f32>,
+  @location(27) f365: f32,
+  @location(7) f366: vec4<i32>,
+  @location(59) f367: vec2<u32>,
+  @location(57) f368: vec2<u32>,
+  @location(47) f369: vec2<f16>,
+  @location(58) f370: vec3<f16>,
+  @location(46) f371: vec4<f32>,
+  @location(3) f372: vec3<u32>,
+  @location(8) f373: vec3<u32>,
+  @location(24) f374: f32,
+  @location(17) f375: vec2<f16>,
+  @location(41) f376: vec4<f16>,
+  @location(5) f377: i32,
+  @location(26) f378: vec3<i32>,
+  @location(29) f379: vec2<f32>,
+  @location(0) f380: f16,
+  @location(16) f381: vec4<f16>,
+  @location(54) f382: f32,
+  @location(44) f383: vec3<f16>,
+  @location(19) f384: vec3<i32>,
+  @location(20) f385: vec2<f16>,
+  @location(2) f386: u32,
+  @location(12) f387: f32,
+  @location(55) f388: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<u32>, @location(16) a1: vec3<f16>, @location(2) a2: vec3<u32>, @location(15) a3: f16, @location(17) a4: vec4<f32>, a5: S37) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder190 = device0.createCommandEncoder();
+let texture131 = device0.createTexture({
+  label: '\ub664\u063c\u{1fc3c}\u0be1\u377e\u6fc8\u3fa8\u{1fa3b}\u88c1\u9fa8\u9e40',
+  size: [2880],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView219 = texture94.createView({label: '\u{1ff02}\u{1ffb6}', dimension: '3d', baseMipLevel: 1, mipLevelCount: 3, arrayLayerCount: 1});
+let renderBundleEncoder81 = device0.createRenderBundleEncoder({
+  label: '\u{1f913}\u{1fead}\ub4ed\u09b1\u869e\u0d9d\u{1fe54}\u1680\ubd31',
+  colorFormats: ['rgba16float', 'r32float'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder16.dispatchWorkgroups(4, 4, 5);
+} catch {}
+try {
+commandEncoder118.resolveQuerySet(querySet82, 274, 828, buffer31, 2560);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 9064, new Int16Array(25003), 21387, 2296);
+} catch {}
+let pipeline98 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'increment-clamp'},
+    stencilReadMask: 1548097312,
+    stencilWriteMask: 4083516081,
+    depthBias: -1150138227,
+    depthBiasSlopeScale: 28.677563729105913,
+  },
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3448,
+        attributes: [
+          {format: 'uint32x4', offset: 88, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 104, shaderLocation: 12},
+          {format: 'float32x4', offset: 1152, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 88, shaderLocation: 3},
+          {format: 'sint32x4', offset: 1540, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 1444, shaderLocation: 0},
+          {format: 'sint32x3', offset: 680, shaderLocation: 18},
+          {format: 'float32', offset: 52, shaderLocation: 1},
+          {format: 'uint16x2', offset: 564, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 664, shaderLocation: 5},
+          {format: 'uint32x3', offset: 440, shaderLocation: 2},
+          {format: 'float32x2', offset: 200, shaderLocation: 8},
+          {format: 'float32x3', offset: 148, shaderLocation: 7},
+          {format: 'sint32x3', offset: 84, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 868, shaderLocation: 10},
+          {format: 'sint8x2', offset: 610, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 240,
+        attributes: [
+          {format: 'sint32x3', offset: 60, shaderLocation: 6},
+          {format: 'uint32x4', offset: 84, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 3636, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 23720,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 11124, shaderLocation: 16},
+          {format: 'uint32x3', offset: 764, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+let offscreenCanvas19 = new OffscreenCanvas(814, 518);
+let commandEncoder191 = device2.createCommandEncoder({label: '\u023c\u{1f87f}\u41b6\u{1fdcb}'});
+let commandBuffer43 = commandEncoder136.finish({});
+try {
+computePassEncoder47.setBindGroup(8, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder73.setPipeline(pipeline97);
+} catch {}
+try {
+commandEncoder183.copyBufferToTexture({
+  /* bytesInLastRow: 528 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 20592 */
+  offset: 20064,
+  bytesPerRow: 768,
+  buffer: buffer30,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder125.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder176.resolveQuerySet(querySet32, 2712, 286, buffer30, 105472);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData13 = new ImageData(52, 44);
+video19.height = 240;
+let commandEncoder192 = device0.createCommandEncoder({label: '\u0687\u0db9\u{1ff9c}\u609a\ud5f5'});
+let texture132 = device0.createTexture({
+  label: '\ud636\u07cf\u153d\u0ad4\u2757\u072b\u8f9f',
+  size: [1290],
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8snorm', 'rgba8snorm'],
+});
+try {
+computePassEncoder73.setPipeline(pipeline84);
+} catch {}
+try {
+commandEncoder109.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: canvas11,
+  origin: { x: 38, y: 6 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 122},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView220 = texture125.createView({
+  label: '\u4b0e\u49cb\u0dba\u3856\u{1ff9b}\ua5ab\ue1df',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 929,
+});
+try {
+commandEncoder181.copyBufferToBuffer(buffer30, 58292, buffer21, 462696, 68920);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder137.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  label: '\u34d9\uea2b\u08a6\ue93e\u703d\ub9c0\u0efc\u9a1e\u9c9d\u053c',
+  layout: bindGroupLayout7,
+  entries: [{binding: 3198, resource: sampler69}],
+});
+let textureView221 = texture14.createView({
+  label: '\u{1f9e8}\u04c3\ud181\u62b7\ub68a\u0f67\u0570\u8b1b\uf59c\u{1ffa4}\u0cfc',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundle107 = renderBundleEncoder3.finish({label: '\u{1fa67}\u99e5\u015b\u027a'});
+try {
+commandEncoder31.resolveQuerySet(querySet22, 586, 1, buffer31, 10752);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder193 = device2.createCommandEncoder({label: '\ue121\ua384\ub2f8'});
+let querySet91 = device2.createQuerySet({type: 'occlusion', count: 2428});
+try {
+computePassEncoder57.dispatchWorkgroups(4, 2, 4);
+} catch {}
+try {
+renderBundleEncoder76.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder76.setPipeline(pipeline97);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+commandEncoder176.copyBufferToBuffer(buffer40, 208336, buffer21, 45380, 79900);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder193.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder122.resolveQuerySet(querySet80, 363, 347, buffer30, 121600);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 81716, new DataView(new ArrayBuffer(1303)), 68, 368);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 13, y: 80 },
+  flipY: true,
+}, {
+  texture: texture113,
+  mipLevel: 1,
+  origin: {x: 207, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas19.getContext('webgpu');
+} catch {}
+document.body.prepend(video21);
+try {
+adapter5.label = '\u06a2\u7682\uca63\ue9eb\u0bc4\u05c1\u2b76\ucf20\ua1dc';
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder();
+let textureView222 = texture5.createView({label: '\u43d3\u097b\u0933', dimension: '2d-array', baseArrayLayer: 0});
+let renderBundleEncoder82 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float', 'r32float'], depthReadOnly: true});
+try {
+computePassEncoder53.setPipeline(pipeline62);
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({label: '\u0c30\u0e95'});
+let renderBundleEncoder83 = device0.createRenderBundleEncoder({colorFormats: ['r16uint', 'rg32uint'], depthReadOnly: true});
+try {
+computePassEncoder16.dispatchWorkgroups(3);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline94);
+} catch {}
+try {
+commandEncoder139.copyBufferToTexture({
+  /* bytesInLastRow: 2792 widthInBlocks: 349 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 22832 */
+  offset: 22832,
+  rowsPerImage: 238,
+  buffer: buffer24,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 349, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer3, 39912, 9720);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u6ec1');
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let videoFrame23 = new VideoFrame(offscreenCanvas11, {timestamp: 0});
+let commandEncoder196 = device0.createCommandEncoder();
+let texture133 = device0.createTexture({
+  label: '\u8021\uac2c\u9ee4',
+  size: {width: 2880, height: 24, depthOrArrayLayers: 61},
+  mipLevelCount: 4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView223 = texture11.createView({label: '\u{1f8cf}\u0f40\u8856\u718f\u61e5'});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup12, new Uint32Array(5866), 70, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer13, 'uint32');
+} catch {}
+try {
+commandEncoder192.clearBuffer(buffer6, 46272, 24524);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+let promise41 = device0.queue.onSubmittedWorkDone();
+gc();
+try {
+  await promise39;
+} catch {}
+let textureView224 = texture97.createView({
+  label: '\u47f0\u5f46\u4e93\u0227\u{1fd6e}\u{1f7e1}\u{1f64c}\u{1fabc}\u0575\u{1f79b}\ue9cf',
+  arrayLayerCount: 1,
+});
+let sampler89 = device2.createSampler({
+  label: '\u0c64\ua030\u{1fb2e}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.52,
+  lodMaxClamp: 63.53,
+});
+let externalTexture83 = device2.importExternalTexture({label: '\u02b5\ue677\u023c\u9f9a\u0ab0\ud850', source: videoFrame10});
+try {
+renderBundleEncoder77.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder182.copyTextureToBuffer({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 162 widthInBlocks: 81 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 18120 */
+  offset: 18120,
+  buffer: buffer21,
+}, {width: 81, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder188.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder191.resolveQuerySet(querySet67, 2609, 768, buffer30, 85248);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: imageData8,
+  origin: { x: 86, y: 8 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 203, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap21 = await createImageBitmap(imageBitmap3);
+let querySet92 = device0.createQuerySet({type: 'occlusion', count: 3056});
+let textureView225 = texture127.createView({label: '\u8ef8\u0174\u28de\u1af5', dimension: '2d'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 10, y: 5 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline99 = device0.createComputePipeline({
+  label: '\u066f\u8949\u89dd\u{1fe59}\u0e13\u9754\u{1fec1}\u2cf0',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise38;
+} catch {}
+document.body.prepend(img16);
+let pipelineLayout36 = device0.createPipelineLayout({
+  label: '\u{1fc2b}\u064f\ub569\u047b\uf755\u{1fe21}\u{1fa54}',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout23, bindGroupLayout23, bindGroupLayout9, bindGroupLayout9, bindGroupLayout2, bindGroupLayout11, bindGroupLayout23],
+});
+let commandEncoder197 = device0.createCommandEncoder({label: '\u3d2a\uee53\u{1fc22}\u0686\uf0aa\uab7b\u396b'});
+let texture134 = device0.createTexture({
+  label: '\u{1f96d}\u00b4\u{1fc28}\uec04\u01f0\u0790\u07ee\ubfa2\u0010\ue907\u5928',
+  size: [645, 1, 1483],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView226 = texture3.createView({label: '\u{1ff20}\u0a01\u0777'});
+let renderBundleEncoder84 = device0.createRenderBundleEncoder({colorFormats: ['r16uint', 'rg32uint'], stencilReadOnly: true});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup3, new Uint32Array(3773), 3429, 0);
+} catch {}
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer33, 8452);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 2,
+  origin: {x: 3, y: 4, z: 0},
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 55_415 */
+{offset: 847, bytesPerRow: 169, rowsPerImage: 301}, {width: 75, height: 22, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: canvas3,
+  origin: { x: 115, y: 8 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 44},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let pipelineLayout37 = device2.createPipelineLayout({
+  label: '\u0d81\u05b6\u5f17\u06f0\ua248\u7330\u7205\ucc7b\uc57e\u0bfb\u{1f80d}',
+  bindGroupLayouts: [bindGroupLayout21, bindGroupLayout33, bindGroupLayout39, bindGroupLayout18, bindGroupLayout34, bindGroupLayout26, bindGroupLayout37, bindGroupLayout41, bindGroupLayout39, bindGroupLayout41],
+});
+let renderBundle108 = renderBundleEncoder72.finish({label: '\u0123\u94e9\uc340\ucf80\uee27\u{1fd6a}\ua9d1'});
+try {
+buffer21.unmap();
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 35680 */
+  offset: 35536,
+  buffer: buffer27,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet41, 1017, 961, buffer30, 74752);
+} catch {}
+let querySet93 = device2.createQuerySet({label: '\u3ebc\u0b0e\u08ca', type: 'occlusion', count: 1766});
+try {
+renderBundleEncoder73.setVertexBuffer(2, buffer28, 90500, 6685);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let computePassEncoder80 = commandEncoder147.beginComputePass({label: '\u0366\ufa4c'});
+let renderBundleEncoder85 = device2.createRenderBundleEncoder({label: '\ucc7b\u4f74\u0673', colorFormats: ['r8uint', 'rg32uint'], depthReadOnly: true});
+try {
+renderBundleEncoder50.setBindGroup(3, bindGroup41, new Uint32Array(128), 54, 0);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer40, 165892, buffer21, 444880, 135020);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1506, height: 1, depthOrArrayLayers: 152}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let img30 = await imageWithData(84, 292, '#5d90ab01', '#2145b6a6');
+let video23 = await videoWithData();
+let commandEncoder198 = device0.createCommandEncoder({label: '\u{1fe84}\u{1ff89}\u05d8\u086a\u0cb6'});
+let texture135 = device0.createTexture({
+  label: '\u7e03\u7163\uadae\uec79\u6d6a\u0355\uf44f',
+  size: [96],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let renderBundleEncoder86 = device0.createRenderBundleEncoder({label: '\u{1fb26}\u09c1\u66b3\ub2cf\u{1fd80}', colorFormats: ['r16uint', 'rg32uint']});
+try {
+commandEncoder65.copyBufferToBuffer(buffer4, 19724, buffer36, 96596, 2336);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder153.copyTextureToBuffer({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 276 widthInBlocks: 69 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9480 */
+  offset: 9480,
+  buffer: buffer6,
+}, {width: 69, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder154.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+let pipeline100 = device0.createComputePipeline({
+  label: '\u07f1\ua01e\u7835\u77de',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}},
+});
+let imageData14 = new ImageData(136, 96);
+canvas12.width = 83;
+gc();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let img31 = await imageWithData(120, 222, '#a1b55a46', '#b4efdafc');
+document.body.prepend(canvas8);
+let imageBitmap22 = await createImageBitmap(offscreenCanvas1);
+let commandEncoder199 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder54.setBindGroup(6, bindGroup61, []);
+} catch {}
+try {
+commandEncoder150.copyBufferToTexture({
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 54900 */
+  offset: 11288,
+  bytesPerRow: 256,
+  rowsPerImage: 34,
+  buffer: buffer24,
+}, {
+  texture: texture87,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 23, height: 1, depthOrArrayLayers: 6});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet48, 826, 1069, buffer15, 52736);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 5912, new Float32Array(60529), 40068, 996);
+} catch {}
+let img32 = await imageWithData(26, 212, '#0b84d4ca', '#82a922aa');
+let commandEncoder200 = device1.createCommandEncoder({label: '\u5c93\uf18c'});
+let renderBundleEncoder87 = device1.createRenderBundleEncoder({
+  label: '\u0719\u3dac\u921d\u0519\u7ad8\u{1f8e2}\u7943\u09b0',
+  colorFormats: ['rg16sint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder27.setStencilReference(1560);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4554, undefined, 0, 4114530055);
+} catch {}
+try {
+renderBundleEncoder67.setPipeline(pipeline39);
+} catch {}
+let pipeline101 = device1.createRenderPipeline({
+  label: '\uad8b\u964b\u07f4\u0138\u15ea',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 2937991048,
+    depthBias: 931794274,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 3440, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 8868, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 6108, shaderLocation: 0},
+          {format: 'sint8x2', offset: 3256, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 3556, shaderLocation: 15},
+          {format: 'sint8x2', offset: 3130, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 3020, shaderLocation: 2},
+          {format: 'sint16x4', offset: 2120, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 4872, shaderLocation: 5},
+          {format: 'uint32x3', offset: 21104, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 18704, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 7472, shaderLocation: 11},
+          {format: 'uint8x2', offset: 1092, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 2048,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 836, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 592, shaderLocation: 1},
+          {format: 'float16x2', offset: 376, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 688, attributes: []},
+      {arrayStride: 5104, attributes: []},
+      {arrayStride: 6404, attributes: []},
+      {
+        arrayStride: 12076,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 1700, shaderLocation: 9}],
+      },
+      {arrayStride: 4440, stepMode: 'vertex', attributes: []},
+      {arrayStride: 6856, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm16x4', offset: 6360, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+try {
+  await promise42;
+} catch {}
+let texture136 = device0.createTexture({
+  size: {width: 15, height: 1, depthOrArrayLayers: 60},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint'],
+});
+let renderBundle109 = renderBundleEncoder82.finish({label: '\u7a28\u2dc4\u{1f6ce}\u558f'});
+try {
+computePassEncoder35.setBindGroup(9, bindGroup38);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(7, bindGroup8, new Uint32Array(1006), 26, 0);
+} catch {}
+try {
+  await buffer38.mapAsync(GPUMapMode.WRITE, 65080, 26628);
+} catch {}
+try {
+commandEncoder177.clearBuffer(buffer6, 100, 50536);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder153.resolveQuerySet(querySet73, 1298, 0, buffer15, 76800);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(176), /* required buffer size: 176 */
+{offset: 176}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2880, height: 24, depthOrArrayLayers: 61}
+*/
+{
+  source: img8,
+  origin: { x: 6, y: 16 },
+  flipY: true,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder201 = device0.createCommandEncoder({label: '\u2fef\u{1f771}\ueba9\u{1fc88}\u0af5\u0939\u0771\u8425\u0832\u60e5'});
+let texture137 = device0.createTexture({
+  label: '\u{1f8fa}\u6df9\u1689\u0542\ueea7\u1b2b\u{1fab0}',
+  size: {width: 2580},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint'],
+});
+let renderBundleEncoder88 = device0.createRenderBundleEncoder({label: '\u31bd\ue434', colorFormats: ['r8unorm']});
+try {
+computePassEncoder29.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(7, buffer31, 12884, 514);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder129.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet2, 852, 1003, buffer0, 134912);
+} catch {}
+document.body.prepend(video2);
+gc();
+let canvas13 = document.createElement('canvas');
+let video24 = await videoWithData();
+let bindGroup63 = device0.createBindGroup({
+  label: '\ub3ea\u0400\ufebf\u8145\u{1fb9a}\u{1fdd5}\u{1f8fd}\u{1fbf8}\u7b26\ua5b9',
+  layout: bindGroupLayout40,
+  entries: [{binding: 85, resource: externalTexture37}],
+});
+let commandEncoder202 = device0.createCommandEncoder({label: '\u3a84\u0b11\u2f28\u6b82\u{1fc7f}\u6396\u97da\u{1fcfd}\u68e9\u0052'});
+let querySet94 = device0.createQuerySet({
+  label: '\u7db5\u01b5\u0868\u0f98\u{1fa9f}\u{1fb2a}\u8b7b\u4592\u{1faf1}\u0571\u3fd2',
+  type: 'occlusion',
+  count: 3371,
+});
+let sampler90 = device0.createSampler({
+  label: '\u{1f63a}\u80e4\u8df8\u345f\uba1f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 78.70,
+  compare: 'always',
+});
+try {
+renderBundleEncoder53.setVertexBuffer(3, buffer6, 2936);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet31, 281, 473, buffer15, 70656);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 6, depthOrArrayLayers: 61}
+*/
+{
+  source: video20,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture133,
+  mipLevel: 2,
+  origin: {x: 40, y: 1, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline102 = await device0.createComputePipelineAsync({
+  label: '\u18d8\uba05\ufd6f\uf7c3\uc625\ua3b4\ufab4',
+  layout: pipelineLayout28,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+video24.height = 185;
+try {
+canvas13.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+offscreenCanvas12.width = 485;
+gc();
+canvas6.height = 468;
+try {
+adapter3.label = '\u{1fab3}\u779a\ued12\u{1f6b6}\u5467\u{1f869}\u57f9\u2614\u126f';
+} catch {}
+try {
+computePassEncoder5.setBindGroup(9, bindGroup9);
+} catch {}
+let arrayBuffer24 = buffer11.getMappedRange(21408, 2040);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder203 = device1.createCommandEncoder();
+let texture138 = device1.createTexture({
+  label: '\u0892\u{1fd9a}\u7985\u067e\u6686\u{1ff01}\u75fc',
+  size: [72],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder29 = commandEncoder200.beginRenderPass({
+  label: '\ue734\u04d9\u618b\u5ccd\u12f0\u{1fe6e}\u8da0\u06de',
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: 821.2, g: 489.5, b: 81.66, a: 951.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet38,
+  maxDrawCount: 925176994,
+});
+let renderBundle110 = renderBundleEncoder62.finish();
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle19, renderBundle67, renderBundle93, renderBundle52, renderBundle55]);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(583);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer34, 'uint16', 36212, 4945);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline39);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(4, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline37);
+} catch {}
+try {
+commandEncoder203.clearBuffer(buffer29);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder203.resolveQuerySet(querySet16, 4012, 37, buffer34, 27392);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView227 = texture13.createView({});
+let externalTexture84 = device0.importExternalTexture({source: videoFrame17});
+try {
+commandEncoder165.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 6224 */
+  offset: 6224,
+  buffer: buffer6,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer36);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 18},
+  aspect: 'all',
+}, new ArrayBuffer(14_376), /* required buffer size: 14_376 */
+{offset: 692, bytesPerRow: 88, rowsPerImage: 155}, {width: 11, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(922, 820);
+try {
+adapter4.label = '\u{1f668}\u{1fdc0}\u8d69\u507c\u0de7\u5176\ue745\ua0e9';
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let canvas14 = document.createElement('canvas');
+let commandEncoder204 = device0.createCommandEncoder({label: '\uea82\u{1fd7a}\uc190'});
+let querySet95 = device0.createQuerySet({label: '\uafc2\u{1ff33}\u{1f68e}\u0397\u50fa\u0f64', type: 'occlusion', count: 3845});
+try {
+computePassEncoder29.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(6, buffer32);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 960 widthInBlocks: 240 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 67176 */
+  offset: 67176,
+  bytesPerRow: 1024,
+  buffer: buffer24,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 240, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder190.resolveQuerySet(querySet14, 579, 284, buffer0, 129792);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 13},
+  aspect: 'all',
+}, arrayBuffer18, /* required buffer size: 235_751 */
+{offset: 723, bytesPerRow: 861, rowsPerImage: 10}, {width: 209, height: 3, depthOrArrayLayers: 28});
+} catch {}
+let offscreenCanvas21 = new OffscreenCanvas(198, 453);
+let img33 = await imageWithData(252, 17, '#ee8fadfc', '#bad8292a');
+try {
+offscreenCanvas20.getContext('bitmaprenderer');
+} catch {}
+let renderBundle111 = renderBundleEncoder42.finish({label: '\uada8\uab45\uec3a\u033d\uf173'});
+try {
+computePassEncoder73.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline63);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(6, bindGroup16);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 800 widthInBlocks: 200 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3500 */
+  offset: 3500,
+  bytesPerRow: 1024,
+  buffer: buffer7,
+}, {
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 7, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 200, height: 291, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12068 */
+  offset: 272,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 5, height: 47, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer25, commandBuffer20]);
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+try {
+  await promise40;
+} catch {}
+let canvas15 = document.createElement('canvas');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas13.width = 4042;
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55) };
+} catch {}
+let externalTexture85 = device2.importExternalTexture({label: '\ua4be\u{1f728}\u0025\u{1f6b7}', source: video4});
+try {
+renderBundleEncoder80.setBindGroup(7, bindGroup41);
+} catch {}
+try {
+renderBundleEncoder73.setIndexBuffer(buffer30, 'uint32', 3712, 82524);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(5, buffer28);
+} catch {}
+try {
+commandEncoder184.copyBufferToBuffer(buffer39, 13216, buffer21, 278952, 7048);
+dissociateBuffer(device2, buffer39);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 33792, new Float32Array(30225));
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder();
+let texture139 = device0.createTexture({
+  size: {width: 1290, height: 1, depthOrArrayLayers: 29},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView228 = texture118.createView({
+  label: '\u{1ffa1}\uee7a',
+  dimension: '2d-array',
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let sampler91 = device0.createSampler({
+  label: '\u{1f92a}\ue7dc\u9e06\u{1f94b}\u{1fd3f}\udf4f\u14a8\u{1fe48}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.25,
+  lodMaxClamp: 92.73,
+  maxAnisotropy: 19,
+});
+let externalTexture86 = device0.importExternalTexture({label: '\ua007\ud3fd\u{1fe5b}\u0c59\u0bfd', source: videoFrame10, colorSpace: 'srgb'});
+try {
+renderBundleEncoder54.setVertexBuffer(1, buffer6, 36680, 3953);
+} catch {}
+video13.width = 220;
+let canvas16 = document.createElement('canvas');
+try {
+bindGroup48.label = '\u03cd\u7994\u0658\ue275\ub9e8\udeb8\ufc68\u9bc0\ub0d0';
+} catch {}
+let commandEncoder206 = device0.createCommandEncoder({label: '\u06bc\u96f0\u{1ff3b}\ubd2e\u0fa1\u{1f6c7}\uf0f1\u7568\u{1fc33}\u057c\u24fc'});
+let texture140 = device0.createTexture({
+  label: '\u0983\u{1f88e}\u0352\u01ca\uf33b\u07dd\u06c7\u9ddd',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let textureView229 = texture19.createView({
+  label: '\u0311\u7ee7\ue6dd\u4f31\u0bae\u52ce\u{1f7a2}\ubff9\ud707\u06d4',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder89 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+commandEncoder177.copyTextureToTexture({
+  texture: texture91,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 125},
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 39},
+  aspect: 'all',
+},
+{width: 172, height: 3, depthOrArrayLayers: 126});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55) };
+} catch {}
+video17.width = 74;
+let promise43 = adapter4.requestAdapterInfo();
+let gpuCanvasContext10 = canvas16.getContext('webgpu');
+try {
+offscreenCanvas21.getContext('webgl2');
+} catch {}
+try {
+commandEncoder21.label = '\u{1fc7a}\u1b95\uc550\u0403\u{1f68b}';
+} catch {}
+let pipelineLayout38 = device0.createPipelineLayout({
+  label: '\ue23d\u{1fd6e}\u6020',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout3, bindGroupLayout11, bindGroupLayout23],
+});
+let externalTexture87 = device0.importExternalTexture({label: '\u0ceb\u{1fb81}\uce6f', source: video13, colorSpace: 'srgb'});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup14, new Uint32Array(1340), 358, 0);
+} catch {}
+try {
+renderBundleEncoder78.setIndexBuffer(buffer5, 'uint16', 30774);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer7, 78408, buffer11, 86524, 21888);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 348},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 238_617 */
+{offset: 735, bytesPerRow: 2246, rowsPerImage: 101}, {width: 513, height: 5, depthOrArrayLayers: 2});
+} catch {}
+try {
+adapter3.label = '\u3b70\u8fa1\u0a66\u8021\u0621\u0d12\u{1f9aa}\ue640\u4c6d\u24f1\udba2';
+} catch {}
+let commandEncoder207 = device0.createCommandEncoder({label: '\u06f6\u{1fa65}\u6fe9\ud01c\u2509'});
+let textureView230 = texture16.createView({label: '\u{1fe99}\u0057\u0a0e\ub9d6\u8961\u{1ff58}\u{1fb73}\u06b6\u{1fdd3}', baseMipLevel: 1});
+let externalTexture88 = device0.importExternalTexture({label: '\u0645\u91af', source: videoFrame20, colorSpace: 'display-p3'});
+let arrayBuffer25 = buffer14.getMappedRange(223560, 21404);
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8392 */
+  offset: 8392,
+  buffer: buffer6,
+}, {width: 68, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 2},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 405 */
+{offset: 405, bytesPerRow: 697}, {width: 328, height: 244, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise43;
+} catch {}
+let canvas17 = document.createElement('canvas');
+let textureView231 = texture38.createView({label: '\u315e\u0516\u{1fc50}\u8909\u757c\u{1fbe1}\u3c7e\u0b72\u45d9\uf6ca\uf4a9'});
+let renderBundleEncoder90 = device1.createRenderBundleEncoder({
+  label: '\u{1fb08}\u0333\u0559\u6d0a\u{1ff3a}\ue150\u0df7\u0517\u{1fa21}\u798c',
+  colorFormats: ['rg16sint'],
+});
+let renderBundle112 = renderBundleEncoder61.finish({label: '\u5f5e\u70ff\u{1f85f}\u{1fa23}\u0703\u0b99'});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup19, new Uint32Array(1969), 1269, 0);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(236);
+} catch {}
+try {
+renderBundleEncoder45.draw(333, 262, 139_900_583);
+} catch {}
+try {
+commandEncoder203.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 31, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder203.clearBuffer(buffer20, 61968);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder203.resolveQuerySet(querySet19, 468, 723, buffer34, 34560);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let promise44 = navigator.gpu.requestAdapter();
+let video25 = await videoWithData();
+let commandEncoder208 = device0.createCommandEncoder({label: '\u2512\u0e20\u8545\u0bdd\u0dc9\u5e17'});
+let querySet96 = device0.createQuerySet({type: 'occlusion', count: 3745});
+let renderBundleEncoder91 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: false, stencilReadOnly: true});
+try {
+renderBundleEncoder64.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder78.setBindGroup(0, bindGroup28, new Uint32Array(9173), 637, 0);
+} catch {}
+try {
+renderBundleEncoder88.setVertexBuffer(2, buffer22, 25088, 22598);
+} catch {}
+try {
+commandEncoder150.copyBufferToBuffer(buffer38, 19764, buffer6, 19116, 17728);
+dissociateBuffer(device0, buffer38);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet11, 3281, 180, buffer0, 39680);
+} catch {}
+let imageData15 = new ImageData(244, 152);
+let bindGroupLayout43 = device0.createBindGroupLayout({
+  label: '\u05af\u19fa',
+  entries: [
+    {binding: 3778, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 228, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 106,
+      visibility: 0,
+      buffer: { type: 'uniform', minBindingSize: 108263813, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder209 = device0.createCommandEncoder({label: '\u84e6\ubc9b\u{1fbe0}\u018e\u0d3e'});
+let commandBuffer44 = commandEncoder162.finish({label: '\u09fc\ud8de\u04de\u{1fdf3}\u0c75\u0ced\u0760'});
+let sampler92 = device0.createSampler({
+  label: '\u0383\u06f4\u0fbc\u3ccf\u0d9d',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 88.31,
+});
+try {
+computePassEncoder29.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(9, bindGroup16);
+} catch {}
+try {
+commandEncoder207.copyBufferToBuffer(buffer25, 255508, buffer4, 73316, 2016);
+dissociateBuffer(device0, buffer25);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder170.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 17512 widthInBlocks: 2189 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2600 */
+  offset: 2600,
+  buffer: buffer6,
+}, {width: 2189, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder114.pushDebugGroup('\u9e51');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 3, depthOrArrayLayers: 61}
+*/
+{
+  source: canvas12,
+  origin: { x: 4, y: 19 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 3,
+  origin: {x: 118, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video23.width = 217;
+canvas14.width = 1605;
+let gpuCanvasContext11 = canvas14.getContext('webgpu');
+let imageBitmap23 = await createImageBitmap(img4);
+document.body.prepend(video20);
+canvas5.width = 689;
+gc();
+let imageBitmap24 = await createImageBitmap(imageBitmap19);
+canvas13.height = 863;
+let texture141 = device0.createTexture({
+  label: '\u5e47\u0c5d\u1463',
+  size: [62, 1, 1],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let sampler93 = device0.createSampler({
+  label: '\uf760\u056c',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 81.03,
+});
+try {
+renderBundleEncoder81.setBindGroup(8, bindGroup28, new Uint32Array(6837), 6222, 0);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer10, 580, buffer9, 38632, 9732);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 37, y: 1, z: 175},
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 69},
+  aspect: 'all',
+},
+{width: 211, height: 1, depthOrArrayLayers: 468});
+} catch {}
+try {
+commandEncoder102.insertDebugMarker('\uaccf');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 67604, new Float32Array(7066), 352, 92);
+} catch {}
+try {
+  await promise41;
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+offscreenCanvas7.width = 5;
+let offscreenCanvas22 = new OffscreenCanvas(52, 73);
+canvas4.height = 382;
+let gpuCanvasContext12 = offscreenCanvas22.getContext('webgpu');
+let commandEncoder210 = device0.createCommandEncoder({label: '\u{1f6c6}\u{1faeb}\u0c54\u06a4\u9a86\u04ec\udfed'});
+let texture142 = device0.createTexture({
+  label: '\u0f00\u1914\uf67f',
+  size: [720, 6, 1450],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm'],
+});
+let textureView232 = texture7.createView({label: '\ud757\ub1f1\u{1fcdb}\u85da\u{1f6b8}\u3af0\u{1fb69}\uda3e\u50f0'});
+let renderBundleEncoder92 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+commandEncoder31.copyBufferToBuffer(buffer24, 67872, buffer9, 20608, 12136);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder190.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 186, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2284 */
+  offset: 2284,
+  buffer: buffer6,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline103 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}}});
+let querySet97 = device0.createQuerySet({label: '\u886a\u0e09\u3d31\u4276\u028d\u7b9b\u06a0\ua1f5\u92df\u808f', type: 'occlusion', count: 839});
+let textureView233 = texture64.createView({label: '\u{1ffd5}\u513d\u0adc\u3e25\u639f\u{1fd4f}\u0592\u010c', aspect: 'all'});
+let sampler94 = device0.createSampler({
+  label: '\ubc0d\u0ec4\u{1fc89}\u07bd\u08fd',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 77.44,
+});
+let externalTexture89 = device0.importExternalTexture({label: '\u{1fa4b}\u{1fbc4}\ucd6a\u8ea2\u04ba\u75eb', source: videoFrame13, colorSpace: 'srgb'});
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(1, bindGroup25, new Uint32Array(8579), 2777, 0);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(4, buffer31);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer7, 33680, buffer6, 37932, 28992);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder102.clearBuffer(buffer11, 83496, 4132);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas5.width = 2169;
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandBuffer45 = commandEncoder0.finish({label: '\u362b\u0947\u0db7\u8eb8\u{1f780}'});
+let textureView234 = texture35.createView({label: '\u70ae\u005d\u3968\u0e49\uf58d\u{1fb58}\uf6f3\u0da7\u9cec\u681c', baseMipLevel: 5});
+let renderBundle113 = renderBundleEncoder86.finish({label: '\u7f1f\ubddf'});
+let sampler95 = device0.createSampler({
+  label: '\ub020\u031c\u{1f8a3}\u54ba\u532c\u730f\uf049\u26f6',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.5462,
+  maxAnisotropy: 6,
+});
+try {
+commandEncoder194.copyTextureToTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 383, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 156, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet82, 1202, 46, buffer0, 102656);
+} catch {}
+try {
+commandEncoder114.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 31, y: 2, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 25_115_423 */
+{offset: 111, bytesPerRow: 10374, rowsPerImage: 121}, {width: 1279, height: 1, depthOrArrayLayers: 21});
+} catch {}
+let pipeline104 = device0.createComputePipeline({
+  label: '\u89c9\u{1fbe4}\u{1fef0}\u9b1e\u{1fe6c}\uea80\uc5f4\u{1f957}',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroup64 = device0.createBindGroup({label: '\u8d8b\uf9d5', layout: bindGroupLayout5, entries: []});
+let textureView235 = texture9.createView({label: '\u21e2\u0a67', dimension: '3d', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler96 = device0.createSampler({
+  label: '\u13f9\u7eab\u06c9\u{1f719}\u0090',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 61.23,
+});
+let externalTexture90 = device0.importExternalTexture({source: videoFrame16, colorSpace: 'srgb'});
+try {
+computePassEncoder16.dispatchWorkgroups(2, 3);
+} catch {}
+let arrayBuffer26 = buffer32.getMappedRange();
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 28, new DataView(new ArrayBuffer(4952)), 2993, 340);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 218, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer10), /* required buffer size: 234 */
+{offset: 234, rowsPerImage: 159}, {width: 1882, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline105 = device0.createComputePipeline({
+  label: '\u302d\u0c7f\u0989\u5652\u4adc\u0c6f\u34ab',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let img34 = await imageWithData(18, 149, '#ffcff648', '#dd8ba5ed');
+let textureView236 = texture92.createView({label: '\u{1fa4c}\ua3ad\u{1f65f}\u2489\uadcb\u9a2c\ue9aa\u7506\ude25\u52d8\u3671'});
+try {
+renderBundleEncoder49.setBindGroup(6, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder92.setVertexBuffer(5, buffer6, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 6592, new DataView(new ArrayBuffer(34148)), 31386, 44);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 6, depthOrArrayLayers: 61}
+*/
+{
+  source: imageData10,
+  origin: { x: 6, y: 14 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 2,
+  origin: {x: 96, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder({});
+let texture143 = device0.createTexture({
+  label: '\ua9bd\u0081\ufad1\u0a0e\uf012\u{1f818}\u043a\ue7a5\uad69',
+  size: [15, 1, 60],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView237 = texture111.createView({label: '\u55ff\u96ba\u04ff\u00e7\u8492', baseMipLevel: 1});
+let renderBundle114 = renderBundleEncoder81.finish({});
+let sampler97 = device0.createSampler({
+  label: '\u17b4\uaaed\u0208\u0be0\ub13e\u0f2f\uf877\u4506',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.75,
+  lodMaxClamp: 96.94,
+});
+try {
+renderBundleEncoder69.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer5), /* required buffer size: 973 */
+{offset: 917}, {width: 14, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline106 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'r32float'}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1204, attributes: []},
+      {
+        arrayStride: 3992,
+        attributes: [
+          {format: 'uint16x2', offset: 684, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 720, shaderLocation: 18},
+          {format: 'sint8x2', offset: 1074, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 48, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 800, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 0},
+          {format: 'uint16x4', offset: 868, shaderLocation: 5},
+          {format: 'sint16x4', offset: 212, shaderLocation: 12},
+          {format: 'float32x4', offset: 536, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 11356,
+        attributes: [
+          {format: 'sint8x4', offset: 1072, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 916, shaderLocation: 4},
+          {format: 'sint32', offset: 2180, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 8888,
+        attributes: [
+          {format: 'float32x2', offset: 1476, shaderLocation: 9},
+          {format: 'uint32', offset: 824, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 25668, shaderLocation: 8},
+          {format: 'float32x4', offset: 12056, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 1128, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 4616,
+        attributes: [
+          {format: 'uint32x2', offset: 312, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 768, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 8640, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 14016,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 3756, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+let imageData16 = new ImageData(8, 88);
+let commandEncoder212 = device0.createCommandEncoder();
+let commandBuffer46 = commandEncoder129.finish();
+let textureView238 = texture4.createView({label: '\u0fad\u0a28\ufdc6\u0525\u1ce8\u4f1f', baseMipLevel: 5, baseArrayLayer: 12, arrayLayerCount: 1});
+let promise45 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas12);
+let offscreenCanvas23 = new OffscreenCanvas(133, 524);
+let imageData17 = new ImageData(88, 100);
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+gc();
+let offscreenCanvas24 = new OffscreenCanvas(971, 218);
+let video26 = await videoWithData();
+let gpuCanvasContext13 = offscreenCanvas24.getContext('webgpu');
+try {
+  await promise45;
+} catch {}
+document.body.prepend(img12);
+let imageBitmap25 = await createImageBitmap(video8);
+try {
+canvas17.getContext('2d');
+} catch {}
+let imageBitmap26 = await createImageBitmap(imageData9);
+let videoFrame24 = new VideoFrame(video1, {timestamp: 0});
+try {
+window.someLabel = externalTexture81.label;
+} catch {}
+document.body.prepend(img13);
+let buffer41 = device0.createBuffer({
+  label: '\u{1f615}\u2947\u2dfa\uccca\u1795\ufcca',
+  size: 315112,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let texture144 = device0.createTexture({
+  size: [15, 1, 60],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let renderBundleEncoder93 = device0.createRenderBundleEncoder({
+  label: '\u0864\u{1f9c2}\ub346\u0058\ue021\u45e4\u5254\u{1fbab}\u{1fbe6}\u1adf\u05a9',
+  colorFormats: ['rgba16float', 'r32float'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder84.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+commandEncoder207.copyBufferToBuffer(buffer4, 69268, buffer15, 71372, 212);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer6, 4656, 9864);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+let imageBitmap27 = await createImageBitmap(offscreenCanvas10);
+let bindGroupLayout44 = device0.createBindGroupLayout({
+  label: '\u{1ff96}\ud40c\u1306\u0d92\u0fd0\uc8af\u8315\ua05d\ua853\ubf93',
+  entries: [
+    {
+      binding: 642,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let bindGroup65 = device0.createBindGroup({
+  label: '\u{1f755}\u{1f768}\ue57b\u6ed6\uc65e\u{1f9df}\u0f02\u31b8',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder213 = device0.createCommandEncoder({label: '\u4405\u{1ff1c}'});
+let texture145 = device0.createTexture({
+  size: [15, 1, 60],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView239 = texture107.createView({
+  label: '\u6fce\u8a75\u0cd9\u126e\u12e7\u04ce\ua476\u779e',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  baseArrayLayer: 4,
+});
+try {
+commandEncoder109.copyBufferToBuffer(buffer7, 107624, buffer6, 25644, 7020);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 676, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 180, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder196.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+canvas15.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({label: '\u0e58\u0a95\u6f5b\u02df\u{1f8fa}\ua242'});
+let texture146 = device0.createTexture({
+  size: [96, 120, 1],
+  mipLevelCount: 6,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView240 = texture135.createView({label: '\u0b51\u{1f77f}', format: 'rgba8unorm-srgb'});
+let computePassEncoder81 = commandEncoder190.beginComputePass({label: '\u0ca9\u011d\uc95c\u1e57\u062a\u763e'});
+try {
+computePassEncoder67.setBindGroup(8, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(2, buffer6, 0);
+} catch {}
+try {
+buffer41.destroy();
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer38, 67028, buffer41, 39172, 8436);
+dissociateBuffer(device0, buffer38);
+dissociateBuffer(device0, buffer41);
+} catch {}
+let commandBuffer47 = commandEncoder205.finish({label: '\ube02\ub1c2\u6d30\u{1fe77}\u{1ff9f}'});
+let renderBundleEncoder94 = device0.createRenderBundleEncoder({
+  label: '\u0ba7\ub4b0\u0d1d\u8f3a\u09a2\u50fb\u{1f8e2}\u0f5e',
+  colorFormats: ['rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle115 = renderBundleEncoder9.finish({label: '\u{1fd5c}\u09e3\u0515\u67bf\u0116\u{1fe7b}\u{1fad3}'});
+let externalTexture91 = device0.importExternalTexture({label: '\u{1fae5}\u6696\u{1fd76}\u2d68', source: video23, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.dispatchWorkgroups(4, 5, 4);
+} catch {}
+try {
+computePassEncoder29.dispatchWorkgroupsIndirect(buffer33, 244980);
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(9, bindGroup6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas22,
+  origin: { x: 2, y: 8 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap28 = await createImageBitmap(offscreenCanvas24);
+let bindGroup66 = device0.createBindGroup({
+  label: '\u0b9a\uf0ab\u5bdd\ub1ad\uda26\u{1fcf4}\u7afe\u7ef9\u0af5',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let computePassEncoder82 = commandEncoder118.beginComputePass({label: '\u0c73\ue805'});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline102);
+} catch {}
+try {
+renderBundleEncoder64.setPipeline(pipeline59);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 22928 */
+  offset: 22928,
+  rowsPerImage: 228,
+  buffer: buffer24,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder204.resolveQuerySet(querySet95, 976, 572, buffer31, 4096);
+} catch {}
+let pipeline107 = device0.createComputePipeline({
+  label: '\ubff5\u8ae2\u0f08\u0be8\ucaac\u{1ff10}\u06dd',
+  layout: 'auto',
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas6);
+canvas15.width = 1021;
+gc();
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+computePassEncoder68.setBindGroup(6, bindGroup17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 16, y: 1, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(6_919_206), /* required buffer size: 6_919_206 */
+{offset: 904, bytesPerRow: 2570, rowsPerImage: 117}, {width: 608, height: 1, depthOrArrayLayers: 24});
+} catch {}
+let promise46 = device0.createRenderPipelineAsync({
+  label: '\u022c\u3a33\u{1f7d4}\u{1f882}\u{1f738}\u0620\ucacb\ucedb',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'r32float', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 280851495,
+    stencilWriteMask: 2064845006,
+    depthBias: -2137598150,
+    depthBiasSlopeScale: 615.0946792786408,
+    depthBiasClamp: -24.62001343473551,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 112,
+        attributes: [
+          {format: 'unorm16x4', offset: 32, shaderLocation: 11},
+          {format: 'sint32x2', offset: 4, shaderLocation: 12},
+          {format: 'uint16x4', offset: 4, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 12, shaderLocation: 19},
+          {format: 'sint16x4', offset: 36, shaderLocation: 17},
+          {format: 'uint32x2', offset: 16, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 12, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 36, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 0},
+          {format: 'sint32x3', offset: 28, shaderLocation: 2},
+          {format: 'uint32x4', offset: 0, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 15},
+          {format: 'uint16x2', offset: 24, shaderLocation: 6},
+          {format: 'sint32x4', offset: 12, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 28, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 3640,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 6, shaderLocation: 14},
+          {format: 'float32x2', offset: 816, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw'},
+});
+let videoFrame25 = new VideoFrame(imageBitmap21, {timestamp: 0});
+let querySet98 = device0.createQuerySet({label: '\u08fa\u0c4c\u50c2\u{1fd7d}\uc1c1\udf8b\u04d1\u{1fc9f}\u8fcf', type: 'occlusion', count: 302});
+let textureView241 = texture63.createView({label: '\udbc4\u408d\u02f5\u09a3\u0c24\u054b', format: 'rgb10a2unorm', arrayLayerCount: 1});
+let computePassEncoder83 = commandEncoder174.beginComputePass({label: '\u0f61\uba88\u904c\ub91b\u51a0\ue3af\u0c66\u38f1\uee27'});
+let renderBundle116 = renderBundleEncoder4.finish({label: '\uba11\u{1fa43}\u4c93\ucb2f\u0b1a\u8e3d\u0a03'});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup1, new Uint32Array(7961), 1209, 0);
+} catch {}
+try {
+commandEncoder212.clearBuffer(buffer3, 86652, 3136);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer24, /* required buffer size: 43_205_909 */
+{offset: 153, bytesPerRow: 1642, rowsPerImage: 184}, {width: 363, height: 1, depthOrArrayLayers: 144});
+} catch {}
+gc();
+let video27 = await videoWithData();
+let commandEncoder215 = device0.createCommandEncoder();
+let textureView242 = texture140.createView({label: '\u{1ffdb}\u1bc5\u{1f6ed}\ufbd1\u0da2\u280a'});
+let sampler98 = device0.createSampler({
+  label: '\u0460\u0db6',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.51,
+  maxAnisotropy: 9,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer25, 174096, buffer3, 73400, 36452);
+dissociateBuffer(device0, buffer25);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder175.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 97, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 36, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 251, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder153.clearBuffer(buffer11, 155188, 7816);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.submit([commandBuffer44, commandBuffer46, commandBuffer45]);
+} catch {}
+gc();
+let imageData18 = new ImageData(28, 192);
+let bindGroupLayout45 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2365,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder216 = device0.createCommandEncoder();
+let querySet99 = device0.createQuerySet({
+  label: '\uf62c\u6e6f\u8f41\u{1fc8f}\ua360\u0db3\ua59c\u0a49\u0c9c\uf430',
+  type: 'occlusion',
+  count: 2357,
+});
+try {
+computePassEncoder5.dispatchWorkgroups(4);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+commandEncoder207.clearBuffer(buffer14, 364136);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 5}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 18, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline108 = await device0.createComputePipelineAsync({
+  label: '\u07ba\u51c3\ub932\ud15c\u{1f6e3}\u{1faac}\u0917\u21c3\uaf92',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline109 = await promise46;
+let imageBitmap29 = await createImageBitmap(video22);
+let buffer42 = device0.createBuffer({size: 50108, usage: GPUBufferUsage.STORAGE, mappedAtCreation: true});
+let commandBuffer48 = commandEncoder177.finish({label: '\u098e\uf334\u012c\u0069\uec03\u3c85\u06dd\u0d54\u857e\ude5f\ub464'});
+let sampler99 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.13,
+  lodMaxClamp: 54.99,
+  maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder70.setVertexBuffer(3182, undefined, 2747064748);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 592 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13696 */
+  offset: 13696,
+  bytesPerRow: 1024,
+  buffer: buffer7,
+}, {
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 74, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 59},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(48)), /* required buffer size: 1_982_206 */
+{offset: 734, bytesPerRow: 192, rowsPerImage: 215}, {width: 8, height: 1, depthOrArrayLayers: 49});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 161, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 35, y: 67 },
+  flipY: false,
+}, {
+  texture: texture139,
+  mipLevel: 3,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline110 = device0.createComputePipeline({
+  label: '\ue320\u0448',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule19, entryPoint: 'compute0'},
+});
+let imageData19 = new ImageData(68, 72);
+let buffer43 = device0.createBuffer({
+  label: '\u08bb\u7c86\ue356\u06d4\uc96b\uce4b\u096b\u0f7f\uf234\u087d\u186a',
+  size: 212163,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder217 = device0.createCommandEncoder({label: '\u0b0e\u043d\ufa97'});
+let textureView243 = texture10.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 15});
+let renderBundleEncoder95 = device0.createRenderBundleEncoder({
+  label: '\u0fb8\u44be\u08e8\u688e\u{1ffb1}\u09c7\u02dc\ue749',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let renderBundle117 = renderBundleEncoder10.finish({label: '\ua618\ub5b0\u0ea2\u1504\u06bd'});
+let externalTexture92 = device0.importExternalTexture({
+  label: '\u2e94\u02c5\uc99c\u574c\uf7f3\u4d49\u250a\u4dcc\u29e0\u{1f9a5}',
+  source: videoFrame18,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder28.setPipeline(pipeline105);
+} catch {}
+try {
+commandEncoder194.copyBufferToBuffer(buffer12, 30244, buffer36, 38580, 6256);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 5720 widthInBlocks: 1430 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32276 */
+  offset: 32276,
+  bytesPerRow: 5888,
+  buffer: buffer43,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1430, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer43);
+} catch {}
+try {
+commandEncoder216.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder215.resolveQuerySet(querySet15, 43, 207, buffer31, 0);
+} catch {}
+document.body.prepend(canvas3);
+try {
+if (!arrayBuffer26.detached) { new Uint8Array(arrayBuffer26).fill(0x55) };
+} catch {}
+gc();
+let buffer44 = device0.createBuffer({size: 414771, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture147 = device0.createTexture({
+  label: '\u0a53\u09f9\u1737\u774b\u2ab5\u08f2',
+  size: {width: 96, height: 120, depthOrArrayLayers: 5},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+try {
+computePassEncoder22.setPipeline(pipeline63);
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 141, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(900), /* required buffer size: 900 */
+{offset: 900, bytesPerRow: 701}, {width: 150, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 3, depthOrArrayLayers: 61}
+*/
+{
+  source: imageBitmap14,
+  origin: { x: 493, y: 147 },
+  flipY: false,
+}, {
+  texture: texture62,
+  mipLevel: 3,
+  origin: {x: 110, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let canvas18 = document.createElement('canvas');
+let imageData20 = new ImageData(76, 8);
+try {
+canvas18.getContext('webgpu');
+} catch {}
+let pipelineLayout39 = device0.createPipelineLayout({
+  label: '\u0629\u7845\u0bcf\ua8c5\u037b\u07f8\ub2fa\u0a91\u{1fdf8}',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout1, bindGroupLayout28, bindGroupLayout23, bindGroupLayout11, bindGroupLayout44],
+});
+let texture148 = device0.createTexture({
+  label: '\u{1fe6c}\u0e2a\u008b\u0cd1\u{1f92a}\u9644\u571f\u053b\u0fbb\u5d7a\uaa99',
+  size: {width: 322},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+  await buffer43.mapAsync(GPUMapMode.WRITE, 0, 136976);
+} catch {}
+try {
+commandEncoder204.copyBufferToBuffer(buffer4, 1240, buffer6, 31848, 884);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 45, y: 15, z: 0},
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 88_557 */
+{offset: 559, bytesPerRow: 481}, {width: 57, height: 183, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 1, depthOrArrayLayers: 649}
+*/
+{
+  source: imageBitmap18,
+  origin: { x: 21, y: 15 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 247},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let commandBuffer49 = commandEncoder217.finish({label: '\u{1fd74}\u0318\udcb5'});
+let textureView244 = texture35.createView({
+  label: '\u0051\u0676\u{1f6c1}\u19cc\u3566\u8ab9\u65d6\u2de5\ue21f\u7966\u2fed',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+});
+let renderBundleEncoder96 = device0.createRenderBundleEncoder({
+  label: '\u2532\u3299\ucdb8\u167f\ud38d',
+  colorFormats: ['r16uint', 'rg32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder5.dispatchWorkgroups(4, 4, 5);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(7, bindGroup23);
+} catch {}
+try {
+commandEncoder211.copyBufferToBuffer(buffer1, 1544, buffer6, 19132, 4944);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder197.copyBufferToTexture({
+  /* bytesInLastRow: 612 widthInBlocks: 153 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10748 */
+  offset: 10748,
+  bytesPerRow: 768,
+  buffer: buffer44,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 153, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer44);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 650 */
+{offset: 650}, {width: 1281, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline111 = device0.createRenderPipeline({
+  layout: pipelineLayout33,
+  multisample: {mask: 0xee568dee},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 2518316112,
+    stencilWriteMask: 1775212425,
+    depthBias: -1932365663,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3796,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 180, shaderLocation: 14},
+          {format: 'uint8x4', offset: 584, shaderLocation: 3},
+          {format: 'float32x2', offset: 732, shaderLocation: 19},
+          {format: 'uint16x2', offset: 388, shaderLocation: 6},
+          {format: 'sint32', offset: 596, shaderLocation: 12},
+          {format: 'uint32x2', offset: 364, shaderLocation: 7},
+          {format: 'sint32', offset: 400, shaderLocation: 10},
+          {format: 'sint32x3', offset: 228, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 46, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 172, shaderLocation: 0},
+          {format: 'uint32x3', offset: 56, shaderLocation: 5},
+          {format: 'sint16x2', offset: 28, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 1784, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 508, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 360, shaderLocation: 1},
+          {format: 'float16x4', offset: 592, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 252, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 156,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 8, shaderLocation: 18}],
+      },
+      {arrayStride: 36, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6356,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 2940, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back'},
+});
+let img35 = await imageWithData(291, 252, '#16ea6f1e', '#51b1125f');
+document.body.prepend(video1);
+let querySet100 = device0.createQuerySet({label: '\u0c37\u0b40\u07d9\u092f\u0329', type: 'occlusion', count: 1255});
+let texture149 = device0.createTexture({
+  label: '\uf762\ud385\u062c\u03cb\u0f4b\u87c9\u06e0\u{1fae4}\u0e0d\u{1f614}\ua2a8',
+  size: {width: 384, height: 480, depthOrArrayLayers: 21},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView245 = texture142.createView({label: '\u{1f7b6}\u1fdd\u1a06\u{1fe61}\u098c\uf0d7', baseMipLevel: 8});
+try {
+renderBundleEncoder53.setVertexBuffer(4, buffer32, 0, 20235);
+} catch {}
+let promise47 = device0.popErrorScope();
+try {
+commandEncoder114.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 111, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1616 widthInBlocks: 404 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36168 */
+  offset: 36168,
+  buffer: buffer6,
+}, {width: 404, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder207.resolveQuerySet(querySet31, 1027, 564, buffer0, 128256);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 240, depthOrArrayLayers: 10}
+*/
+{
+  source: imageData9,
+  origin: { x: 5, y: 8 },
+  flipY: false,
+}, {
+  texture: texture149,
+  mipLevel: 1,
+  origin: {x: 25, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise47;
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(806, 862);
+try {
+offscreenCanvas25.getContext('bitmaprenderer');
+} catch {}
+document.body.prepend(canvas6);
+gc();
+let offscreenCanvas26 = new OffscreenCanvas(759, 337);
+let img36 = await imageWithData(89, 32, '#a3c0805e', '#79741d30');
+let imageData21 = new ImageData(172, 236);
+let canvas19 = document.createElement('canvas');
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+try {
+commandEncoder19.label = '\u{1fb4d}\u0ab5';
+} catch {}
+let renderBundle118 = renderBundleEncoder88.finish();
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer5, 11948);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(9, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(1, bindGroup14, new Uint32Array(9090), 2032, 0);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder165.copyBufferToBuffer(buffer4, 57908, buffer11, 111752, 16088);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 39072 */
+  offset: 39072,
+  bytesPerRow: 0,
+  rowsPerImage: 24,
+  buffer: buffer24,
+}, {
+  texture: texture21,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 24},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 137});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder198.clearBuffer(buffer11, 46484, 26128);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.submit([commandBuffer47]);
+} catch {}
+let pipeline112 = device0.createComputePipeline({
+  label: '\u93c6\ueb0c\u{1fb0d}\u0c19\u9dae\u033a',
+  layout: pipelineLayout29,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let img37 = await imageWithData(115, 192, '#e636adb8', '#1c326176');
+let videoFrame26 = new VideoFrame(img17, {timestamp: 0});
+try {
+canvas19.getContext('2d');
+} catch {}
+video19.width = 229;
+let shaderModule30 = device1.createShaderModule({
+  label: '\u5236\u8309\u1a11',
+  code: `@group(4) @binding(4694)
+var<storage, read_write> function26: array<u32>;
+@group(1) @binding(4694)
+var<storage, read_write> type12: array<u32>;
+@group(5) @binding(1552)
+var<storage, read_write> field16: array<u32>;
+@group(4) @binding(8797)
+var<storage, read_write> local16: array<u32>;
+@group(1) @binding(8797)
+var<storage, read_write> global17: array<u32>;
+@group(2) @binding(1552)
+var<storage, read_write> local17: array<u32>;
+@group(0) @binding(2548)
+var<storage, read_write> type13: array<u32>;
+@group(3) @binding(133)
+var<storage, read_write> function27: array<u32>;
+@group(6) @binding(1001)
+var<storage, read_write> parameter21: array<u32>;
+@group(6) @binding(6964)
+var<storage, read_write> parameter22: array<u32>;
+@group(0) @binding(2591)
+var<storage, read_write> local18: array<u32>;
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> @location(200) vec3<i32> {
+return vec3<i32>();
+}
+
+struct S39 {
+  @location(4) f0: vec2<f16>,
+  @location(17) f1: i32,
+  @location(9) f2: vec2<u32>,
+  @location(6) f3: vec3<f32>,
+  @location(2) f4: i32,
+  @location(1) f5: vec4<f32>,
+  @location(8) f6: vec3<f32>,
+  @location(5) f7: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S39, @location(12) a1: vec2<f32>, @builtin(instance_index) a2: u32, @location(13) a3: vec4<u32>, @location(14) a4: vec4<f16>, @location(11) a5: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture150 = device1.createTexture({
+  label: '\u8b90\u{1fb3c}\u0eb0\uee31\u4b4e\u0fae\u00a1\u02e8',
+  size: [273, 2, 705],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView246 = texture27.createView({
+  label: '\u0307\u0ea7\u0297\u{1fe0e}\u{1f791}\u0e4b\u{1fae1}\u0c22\u9239',
+  format: 'etc2-rgb8a1unorm-srgb',
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder28.beginOcclusionQuery(1505);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder45.draw(416, 488, 137_125_948, 1_223_341_026);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(27);
+} catch {}
+try {
+renderBundleEncoder45.drawIndirect(buffer17, 21816);
+} catch {}
+try {
+commandEncoder203.clearBuffer(buffer34);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(348), /* required buffer size: 348 */
+{offset: 348}, {width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas26.getContext('webgpu');
+let textureView247 = texture115.createView({label: '\u7368\uc03a\uedc8\u0f44\u0280', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder84 = commandEncoder186.beginComputePass({label: '\u3f76\u036a\u0a64'});
+let renderBundleEncoder97 = device0.createRenderBundleEncoder({
+  label: '\u695d\ub2ac\u748a\u48cf\u40bc\u03f6\u0398\u7bf6\u7b59',
+  colorFormats: ['rgba8unorm'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle119 = renderBundleEncoder9.finish();
+try {
+computePassEncoder40.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(6, bindGroup53, new Uint32Array(7666), 3568, 0);
+} catch {}
+try {
+commandEncoder197.copyBufferToBuffer(buffer1, 12372, buffer11, 111064, 8804);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder212.copyBufferToTexture({
+  /* bytesInLastRow: 8896 widthInBlocks: 1112 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 512 */
+  offset: 512,
+  buffer: buffer24,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1112, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder209.copyTextureToTexture({
+  texture: texture133,
+  mipLevel: 1,
+  origin: {x: 139, y: 6, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture133,
+  mipLevel: 1,
+  origin: {x: 39, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 921, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(72)), /* required buffer size: 25_216 */
+{offset: 797, bytesPerRow: 218, rowsPerImage: 16}, {width: 3, height: 1, depthOrArrayLayers: 8});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 6, height: 7, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 18, y: 299 },
+  flipY: false,
+}, {
+  texture: texture149,
+  mipLevel: 6,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline113 = await device0.createRenderPipelineAsync({
+  label: '\u0a38\u7597\uf310',
+  layout: pipelineLayout38,
+  fragment: {module: shaderModule16, entryPoint: 'fragment0', targets: [{format: 'rgba8unorm', writeMask: 0}]},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint16x4', offset: 372, shaderLocation: 0},
+          {format: 'uint32x3', offset: 14868, shaderLocation: 5},
+          {format: 'sint32', offset: 3076, shaderLocation: 18},
+          {format: 'uint32x4', offset: 10044, shaderLocation: 2},
+          {format: 'float32x4', offset: 12396, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 15760, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 60, shaderLocation: 16},
+          {format: 'sint32', offset: 8076, shaderLocation: 3},
+          {format: 'sint16x4', offset: 264, shaderLocation: 19},
+          {format: 'float32x2', offset: 4884, shaderLocation: 7},
+          {format: 'sint32x3', offset: 9556, shaderLocation: 13},
+          {format: 'float16x4', offset: 4796, shaderLocation: 4},
+          {format: 'uint32x2', offset: 416, shaderLocation: 8},
+          {format: 'float32x2', offset: 5544, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 15224, shaderLocation: 17},
+          {format: 'float32x2', offset: 272, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 716, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 1320,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x2', offset: 134, shaderLocation: 10},
+          {format: 'sint32', offset: 112, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 4020, attributes: [{format: 'unorm8x2', offset: 2226, shaderLocation: 1}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw'},
+});
+let textureView248 = texture118.createView({
+  label: '\u0022\ue81d\ue7c1\u9059\u1a0c\u{1fa26}\u084c',
+  dimension: '2d-array',
+  format: 'rgb10a2unorm',
+  baseMipLevel: 4,
+});
+try {
+commandEncoder198.copyBufferToBuffer(buffer44, 244800, buffer4, 20180, 31636);
+dissociateBuffer(device0, buffer44);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder170.resolveQuerySet(querySet96, 2142, 1524, buffer15, 3840);
+} catch {}
+let videoFrame27 = new VideoFrame(img17, {timestamp: 0});
+let imageData22 = new ImageData(68, 164);
+let commandEncoder218 = device0.createCommandEncoder();
+let texture151 = device0.createTexture({
+  label: '\u6417\ub960\u{1fc8f}\u0ec0',
+  size: {width: 645, height: 1, depthOrArrayLayers: 1511},
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder85 = commandEncoder168.beginComputePass();
+let externalTexture93 = device0.importExternalTexture({source: videoFrame17, colorSpace: 'srgb'});
+try {
+computePassEncoder74.setPipeline(pipeline63);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(9, bindGroup66);
+} catch {}
+try {
+commandEncoder210.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 548 widthInBlocks: 137 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 49472 */
+  offset: 49472,
+  buffer: buffer6,
+}, {width: 137, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let textureView249 = texture105.createView({label: '\u05e6\u04f3\ua855\u5652\u{1fc0e}\u04b1', dimension: '3d', format: 'r32uint'});
+let renderBundle120 = renderBundleEncoder40.finish({label: '\u16e9\u0710\ua2ca\u99c6\u{1f7c5}\u2933\u{1fe16}\u0e29\u0ccb\u64ff'});
+let sampler100 = device0.createSampler({
+  label: '\u0186\u{1f627}\u0b27\u0d36\ubdce\ufb07\ufd5e\u4f91\u0051\ua2b4\u37df',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.67,
+  lodMaxClamp: 79.90,
+  maxAnisotropy: 15,
+});
+let externalTexture94 = device0.importExternalTexture({
+  label: '\u22b0\ueed7\ub4dd\u6561\u061d\u0924\uba2c\u1c74\uf396\ua8dd',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder66.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder218.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 83968 */
+  offset: 83968,
+  bytesPerRow: 0,
+  rowsPerImage: 196,
+  buffer: buffer41,
+}, {width: 0, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer41);
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageBitmap21);
+let texture152 = device0.createTexture({
+  size: {width: 192, height: 240, depthOrArrayLayers: 10},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32uint'],
+});
+try {
+commandEncoder24.copyBufferToBuffer(buffer26, 14804, buffer6, 56908, 4172);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+offscreenCanvas18.width = 419;
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+adapter5.label = '\ub32a\u812b';
+} catch {}
+gc();
+let shaderModule31 = device0.createShaderModule({
+  label: '\u{1fa03}\u{1f83d}\u05c4\ub449\u465e',
+  code: `
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S41 {
+  @location(60) f0: vec2<f32>,
+  @location(59) f1: vec3<i32>,
+  @location(71) f2: vec3<u32>,
+  @location(12) f3: vec2<u32>,
+  @location(74) f4: vec2<u32>,
+  @location(10) f5: vec4<u32>,
+  @location(8) f6: vec4<f32>,
+  @location(28) f7: vec2<f32>,
+  @location(46) f8: i32,
+  @builtin(sample_index) f9: u32,
+  @location(29) f10: vec3<f16>,
+  @location(50) f11: vec2<f32>,
+  @location(34) f12: i32,
+  @location(73) f13: vec2<f16>,
+  @location(11) f14: vec4<f16>,
+  @location(58) f15: u32,
+  @location(75) f16: f16,
+  @location(54) f17: u32,
+  @location(2) f18: vec4<i32>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(a0: S41, @location(3) a1: vec3<f16>, @location(47) a2: vec3<u32>, @location(19) a3: vec3<i32>, @location(55) a4: f32, @location(77) a5: vec3<i32>, @location(40) a6: vec2<f32>, @location(9) a7: vec2<u32>, @location(24) a8: vec2<i32>, @location(76) a9: vec4<i32>, @builtin(position) a10: vec4<f32>, @location(53) a11: vec3<f16>, @location(4) a12: vec2<i32>, @location(80) a13: vec3<f16>, @location(70) a14: vec4<f16>, @builtin(front_facing) a15: bool, @location(43) a16: i32, @location(0) a17: f16, @location(56) a18: i32, @location(64) a19: vec2<f32>, @location(65) a20: vec3<f32>, @location(48) a21: vec4<f16>, @builtin(sample_mask) a22: u32, @location(42) a23: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S40 {
+  @location(12) f0: vec2<f16>,
+  @location(3) f1: vec4<f32>,
+  @location(11) f2: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(60) f389: vec2<f32>,
+  @location(46) f390: i32,
+  @location(53) f391: vec3<f16>,
+  @location(76) f392: vec4<i32>,
+  @location(9) f393: vec2<u32>,
+  @location(40) f394: vec2<f32>,
+  @location(0) f395: f16,
+  @location(50) f396: vec2<f32>,
+  @location(24) f397: vec2<i32>,
+  @location(11) f398: vec4<f16>,
+  @location(48) f399: vec4<f16>,
+  @location(58) f400: u32,
+  @location(55) f401: f32,
+  @location(10) f402: vec4<u32>,
+  @location(64) f403: vec2<f32>,
+  @location(2) f404: vec4<i32>,
+  @location(75) f405: f16,
+  @location(12) f406: vec2<u32>,
+  @location(80) f407: vec3<f16>,
+  @location(34) f408: i32,
+  @location(65) f409: vec3<f32>,
+  @location(77) f410: vec3<i32>,
+  @location(3) f411: vec3<f16>,
+  @location(73) f412: vec2<f16>,
+  @location(28) f413: vec2<f32>,
+  @location(42) f414: vec3<u32>,
+  @location(56) f415: i32,
+  @location(8) f416: vec4<f32>,
+  @location(29) f417: vec3<f16>,
+  @location(59) f418: vec3<i32>,
+  @location(47) f419: vec3<u32>,
+  @location(74) f420: vec2<u32>,
+  @location(71) f421: vec3<u32>,
+  @location(54) f422: u32,
+  @location(43) f423: i32,
+  @builtin(position) f424: vec4<f32>,
+  @location(19) f425: vec3<i32>,
+  @location(70) f426: vec4<f16>,
+  @location(4) f427: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: u32, @builtin(vertex_index) a1: u32, @builtin(instance_index) a2: u32, @location(17) a3: vec4<i32>, @location(15) a4: vec4<u32>, @location(18) a5: vec4<f32>, @location(13) a6: vec4<u32>, @location(16) a7: vec2<f16>, @location(6) a8: vec3<f32>, @location(10) a9: vec2<i32>, @location(1) a10: i32, @location(8) a11: i32, @location(5) a12: vec2<f32>, @location(9) a13: f16, @location(7) a14: vec3<f32>, @location(2) a15: vec4<f32>, @location(19) a16: vec2<f16>, a17: S40) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let sampler101 = device0.createSampler({
+  label: '\u2806\u{1f8b1}\u01c2\u0261',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.063,
+  lodMaxClamp: 89.20,
+});
+try {
+computePassEncoder67.setBindGroup(5, bindGroup7, new Uint32Array(2521), 2398, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+commandEncoder208.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let pipeline114 = await device0.createComputePipelineAsync({
+  label: '\u{1f767}\u9bdd\ucf4d\uaa2d\u{1ff12}\u74e3\u{1f955}\u{1fd0f}\u09a7\uc9ac\uff0d',
+  layout: pipelineLayout23,
+  compute: {module: shaderModule31, entryPoint: 'compute0'},
+});
+let texture153 = gpuCanvasContext5.getCurrentTexture();
+let textureView250 = texture153.createView({
+  label: '\ubcc9\u{1f72d}\ub5b0\u27ad\u{1fbb9}\u0bf3\udaf7\u{1f981}\u{1fc84}\ub871\ua8ca',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'bgra8unorm',
+});
+let sampler102 = device0.createSampler({
+  label: '\udd9e\u496e\u{1fb41}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.76,
+  lodMaxClamp: 62.28,
+  compare: 'less-equal',
+  maxAnisotropy: 19,
+});
+try {
+renderBundleEncoder57.setPipeline(pipeline59);
+} catch {}
+let arrayBuffer27 = buffer11.getMappedRange(20536, 616);
+try {
+commandEncoder202.copyBufferToBuffer(buffer44, 67332, buffer11, 89016, 49000);
+dissociateBuffer(device0, buffer44);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder196.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 15220, new Int16Array(40530), 13979, 380);
+} catch {}
+let bindGroupLayout46 = device0.createBindGroupLayout({
+  label: '\ua6d3\u1d9d\u{1f7a9}\u8abf\u2a7e',
+  entries: [
+    {
+      binding: 1376,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+try {
+renderBundleEncoder54.setPipeline(pipeline106);
+} catch {}
+try {
+renderBundleEncoder92.setVertexBuffer(0, buffer31, 11404, 777);
+} catch {}
+let video28 = await videoWithData();
+let shaderModule32 = device0.createShaderModule({
+  label: '\u734f\u{1f8bc}\u{1fe42}\u0306\u0323\u02c1\u{1febf}\uca11\uca1b\u0bdd',
+  code: `@group(2) @binding(1904)
+var<storage, read_write> local19: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S43 {
+  @location(45) f0: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(7) f2: vec3<u32>,
+  @location(1) f3: f32
+}
+
+@fragment
+fn fragment0(@location(72) a0: vec2<u32>, @location(61) a1: vec4<i32>, @builtin(position) a2: vec4<f32>, @location(22) a3: vec3<f32>, @location(68) a4: vec3<f16>, @location(15) a5: vec3<u32>, @location(59) a6: vec4<i32>, @location(67) a7: f16, @location(6) a8: vec3<f32>, @location(16) a9: vec3<i32>, @location(75) a10: vec3<u32>, @location(69) a11: vec4<f16>, @location(80) a12: vec4<f32>, @location(32) a13: vec3<i32>, @location(24) a14: vec4<f32>, @builtin(front_facing) a15: bool, @location(5) a16: vec3<u32>, @location(4) a17: vec3<f32>, @location(28) a18: vec3<i32>, a19: S43, @location(27) a20: vec4<i32>, @location(47) a21: vec4<f32>, @location(29) a22: vec4<f32>, @location(42) a23: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S42 {
+  @location(16) f0: vec3<u32>,
+  @location(15) f1: vec3<f32>,
+  @builtin(vertex_index) f2: u32,
+  @location(7) f3: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(69) f428: vec4<f16>,
+  @location(72) f429: vec2<u32>,
+  @location(13) f430: vec3<f16>,
+  @location(22) f431: vec3<f32>,
+  @location(29) f432: vec4<f32>,
+  @location(75) f433: vec3<u32>,
+  @location(16) f434: vec3<i32>,
+  @location(27) f435: vec4<i32>,
+  @location(15) f436: vec3<u32>,
+  @location(59) f437: vec4<i32>,
+  @location(80) f438: vec4<f32>,
+  @location(19) f439: vec3<i32>,
+  @location(47) f440: vec4<f32>,
+  @location(4) f441: vec3<f32>,
+  @location(28) f442: vec3<i32>,
+  @location(5) f443: vec3<u32>,
+  @location(61) f444: vec4<i32>,
+  @location(21) f445: vec3<f32>,
+  @builtin(position) f446: vec4<f32>,
+  @location(32) f447: vec3<i32>,
+  @location(3) f448: vec2<i32>,
+  @location(6) f449: vec3<f32>,
+  @location(68) f450: vec3<f16>,
+  @location(67) f451: f16,
+  @location(45) f452: i32,
+  @location(24) f453: vec4<f32>,
+  @location(42) f454: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec4<u32>, @location(4) a1: vec4<u32>, @location(14) a2: vec3<f32>, @location(17) a3: vec2<u32>, @location(0) a4: f32, @location(1) a5: i32, @location(10) a6: u32, @location(13) a7: f16, @location(11) a8: vec4<f16>, a9: S42, @location(19) a10: vec2<u32>, @location(12) a11: vec2<f16>, @location(6) a12: vec2<f16>, @builtin(instance_index) a13: u32, @location(5) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let externalTexture95 = device0.importExternalTexture({
+  label: '\ufdc1\u0995\u5442\u{1fac5}\u0b44\ue13b\ufb8d\ua2e2\u{1ff21}',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder59.setVertexBuffer(6, buffer32, 143940, 29056);
+} catch {}
+let gpuCanvasContext15 = canvas20.getContext('webgpu');
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let commandEncoder219 = device1.createCommandEncoder({label: '\ue4db\uc60d\u20bf\u0274\u0a84\uaaa5\u6134'});
+let textureView251 = texture31.createView({label: '\u{1f637}\u4dc8\u073e\u0f1c\ucd40', dimension: '2d', format: 'rg16sint', baseArrayLayer: 924});
+try {
+renderPassEncoder26.setBlendConstant({ r: -594.0, g: 47.60, b: 746.2, a: -653.5, });
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(47, 1, 11, 0);
+} catch {}
+try {
+renderPassEncoder11.setViewport(10.12, 0.00104, 9.075, 0.8885, 0.5991, 0.8318);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer23, 15368);
+} catch {}
+try {
+commandEncoder203.resolveQuerySet(querySet28, 739, 14, buffer34, 41728);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let canvas21 = document.createElement('canvas');
+let imageData23 = new ImageData(84, 244);
+gc();
+try {
+adapter6.label = '\ud3a0\u01f5\u05c8\u{1ff89}';
+} catch {}
+try {
+canvas21.getContext('webgl2');
+} catch {}
+let shaderModule33 = device1.createShaderModule({
+  label: '\u033b\u{1fea9}\u5507\u30e1\u054c\u0a62\u5247\ub527\uaca3\u{1f9bb}',
+  code: `@group(4) @binding(1191)
+var<storage, read_write> function28: array<u32>;
+@group(3) @binding(1382)
+var<storage, read_write> type14: array<u32>;
+@group(1) @binding(37)
+var<storage, read_write> n16: array<u32>;
+@group(6) @binding(3477)
+var<storage, read_write> type15: array<u32>;
+@group(5) @binding(1904)
+var<storage, read_write> type16: array<u32>;
+@group(6) @binding(2060)
+var<storage, read_write> local20: array<u32>;
+@group(1) @binding(550)
+var<storage, read_write> local21: array<u32>;
+@group(4) @binding(3682)
+var<storage, read_write> parameter23: array<u32>;
+@group(3) @binding(2425)
+var<storage, read_write> local22: array<u32>;
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f32>, @location(19) a1: vec3<f16>, @location(7) a2: vec4<i32>, @location(17) a3: vec3<f32>, @location(10) a4: vec4<f32>, @builtin(instance_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder5.dispatchWorkgroups(2, 4, 2);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline105);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer1, 18484, buffer41, 109756, 10640);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder185.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 22824, new DataView(new ArrayBuffer(24172)), 10676, 312);
+} catch {}
+document.body.prepend(img9);
+let promise48 = adapter6.requestAdapterInfo();
+let texture154 = device2.createTexture({
+  size: [132],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8uint', 'rg8uint'],
+});
+let textureView252 = texture124.createView({dimension: '3d', baseMipLevel: 1});
+let renderBundleEncoder98 = device2.createRenderBundleEncoder({
+  label: '\u8c46\uec1b\ubb82\u{1f7e6}\u0202\u{1f854}\u02d8\ub4b4\u3f2f\u{1f9a2}\u{1fa2c}',
+  colorFormats: ['rg8uint', 'rgba16sint', 'bgra8unorm'],
+  stencilReadOnly: true,
+});
+let sampler103 = device2.createSampler({
+  label: '\u0453\ub7fe\u86ff\u052b\u363b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.06,
+  lodMaxClamp: 76.55,
+});
+let externalTexture96 = device2.importExternalTexture({label: '\u05d6\u{1f9e4}\u{1fece}\u{1fafe}', source: video6});
+try {
+computePassEncoder21.setBindGroup(8, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(1, buffer28, 0, 135184);
+} catch {}
+let pipeline115 = device2.createComputePipeline({
+  label: '\ufacd\ufb9d\ua46f',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let texture155 = device0.createTexture({
+  label: '\u4483\u27b4\ub6ae\u{1fe8c}\u8dc2\u89ec\u46e9\u0f34\ubb32\uec8d',
+  size: [322],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let renderBundleEncoder99 = device0.createRenderBundleEncoder({
+  label: '\ue401\u23b3\u5d62\uc689\u8788\u0835\u{1fe29}\u1367\u{1fe38}\u0ba4\u0d58',
+  colorFormats: ['rgba16float', 'r32float'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder95.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 1108 widthInBlocks: 277 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 137500 */
+  offset: 16072,
+  bytesPerRow: 1280,
+  rowsPerImage: 47,
+  buffer: buffer44,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 277, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer44);
+} catch {}
+try {
+commandEncoder31.copyTextureToBuffer({
+  texture: texture85,
+  mipLevel: 3,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 66 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 24786 */
+  offset: 11152,
+  bytesPerRow: 256,
+  buffer: buffer41,
+}, {width: 33, height: 54, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder201.clearBuffer(buffer41);
+dissociateBuffer(device0, buffer41);
+} catch {}
+let texture156 = device0.createTexture({
+  size: {width: 15, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder100 = device0.createRenderBundleEncoder({
+  label: '\u{1ffa3}\u6755\u01c6\uf4df\u5d03\uea44\u{1fec7}\u08e5\u07b7\uba2a\u1820',
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let externalTexture97 = device0.importExternalTexture({label: '\u0f6b\u051d\ue461\u{1fabe}', source: videoFrame27, colorSpace: 'srgb'});
+try {
+computePassEncoder5.dispatchWorkgroupsIndirect(buffer5, 25248);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline87);
+} catch {}
+try {
+commandEncoder179.copyBufferToBuffer(buffer4, 70616, buffer9, 30424, 2680);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder206.copyBufferToTexture({
+  /* bytesInLastRow: 2676 widthInBlocks: 669 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14820 */
+  offset: 12144,
+  buffer: buffer24,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 669, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 17784, new DataView(new ArrayBuffer(37810)), 13000, 384);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 645, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData14,
+  origin: { x: 40, y: 5 },
+  flipY: false,
+}, {
+  texture: texture139,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas2.width = 503;
+let commandEncoder220 = device0.createCommandEncoder({label: '\u01bd\u7d4f\u77ab\u{1ff14}\u1c55\u00c2\u0e56\u59eb\u{1f9c0}'});
+let texture157 = device0.createTexture({
+  size: [125],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let renderBundleEncoder101 = device0.createRenderBundleEncoder({
+  label: '\u{1fab2}\u{1faa6}\u1bbb\u0952\u{1f8e7}\u0d15\u9c23\u8b41\u019a\ufe59\ub3bc',
+  colorFormats: ['rgba16float', 'r32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder100.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder101.setPipeline(pipeline47);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(531, 557);
+try {
+offscreenCanvas27.getContext('webgl');
+} catch {}
+let querySet101 = device0.createQuerySet({label: '\ufbba\u{1fe37}\u{1fb95}', type: 'occlusion', count: 3917});
+let textureView253 = texture94.createView({
+  label: '\u0ed5\u96cc\u5371\u95b1\u09f9\u{1f9dd}\u00d3\u{1f9e5}\u6193\u8a81\u083d',
+  format: 'r32float',
+  baseMipLevel: 4,
+  arrayLayerCount: 1,
+});
+let sampler104 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.76,
+  lodMaxClamp: 68.41,
+});
+let externalTexture98 = device0.importExternalTexture({label: '\u{1f67c}\u{1fd27}\ub0b7\u0227\u0fcf\uc6a9\u6d3f', source: videoFrame22, colorSpace: 'srgb'});
+try {
+renderBundleEncoder64.setBindGroup(2, bindGroup1, new Uint32Array(9218), 4607, 0);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15500 */
+  offset: 15500,
+  rowsPerImage: 239,
+  buffer: buffer44,
+}, {
+  texture: texture118,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer15), /* required buffer size: 17_955 */
+{offset: 699}, {width: 2157, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise48;
+} catch {}
+let commandEncoder221 = device0.createCommandEncoder({label: '\ub2b9\udf14'});
+let textureView254 = texture83.createView({
+  label: '\u54f3\u{1fa19}\u641f\u{1f884}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  baseArrayLayer: 32,
+  arrayLayerCount: 18,
+});
+let externalTexture99 = device0.importExternalTexture({
+  label: '\u{1f988}\u32bb\u003c\u32f6\u7456\u04d7\u05e7\u8ef6\u07ca\uf064',
+  source: videoFrame20,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder50.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder91.setBindGroup(4, bindGroup12, new Uint32Array(4587), 3635, 0);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(4916, undefined, 3771911856, 6405022);
+} catch {}
+try {
+commandEncoder221.resolveQuerySet(querySet5, 1113, 1500, buffer44, 107520);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline116 = await device0.createComputePipelineAsync({
+  label: '\u0887\ufc12\u0fc5\u4ad5\uc739\u965f',
+  layout: 'auto',
+  compute: {module: shaderModule23, entryPoint: 'compute0'},
+});
+document.body.prepend(video14);
+let img38 = await imageWithData(27, 193, '#11ef8b70', '#2db14d5f');
+let commandEncoder222 = device0.createCommandEncoder({label: '\uc801\u191f\u{1f838}\u7298\u4218\ud197\u1a9b\u5b26\u071b'});
+let querySet102 = device0.createQuerySet({
+  label: '\u0148\u9425\u{1f640}\u{1fcdb}\u8301\ub25b\u{1f688}\uc919\u7571',
+  type: 'occlusion',
+  count: 3244,
+});
+let textureView255 = texture34.createView({label: '\u{1fc74}\u0f5d', baseMipLevel: 2});
+let renderBundleEncoder102 = device0.createRenderBundleEncoder({colorFormats: ['r16uint', 'rg32uint']});
+let sampler105 = device0.createSampler({
+  label: '\ud13b\u5edc',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  lodMinClamp: 39.56,
+  lodMaxClamp: 45.28,
+});
+let externalTexture100 = device0.importExternalTexture({label: '\u{1f72e}\ue9f2', source: video14, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder93.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+commandEncoder207.copyBufferToBuffer(buffer7, 31500, buffer9, 19812, 19784);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder201.copyBufferToTexture({
+  /* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1668 */
+  offset: 1544,
+  buffer: buffer7,
+}, {
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline117 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout29,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'dst'},
+  },
+}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1808,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 368, shaderLocation: 18}],
+      },
+      {
+        arrayStride: 432,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 224, shaderLocation: 10},
+          {format: 'float32x3', offset: 88, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 60, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 16},
+          {format: 'float16x4', offset: 36, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 136, shaderLocation: 14},
+          {format: 'sint32x4', offset: 20, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 44, shaderLocation: 11},
+          {format: 'sint8x2', offset: 54, shaderLocation: 17},
+          {format: 'uint32x4', offset: 12, shaderLocation: 3},
+          {format: 'sint8x2', offset: 28, shaderLocation: 2},
+          {format: 'uint16x4', offset: 16, shaderLocation: 6},
+          {format: 'float16x4', offset: 20, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 40, shaderLocation: 15},
+          {format: 'uint32', offset: 100, shaderLocation: 5},
+          {format: 'uint32', offset: 156, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 4800, stepMode: 'instance', attributes: []},
+      {arrayStride: 8040, stepMode: 'instance', attributes: []},
+      {arrayStride: 6804, attributes: []},
+      {arrayStride: 16604, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 27756,
+        attributes: [
+          {format: 'snorm16x4', offset: 1972, shaderLocation: 4},
+          {format: 'float32x2', offset: 2888, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+document.body.prepend(video4);
+let querySet103 = device0.createQuerySet({
+  label: '\u2f2d\udacd\u0ab8\u5a5c\u99db\u{1fd6e}\uc458\u9f32\u0330\u048b\u0f35',
+  type: 'occlusion',
+  count: 2909,
+});
+try {
+computePassEncoder45.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(5, bindGroup66);
+} catch {}
+let texture158 = device0.createTexture({
+  label: '\u7e8b\u45b4\u0cf2\u0f91\u0f80\uee27\u{1f878}\ue23f\ud6fb',
+  size: [360, 3, 22],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+let externalTexture101 = device0.importExternalTexture({label: '\u48d3\u{1f92d}\u{1f8ec}\u{1fc11}', source: videoFrame15, colorSpace: 'srgb'});
+try {
+renderBundleEncoder78.setVertexBuffer(4, buffer31, 0, 10153);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture152,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 65256 */
+  offset: 1592,
+  bytesPerRow: 256,
+  rowsPerImage: 221,
+  buffer: buffer6,
+}, {width: 44, height: 28, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(41), /* required buffer size: 41 */
+{offset: 41}, {width: 279, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData24 = new ImageData(144, 188);
+gc();
+let bindGroupLayout47 = device0.createBindGroupLayout({label: '\u2293\u1636\u{1f7a3}\u0889\u5989\ua7c9\u0c7b\u7f06', entries: []});
+let commandEncoder223 = device0.createCommandEncoder();
+let renderBundleEncoder103 = device0.createRenderBundleEncoder({
+  label: '\u08bf\u06b9\u{1ffa2}\u0965\u0f6d\u0f61\u0e3d\u7e4d\u0d46',
+  colorFormats: ['r16uint', 'rg32uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder5.dispatchWorkgroups(1, 5, 2);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(3, buffer31, 0, 427);
+} catch {}
+let img39 = await imageWithData(199, 98, '#f4600ca2', '#828b599d');
+let videoFrame28 = new VideoFrame(img30, {timestamp: 0});
+canvas3.height = 287;
+let img40 = await imageWithData(155, 42, '#6dd5b307', '#cb108b94');
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let videoFrame29 = new VideoFrame(img35, {timestamp: 0});
+let querySet104 = device2.createQuerySet({label: '\u0efe\uecc1\uf9e5', type: 'occlusion', count: 3739});
+let computePassEncoder86 = commandEncoder137.beginComputePass({});
+try {
+renderBundleEncoder98.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder191.copyBufferToBuffer(buffer30, 111848, buffer21, 335676, 7988);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3448 */
+  offset: 3448,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+renderBundleEncoder73.insertDebugMarker('\ucb07');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 28048, new BigUint64Array(25086));
+} catch {}
+let promise49 = device2.createComputePipelineAsync({layout: pipelineLayout34, compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}}});
+let video29 = await videoWithData();
+let img41 = await imageWithData(11, 145, '#477c7aee', '#ab660356');
+let pipelineLayout40 = device0.createPipelineLayout({
+  label: '\ube8c\u0f9e\u0351\u0c30\u0804\u04ed\u142f\u{1ff8a}',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout9, bindGroupLayout46, bindGroupLayout4, bindGroupLayout46, bindGroupLayout9, bindGroupLayout1, bindGroupLayout46],
+});
+let querySet105 = device0.createQuerySet({label: '\u608f\uea05\u0aa6\uc928\u8499\u92ba\u{1ffa1}', type: 'occlusion', count: 2596});
+let textureView256 = texture79.createView({label: '\u{1fe51}\u096d\u90cf', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 52});
+let computePassEncoder87 = commandEncoder138.beginComputePass({label: '\u0b98\u04a1\u135f\u626b\u0638\u0312\u{1f797}\ua71e\uace3'});
+let renderBundleEncoder104 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let sampler106 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 99.66,
+  lodMaxClamp: 99.67,
+});
+try {
+commandEncoder215.copyBufferToTexture({
+  /* bytesInLastRow: 248 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 158592 */
+  offset: 5256,
+  bytesPerRow: 256,
+  rowsPerImage: 374,
+  buffer: buffer44,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 48, y: 1, z: 7},
+  aspect: 'all',
+}, {width: 31, height: 225, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer44);
+} catch {}
+try {
+commandEncoder204.copyTextureToBuffer({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24320 */
+  offset: 24320,
+  buffer: buffer6,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline118 = await device0.createRenderPipelineAsync({
+  label: '\u{1fca3}\u{1fae9}\u{1f746}\u3f24\u{1f962}\u0254\u06bf\u9a4a\u2f18\u05bd',
+  layout: pipelineLayout31,
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: [{format: 'uint32x3', offset: 28, shaderLocation: 9}]},
+      {
+        arrayStride: 12540,
+        attributes: [
+          {format: 'unorm8x2', offset: 430, shaderLocation: 8},
+          {format: 'sint32x4', offset: 4460, shaderLocation: 2},
+          {format: 'sint8x2', offset: 4184, shaderLocation: 19},
+          {format: 'sint16x2', offset: 24, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 4856, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2808,
+        attributes: [
+          {format: 'unorm8x2', offset: 514, shaderLocation: 7},
+          {format: 'sint32x2', offset: 200, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 2260, attributes: [{format: 'float32x3', offset: 144, shaderLocation: 6}]},
+      {
+        arrayStride: 2112,
+        attributes: [
+          {format: 'sint32x2', offset: 200, shaderLocation: 3},
+          {format: 'float16x2', offset: 264, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1548,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 148, shaderLocation: 11},
+          {format: 'uint16x2', offset: 184, shaderLocation: 4},
+          {format: 'uint32x3', offset: 656, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 5200,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 8, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 100, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+});
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let canvas22 = document.createElement('canvas');
+let commandEncoder224 = device0.createCommandEncoder({label: '\u30ef\u9041\u3e60\u36bc\u7c92\u4e25\u90a5\u0492\u0baa\uddea\u07da'});
+let querySet106 = device0.createQuerySet({type: 'occlusion', count: 3353});
+let computePassEncoder88 = commandEncoder114.beginComputePass({label: '\u{1fe27}\u06b9\u540a\u0c22\u6fab\u0606'});
+let renderBundleEncoder105 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgb10a2uint', 'rgba16float', 'rgb10a2uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle121 = renderBundleEncoder96.finish({label: '\u342a\u4d79\ub4f0\u{1fcc0}\uf8c8\u0bb0\u0091\udd7f\u7358\u{1f80b}'});
+try {
+renderBundleEncoder99.setBindGroup(7, bindGroup43);
+} catch {}
+try {
+device0.queue.submit([commandBuffer48]);
+} catch {}
+let pipeline119 = device0.createRenderPipeline({
+  label: '\u78b5\u5c5b\u0724',
+  layout: pipelineLayout15,
+  multisample: {count: 4, mask: 0x411a7277},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {format: 'r32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2868338285,
+    stencilWriteMask: 2255504715,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10692,
+        attributes: [
+          {format: 'uint32x2', offset: 1204, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 336, shaderLocation: 7},
+          {format: 'sint16x4', offset: 1268, shaderLocation: 4},
+          {format: 'sint8x4', offset: 2156, shaderLocation: 14},
+          {format: 'float32x2', offset: 252, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 500, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 2992, shaderLocation: 5},
+          {format: 'uint16x4', offset: 260, shaderLocation: 19},
+          {format: 'sint8x2', offset: 706, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 4816, shaderLocation: 9},
+          {format: 'sint32', offset: 56, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 3096, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 9224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 2328, shaderLocation: 12},
+          {format: 'uint32x3', offset: 880, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 11452, shaderLocation: 13},
+          {format: 'float32', offset: 24028, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x4', offset: 6416, shaderLocation: 18},
+          {format: 'uint32', offset: 4040, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 16648, shaderLocation: 3},
+          {format: 'sint16x2', offset: 2836, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: false},
+});
+let imageBitmap31 = await createImageBitmap(offscreenCanvas13);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let gpuCanvasContext16 = canvas22.getContext('webgpu');
+let textureView257 = texture16.createView({dimension: '2d-array', baseMipLevel: 1});
+let renderBundleEncoder106 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'bgra8unorm', 'rg8sint', 'rgba8sint', 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle122 = renderBundleEncoder37.finish({label: '\u560f\ufe0f\u03af\u4133\u{1fa14}'});
+try {
+renderBundleEncoder64.setBindGroup(7, bindGroup7, new Uint32Array(2423), 1715, 0);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(2, buffer6, 66088, 8535);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 6280, new Float32Array(32953), 12316, 1156);
+} catch {}
+let pipeline120 = await device0.createComputePipelineAsync({
+  label: '\ua5f6\u{1fbe8}\u0197\u04ec\uc39b\u182a\u80f9',
+  layout: 'auto',
+  compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule34 = device0.createShaderModule({
+  label: '\u{1fc5d}\u032a\u06cb\u07cc\u9a57',
+  code: `@group(2) @binding(2060)
+var<storage, read_write> parameter24: array<u32>;
+@group(2) @binding(3477)
+var<storage, read_write> global18: array<u32>;
+@group(0) @binding(1191)
+var<storage, read_write> n17: array<u32>;
+@group(0) @binding(3682)
+var<storage, read_write> local23: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(0) f1: vec2<f32>,
+  @location(6) f2: vec3<f32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec2<u32>, @location(1) a1: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup67 = device0.createBindGroup({
+  label: '\u0c4b\uc252\ubeef\u6502\u0271\u3583\u{1f772}\u7884\ub77e\u8206\u0300',
+  layout: bindGroupLayout23,
+  entries: [],
+});
+let texture159 = device0.createTexture({
+  label: '\u0224\u46cd\u03c7\u{1fcdc}',
+  size: [62, 1, 72],
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let textureView258 = texture1.createView({label: '\u41e0\u424f\ufa0b\u0b26\u{1fafc}', format: 'r32uint', baseMipLevel: 3});
+let renderBundle123 = renderBundleEncoder42.finish({label: '\u0539\u818c'});
+let sampler107 = device0.createSampler({
+  label: '\u0dbe\ude9e\u00a1\u0016\u06c8\u0afc\u7ccc',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 87.74,
+  lodMaxClamp: 90.24,
+  compare: 'greater',
+});
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 488, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(img26);
+offscreenCanvas13.height = 798;
+let offscreenCanvas28 = new OffscreenCanvas(183, 773);
+let imageData25 = new ImageData(12, 4);
+let gpuCanvasContext17 = offscreenCanvas28.getContext('webgpu');
+try {
+adapter5.label = '\uea47\u3817\u595a';
+} catch {}
+document.body.prepend(img23);
+let commandEncoder225 = device0.createCommandEncoder({label: '\uf5ce\u{1fac2}'});
+let querySet107 = device0.createQuerySet({label: '\u041f\ue31c\u29c5\ubcf3', type: 'occlusion', count: 2691});
+let texture160 = device0.createTexture({
+  label: '\ub37d\u72be\u{1f67b}',
+  size: [2580, 1, 536],
+  mipLevelCount: 8,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+let externalTexture102 = device0.importExternalTexture({label: '\ua2aa\u3693', source: video26, colorSpace: 'srgb'});
+try {
+computePassEncoder74.setBindGroup(8, bindGroup58, new Uint32Array(2967), 1877, 0);
+} catch {}
+try {
+renderBundleEncoder104.setIndexBuffer(buffer13, 'uint32');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new DataView(arrayBuffer5), /* required buffer size: 13_249_985 */
+{offset: 381, bytesPerRow: 636, rowsPerImage: 224}, {width: 113, height: 1, depthOrArrayLayers: 94});
+} catch {}
+let videoFrame30 = new VideoFrame(imageBitmap22, {timestamp: 0});
+let canvas23 = document.createElement('canvas');
+let img42 = await imageWithData(27, 7, '#2a6a73cc', '#6814c221');
+let gpuCanvasContext18 = canvas23.getContext('webgpu');
+let video30 = await videoWithData();
+let texture161 = device0.createTexture({
+  label: '\u876e\ucd8d\u0704\uf524',
+  size: [2880, 24, 61],
+  mipLevelCount: 5,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler108 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 81.68,
+});
+try {
+computePassEncoder67.setPipeline(pipeline105);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline106);
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 1140 widthInBlocks: 285 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18732 */
+  offset: 18732,
+  buffer: buffer24,
+}, {
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 285, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer24), /* required buffer size: 225 */
+{offset: 225}, {width: 1210, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline121 = await device0.createComputePipelineAsync({
+  label: '\u7999\uaf55\u8978\u4107',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule31, entryPoint: 'compute0', constants: {}},
+});
+let img43 = await imageWithData(254, 195, '#129cb952', '#f370c6ba');
+let video31 = await videoWithData();
+let offscreenCanvas29 = new OffscreenCanvas(3, 542);
+let shaderModule35 = device0.createShaderModule({
+  label: '\u2918\u9a8a\u0bbb\u{1fd83}\ud139\u23e6\udc4f\u0eb1\u85d3',
+  code: `@group(5) @binding(37)
+var<storage, read_write> function29: array<u32>;
+@group(4) @binding(1221)
+var<storage, read_write> parameter25: array<u32>;
+@group(1) @binding(550)
+var<storage, read_write> n18: array<u32>;
+@group(5) @binding(550)
+var<storage, read_write> global19: array<u32>;
+@group(1) @binding(37)
+var<storage, read_write> local24: array<u32>;
+@group(0) @binding(1904)
+var<storage, read_write> local25: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S45 {
+  @location(68) f0: vec2<f16>,
+  @location(54) f1: vec2<f32>,
+  @location(70) f2: i32,
+  @location(14) f3: vec2<f32>,
+  @location(62) f4: vec2<i32>,
+  @location(26) f5: vec3<f32>,
+  @builtin(front_facing) f6: bool,
+  @location(74) f7: vec2<i32>,
+  @builtin(position) f8: vec4<f32>,
+  @location(7) f9: f32,
+  @location(29) f10: f16,
+  @builtin(sample_index) f11: u32,
+  @location(80) f12: vec3<i32>,
+  @location(58) f13: vec2<f32>,
+  @location(45) f14: vec4<i32>,
+  @location(8) f15: vec2<u32>,
+  @location(37) f16: u32,
+  @location(71) f17: vec4<i32>,
+  @location(76) f18: f32,
+  @location(38) f19: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(77) a0: vec3<f32>, @location(30) a1: vec4<u32>, @builtin(sample_mask) a2: u32, @location(81) a3: vec3<i32>, @location(11) a4: vec4<u32>, @location(31) a5: vec3<f16>, @location(69) a6: vec3<f16>, @location(32) a7: f16, @location(15) a8: vec2<u32>, a9: S45, @location(57) a10: vec2<i32>, @location(63) a11: vec3<f32>, @location(50) a12: vec2<f16>, @location(59) a13: f16, @location(46) a14: vec4<i32>, @location(9) a15: vec2<f32>, @location(13) a16: vec3<u32>, @location(55) a17: i32, @location(22) a18: vec2<i32>, @location(2) a19: vec3<i32>, @location(34) a20: vec4<f16>, @location(27) a21: f32, @location(0) a22: vec3<f16>, @location(48) a23: u32, @location(78) a24: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S44 {
+  @location(4) f0: vec4<f32>,
+  @location(11) f1: vec4<f16>,
+  @location(13) f2: i32
+}
+struct VertexOutput0 {
+  @location(74) f455: vec2<i32>,
+  @location(63) f456: vec3<f32>,
+  @location(9) f457: vec2<f32>,
+  @location(62) f458: vec2<i32>,
+  @location(68) f459: vec2<f16>,
+  @location(78) f460: vec2<u32>,
+  @location(71) f461: vec4<i32>,
+  @location(69) f462: vec3<f16>,
+  @location(7) f463: f32,
+  @location(48) f464: u32,
+  @location(27) f465: f32,
+  @location(59) f466: f16,
+  @location(76) f467: f32,
+  @location(50) f468: vec2<f16>,
+  @location(22) f469: vec2<i32>,
+  @location(14) f470: vec2<f32>,
+  @location(32) f471: f16,
+  @location(15) f472: vec2<u32>,
+  @location(77) f473: vec3<f32>,
+  @location(45) f474: vec4<i32>,
+  @location(0) f475: vec3<f16>,
+  @location(80) f476: vec3<i32>,
+  @location(55) f477: i32,
+  @location(58) f478: vec2<f32>,
+  @location(46) f479: vec4<i32>,
+  @location(38) f480: vec2<i32>,
+  @location(11) f481: vec4<u32>,
+  @location(57) f482: vec2<i32>,
+  @location(8) f483: vec2<u32>,
+  @location(37) f484: u32,
+  @location(31) f485: vec3<f16>,
+  @location(54) f486: vec2<f32>,
+  @location(34) f487: vec4<f16>,
+  @location(26) f488: vec3<f32>,
+  @location(70) f489: i32,
+  @location(81) f490: vec3<i32>,
+  @location(30) f491: vec4<u32>,
+  @location(13) f492: vec3<u32>,
+  @location(29) f493: f16,
+  @location(2) f494: vec3<i32>,
+  @builtin(position) f495: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, a1: S44) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView259 = texture7.createView({
+  label: '\u25a8\u06ec\u314f\uf43a\u{1fe50}\u{1ff18}\u0b6d\u152d\u96ce',
+  aspect: 'all',
+  format: 'rgba16float',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder59.setBindGroup(3, bindGroup6);
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(763, 980);
+let bindGroupLayout48 = pipeline71.getBindGroupLayout(2);
+let bindGroup68 = device0.createBindGroup({
+  label: '\u0549\u4f3e\u0e55\u83e0\u04c3\uf45a\u1d80',
+  layout: bindGroupLayout6,
+  entries: [{binding: 3682, resource: sampler30}, {binding: 1191, resource: sampler97}],
+});
+let commandEncoder226 = device0.createCommandEncoder({label: '\u9309\u{1fe4b}\u0840\u0129\u02e3\ud386'});
+let querySet108 = device0.createQuerySet({label: '\u9359\u{1fe1f}\u{1fbfb}\u{1fcb4}\u6053\u4757', type: 'occlusion', count: 1743});
+let textureView260 = texture99.createView({
+  label: '\u0099\u{1f8d5}\u0c77\u0447\u09c4\u88fc\u64de\uc3c4\u02d9\ua7af\u0b8d',
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder107 = device0.createRenderBundleEncoder({
+  label: '\u591c\u36fd\ucc3d\u5a62\u07cc\uedc9\u50c6\u835c\u0894\u3aee\u4337',
+  colorFormats: ['r16uint', 'rg32uint'],
+  depthReadOnly: true,
+});
+let externalTexture103 = device0.importExternalTexture({label: '\u0eb1\u40ec\u2421\ucb2e', source: video13, colorSpace: 'display-p3'});
+try {
+commandEncoder222.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas6);
+let imageData26 = new ImageData(84, 188);
+let bindGroup69 = device0.createBindGroup({
+  label: '\uc588\u{1fa27}\udd44\u0bcf\u6095\u6841\u485e\u{1f641}\u{1fbcb}\u3e1e\u0c5f',
+  layout: bindGroupLayout23,
+  entries: [],
+});
+let commandEncoder227 = device0.createCommandEncoder({label: '\u{1fdfd}\u08a5\u{1fee8}\ue35d\u021f'});
+let querySet109 = device0.createQuerySet({label: '\u{1fc73}\ub48e', type: 'occlusion', count: 511});
+let commandBuffer50 = commandEncoder222.finish({label: '\u026e\u{1fbb7}\ue2e3\u657d\u05ef\u{1fda4}\u65a8\u92a6\u4e63\ua5f9'});
+try {
+computePassEncoder88.setPipeline(pipeline99);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder170.copyBufferToBuffer(buffer43, 49600, buffer15, 50884, 22128);
+dissociateBuffer(device0, buffer43);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let textureView261 = texture89.createView({
+  label: '\u{1f743}\u{1f938}\u{1fc26}\u053b\u{1fd0f}\ufd57\u029d\u23b9\u085c\u{1f925}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let sampler109 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.96,
+  compare: 'less',
+});
+try {
+device2.queue.writeBuffer(buffer21, 88896, new DataView(new ArrayBuffer(5133)), 3972, 252);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 19},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 1_327_680 */
+{offset: 264, bytesPerRow: 2124, rowsPerImage: 208}, {width: 510, height: 1, depthOrArrayLayers: 4});
+} catch {}
+video15.width = 162;
+let gpuCanvasContext19 = offscreenCanvas30.getContext('webgpu');
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let texture162 = device0.createTexture({
+  label: '\u6245\u11b7\uf44f\u023d',
+  size: {width: 2880, height: 24, depthOrArrayLayers: 61},
+  mipLevelCount: 6,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler110 = device0.createSampler({
+  label: '\u2433\u4225\u9d88\u0a6e\ube8d\u91fd',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.81,
+  lodMaxClamp: 91.21,
+  compare: 'always',
+});
+try {
+computePassEncoder5.dispatchWorkgroupsIndirect(buffer5, 12036);
+} catch {}
+try {
+renderBundleEncoder83.setIndexBuffer(buffer33, 'uint32', 116604, 455799);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer24, 32088, buffer41, 219672, 56028);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder215.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1624, new BigUint64Array(41017), 10959, 32);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(img36);
+let commandEncoder228 = device0.createCommandEncoder();
+let texture163 = device0.createTexture({
+  label: '\u0370\u5c6c\u5cb9\u{1fc41}\u0fdd\u05dc\ud839',
+  size: [768],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+try {
+renderBundleEncoder54.setPipeline(pipeline47);
+} catch {}
+let arrayBuffer28 = buffer32.getMappedRange(224424, 0);
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 23, y: 27, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 8});
+} catch {}
+let pipeline122 = device0.createRenderPipeline({
+  label: '\u08b6\u9197\u0286\ua6b8\u068f\u{1f993}\u33f5\u084b\u505d\u{1f6f2}\u0d0b',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x2897cea3},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32float', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'replace', passOp: 'invert'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilReadMask: 2376331893,
+    stencilWriteMask: 1133349866,
+    depthBias: -1500595213,
+    depthBiasSlopeScale: 936.8623537829269,
+  },
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 7428, attributes: []},
+      {
+        arrayStride: 26524,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 3332, shaderLocation: 6},
+          {format: 'uint16x4', offset: 12088, shaderLocation: 17},
+          {format: 'uint32x2', offset: 3496, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 1764,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 20, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 334, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 10536, attributes: []},
+      {
+        arrayStride: 11236,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 3228, shaderLocation: 14},
+          {format: 'uint32', offset: 84, shaderLocation: 13},
+          {format: 'sint32x4', offset: 448, shaderLocation: 4},
+          {format: 'uint32x3', offset: 1764, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 384, shaderLocation: 5},
+          {format: 'uint32x3', offset: 288, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 2798, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 2200, shaderLocation: 7},
+          {format: 'sint32x4', offset: 736, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 1656, shaderLocation: 8},
+          {format: 'sint32x4', offset: 220, shaderLocation: 18},
+          {format: 'float16x4', offset: 1232, shaderLocation: 10},
+          {format: 'float32x3', offset: 2572, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 1216, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 2264, attributes: [{format: 'sint8x2', offset: 346, shaderLocation: 16}]},
+    ],
+  },
+});
+let canvas24 = document.createElement('canvas');
+gc();
+let offscreenCanvas31 = new OffscreenCanvas(446, 93);
+let videoFrame31 = new VideoFrame(video15, {timestamp: 0});
+document.body.prepend(video5);
+try {
+externalTexture61.label = '\u755d\u1564\u5b6c\ufe80\u9ab6\u8e78\u0d99\u{1f9a4}\u{1fb5d}\ub9a6';
+} catch {}
+let video32 = await videoWithData();
+let imageData27 = new ImageData(36, 12);
+let bindGroup70 = device0.createBindGroup({
+  label: '\u00c0\u05b6\u027d\u{1f61f}\u7e19\ue2b1\u0319\u2b1f\u{1fe98}\u{1f761}\u2e46',
+  layout: bindGroupLayout46,
+  entries: [{binding: 1376, resource: sampler13}],
+});
+let querySet110 = device0.createQuerySet({label: '\ua413\u07ef\u{1fe89}\u01c2', type: 'occlusion', count: 1405});
+let texture164 = device0.createTexture({
+  label: '\u59bb\u9aad\u22a7\u1841\u0e39\udfd0\u3848\u396b\u{1f9c1}\u020f',
+  size: [360],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView262 = texture50.createView({
+  label: '\u4eaa\u{1f77d}\u0a38\u{1f8c8}\ua9e5\u8670\u2df8\u5949\u{1fbd4}',
+  dimension: '2d',
+  baseArrayLayer: 398,
+});
+let renderBundle124 = renderBundleEncoder3.finish({label: '\u6b3d\u167a\u6a73\u0f42'});
+let sampler111 = device0.createSampler({
+  label: '\u9519\u00f7\ub80f\u641c\u9f91\u0f2a\u01f7\ua304',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.80,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder5.dispatchWorkgroups(1, 4, 5);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(9, bindGroup63);
+} catch {}
+try {
+renderBundleEncoder97.setPipeline(pipeline113);
+} catch {}
+try {
+commandEncoder220.copyBufferToBuffer(buffer10, 2960, buffer11, 132140, 12172);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer6, 32976, 26572);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer49]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 29348, new Float32Array(60771), 52726, 272);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 274, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 3_696_300 */
+{offset: 925, bytesPerRow: 2467, rowsPerImage: 65}, {width: 569, height: 3, depthOrArrayLayers: 24});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1440, height: 12, depthOrArrayLayers: 61}
+*/
+{
+  source: offscreenCanvas15,
+  origin: { x: 37, y: 19 },
+  flipY: true,
+}, {
+  texture: texture133,
+  mipLevel: 1,
+  origin: {x: 125, y: 5, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline123 = await device0.createRenderPipelineAsync({
+  label: '\u{1fef3}\u0c78\u0001\u0453\ufaf9\u9bb7\u{1f7b4}\ubae6',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3964,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 50, shaderLocation: 19},
+          {format: 'sint16x4', offset: 612, shaderLocation: 5},
+          {format: 'float16x2', offset: 80, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 5028,
+        attributes: [
+          {format: 'snorm8x4', offset: 1632, shaderLocation: 16},
+          {format: 'uint32x3', offset: 448, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 448, shaderLocation: 14},
+          {format: 'uint32x4', offset: 304, shaderLocation: 4},
+          {format: 'uint8x2', offset: 58, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 122, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 3008, shaderLocation: 13},
+          {format: 'sint32x3', offset: 120, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 7172,
+        attributes: [
+          {format: 'sint8x4', offset: 540, shaderLocation: 1},
+          {format: 'float32x2', offset: 620, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 8468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 200, shaderLocation: 9},
+          {format: 'uint16x4', offset: 1608, shaderLocation: 10},
+          {format: 'sint32x2', offset: 832, shaderLocation: 0},
+          {format: 'sint32x3', offset: 2096, shaderLocation: 7},
+          {format: 'sint32x4', offset: 1452, shaderLocation: 18},
+          {format: 'sint32x3', offset: 3064, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 764, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let imageBitmap32 = await createImageBitmap(video9);
+let videoFrame32 = new VideoFrame(video11, {timestamp: 0});
+try {
+offscreenCanvas31.getContext('webgl2');
+} catch {}
+let commandEncoder229 = device0.createCommandEncoder({});
+let textureView263 = texture120.createView({label: '\u0d46\uc543\u824f\u{1fa92}\u9895\ueb06\u33f4\ueaa7\uaf8e'});
+let computePassEncoder89 = commandEncoder48.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(8, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder92.setIndexBuffer(buffer13, 'uint32', 71772);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer32, 0, 55383);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 3, y: 7, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5324 */
+  offset: 5324,
+  bytesPerRow: 0,
+  buffer: buffer6,
+}, {width: 0, height: 25, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture152,
+  mipLevel: 3,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder202.clearBuffer(buffer11, 112616, 39244);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder226.resolveQuerySet(querySet66, 1252, 455, buffer15, 7680);
+} catch {}
+try {
+adapter1.label = '\u{1f7f8}\uf6b5';
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let video33 = await videoWithData();
+offscreenCanvas25.width = 1482;
+let bindGroupLayout49 = device0.createBindGroupLayout({
+  label: '\u13dc\ue9d8\u{1f837}\u0790\u05d4',
+  entries: [
+    {
+      binding: 1978,
+      visibility: 0,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder230 = device0.createCommandEncoder({label: '\udc4c\u{1fcec}\u6be2\u92d6'});
+let texture165 = device0.createTexture({
+  label: '\u492b\u0108\u0f1a\u9021\u0ab7\u0f98',
+  size: {width: 15, height: 1, depthOrArrayLayers: 564},
+  mipLevelCount: 3,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView264 = texture48.createView({label: '\u56b0\u188e\u181b'});
+let renderBundleEncoder108 = device0.createRenderBundleEncoder({
+  label: '\u0511\uad6b\u1f0c\ua297\u9376\u043f\u7dad\u390a\uaff1\u{1f71b}',
+  colorFormats: ['r32float', 'rgba32uint'],
+  depthReadOnly: true,
+});
+let renderBundle125 = renderBundleEncoder42.finish({label: '\u029f\u{1ff31}\u1998\u03d6'});
+try {
+computePassEncoder40.setPipeline(pipeline110);
+} catch {}
+try {
+renderBundleEncoder92.setBindGroup(9, bindGroup57, new Uint32Array(2110), 868, 0);
+} catch {}
+let arrayBuffer29 = buffer36.getMappedRange(93384, 380);
+try {
+commandEncoder2.copyBufferToBuffer(buffer38, 39676, buffer6, 34056, 35752);
+dissociateBuffer(device0, buffer38);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 3});
+} catch {}
+offscreenCanvas13.width = 422;
+canvas20.height = 399;
+let canvas25 = document.createElement('canvas');
+let commandEncoder231 = device0.createCommandEncoder({label: '\u24f7\u{1fdbf}\u6e13\u86ad\u3812\u0950'});
+let querySet111 = device0.createQuerySet({
+  label: '\u220f\u{1fe95}\u06a9\uf8af\u092a\ue89b\u2a2b\u0308\u{1fd55}\uf6c4',
+  type: 'occlusion',
+  count: 23,
+});
+let textureView265 = texture148.createView({label: '\uafa0\uf7f5\u80e9\u0f2b\u4093', aspect: 'all'});
+try {
+renderBundleEncoder102.setVertexBuffer(0, buffer22, 0, 109642);
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder154.resolveQuerySet(querySet0, 103, 31, buffer0, 133376);
+} catch {}
+try {
+device0.queue.submit([commandBuffer50]);
+} catch {}
+gc();
+let querySet112 = device0.createQuerySet({
+  label: '\u04e3\u58d1\u{1f7ac}\u{1fc8b}\u90ef\ua50c\u1a68\u0204\u0c9f\u06be',
+  type: 'occlusion',
+  count: 377,
+});
+let textureView266 = texture55.createView({label: '\u6cce\u0314', dimension: '2d-array', format: 'bgra8unorm'});
+let renderBundle126 = renderBundleEncoder94.finish();
+try {
+computePassEncoder12.setPipeline(pipeline102);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline106);
+} catch {}
+let img44 = await imageWithData(173, 221, '#4539a379', '#9b9d54fe');
+canvas15.height = 1130;
+let textureView267 = texture120.createView({label: '\u324c\u{1f877}', dimension: '1d'});
+let renderBundleEncoder109 = device0.createRenderBundleEncoder({
+  label: '\u0e10\udcbf\u596b\u{1fcc1}\u667e\u0628\u40e5\u4f9d\u0338\u0f82\u014c',
+  colorFormats: ['rgba32sint', 'bgra8unorm', 'rg8sint', 'rgba8sint', 'rgba8unorm'],
+});
+let renderBundle127 = renderBundleEncoder57.finish();
+try {
+renderBundleEncoder64.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder99.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+commandEncoder228.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 2_875_011 */
+{offset: 833, bytesPerRow: 178, rowsPerImage: 241}, {width: 3, height: 1, depthOrArrayLayers: 68});
+} catch {}
+let pipeline124 = device0.createComputePipeline({layout: pipelineLayout25, compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}}});
+let pipeline125 = device0.createRenderPipeline({
+  label: '\u{1fc4a}\u0107\udc67\u2c2d',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1384, attributes: []},
+      {
+        arrayStride: 644,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 84, shaderLocation: 10},
+          {format: 'sint8x4', offset: 216, shaderLocation: 3},
+          {format: 'uint32x2', offset: 60, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 112, shaderLocation: 6},
+          {format: 'sint8x2', offset: 82, shaderLocation: 19},
+          {format: 'float16x2', offset: 88, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 17},
+          {format: 'sint32x2', offset: 144, shaderLocation: 18},
+          {format: 'uint32x3', offset: 8, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 15796,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 4864, shaderLocation: 4}],
+      },
+      {arrayStride: 23936, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 5448, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 8684, shaderLocation: 16},
+          {format: 'sint8x4', offset: 34652, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 1844, shaderLocation: 7},
+          {format: 'sint32x3', offset: 620, shaderLocation: 0},
+          {format: 'float32', offset: 492, shaderLocation: 9},
+          {format: 'uint32x2', offset: 320, shaderLocation: 5},
+          {format: 'sint32x2', offset: 16988, shaderLocation: 12},
+          {format: 'float16x2', offset: 200, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 1048,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 0, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let querySet113 = device0.createQuerySet({type: 'occlusion', count: 1789});
+let texture166 = device0.createTexture({
+  label: '\u06ae\u1886\u1b4a\u0168\u{1fd33}\u{1fb84}\u08d0\u{1fba0}',
+  size: [1440],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView268 = texture107.createView({
+  label: '\u0d78\u5de7\u{1fb9b}\u7188\u010b',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 55,
+  arrayLayerCount: 1,
+});
+try {
+commandEncoder212.copyBufferToBuffer(buffer26, 8276, buffer41, 200976, 8992);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 85664 */
+  offset: 1952,
+  bytesPerRow: 256,
+  rowsPerImage: 109,
+  buffer: buffer7,
+}, {
+  texture: texture145,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 279, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer13), /* required buffer size: 491 */
+{offset: 491}, {width: 154, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData28 = new ImageData(96, 256);
+let video34 = await videoWithData();
+let imageBitmap33 = await createImageBitmap(offscreenCanvas8);
+let bindGroupLayout50 = pipeline78.getBindGroupLayout(2);
+let bindGroup71 = device0.createBindGroup({layout: bindGroupLayout15, entries: []});
+let textureView269 = texture13.createView({label: '\u{1fa26}\u03d3\ua020\u0c14\uad9a', aspect: 'all'});
+try {
+renderBundleEncoder43.setVertexBuffer(5154, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer8), /* required buffer size: 547 */
+{offset: 547}, {width: 31, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext20 = canvas25.getContext('webgpu');
+let querySet114 = device1.createQuerySet({label: '\u{1fadc}\ubcca\u137b\u{1ffc8}\u5ce2\ub470\ucbe1', type: 'occlusion', count: 515});
+let texture167 = device1.createTexture({
+  label: '\u0be9\uf62d\u643e',
+  size: {width: 136},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView270 = texture72.createView({});
+let externalTexture104 = device1.importExternalTexture({
+  label: '\u0424\u03ba\u0273\u{1f7d9}\u2333\u7c0a\ua3b9\ucdbb\u03f3',
+  source: video7,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(7, bindGroup24, []);
+} catch {}
+try {
+renderBundleEncoder45.draw(112);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexedIndirect(buffer17, 15856);
+} catch {}
+try {
+renderBundleEncoder67.setPipeline(pipeline77);
+} catch {}
+try {
+commandEncoder203.copyBufferToTexture({
+  /* bytesInLastRow: 1024 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 59648 */
+  offset: 14592,
+  bytesPerRow: 1024,
+  buffer: buffer19,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'all',
+}, {width: 256, height: 176, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder219.resolveQuerySet(querySet71, 1088, 522, buffer34, 2816);
+} catch {}
+video1.width = 263;
+let commandEncoder232 = device0.createCommandEncoder({label: '\uea0d\uf376\u08d8\u0137'});
+let querySet115 = device0.createQuerySet({label: '\uf458\u5e47\u66a6\u065c\u045b', type: 'occlusion', count: 2742});
+let texture168 = device0.createTexture({
+  label: '\u{1fc3a}\u00fb\uab06\u01f4\u04bc\u{1fb4d}\ua69a',
+  size: [62],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let externalTexture105 = device0.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+let pipeline126 = device0.createComputePipeline({
+  label: '\u5b9c\u0043\u91d1\u{1f6a7}\u063b',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let img45 = await imageWithData(258, 71, '#d7c8f42c', '#bf167a8c');
+let video35 = await videoWithData();
+try {
+device0.label = '\uada2\u0da9\u2120\u{1f64a}\udb29\u01e2\ubb46\u{1fd30}\u3022\u04c0\ucd35';
+} catch {}
+let bindGroupLayout51 = device0.createBindGroupLayout({
+  label: '\u00d8\u0acb\u{1fe87}\uecbd\ua6fb\u0465\u021b\u7cfc\u{1f682}\u{1fca1}',
+  entries: [
+    {
+      binding: 3878,
+      visibility: 0,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+try {
+computePassEncoder5.dispatchWorkgroupsIndirect(buffer5, 1636);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline52);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer4, 8532, buffer36, 6408, 12628);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 12656 widthInBlocks: 1582 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7336 */
+  offset: 7336,
+  buffer: buffer7,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1582, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder207.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 236_902 */
+{offset: 98, bytesPerRow: 266, rowsPerImage: 178}, {width: 16, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+offscreenCanvas30.width = 48;
+gc();
+let gpuCanvasContext21 = offscreenCanvas29.getContext('webgpu');
+let imageData29 = new ImageData(172, 104);
+try {
+canvas24.getContext('webgl');
+} catch {}
+let img46 = await imageWithData(26, 273, '#db8a5ce7', '#e52ac01a');
+let bindGroupLayout52 = device0.createBindGroupLayout({
+  label: '\u1366\u{1fab1}\u{1fdf1}\ud7a7\u{1f63b}\u180c\u0968\u0791',
+  entries: [
+    {
+      binding: 1940,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer45 = device0.createBuffer({size: 292504, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder233 = device0.createCommandEncoder({label: '\u0485\u66eb\u{1f78f}\ue3a0'});
+let querySet116 = device0.createQuerySet({type: 'occlusion', count: 2277});
+let commandBuffer51 = commandEncoder196.finish({label: '\u{1fd6b}\u0d0a\u6578\ud336\u0530\u{1f8e9}\u029c'});
+let textureView271 = texture63.createView({label: '\u4eef\u13cc\u{1f9ca}\u00c6\u{1fdb2}\u900f'});
+try {
+renderBundleEncoder103.setIndexBuffer(buffer5, 'uint16', 31896, 3455);
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(0, buffer22, 0, 67787);
+} catch {}
+try {
+commandEncoder216.copyBufferToBuffer(buffer38, 43404, buffer3, 133588, 10436);
+dissociateBuffer(device0, buffer38);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 10828, new DataView(new ArrayBuffer(63989)), 18543, 3504);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 1_363 */
+{offset: 535}, {width: 828, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let buffer46 = device0.createBuffer({size: 290048, usage: GPUBufferUsage.INDEX, mappedAtCreation: true});
+let renderBundle128 = renderBundleEncoder103.finish({label: '\u{1fc43}\u{1fc33}\u2f90\u080d\u04e6\u5d28\u093c\u3447\u0e87\u5812\ua9ae'});
+let sampler112 = device0.createSampler({
+  label: '\u6d3e\u02fa\u{1f8bf}\u61a1\u0008\ua473\u5616',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 33.89,
+  lodMaxClamp: 64.37,
+  compare: 'greater',
+});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture139,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 88, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 109, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer23), /* required buffer size: 933 */
+{offset: 933}, {width: 203, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 7, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 8, y: 28 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline127 = device0.createComputePipeline({
+  label: '\u64e8\u08f4\u863c\u3848\udcab',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap34 = await createImageBitmap(offscreenCanvas13);
+let querySet117 = device0.createQuerySet({type: 'occlusion', count: 372});
+let texture169 = device0.createTexture({
+  label: '\ufa28\ud1bc\u0da3',
+  size: {width: 2880, height: 24, depthOrArrayLayers: 61},
+  mipLevelCount: 5,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+try {
+computePassEncoder5.setBindGroup(7, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder95.setIndexBuffer(buffer33, 'uint32', 506520, 58800);
+} catch {}
+try {
+renderBundleEncoder83.setPipeline(pipeline123);
+} catch {}
+try {
+commandEncoder218.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 27128 */
+  offset: 27128,
+  buffer: buffer24,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder224.resolveQuerySet(querySet25, 9, 24, buffer0, 52736);
+} catch {}
+let promise50 = device0.queue.onSubmittedWorkDone();
+gc();
+let canvas26 = document.createElement('canvas');
+try {
+canvas26.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline59);
+} catch {}
+try {
+commandEncoder192.copyTextureToBuffer({
+  texture: texture145,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 146980 */
+  offset: 20,
+  bytesPerRow: 256,
+  rowsPerImage: 41,
+  buffer: buffer45,
+}, {width: 4, height: 1, depthOrArrayLayers: 15});
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let img47 = await imageWithData(102, 37, '#83ce1e9b', '#4d6ce702');
+let bindGroup72 = device0.createBindGroup({label: '\ub3c6\u012e\u{1fa44}\u0e01\u4ae4\udecb\u4fa2\ue0bd', layout: bindGroupLayout23, entries: []});
+let commandEncoder234 = device0.createCommandEncoder({label: '\uc3e4\u9cbc'});
+let texture170 = device0.createTexture({
+  label: '\u3229\u07f7\u0946\u{1f881}\u2bc1\u0193\u{1fb74}\u0ae2\u0157',
+  size: {width: 125, height: 1, depthOrArrayLayers: 229},
+  mipLevelCount: 6,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView272 = texture11.createView({});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup43, new Uint32Array(2546), 591, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline108);
+} catch {}
+try {
+commandEncoder194.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1776, new DataView(new ArrayBuffer(40549)), 39524, 348);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 470 */
+{offset: 470}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 3, depthOrArrayLayers: 61}
+*/
+{
+  source: img13,
+  origin: { x: 30, y: 15 },
+  flipY: false,
+}, {
+  texture: texture161,
+  mipLevel: 3,
+  origin: {x: 19, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder235 = device0.createCommandEncoder({label: '\u{1f7d2}\u52a2\ube90\u60fe\ua2a5\u{1ff08}\u6832\u78dd'});
+let querySet118 = device0.createQuerySet({label: '\ue445\u493c\u5a8c\ufb26\ub67a\ud0e7', type: 'occlusion', count: 749});
+let textureView273 = texture20.createView({label: '\u5590\uc19e\u{1ffb6}\u84ea', aspect: 'all', arrayLayerCount: 1});
+let renderBundleEncoder110 = device0.createRenderBundleEncoder({
+  label: '\u0db7\u{1f608}\ued60\u8cce\u0b79\u{1f62c}\uc414',
+  colorFormats: ['r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder139.copyTextureToBuffer({
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 392 widthInBlocks: 98 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14116 */
+  offset: 14116,
+  buffer: buffer45,
+}, {width: 98, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet101, 736, 713, buffer0, 73472);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let querySet119 = device0.createQuerySet({label: '\uc465\u{1f60a}\u{1f649}\u44a1\u0a51\u8013\u3ba3\uc33a', type: 'occlusion', count: 1301});
+let textureView274 = texture18.createView({
+  label: '\u{1ffb0}\u0fb1\uf8a1\u2c22\u0d7e\u6875\u{1fdb2}\u6086\ubc17\u911b\u{1fc21}',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+try {
+commandEncoder175.copyBufferToBuffer(buffer10, 4060, buffer15, 32724, 9660);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer15);
+} catch {}
+let pipeline128 = device0.createRenderPipeline({
+  label: '\u3b3e\u0f49\u8131\u{1ffdc}\ua221\ucafc\u522f\u45da',
+  layout: pipelineLayout22,
+  multisample: {mask: 0x9527e44d},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'r32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilWriteMask: 479520218,
+    depthBias: 375566842,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9876,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 4316, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 1200, shaderLocation: 11},
+          {format: 'float16x2', offset: 3052, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 3416,
+        attributes: [
+          {format: 'sint32x4', offset: 2008, shaderLocation: 3},
+          {format: 'float16x2', offset: 44, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 10924,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 6732, shaderLocation: 19},
+          {format: 'uint32x4', offset: 5868, shaderLocation: 9},
+          {format: 'sint32', offset: 528, shaderLocation: 2},
+          {format: 'float32', offset: 2364, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 3076, shaderLocation: 10},
+          {format: 'uint32x4', offset: 964, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 9044, shaderLocation: 6},
+          {format: 'sint32x4', offset: 1092, shaderLocation: 18},
+          {format: 'sint32x2', offset: 1296, shaderLocation: 12},
+          {format: 'sint8x4', offset: 30080, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: false},
+});
+let commandEncoder236 = device0.createCommandEncoder({label: '\u1af2\u0f23\u{1fb07}'});
+let textureView275 = texture50.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 494});
+let renderBundleEncoder111 = device0.createRenderBundleEncoder({label: '\u04d3\u0c89\ud6f4', colorFormats: ['r16uint', 'rg32uint'], stencilReadOnly: true});
+let renderBundle129 = renderBundleEncoder109.finish({label: '\uf770\u00a2'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule36 = device0.createShaderModule({
+  label: '\ud3ba\u94b7\u0121\ubff3\uc237\u{1f8c2}\uc78d\u{1fab1}\u8be8\u804e',
+  code: `@group(2) @binding(607)
+var<storage, read_write> parameter26: array<u32>;
+@group(2) @binding(459)
+var<storage, read_write> global20: array<u32>;
+@group(2) @binding(3877)
+var<storage, read_write> function30: array<u32>;
+@group(0) @binding(1922)
+var<storage, read_write> function31: array<u32>;
+
+@compute @workgroup_size(3, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: i32,
+  @location(1) f1: vec4<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(2) f4: vec4<i32>,
+  @location(0) f5: vec4<i32>,
+  @location(5) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S46 {
+  @location(9) f0: vec4<u32>,
+  @location(1) f1: i32
+}
+
+@vertex
+fn vertex0(a0: S46, @location(19) a1: vec4<f16>, @location(16) a2: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderBundleEncoder99.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder78.insertDebugMarker('\u3f69');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 12, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 32, y: 102 },
+  flipY: true,
+}, {
+  texture: texture149,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline129 = device0.createComputePipeline({
+  label: '\u1043\u0137\u8793\udc93\u0c7a\u0e3b',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule32, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule37 = device0.createShaderModule({
+  label: '\u35d9\u{1fe96}\u5c32',
+  code: `@group(5) @binding(642)
+var<storage, read_write> global21: array<u32>;
+@group(0) @binding(1140)
+var<storage, read_write> type17: array<u32>;
+@group(2) @binding(1382)
+var<storage, read_write> field17: array<u32>;
+@group(2) @binding(2425)
+var<storage, read_write> parameter27: array<u32>;
+@group(4) @binding(1904)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S47 {
+  @location(4) f0: vec2<f32>,
+  @location(1) f1: u32,
+  @location(18) f2: vec3<f32>,
+  @location(17) f3: vec2<f16>,
+  @location(5) f4: vec3<f32>,
+  @location(16) f5: f32,
+  @location(8) f6: f32
+}
+
+@vertex
+fn vertex0(a0: S47, @location(3) a1: vec4<f16>, @location(11) a2: vec3<u32>, @location(12) a3: vec4<i32>, @location(0) a4: vec4<f32>, @location(10) a5: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder237 = device0.createCommandEncoder({label: '\u3af3\u{1ff4c}\u9791\u{1fcda}\u61ff\u6fb8'});
+let textureView276 = texture0.createView({label: '\u0bc5\u78aa\ucce2\u3a30\u069c'});
+let externalTexture106 = device0.importExternalTexture({label: '\uc74c\u028a\u67ff\u0bc5\u0939', source: videoFrame20, colorSpace: 'srgb'});
+try {
+renderBundleEncoder70.setPipeline(pipeline123);
+} catch {}
+try {
+commandEncoder223.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 11, y: 8, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 259700 */
+  offset: 36204,
+  bytesPerRow: 256,
+  rowsPerImage: 249,
+  buffer: buffer41,
+}, {width: 2, height: 127, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder206.resolveQuerySet(querySet45, 1135, 470, buffer15, 75776);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 161, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: video31,
+  origin: { x: 6, y: 10 },
+  flipY: true,
+}, {
+  texture: texture139,
+  mipLevel: 3,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline130 = await device0.createComputePipelineAsync({
+  label: '\u962d\u05d2\u3156\u{1f9d8}\u0980\u68c1\u27fc\uab26\u3560\ubb31',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule23, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise50;
+} catch {}
+let commandEncoder238 = device0.createCommandEncoder({label: '\u87a5\u2488\u68a7\u1f43\u4551\u0633\u6283\u{1fbd6}\u0f26\u06f5\u{1f935}'});
+let textureView277 = texture34.createView({label: '\u2cda\ufbe0\u010e', aspect: 'all', format: 'r32float', baseMipLevel: 2});
+let computePassEncoder90 = commandEncoder24.beginComputePass({label: '\u5c41\u{1fa00}'});
+try {
+texture149.destroy();
+} catch {}
+try {
+commandEncoder197.copyBufferToTexture({
+  /* bytesInLastRow: 1492 widthInBlocks: 373 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5036 */
+  offset: 5036,
+  buffer: buffer7,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 373, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder233.resolveQuerySet(querySet89, 480, 22, buffer15, 96256);
+} catch {}
+try {
+commandEncoder228.pushDebugGroup('\u61c2');
+} catch {}
+try {
+commandEncoder228.popDebugGroup();
+} catch {}
+let canvas27 = document.createElement('canvas');
+let imageBitmap35 = await createImageBitmap(img1);
+try {
+adapter4.label = '\u0b8e\u0c04\u0794\u0e98\u01b3\u{1fb78}\u{1fb8b}\u961a';
+} catch {}
+let canvas28 = document.createElement('canvas');
+let imageData30 = new ImageData(224, 148);
+try {
+canvas27.getContext('webgpu');
+} catch {}
+let bindGroupLayout53 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2261,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView278 = texture156.createView({label: '\u1cf6\u57ea\u26cb', dimension: '2d-array', format: 'rg8sint', baseMipLevel: 1});
+let sampler113 = device0.createSampler({
+  label: '\u5a41\ub092\u49bd\ud758\u8b69\ua9ed',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.63,
+  lodMaxClamp: 45.14,
+  maxAnisotropy: 19,
+});
+try {
+renderBundleEncoder99.setPipeline(pipeline106);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer1, 20740, buffer6, 10908, 3884);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline131 = device0.createComputePipeline({
+  label: '\u05af\u{1fe62}\uf607\u{1f6aa}\u1b4f\u88ed\u{1f816}\uaa6e\u0cc0',
+  layout: 'auto',
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let promise51 = device0.createRenderPipelineAsync({
+  label: '\u06fd\u4a0f\u0f88\u4705\uf216\u4a63\u3b8d\u065d\u11a7\u397b',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule31,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 12048,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 416, shaderLocation: 18},
+          {format: 'sint8x2', offset: 302, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 160, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 3808, shaderLocation: 11},
+          {format: 'uint8x4', offset: 620, shaderLocation: 4},
+          {format: 'float32x4', offset: 800, shaderLocation: 2},
+          {format: 'float32x2', offset: 2440, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 3416, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 224, shaderLocation: 12},
+          {format: 'sint32', offset: 2664, shaderLocation: 10},
+          {format: 'float16x4', offset: 44, shaderLocation: 6},
+          {format: 'sint16x2', offset: 1224, shaderLocation: 8},
+          {format: 'uint32x3', offset: 6484, shaderLocation: 13},
+          {format: 'sint32', offset: 1456, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 5764, shaderLocation: 7},
+          {format: 'float16x4', offset: 100, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 2000, attributes: [{format: 'uint8x2', offset: 14, shaderLocation: 15}]},
+      {arrayStride: 3968, attributes: []},
+      {arrayStride: 2256, attributes: []},
+      {
+        arrayStride: 7108,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 40, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+device0.destroy();
+} catch {}
+gc();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let gpuCanvasContext22 = canvas28.getContext('webgpu');
+let img48 = await imageWithData(272, 204, '#1f97914a', '#a6a53cc7');
+let imageData31 = new ImageData(152, 152);
+let canvas29 = document.createElement('canvas');
+let gpuCanvasContext23 = canvas29.getContext('webgpu');
+let videoFrame33 = new VideoFrame(canvas29, {timestamp: 0});
+gc();
+let img49 = await imageWithData(189, 279, '#24001802', '#014c6cfd');
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55) };
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(20, 852);
+video21.height = 37;
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let video36 = await videoWithData();
+try {
+offscreenCanvas32.getContext('webgpu');
+} catch {}
+let commandEncoder239 = device0.createCommandEncoder();
+let querySet120 = device0.createQuerySet({label: '\u29b4\ue17d\u07ee\u7f0b\uc72a\u9e29\u7243\u6e61\ubbd6\uf5ea', type: 'occlusion', count: 3729});
+try {
+renderBundleEncoder97.setPipeline(pipeline113);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder213.copyBufferToBuffer(buffer1, 26212, buffer45, 152272, 11016);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let video37 = await videoWithData();
+let bindGroupLayout54 = device2.createBindGroupLayout({
+  label: '\u0041\u0f40\uc4f1\u9d76\u4915\u0094\u41f4\u5178\ua620\uacf9\u043d',
+  entries: [
+    {binding: 3795, visibility: 0, sampler: { type: 'comparison' }},
+    {
+      binding: 1907,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let pipelineLayout41 = device2.createPipelineLayout({
+  label: '\u69f2\u057b\u08e1\u9312\u0466\u4827\ue992\u0aea',
+  bindGroupLayouts: [bindGroupLayout21, bindGroupLayout34, bindGroupLayout37, bindGroupLayout19, bindGroupLayout19, bindGroupLayout37, bindGroupLayout20],
+});
+let querySet121 = device2.createQuerySet({type: 'occlusion', count: 3310});
+let textureView279 = texture125.createView({
+  label: '\u{1f77d}\u0057\uc7fc\u04b0\u0c3b\u031d',
+  baseMipLevel: 2,
+  baseArrayLayer: 1017,
+  arrayLayerCount: 195,
+});
+try {
+computePassEncoder34.setBindGroup(4, bindGroup60, new Uint32Array(8368), 1423, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline75);
+} catch {}
+let pipeline132 = device2.createComputePipeline({
+  label: '\u{1ff38}\u{1fae0}\u1661\ucbf7\uaea0\u0eed\uc40b',
+  layout: pipelineLayout37,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let canvas30 = document.createElement('canvas');
+let videoFrame34 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let imageData32 = new ImageData(156, 196);
+let textureView280 = texture29.createView({label: '\u5cd7\u430c\u{1faba}'});
+let computePassEncoder91 = commandEncoder219.beginComputePass({});
+let renderPassEncoder30 = commandEncoder203.beginRenderPass({
+  label: '\u42d2\ufaf2\u096e\u00d3\u916a\u8d2e\uae33\u0cda\udb4c\u0954',
+  colorAttachments: [{view: textureView181, depthSlice: 93, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet59,
+});
+let externalTexture107 = device1.importExternalTexture({
+  label: '\u9a68\u{1fc24}\u08aa\uc532\u056d\uc424\u{1f76d}\u0338\u{1fd01}\u0ed4\u{1fe1a}',
+  source: videoFrame26,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder15.setBindGroup(4, bindGroup24);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(1, 0, 41, 1);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder90.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder45.draw(168, 142, 609_212_608, 145_680_088);
+} catch {}
+try {
+renderBundleEncoder71.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(2, buffer17, 0, 59246);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(65), /* required buffer size: 65 */
+{offset: 65}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img50 = await imageWithData(52, 215, '#20d45cdd', '#1a9575a4');
+let gpuCanvasContext24 = canvas30.getContext('webgpu');
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55) };
+} catch {}
+document.body.prepend(video18);
+let imageData33 = new ImageData(104, 200);
+let renderBundleEncoder112 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderPassEncoder25.executeBundles([renderBundle56, renderBundle55, renderBundle82, renderBundle105, renderBundle37, renderBundle26, renderBundle87]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(39, 1, 17, 0);
+} catch {}
+try {
+renderBundleEncoder45.draw(32, 54);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(16, 101, 2_329_155_389);
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\u7821');
+} catch {}
+let pipeline133 = device1.createComputePipeline({
+  label: '\u{1f830}\u0bce\u{1f86d}\u8fd7\u295b\ucc3e',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let adapter7 = await navigator.gpu.requestAdapter({});
+let imageData34 = new ImageData(256, 92);
+let shaderModule38 = device1.createShaderModule({
+  label: '\ufb42\u{1f812}\u642e\u{1f7a6}\u2447\u5998\u{1f67e}\u3e01',
+  code: `@group(0) @binding(1552)
+var<storage, read_write> function32: array<u32>;
+@group(1) @binding(3101)
+var<storage, read_write> parameter28: array<u32>;
+@group(1) @binding(3076)
+var<storage, read_write> local27: array<u32>;
+@group(3) @binding(3157)
+var<storage, read_write> field18: array<u32>;
+@group(2) @binding(3157)
+var<storage, read_write> parameter29: array<u32>;
+
+@compute @workgroup_size(3, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S49 {
+  @location(66) f0: vec3<i32>,
+  @location(45) f1: vec3<i32>,
+  @location(3) f2: vec3<f16>,
+  @location(115) f3: vec2<u32>,
+  @location(60) f4: vec4<u32>,
+  @builtin(sample_index) f5: u32,
+  @location(24) f6: vec3<f16>,
+  @location(75) f7: vec3<u32>,
+  @builtin(sample_mask) f8: u32,
+  @location(15) f9: vec3<i32>,
+  @location(77) f10: u32,
+  @location(90) f11: i32,
+  @location(76) f12: vec4<u32>,
+  @location(0) f13: vec2<f32>,
+  @location(8) f14: vec2<i32>,
+  @location(44) f15: f32,
+  @builtin(position) f16: vec4<f32>,
+  @location(118) f17: vec4<u32>,
+  @location(79) f18: vec4<i32>,
+  @location(18) f19: vec4<u32>,
+  @location(46) f20: vec4<f16>,
+  @location(47) f21: f32,
+  @location(91) f22: vec3<u32>,
+  @location(61) f23: vec4<f32>,
+  @location(41) f24: vec2<i32>,
+  @builtin(front_facing) f25: bool,
+  @location(78) f26: vec3<i32>,
+  @location(97) f27: vec2<f32>,
+  @location(107) f28: vec4<i32>,
+  @location(38) f29: f16,
+  @location(43) f30: vec2<i32>,
+  @location(82) f31: vec4<u32>,
+  @location(109) f32: vec2<i32>,
+  @location(70) f33: i32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(84) a0: vec3<u32>, a1: S49, @location(105) a2: vec2<f32>, @location(63) a3: vec3<u32>, @location(34) a4: vec4<f16>, @location(101) a5: vec2<u32>, @location(114) a6: vec2<u32>, @location(117) a7: vec4<f32>, @location(26) a8: vec2<f16>, @location(72) a9: vec2<f16>, @location(65) a10: f16, @location(102) a11: vec3<f16>, @location(62) a12: vec3<f16>, @location(52) a13: vec4<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S48 {
+  @location(2) f0: vec4<f32>,
+  @location(9) f1: vec4<f16>,
+  @location(3) f2: vec4<u32>,
+  @location(16) f3: vec4<f16>,
+  @location(17) f4: vec4<i32>,
+  @location(14) f5: vec4<f16>,
+  @location(10) f6: vec4<i32>,
+  @location(1) f7: i32,
+  @location(5) f8: vec3<f16>,
+  @location(7) f9: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(52) f496: vec4<u32>,
+  @location(105) f497: vec2<f32>,
+  @location(66) f498: vec3<i32>,
+  @location(90) f499: i32,
+  @location(115) f500: vec2<u32>,
+  @location(76) f501: vec4<u32>,
+  @location(0) f502: vec2<f32>,
+  @location(75) f503: vec3<u32>,
+  @location(41) f504: vec2<i32>,
+  @location(65) f505: f16,
+  @location(82) f506: vec4<u32>,
+  @location(109) f507: vec2<i32>,
+  @location(43) f508: vec2<i32>,
+  @location(45) f509: vec3<i32>,
+  @location(79) f510: vec4<i32>,
+  @location(78) f511: vec3<i32>,
+  @location(47) f512: f32,
+  @location(114) f513: vec2<u32>,
+  @location(91) f514: vec3<u32>,
+  @location(118) f515: vec4<u32>,
+  @location(24) f516: vec3<f16>,
+  @builtin(position) f517: vec4<f32>,
+  @location(38) f518: f16,
+  @location(72) f519: vec2<f16>,
+  @location(8) f520: vec2<i32>,
+  @location(26) f521: vec2<f16>,
+  @location(102) f522: vec3<f16>,
+  @location(61) f523: vec4<f32>,
+  @location(77) f524: u32,
+  @location(97) f525: vec2<f32>,
+  @location(18) f526: vec4<u32>,
+  @location(107) f527: vec4<i32>,
+  @location(3) f528: vec3<f16>,
+  @location(44) f529: f32,
+  @location(101) f530: vec2<u32>,
+  @location(84) f531: vec3<u32>,
+  @location(34) f532: vec4<f16>,
+  @location(70) f533: i32,
+  @location(117) f534: vec4<f32>,
+  @location(46) f535: vec4<f16>,
+  @location(62) f536: vec3<f16>,
+  @location(60) f537: vec4<u32>,
+  @location(63) f538: vec3<u32>,
+  @location(15) f539: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32, @location(6) a2: i32, @location(13) a3: vec2<f32>, @location(15) a4: vec4<f32>, @location(11) a5: f16, a6: S48, @location(0) a7: vec2<i32>, @location(12) a8: vec4<f16>, @location(4) a9: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let bindGroup73 = device1.createBindGroup({label: '\u0949\u{1facd}', layout: bindGroupLayout31, entries: [{binding: 1552, resource: sampler40}]});
+let texture171 = device1.createTexture({
+  label: '\u9d09\ubc0c\u004d',
+  size: {width: 36, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView281 = texture138.createView({label: '\u6831\ubde4\u0cbc\u28bb\uae19\u073f\u{1fc03}\u{1fd92}', mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture108 = device1.importExternalTexture({
+  label: '\u99d5\u1cc2\u88ea\u7d09\u{1f818}\u07fa\u0f53\u053a\u{1fe91}\ub3d1\u{1fd83}',
+  source: video12,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder70.setBindGroup(6, bindGroup15, new Uint32Array(5195), 3145, 0);
+} catch {}
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer34, 436, 12934);
+} catch {}
+try {
+renderBundleEncoder45.draw(7, 109, 685_818_471, 124_758_957);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(141, 13);
+} catch {}
+try {
+renderBundleEncoder45.drawIndirect(buffer17, 67112);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer18, 10740, buffer20, 56128, 12536);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 2760, new DataView(new ArrayBuffer(58742)), 2993, 4388);
+} catch {}
+let video38 = await videoWithData();
+let video39 = await videoWithData();
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(video10);
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+video22.width = 110;
+video32.width = 143;
+let img51 = await imageWithData(291, 22, '#68f6eaaf', '#9c939b85');
+let videoFrame35 = new VideoFrame(videoFrame31, {timestamp: 0});
+let imageBitmap36 = await createImageBitmap(img28);
+document.body.prepend(img21);
+video25.width = 281;
+let video40 = await videoWithData();
+let commandEncoder240 = device1.createCommandEncoder();
+let texture172 = device1.createTexture({
+  size: {width: 68, height: 1, depthOrArrayLayers: 176},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+let renderPassEncoder31 = commandEncoder240.beginRenderPass({
+  colorAttachments: [{view: textureView185, depthSlice: 87, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 273605795,
+});
+let renderBundle130 = renderBundleEncoder75.finish({});
+let sampler114 = device1.createSampler({
+  label: '\u{1f937}\ue224\u{1f94a}\ubd28',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 78.20,
+  lodMaxClamp: 95.72,
+});
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(2676);
+} catch {}
+try {
+renderPassEncoder19.setViewport(0.7549, 1.865, 0.00842, 0.06713, 0.2630, 0.9093);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer34, 28020, 8348);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup50, new Uint32Array(9464), 6702, 0);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(52, 105, 478_662_805, 188_872_144, 46_137_226);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(4, buffer34, 0, 16425);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer16, 36320, buffer34, 24728, 16324);
+dissociateBuffer(device1, buffer16);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer20);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet72, 329, 236, buffer34, 3072);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 6612, new DataView(new ArrayBuffer(55635)), 51685, 124);
+} catch {}
+let pipeline134 = device1.createRenderPipeline({
+  layout: pipelineLayout14,
+  multisample: {count: 4, mask: 0x59bbaae1},
+  fragment: {module: shaderModule14, entryPoint: 'fragment0', targets: [{format: 'rg16sint', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilWriteMask: 1104676079,
+    depthBias: 1989529104,
+    depthBiasSlopeScale: 2.851919627357532,
+    depthBiasClamp: -43.13672562505473,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4692,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 468, shaderLocation: 8},
+          {format: 'uint8x4', offset: 784, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 480, shaderLocation: 11},
+          {format: 'sint32x2', offset: 484, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 576, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 264, shaderLocation: 17},
+          {format: 'float32x3', offset: 2520, shaderLocation: 16},
+          {format: 'float32x3', offset: 80, shaderLocation: 7},
+          {format: 'sint8x4', offset: 1228, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 296, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 5},
+          {format: 'uint32x4', offset: 1212, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 3784,
+        attributes: [
+          {format: 'sint16x4', offset: 440, shaderLocation: 1},
+          {format: 'uint32', offset: 772, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 420, shaderLocation: 10},
+          {format: 'uint32', offset: 1468, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 5588,
+        attributes: [
+          {format: 'float32x3', offset: 1184, shaderLocation: 9},
+          {format: 'float32x4', offset: 120, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+offscreenCanvas20.height = 524;
+let img52 = await imageWithData(186, 58, '#95095614', '#5952d1d2');
+let imageBitmap37 = await createImageBitmap(img32);
+let bindGroup74 = device2.createBindGroup({
+  label: '\u{1fc4c}\u12c9\u04bd\u0b39\u0f08\u9452\u{1f9cd}',
+  layout: bindGroupLayout37,
+  entries: [{binding: 7590, resource: sampler67}],
+});
+let textureView282 = texture122.createView({baseMipLevel: 1});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(8, bindGroup46, new Uint32Array(8742), 6996, 0);
+} catch {}
+try {
+renderBundleEncoder98.setIndexBuffer(buffer30, 'uint32', 113732, 3130);
+} catch {}
+try {
+commandEncoder183.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2602 */
+  offset: 2542,
+  rowsPerImage: 185,
+  buffer: buffer39,
+}, {
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer39);
+} catch {}
+try {
+commandEncoder128.resolveQuerySet(querySet68, 724, 2187, buffer30, 30720);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 17},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer4), /* required buffer size: 75_267_609 */
+{offset: 249, bytesPerRow: 285, rowsPerImage: 288}, {width: 2, height: 0, depthOrArrayLayers: 918});
+} catch {}
+video3.height = 129;
+let imageBitmap38 = await createImageBitmap(imageBitmap19);
+gc();
+try {
+textureView46.label = '\u3c9b\uf385\u3764\u7dac\u7abd\u21cc\uc95a';
+} catch {}
+gc();
+try {
+window.someLabel = commandEncoder162.label;
+} catch {}
+try {
+adapter4.label = '\uf952\uea11\u6507\u8d1c\u4cd3\u0664\u0e33\u24f0\u{1ff31}\u{1fb9a}\ud4e0';
+} catch {}
+let img53 = await imageWithData(282, 43, '#09a5330a', '#b457c292');
+video12.height = 113;
+try {
+if (!arrayBuffer26.detached) { new Uint8Array(arrayBuffer26).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55) };
+} catch {}
+video26.width = 273;
+let videoFrame36 = new VideoFrame(videoFrame1, {timestamp: 0});
+document.body.prepend(img4);
+try {
+adapter4.label = '\ubf19\u4f80\u{1f718}\u{1fd95}\ua5ce\u0316\u{1fc2e}\u08cc\u0b25\uaaad\u{1f805}';
+} catch {}
+let textureView283 = texture124.createView({label: '\u0673\u09f6\u28d2\u02a3\u2890\u0aca\u6a28\u097d', baseMipLevel: 1});
+let computePassEncoder92 = commandEncoder104.beginComputePass({label: '\u6770\u{1ffc5}\u0e33\u0246\u{1f9a9}\u{1fcf5}\uf788'});
+try {
+computePassEncoder47.setBindGroup(8, bindGroup46);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(3, bindGroup27, new Uint32Array(3117), 1939, 0);
+} catch {}
+try {
+device2.queue.submit([commandBuffer41, commandBuffer42]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer21, 192088, new BigUint64Array(22967));
+} catch {}
+let promise52 = adapter4.requestAdapterInfo();
+gc();
+let img54 = await imageWithData(28, 113, '#268b341c', '#cbf097f3');
+video0.width = 99;
+let offscreenCanvas33 = new OffscreenCanvas(152, 66);
+let gpuCanvasContext25 = offscreenCanvas33.getContext('webgpu');
+let videoFrame37 = videoFrame12.clone();
+document.body.prepend(video36);
+canvas28.width = 853;
+gc();
+let video41 = await videoWithData();
+let img55 = await imageWithData(138, 123, '#03ceb225', '#97d96c9b');
+let buffer47 = device0.createBuffer({
+  label: '\u0a56\u{1fa1e}\uc0e4\ub77d\ufc90\u2686\ua3a0\u9e4a\u4d0c',
+  size: 33460,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet122 = device0.createQuerySet({label: '\u4165\u0a20\ucc4b\ub824\u{1fe9f}\ua5eb\u0611\uab0c', type: 'occlusion', count: 1112});
+let textureView284 = texture135.createView({
+  label: '\uec75\ue491\ucdf2\u9209\u{1ffec}\uea19\u{1fe1e}\u0ad1\u7edb',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+let computePassEncoder93 = commandEncoder194.beginComputePass({label: '\u{1fcb9}\u694d\u2fca\u065d\uda50'});
+try {
+computePassEncoder73.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder92.setBindGroup(3, bindGroup14);
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(174, 2);
+let video42 = await videoWithData();
+let gpuCanvasContext26 = offscreenCanvas34.getContext('webgpu');
+document.body.prepend(canvas23);
+let imageData35 = new ImageData(52, 116);
+try {
+  await promise52;
+} catch {}
+gc();
+document.body.prepend(video5);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas31 = document.createElement('canvas');
+let imageData36 = new ImageData(124, 236);
+document.body.prepend(img21);
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+document.body.prepend(img52);
+let canvas32 = document.createElement('canvas');
+let video43 = await videoWithData();
+let video44 = await videoWithData();
+let adapter8 = await navigator.gpu.requestAdapter({});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let imageBitmap39 = await createImageBitmap(video22);
+let canvas33 = document.createElement('canvas');
+gc();
+let img56 = await imageWithData(28, 153, '#6aa76fac', '#5727ffa0');
+let video45 = await videoWithData();
+canvas10.width = 896;
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let canvas34 = document.createElement('canvas');
+video36.width = 168;
+try {
+canvas31.getContext('2d');
+} catch {}
+let gpuCanvasContext27 = canvas32.getContext('webgpu');
+let adapter9 = await navigator.gpu.requestAdapter();
+let offscreenCanvas35 = new OffscreenCanvas(130, 392);
+document.body.prepend(video11);
+let gpuCanvasContext28 = canvas33.getContext('webgpu');
+gc();
+let offscreenCanvas36 = new OffscreenCanvas(258, 189);
+let imageData37 = new ImageData(76, 216);
+let imageData38 = new ImageData(192, 200);
+document.body.prepend(canvas34);
+let video46 = await videoWithData();
+document.body.prepend(img40);
+let video47 = await videoWithData();
+let pipelineLayout42 = device1.createPipelineLayout({label: '\u{1f6eb}\u051a\u91dc', bindGroupLayouts: [bindGroupLayout16, bindGroupLayout10]});
+let commandEncoder241 = device1.createCommandEncoder({});
+let querySet123 = device1.createQuerySet({
+  label: '\ub9f5\u0a9a\u2355\u0b6d\u0961\u09a3\u0454\u{1f80f}\u{1fe54}\u46b8\u{1f690}',
+  type: 'occlusion',
+  count: 2563,
+});
+let computePassEncoder94 = commandEncoder241.beginComputePass();
+try {
+computePassEncoder39.setBindGroup(1, bindGroup56, new Uint32Array(8231), 6110, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(740);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle16, renderBundle72, renderBundle75, renderBundle97, renderBundle77, renderBundle93, renderBundle75, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3183);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(5, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder90.setIndexBuffer(buffer23, 'uint32');
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(0, buffer23, 0, 7813);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer18, 43300, buffer20, 49412, 4656);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder105.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 6, y: 24, z: 70},
+  aspect: 'all',
+},
+{
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+},
+{width: 64, height: 138, depthOrArrayLayers: 0});
+} catch {}
+let video48 = await videoWithData();
+let canvas35 = document.createElement('canvas');
+let img57 = await imageWithData(190, 234, '#01d698c2', '#23b09df7');
+let img58 = await imageWithData(145, 32, '#5043e1c9', '#c7c162f8');
+let offscreenCanvas37 = new OffscreenCanvas(1008, 842);
+try {
+adapter1.label = '\u7926\udd2a\u8aca\uea0b\u0e1f\u{1f6f5}\u06a2\u0f06\u{1fb1f}\u{1fe3a}\u0283';
+} catch {}
+document.body.prepend(canvas1);
+let img59 = await imageWithData(226, 288, '#21c58eeb', '#33caf9af');
+let imageBitmap40 = await createImageBitmap(img0);
+let commandEncoder242 = device1.createCommandEncoder({label: '\u{1fab0}\u{1fd01}\u841b\u{1f9e9}\u5b1c\u{1f66a}\u4fdc\ua844\u0c01'});
+let textureView285 = texture39.createView({label: '\u0918\uffea\uabf0\u21b9\u40d3', baseArrayLayer: 0});
+let renderPassEncoder32 = commandEncoder105.beginRenderPass({
+  label: '\ue055\u4ca5\u9c43\u{1f978}\u{1fda0}\u{1fc52}\u{1f862}\u215b',
+  colorAttachments: [{view: textureView181, depthSlice: 96, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet29,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup26, new Uint32Array(652), 56, 0);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(39, 0, 18, 0);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(3375);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(148, 282, 540_847_966, 78_728_106, 735_501_356);
+} catch {}
+try {
+renderBundleEncoder45.drawIndirect(buffer17, 18956);
+} catch {}
+try {
+commandEncoder242.copyBufferToBuffer(buffer19, 127256, buffer20, 11480, 1376);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder242.insertDebugMarker('\u{1f74c}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 4660, new Float32Array(9312));
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas37.getContext('webgpu');
+let gpuCanvasContext30 = offscreenCanvas36.getContext('webgpu');
+document.body.prepend(video5);
+let video49 = await videoWithData();
+let gpuCanvasContext31 = offscreenCanvas35.getContext('webgpu');
+video13.height = 146;
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let video50 = await videoWithData();
+let imageData39 = new ImageData(28, 96);
+let commandEncoder243 = device1.createCommandEncoder({});
+let texture173 = device1.createTexture({
+  size: [1152, 6, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'astc-8x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+let textureView286 = texture45.createView({
+  label: '\ub00c\ueeee\u1bb8\u{1fdb0}\u0059\u4c6d\u384f\u0211\u310a\u0988',
+  format: 'rg16sint',
+  baseArrayLayer: 0,
+});
+let computePassEncoder95 = commandEncoder242.beginComputePass();
+let renderPassEncoder33 = commandEncoder243.beginRenderPass({
+  label: '\u5aa3\ue66d\u0d09\u5008',
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: 852.3, g: 395.2, b: 10.71, a: -899.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet27,
+});
+let renderBundleEncoder113 = device1.createRenderBundleEncoder({label: '\u0434\u6fcf\u{1f7ba}\u0bf1\u{1f686}', colorFormats: ['rg16sint'], stencilReadOnly: true});
+let sampler115 = device1.createSampler({
+  label: '\u0171\uf0f2',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 82.85,
+  lodMaxClamp: 94.06,
+});
+try {
+renderPassEncoder7.setBindGroup(4, bindGroup15);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer23, 'uint32');
+} catch {}
+try {
+renderBundleEncoder45.drawIndexedIndirect(buffer17, 19436);
+} catch {}
+try {
+renderBundleEncoder45.drawIndirect(buffer17, 10472);
+} catch {}
+try {
+renderBundleEncoder71.setPipeline(pipeline8);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let imageData40 = new ImageData(232, 140);
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55) };
+} catch {}
+video3.width = 68;
+let canvas36 = document.createElement('canvas');
+let gpuCanvasContext32 = canvas36.getContext('webgpu');
+try {
+canvas35.getContext('webgpu');
+} catch {}
+gc();
+let gpuCanvasContext33 = canvas34.getContext('webgpu');
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+try {
+window.someLabel = commandEncoder60.label;
+} catch {}
+offscreenCanvas33.width = 895;
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+offscreenCanvas22.width = 374;
+let computePassEncoder96 = commandEncoder53.beginComputePass({label: '\ub054\u0107\uedf0'});
+let renderBundle131 = renderBundleEncoder4.finish({label: '\u062e\u{1ffa3}'});
+try {
+computePassEncoder28.dispatchWorkgroups(4, 2);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(5, bindGroup71);
+} catch {}
+try {
+renderBundleEncoder104.setBindGroup(0, bindGroup67, new Uint32Array(674), 238, 0);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline113);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 621, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 780 */
+{offset: 780, bytesPerRow: 5212}, {width: 1291, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas35,
+  origin: { x: 10, y: 32 },
+  flipY: true,
+}, {
+  texture: texture118,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+  await adapter9.requestAdapterInfo();
+} catch {}
+let imageData41 = new ImageData(132, 172);
+let buffer48 = device2.createBuffer({size: 222041, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let commandBuffer52 = commandEncoder148.finish({label: '\u0862\u47b9\u00c7\u0fed\u{1fd76}\u7e80\uf6b7'});
+let textureView287 = texture78.createView({label: '\u40d1\u950f\ufa0d', dimension: '2d-array'});
+let renderBundle132 = renderBundleEncoder36.finish({label: '\u{1ff48}\u{1fc15}\u{1ff3e}'});
+let externalTexture109 = device2.importExternalTexture({label: '\u132f\u{1fec9}', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder73.setPipeline(pipeline51);
+} catch {}
+try {
+commandEncoder187.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7392 */
+  offset: 7304,
+  buffer: buffer39,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer39);
+} catch {}
+try {
+device2.queue.submit([commandBuffer37]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer10), /* required buffer size: 736 */
+{offset: 736}, {width: 72, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+let imageBitmap41 = await createImageBitmap(img53);
+document.body.prepend(video17);
+canvas11.height = 687;
+let videoFrame38 = new VideoFrame(videoFrame19, {timestamp: 0});
+video25.height = 278;
+document.body.prepend(canvas9);
+gc();
+let video51 = await videoWithData();
+let bindGroup75 = device2.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 6715, resource: externalTexture20}]});
+let textureView288 = texture70.createView({dimension: '2d-array'});
+let sampler116 = device2.createSampler({
+  label: '\u6938\u{1faaa}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.95,
+  lodMaxClamp: 34.64,
+});
+try {
+computePassEncoder78.setPipeline(pipeline36);
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.WRITE, 6960, 2068);
+} catch {}
+try {
+commandEncoder188.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet36, 3447, 39, buffer30, 113152);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(841, 872);
+offscreenCanvas4.height = 997;
+document.body.prepend(canvas36);
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55) };
+} catch {}
+document.body.prepend(canvas14);
+offscreenCanvas28.width = 976;
+let videoFrame39 = new VideoFrame(videoFrame27, {timestamp: 0});
+let img60 = await imageWithData(40, 44, '#800fd7da', '#632d1999');
+let imageData42 = new ImageData(88, 152);
+let gpuCanvasContext34 = offscreenCanvas38.getContext('webgpu');
+let imageData43 = new ImageData(128, 4);
+let imageData44 = new ImageData(112, 48);
+let canvas37 = document.createElement('canvas');
+let img61 = await imageWithData(23, 124, '#c08e3a11', '#e7c658f9');
+let imageData45 = new ImageData(56, 12);
+gc();
+try {
+canvas37.getContext('webgl');
+} catch {}
+let videoFrame40 = new VideoFrame(imageBitmap37, {timestamp: 0});
+let videoFrame41 = new VideoFrame(videoFrame30, {timestamp: 0});
+document.body.prepend(video4);
+gc();
+let offscreenCanvas39 = new OffscreenCanvas(882, 247);
+let gpuCanvasContext35 = offscreenCanvas39.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.prepend(canvas23);
+let imageBitmap42 = await createImageBitmap(imageData39);
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(419, 695);
+let offscreenCanvas41 = new OffscreenCanvas(330, 836);
+try {
+window.someLabel = externalTexture35.label;
+} catch {}
+let device3 = await adapter5.requestDevice({
+  label: '\u0c42\u8e1d\u03df\u81a6\u0b10\u49a8\ubaf3',
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 59,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 53264,
+    maxStorageTexturesPerShaderStage: 34,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 37148,
+    maxDynamicUniformBuffersPerPipelineLayout: 46579,
+    maxBindingsPerBindGroup: 3921,
+    maxTextureArrayLayers: 1863,
+    maxTextureDimension1D: 12715,
+    maxTextureDimension2D: 15059,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 64945140,
+    maxStorageBufferBindingSize: 147938966,
+    maxUniformBuffersPerShaderStage: 44,
+    maxSampledTexturesPerShaderStage: 28,
+    maxInterStageShaderVariables: 35,
+    maxInterStageShaderComponents: 123,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let video52 = await videoWithData();
+let canvas38 = document.createElement('canvas');
+try {
+offscreenCanvas40.getContext('bitmaprenderer');
+} catch {}
+document.body.prepend(video36);
+let videoFrame42 = new VideoFrame(canvas27, {timestamp: 0});
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+gc();
+let imageBitmap43 = await createImageBitmap(imageData29);
+let imageData46 = new ImageData(48, 28);
+let texture174 = device3.createTexture({
+  label: '\u0975\uae0b\u{1fe7f}\u{1f6b4}\uf5ce\ud321\u7be9\u2f5f\u4d79\u402e\u889d',
+  size: [844, 160, 1],
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let textureView289 = texture174.createView({label: '\u9c04\u0166\u{1f90f}\uacad\u1d2f', baseMipLevel: 1});
+let imageBitmap44 = await createImageBitmap(video47);
+try {
+canvas38.getContext('webgl');
+} catch {}
+try {
+texture122.label = '\u9fc5\u02a3\u0f6a';
+} catch {}
+let gpuCanvasContext36 = offscreenCanvas41.getContext('webgpu');
+let offscreenCanvas42 = new OffscreenCanvas(877, 938);
+let videoFrame43 = new VideoFrame(img6, {timestamp: 0});
+let canvas39 = document.createElement('canvas');
+let gpuCanvasContext37 = offscreenCanvas42.getContext('webgpu');
+canvas14.width = 226;
+let buffer49 = device3.createBuffer({
+  label: '\u{1fadb}\u5868\u5746',
+  size: 378883,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder244 = device3.createCommandEncoder({label: '\u0bb4\u8012\ueba2\u529c\u{1faee}\ucd9b\u4445\u0f9c'});
+let sampler117 = device3.createSampler({
+  label: '\u3bea\u{1fe3d}\u4cf6\u{1f7b6}\u{1fd38}\u0eb7\u521e\u324a\u14ce\u07c7\u30c9',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.579,
+  lodMaxClamp: 52.40,
+  maxAnisotropy: 7,
+});
+try {
+commandEncoder244.copyTextureToTexture({
+  texture: texture174,
+  mipLevel: 1,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture174,
+  mipLevel: 1,
+  origin: {x: 59, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 166, height: 54, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+canvas3.height = 528;
+let gpuCanvasContext38 = canvas39.getContext('webgpu');
+let img62 = await imageWithData(170, 250, '#2e1c7813', '#74918778');
+let textureView290 = texture174.createView({label: '\ud35f\ua775\u0bf8\ub4c4\u{1f7f0}'});
+let computePassEncoder97 = commandEncoder244.beginComputePass({label: '\u341a\u0f56\u89c7\u{1f73f}\u970a\u0e62\u0e40\u{1fcbf}'});
+try {
+device3.queue.writeTexture({
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 21, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(15_878), /* required buffer size: 15_878 */
+{offset: 414, bytesPerRow: 1737}, {width: 784, height: 9, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout55 = device3.createBindGroupLayout({
+  label: '\u91e2\u0cfb\u0573\u3cfb\u0ccf\ueac8\u51a4\u{1f9bc}\u32e8\u44b5',
+  entries: [
+    {binding: 784, visibility: 0, texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true }},
+    {
+      binding: 2578,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let pipelineLayout43 = device3.createPipelineLayout({
+  label: '\u{1f98f}\u7b72\u02a6\u8a92\u{1fc10}\u0613\u{1fe6e}\u{1f8aa}\u{1fa69}\ud0c6',
+  bindGroupLayouts: [bindGroupLayout55, bindGroupLayout55, bindGroupLayout55, bindGroupLayout55, bindGroupLayout55, bindGroupLayout55, bindGroupLayout55, bindGroupLayout55],
+});
+let commandEncoder245 = device3.createCommandEncoder({label: '\u7975\ue01e\u5641\u46e8\u0e71'});
+let textureView291 = texture174.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+commandEncoder245.copyTextureToTexture({
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 0, y: 33, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 61, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 741, height: 28, depthOrArrayLayers: 0});
+} catch {}
+let canvas40 = document.createElement('canvas');
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let shaderModule39 = device3.createShaderModule({
+  code: `@group(5) @binding(2578)
+var<storage, read_write> n19: array<u32>;
+@group(1) @binding(784)
+var<storage, read_write> n20: array<u32>;
+@group(6) @binding(784)
+var<storage, read_write> parameter30: array<u32>;
+@group(2) @binding(2578)
+var<storage, read_write> function33: array<u32>;
+@group(1) @binding(2578)
+var<storage, read_write> n21: array<u32>;
+@group(5) @binding(784)
+var<storage, read_write> global22: array<u32>;
+@group(2) @binding(784)
+var<storage, read_write> n22: array<u32>;
+@group(0) @binding(2578)
+var<storage, read_write> type18: array<u32>;
+@group(3) @binding(784)
+var<storage, read_write> local28: array<u32>;
+@group(7) @binding(784)
+var<storage, read_write> local29: array<u32>;
+@group(4) @binding(784)
+var<storage, read_write> parameter31: array<u32>;
+@group(4) @binding(2578)
+var<storage, read_write> local30: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: i32,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(9) f540: vec2<i32>,
+  @location(24) f541: i32,
+  @location(14) f542: vec3<u32>,
+  @location(13) f543: vec2<f32>,
+  @location(12) f544: u32,
+  @location(26) f545: vec2<f16>,
+  @location(7) f546: vec2<f16>,
+  @location(0) f547: f32,
+  @location(20) f548: f16,
+  @location(34) f549: vec3<i32>,
+  @location(21) f550: vec2<u32>,
+  @location(18) f551: vec3<f16>,
+  @location(17) f552: vec2<f16>,
+  @location(33) f553: vec2<f32>,
+  @builtin(position) f554: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder246 = device3.createCommandEncoder({label: '\ub6bc\u0577\u581f\u5b0c\u30c2\u8198'});
+let computePassEncoder98 = commandEncoder245.beginComputePass({label: '\u0596\u8961\u771a\u2b0f\u2ca1\u20ee\u{1fd44}'});
+try {
+buffer49.unmap();
+} catch {}
+try {
+device3.queue.submit([]);
+} catch {}
+let gpuCanvasContext39 = canvas40.getContext('webgpu');
+let imageData47 = new ImageData(228, 104);
+let offscreenCanvas43 = new OffscreenCanvas(285, 770);
+let imageData48 = new ImageData(60, 172);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let img63 = await imageWithData(290, 103, '#15d8e63a', '#d2dc4edf');
+let buffer50 = device3.createBuffer({
+  label: '\u{1fc66}\u{1f6c2}\u4ed4\u002b\uca68\u93bd\ud755\u03c6\u0cef\udf9c',
+  size: 285856,
+  usage: GPUBufferUsage.COPY_SRC,
+});
+let commandEncoder247 = device3.createCommandEncoder({label: '\u67f2\u0958\u0077\udde1\u74f0\ube89\u4984\u661b\ue188\u079d\u0afa'});
+let textureView292 = texture174.createView({label: '\uee89\ue91d', dimension: '2d-array', baseMipLevel: 1, baseArrayLayer: 0});
+let sampler118 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.59,
+  lodMaxClamp: 69.75,
+});
+try {
+buffer49.destroy();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -276,9 +276,12 @@ id<MTLSamplerState> Sampler::samplerState() const
         return samplerState;
 
     id<MTLDevice> device = m_device->device();
+    if (!device || !lastAccessedKeys.count)
+        return nil;
     if (cachedSamplerStates.count >= device.maxArgumentBufferSamplerCount) {
         SamplerIdentifier* key = [lastAccessedKeys objectAtIndex:0];
-        [cachedSamplerStates removeObjectForKey:key];
+        if (key)
+            [cachedSamplerStates removeObjectForKey:key];
         [lastAccessedKeys removeObjectAtIndex:0];
         ASSERT(cachedSamplerStates.count < device.maxArgumentBufferSamplerCount);
     }


### PR DESCRIPTION
#### ea6fdc4592a397155b2db826702d13ecebf07e84
<pre>
[WebGPU] Sampler::samplerState() will throw an exception if the device is nil
<a href="https://bugs.webkit.org/show_bug.cgi?id=277552">https://bugs.webkit.org/show_bug.cgi?id=277552</a>
radar://130092543

Reviewed by Tadeu Zagallo.

A valid sampler with a destroyed device could end up raising
NSExceptions because we would attempt to remove objects from
an empty cache.

* LayoutTests/fast/webgpu/nocrash/fuzz-277552-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277552.html: Added.
* Source/WebGPU/WebGPU/Sampler.mm:
(WebGPU::Sampler::samplerState const):

Canonical link: <a href="https://commits.webkit.org/281855@main">https://commits.webkit.org/281855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a3be79bb2fc6a570eb06280ea5a90faaf2a374

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49249 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7956 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9997 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56614 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13649 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4027 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36078 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->