### PR TITLE
Unprefix -webkit-ruby-position

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -270,6 +270,7 @@ PASS right
 PASS rotate
 PASS row-gap
 PASS ruby-align
+PASS ruby-position
 PASS rx
 PASS ry
 PASS scale
@@ -411,10 +412,8 @@ PASS -webkit-mask-clip
 PASS -webkit-mask-composite
 PASS -webkit-mask-position-x
 PASS -webkit-mask-position-y
-PASS -webkit-mask-source-type
 PASS -webkit-nbsp-mode
 PASS -webkit-rtl-ordering
-PASS -webkit-ruby-position
 PASS -webkit-text-combine
 PASS -webkit-text-fill-color
 PASS -webkit-text-security

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/inheritance-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Property ruby-align has initial value space-around
 PASS Property ruby-align inherits
-FAIL Property ruby-position has initial value alternate assert_true: ruby-position doesn't seem to be supported in the computed style expected true got false
-FAIL Property ruby-position inherits assert_true: ruby-position doesn't seem to be supported in the computed style expected true got false
+FAIL Property ruby-position has initial value alternate assert_equals: expected "alternate" but got "over"
+PASS Property ruby-position inherits
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/line-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/line-spacing-expected.txt
@@ -23,8 +23,8 @@ baseannotation
 
 PASS Over ruby doesn't overflow the block
 PASS Over ruby + vertical-align doesn't overflow the block
-FAIL Under ruby doesn't overflow the block assert_true: expected true got false
-FAIL Under ruby + vertical-align doesn't overflow the block assert_true: expected true got false
+PASS Under ruby doesn't overflow the block
+PASS Under ruby + vertical-align doesn't overflow the block
 PASS Under ruby doesn't overwrap with the next block
 PASS Expand inter-lines spacing
 PASS Consume half-leading of the previous line

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/parsing/ruby-position-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/parsing/ruby-position-valid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['ruby-position'] = "over" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['ruby-position'] = "under" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['ruby-position'] = "inter-character" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['ruby-position'] = "over" should set the property value
+PASS e.style['ruby-position'] = "under" should set the property value
+PASS e.style['ruby-position'] = "inter-character" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -163,6 +163,9 @@ PASS resize: "both" onto "horizontal"
 PASS ruby-align (type: discrete) has testAccumulation function
 PASS ruby-align: "center" onto "start"
 PASS ruby-align: "start" onto "center"
+PASS ruby-position (type: discrete) has testAccumulation function
+PASS ruby-position: "over" onto "under"
+PASS ruby-position: "under" onto "over"
 PASS scroll-behavior (type: discrete) has testAccumulation function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -163,6 +163,9 @@ PASS resize: "both" onto "horizontal"
 PASS ruby-align (type: discrete) has testAddition function
 PASS ruby-align: "center" onto "start"
 PASS ruby-align: "start" onto "center"
+PASS ruby-position (type: discrete) has testAddition function
+PASS ruby-position: "over" onto "under"
+PASS ruby-position: "under" onto "over"
 PASS scroll-behavior (type: discrete) has testAddition function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -200,6 +200,10 @@ PASS ruby-align (type: discrete) has testInterpolation function
 PASS ruby-align uses discrete animation when animating between "start" and "center" with linear easing
 PASS ruby-align uses discrete animation when animating between "start" and "center" with effect easing
 PASS ruby-align uses discrete animation when animating between "start" and "center" with keyframe easing
+PASS ruby-position (type: discrete) has testInterpolation function
+PASS ruby-position uses discrete animation when animating between "under" and "over" with linear easing
+PASS ruby-position uses discrete animation when animating between "under" and "over" with effect easing
+PASS ruby-position uses discrete animation when animating between "under" and "over" with keyframe easing
 PASS scroll-behavior (type: discrete) has testInterpolation function
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with linear easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with effect easing

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3972,7 +3972,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<PointerEvents>(CSSPropertyPointerEvents, &RenderStyle::pointerEvents, &RenderStyle::setPointerEvents),
         new DiscretePropertyWrapper<PositionType>(CSSPropertyPosition, &RenderStyle::position, &RenderStyle::setPosition),
         new DiscretePropertyWrapper<Resize>(CSSPropertyResize, &RenderStyle::resize, &RenderStyle::setResize),
-        new DiscretePropertyWrapper<RubyPosition>(CSSPropertyWebkitRubyPosition, &RenderStyle::rubyPosition, &RenderStyle::setRubyPosition),
+        new DiscretePropertyWrapper<RubyPosition>(CSSPropertyRubyPosition, &RenderStyle::rubyPosition, &RenderStyle::setRubyPosition),
         new DiscretePropertyWrapper<RubyAlign>(CSSPropertyRubyAlign, &RenderStyle::rubyAlign, &RenderStyle::setRubyAlign),
         new DiscretePropertyWrapper<TableLayoutType>(CSSPropertyTableLayout, &RenderStyle::tableLayout, &RenderStyle::setTableLayout),
         new DiscretePropertyWrapper<TextAlignMode>(CSSPropertyTextAlign, &RenderStyle::textAlign, &RenderStyle::setTextAlign),
@@ -4309,6 +4309,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyWebkitMaskSourceType:
         case CSSPropertyWebkitNbspMode:
         case CSSPropertyWebkitPerspective:
+        case CSSPropertyWebkitRubyPosition:
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
         case CSSPropertyWebkitOverflowScrolling:
 #endif

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1526,11 +1526,37 @@ template<> constexpr TextCombine fromCSSValueID(CSSValueID valueID)
     return TextCombine::None;
 }
 
-#define TYPE RubyPosition
-#define FOR_EACH(CASE) CASE(Before) CASE(After) CASE(InterCharacter)
-DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
-#undef TYPE
-#undef FOR_EACH
+constexpr CSSValueID toCSSValueID(RubyPosition e)
+{
+    switch (e) {
+    case RubyPosition::Over:
+        return CSSValueOver;
+    case RubyPosition::Under:
+        return CSSValueUnder;
+    case RubyPosition::InterCharacter:
+        return CSSValueInterCharacter;
+    }
+    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+    return CSSValueInvalid;
+}
+
+template<> constexpr RubyPosition fromCSSValueID(CSSValueID valueID)
+{
+    switch (valueID) {
+    case CSSValueOver:
+    case CSSValueBefore: // -webkit-ruby-position only
+        return RubyPosition::Over;
+    case CSSValueUnder:
+    case CSSValueAfter: // -webkit-ruby-position only
+        return RubyPosition::Under;
+    case CSSValueInterCharacter:
+        return RubyPosition::InterCharacter;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+    return RubyPosition::Over;
+}
 
 #define TYPE RubyAlign
 #define FOR_EACH(CASE) CASE(Start) CASE(Center) CASE(SpaceBetween) CASE(SpaceAround)

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -161,10 +161,11 @@
         "An array of the alternative names for this property. Aliases are folded at",
         "parse time and don't have their own CSSPropertyID.",
         "",
-        "* synonym:",
+        "* cascade-alias:",
         "An alternative name for this property that gets its own CSSPropertyID.",
         "This allows parsing code to handle differences in allowed values.",
-        "Style builder code is shared with the original property.",
+        "In terms of cascade they behave like the same property.",
+        "Must also set skip-builder.",
         "",
         "* enable-if:",
         "Indicates that code should only be generated for this property/value if the",
@@ -1305,6 +1306,27 @@
                 "url": "https://msdn.microsoft.com/en-us/library/ms531189(v=vs.85).aspx"
             }
         },
+        "ruby-position": {
+            "inherited": true,
+            "values": [
+                "over",
+                "under",
+                "inter-character",
+                {
+                    "value": "alternate",
+                    "status": "unimplemented"
+                }
+            ],
+            "codegen-properties": {
+                "top-priority": true,
+                "comment": "This is a top priority property to ensure that its value can be checked when determining a smart default font size', (<https://trac.webkit.org/browser/trunk/Source/WebCore/ChangeLog?rev=172861>).",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-ruby",
+                "url": "https://www.w3.org/TR/css-ruby-1/#rubypos"
+            }
+        },
         "-webkit-ruby-position": {
             "inherited": true,
             "values": [
@@ -1316,22 +1338,13 @@
                     "value": "after",
                     "status": "deprecated"
                 },
-                "inter-character",
-                {
-                    "value": "over",
-                    "status": "unimplemented"
-                },
-                {
-                    "value": "under",
-                    "status": "unimplemented"
-                }
+                "inter-character"
             ],
             "codegen-properties": {
-                "top-priority": true,
-                "comment": "This is a top priority property to ensure that its value can be checked when determining a smart default font size', (<https://trac.webkit.org/browser/trunk/Source/WebCore/ChangeLog?rev=172861>).",
-                "parser-grammar": "<<values>>"
+                "cascade-alias": "ruby-position",
+                "parser-grammar": "<<values>>",
+                "skip-builder": true
             },
-            "status": "experimental",
             "specification": {
                 "category": "css-ruby",
                 "url": "https://www.w3.org/TR/css-ruby-1/#rubypos"
@@ -4448,7 +4461,6 @@
         },
         "mask-mode": {
             "codegen-properties": {
-                "related-property": "-webkit-mask-source-type",
                 "name-for-methods": "MaskMode",
                 "fill-layer-property": true,
                 "parser-grammar": "<single-mask-mode>#"
@@ -8019,10 +8031,10 @@
         },
         "-webkit-mask-source-type": {
             "codegen-properties": {
-                "related-property": "mask-mode",
-                "synonym": "mask-mode",
+                "cascade-alias": "mask-mode",
                 "comment": "Deprecated alias for mask-mode, supports an 'auto' value, does not support 'match-source'",
-                "parser-grammar": "<single-webkit-mask-source-type>#"
+                "parser-grammar": "<single-webkit-mask-source-type>#",
+                "skip-builder": true
             },
             "status": "non-standard",
             "specification": {

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -276,8 +276,7 @@ void CSSToStyleMap::mapFillMaskMode(CSSPropertyID propertyID, FillLayer& layer, 
         ASSERT(propertyID == CSSPropertyMaskMode);
         maskMode = MaskMode::MatchSource;
         break;
-    case CSSValueAuto:
-        ASSERT(propertyID == CSSPropertyWebkitMaskSourceType);
+    case CSSValueAuto: // -webkit-mask-source-type
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1803,6 +1803,21 @@ static Ref<CSSValue> createLineBoxContainValue(OptionSet<LineBoxContain> lineBox
     return CSSLineBoxContainValue::create(lineBoxContain);
 }
 
+static Ref<CSSValue> valueForWebkitRubyPosition(RubyPosition position)
+{
+    return CSSPrimitiveValue::create([&] {
+        switch (position) {
+        case RubyPosition::Over:
+            return CSSValueBefore;
+        case RubyPosition::Under:
+            return CSSValueAfter;
+        case RubyPosition::InterCharacter:
+            return CSSValueInterCharacter;
+        }
+        return CSSValueBefore;
+    }());
+}
+
 static Element* styleElementForNode(Node* node)
 {
     if (!node)
@@ -3996,8 +4011,10 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return createConvertingToCSSValueID(style.position());
     case CSSPropertyRight:
         return positionOffsetValue(style, CSSPropertyRight, renderer);
-    case CSSPropertyWebkitRubyPosition:
+    case CSSPropertyRubyPosition:
         return createConvertingToCSSValueID(style.rubyPosition());
+    case CSSPropertyWebkitRubyPosition:
+        return valueForWebkitRubyPosition(style.rubyPosition());
     case CSSPropertyRubyAlign:
         return createConvertingToCSSValueID(style.rubyAlign());
     case CSSPropertyTableLayout:

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -588,7 +588,7 @@ std::pair<InlineLayoutUnit, InlineLayoutUnit> InlineFormattingUtils::textEmphasi
     };
     if (auto* rubyBase = enclosingRubyBase(); rubyBase && RubyFormattingContext::hasInterlinearAnnotation(*rubyBase)) {
         auto annotationPosition = rubyBase->style().rubyPosition();
-        if ((hasAboveTextEmphasis && annotationPosition == RubyPosition::Before) || (hasUnderTextEmphasis && annotationPosition == RubyPosition::After)) {
+        if ((hasAboveTextEmphasis && annotationPosition == RubyPosition::Over) || (hasUnderTextEmphasis && annotationPosition == RubyPosition::Under)) {
             // FIXME: Check if annotation box has content.
             return { };
         }

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -54,7 +54,7 @@ static RubyPosition rubyPosition(const Box& rubyBaseLayoutBox)
     if (rubyBaseLayoutBox.style().isHorizontalWritingMode())
         return computedRubyPosition;
     // inter-character: If the writing mode of the enclosing ruby container is vertical, this value has the same effect as over.
-    return computedRubyPosition == RubyPosition::InterCharacter ? RubyPosition::Before : computedRubyPosition;
+    return computedRubyPosition == RubyPosition::InterCharacter ? RubyPosition::Over : computedRubyPosition;
 }
 
 static inline InlineRect annotationMarginBoxVisualRect(const Box& annotationBox, InlineLayoutUnit lineHeight, const InlineFormattingContext& inlineFormattingContext)
@@ -356,7 +356,7 @@ InlineLayoutPoint RubyFormattingContext::placeAnnotationBox(const Box& rubyBaseL
     if (hasInterlinearAnnotation(rubyBaseLayoutBox)) {
         // Move it over/under the base and make it border box positioned.
         auto leftOffset = annotationBoxLogicalGeometry.marginStart();
-        auto topOffset = rubyPosition(rubyBaseLayoutBox) == RubyPosition::Before ? -annotationBoxLogicalGeometry.marginBoxHeight() : rubyBaseMarginBoxLogicalRect.height();
+        auto topOffset = rubyPosition(rubyBaseLayoutBox) == RubyPosition::Over ? -annotationBoxLogicalGeometry.marginBoxHeight() : rubyBaseMarginBoxLogicalRect.height();
         auto logicalTopLeft = rubyBaseMarginBoxLogicalRect.topLeft();
         logicalTopLeft.move(LayoutSize { leftOffset, topOffset });
         return logicalTopLeft;
@@ -415,7 +415,7 @@ void RubyFormattingContext::adjustLayoutBoundsAndStretchAncestorRubyBase(LineBox
     auto over = InlineLayoutUnit { };
     auto under = InlineLayoutUnit { };
     auto annotationBoxLogicalHeight = InlineLayoutUnit { inlineFormattingContext.geometryForBox(*annotationBox).marginBoxHeight() };
-    auto isAnnotationBefore = rubyPosition(rubyBaseLayoutBox) == RubyPosition::Before;
+    auto isAnnotationBefore = rubyPosition(rubyBaseLayoutBox) == RubyPosition::Over;
     if (isAnnotationBefore)
         over = annotationBoxLogicalHeight;
     else

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2074,7 +2074,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         if (first.textUnderlinePosition != second.textUnderlinePosition)
             changingProperties.m_properties.set(CSSPropertyTextUnderlinePosition);
         if (first.rubyPosition != second.rubyPosition)
-            changingProperties.m_properties.set(CSSPropertyWebkitRubyPosition);
+            changingProperties.m_properties.set(CSSPropertyRubyPosition);
         if (first.rubyAlign != second.rubyAlign)
             changingProperties.m_properties.set(CSSPropertyRubyAlign);
         if (first.strokeColor != second.strokeColor)

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -935,8 +935,8 @@ TextStream& operator<<(TextStream& ts, Resize resize)
 TextStream& operator<<(TextStream& ts, RubyPosition position)
 {
     switch (position) {
-    case RubyPosition::Before: ts << "before"; break;
-    case RubyPosition::After: ts << "after"; break;
+    case RubyPosition::Over: ts << "over"; break;
+    case RubyPosition::Under: ts << "under"; break;
     case RubyPosition::InterCharacter: ts << "inter-character"; break;
     }
     return ts;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1019,8 +1019,8 @@ enum class LineAlign : bool {
 };
 
 enum class RubyPosition : uint8_t {
-    Before,
-    After,
+    Over,
+    Under,
     InterCharacter
 };
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -446,7 +446,7 @@ constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
 inline Length RenderStyle::initialRadius() { return LengthType::Auto; }
 constexpr Resize RenderStyle::initialResize() { return Resize::None; }
 inline GapLength RenderStyle::initialRowGap() { return { }; }
-constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Before; }
+constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Over; }
 constexpr RubyAlign RenderStyle::initialRubyAlign() { return RubyAlign::SpaceAround; }
 inline Length RenderStyle::initialScrollMargin() { return zeroLength(); }
 inline Length RenderStyle::initialScrollPadding() { return { }; }

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -207,7 +207,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
         if ((important == IsImportant::No && current.isImportant()) || (important == IsImportant::Yes && !current.isImportant()))
             continue;
 
-        auto propertyID = current.id();
+        auto propertyID = cascadeAliasProperty(current.id());
 
         auto shouldIncludeProperty = [&] {
 #if ENABLE(VIDEO)

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -372,6 +372,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
         keys_and_validators = {
             'aliases': self.validate_array,
             'auto-functions': self.validate_boolean,
+            'cascade-alias': self.validate_string,
             'color-property': self.validate_boolean,
             'comment': self.validate_string,
             'computable': self.validate_boolean,


### PR DESCRIPTION
#### ba5aedf5f753d40e7f3d45e56105762b7408d9ea
<pre>
Unprefix -webkit-ruby-position
<a href="https://bugs.webkit.org/show_bug.cgi?id=151306">https://bugs.webkit.org/show_bug.cgi?id=151306</a>
<a href="https://rdar.apple.com/86128259">rdar://86128259</a>

Reviewed by Alan Baradlay.

Support `ruby-position` with the standard value names (over/under/inter-character) excluding &apos;alternate&apos;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/line-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ruby/parsing/ruby-position-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/css/CSSProperties.json:

Add `ruby-position` and mark `-webkit-ruby-position` as its cascade alias.

Use the new cascade-alias mechanism as a simple alias does not work because the syntax differs
and the related-property mechanism can&apos;t be used as the property is marked top-priority.

The new mechanism replaces the existing &apos;synonym&apos; mechanism that does not have correct behavior
when both synonyms are specified (the latter should override the earlier one). It was only used
by one property.

Also use the mechanism for -webkit-mask-source-type.

* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapFillMaskMode):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/process-css-properties.py:
(StylePropertyCodeGenProperties):
(StylePropertyCodeGenProperties.from_json):
(StyleProperty.perform_fixups_for_cascade_alias_properties):
(StyleProperty.perform_fixups):
(GenerateCSSPropertyNames):

Add support for cascade-alias mechanism.

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::textEmphasisForInlineBox):
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
(WebCore::Layout::rubyPosition):
(WebCore::Layout::RubyFormattingContext::placeAnnotationBox):
(WebCore::Layout::RubyFormattingContext::adjustLayoutBoundsAndStretchAncestorRubyBase):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:

Rename to match the standard naming.

* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialRubyPosition):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:
(JSONCSSPropertiesChecker.check_codegen_properties):

Canonical link: <a href="https://commits.webkit.org/281804@main">https://commits.webkit.org/281804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb1f51d96a5156610d277736b3ebf876945df56c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11879 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37611 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30182 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/60580 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/10119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5002 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56914 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4143 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36220 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->