### PR TITLE
Overlay Regions should be updated when loading a PDF

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -93,6 +93,10 @@ enum class TapHandlingResult : uint8_t;
 - (void)_setHasCustomContentView:(BOOL)hasCustomContentView loadedMIMEType:(const WTF::String&)mimeType;
 - (void)_didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:(const WTF::String&)suggestedFilename data:(NSData *)data;
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+- (void)_updateOverlayRegionsForCustomContentView;
+#endif
+
 - (void)_willInvokeUIScrollViewDelegateCallback;
 - (void)_didInvokeUIScrollViewDelegateCallback;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1257,7 +1257,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
         overlayRegionRects.add(WebCore::enclosingIntRect(snappedRect));
     }
 
-    [scrollView _updateOverlayRegionsBehavior:true];
+    [scrollView _updateOverlayRegionsBehavior:YES];
     [scrollView _updateOverlayRegionRects:overlayRegionRects];
 }
 
@@ -1282,7 +1282,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
     if ([self _scrollViewCanHaveOverlayRegions:_scrollView.get()])
         overlayRegionScrollView = _scrollView.get();
     else
-        [_scrollView _updateOverlayRegionsBehavior:false];
+        [_scrollView _updateOverlayRegionsBehavior:NO];
 
     auto candidates = coordinatorProxy->overlayRegionScrollViewCandidates();
     std::sort(candidates.begin(), candidates.end(), [] (auto& first, auto& second) {
@@ -1293,7 +1293,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
         if (!overlayRegionScrollView && [self _scrollViewCanHaveOverlayRegions:scrollView])
             overlayRegionScrollView = scrollView;
         else
-            [scrollView _updateOverlayRegionsBehavior:false];
+            [scrollView _updateOverlayRegionsBehavior:NO];
     }
 
     return overlayRegionScrollView;
@@ -1322,6 +1322,17 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
     configureScrollViewWithOverlayRegionsIDs(overlayRegionScrollView, layerTreeHost, overlayRegionsIDs);
 
     scrollingCoordinatorProxy->updateOverlayRegionLayerIDs(overlayRegionsIDs);
+}
+
+- (void)_updateOverlayRegionsForCustomContentView
+{
+    if (![self _scrollViewCanHaveOverlayRegions:_scrollView.get()]) {
+        [_scrollView _updateOverlayRegionsBehavior:NO];
+        return;
+    }
+
+    [_scrollView _updateOverlayRegionsBehavior:YES];
+    [_scrollView _updateOverlayRegionRects: { }];
 }
 #endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -54,7 +54,7 @@
 @property (nonatomic, readonly, getter=overlayRegionsForTesting) HashSet<WebCore::IntRect>& overlayRegionRects;
 
 - (BOOL)_hasEnoughContentForOverlayRegions;
-- (void)_updateOverlayRegionRects:(HashSet<WebCore::IntRect>&)overlayRegions;
+- (void)_updateOverlayRegionRects:(const HashSet<WebCore::IntRect>&)overlayRegions;
 - (void)_updateOverlayRegionsBehavior:(BOOL)selected;
 #endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -182,7 +182,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #else
 - (BOOL)_hasEnoughContentForOverlayRegions { return false; }
 - (void)_updateOverlayRegionsBehavior:(BOOL)selected { }
-- (void)_updateOverlayRegionRects:(HashSet<WebCore::IntRect>&)overlayRegions { }
+- (void)_updateOverlayRegionRects:(const HashSet<WebCore::IntRect>&)overlayRegions { }
 - (void)_updateOverlayRegions:(NSArray<NSData *> *)overlayRegions { }
 #endif
 


### PR DESCRIPTION
#### 16b1f218b34090cb7e7f23569bebd49966b7df45
<pre>
Overlay Regions should be updated when loading a PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=277556">https://bugs.webkit.org/show_bug.cgi?id=277556</a>
&lt;<a href="https://rdar.apple.com/125667363">rdar://125667363</a>&gt;

Reviewed by Abrar Rahman Protyasha.

We need to observe the contentSize updates made from PDFKit to properly
maintain Overlay Regions when a PDF is loaded.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateOverlayRegionsForCustomContentView]):
Introduce a new method to refresh the Overlay Region settings for custom
content views.

* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView web_initWithFrame:webView:mimeType:]):
Add an observer on the scrollview&apos;s contentSize.
(-[WKPDFView dealloc]):
Remove the observer.
(-[WKPDFView observeValueForKeyPath:ofObject:change:context:]):
Update Overlay Regions when the contentSize is updated.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView _updateOverlayRegionRects:]):
Switch to a const ref.

Canonical link: <a href="https://commits.webkit.org/281936@main">https://commits.webkit.org/281936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78816f060365b911115fe221050820e4f67b130e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65328 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11924 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49580 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34530 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67059 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56954 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57169 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4394 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36540 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->