### PR TITLE
Clean up some radial-size logic in shapes and gradients

### DIFF
--- a/Source/WebCore/platform/graphics/FloatQuad.cpp
+++ b/Source/WebCore/platform/graphics/FloatQuad.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "FloatQuad.h"
 
+#include "GeometryUtilities.h"
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -39,16 +40,6 @@
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
-
-static inline float min4(float a, float b, float c, float d)
-{
-    return std::min(std::min(a, b), std::min(c, d));
-}
-
-static inline float max4(float a, float b, float c, float d)
-{
-    return std::max(std::max(a, b), std::max(c, d));
-}
 
 inline float dot(const FloatSize& a, const FloatSize& b)
 {

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -278,6 +278,56 @@ RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect& box, const Float
     return RectEdges<double>(top, right, bottom, left);
 }
 
+float distanceToClosestSide(FloatPoint p, FloatSize size)
+{
+    float widthDelta = std::abs(size.width() - p.x());
+    float heightDelta = std::abs(size.height() - p.y());
+
+    return min4(std::abs(p.x()), widthDelta, std::abs(p.y()), heightDelta);
+}
+
+float distanceToFarthestSide(FloatPoint p, FloatSize size)
+{
+    float widthDelta = std::abs(size.width() - p.x());
+    float heightDelta = std::abs(size.height() - p.y());
+
+    return max4(std::abs(p.x()), widthDelta, std::abs(p.y()), heightDelta);
+}
+
+float distanceToClosestCorner(FloatPoint p, FloatSize size)
+{
+    FloatPoint topLeft;
+    float topLeftDistance = FloatSize(p - topLeft).diagonalLength();
+
+    FloatPoint topRight(size.width(), 0);
+    float topRightDistance = FloatSize(p - topRight).diagonalLength();
+
+    FloatPoint bottomLeft(0, size.height());
+    float bottomLeftDistance = FloatSize(p - bottomLeft).diagonalLength();
+
+    FloatPoint bottomRight(size.width(), size.height());
+    float bottomRightDistance = FloatSize(p - bottomRight).diagonalLength();
+
+    return min4(topLeftDistance, topRightDistance, bottomLeftDistance, bottomRightDistance);
+}
+
+float distanceToFarthestCorner(FloatPoint p, FloatSize size)
+{
+    FloatPoint topLeft;
+    float topLeftDistance = FloatSize(p - topLeft).diagonalLength();
+
+    FloatPoint topRight(size.width(), 0);
+    float topRightDistance = FloatSize(p - topRight).diagonalLength();
+
+    FloatPoint bottomLeft(0, size.height());
+    float bottomLeftDistance = FloatSize(p - bottomLeft).diagonalLength();
+
+    FloatPoint bottomRight(size.width(), size.height());
+    float bottomRightDistance = FloatSize(p - bottomRight).diagonalLength();
+
+    return max4(topLeftDistance, topRightDistance, bottomLeftDistance, bottomRightDistance);
+}
+
 std::array<FloatPoint, 4> verticesForBox(const FloatRect& box, const FloatPoint position)
 {
     return { FloatPoint(-position.x(), -position.y()),

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -89,6 +89,11 @@ float angleOfPointToSideOfIntersection(const FloatRect& boundingRect, const std:
 // Given a box and an offset from the top left corner, calculate the distance of the point from each side
 RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect&, const FloatPoint&);
 
+float distanceToClosestSide(FloatPoint, FloatSize);
+float distanceToFarthestSide(FloatPoint, FloatSize);
+float distanceToClosestCorner(FloatPoint, FloatSize);
+float distanceToFarthestCorner(FloatPoint, FloatSize);
+
 // Given a box and an offset from the top left corner, construct a coordinate system with this offset as the origin,
 // and return the vertices of the box in this coordinate system
 std::array<FloatPoint, 4> verticesForBox(const FloatRect&, const FloatPoint);
@@ -105,5 +110,15 @@ struct RotatedRect {
 };
 
 WEBCORE_EXPORT RotatedRect rotatedBoundingRectWithMinimumAngleOfRotation(const FloatQuad&, std::optional<float> minRotationInRadians = std::nullopt);
+
+static inline float min4(float a, float b, float c, float d)
+{
+    return std::min(std::min(a, b), std::min(c, d));
+}
+
+static inline float max4(float a, float b, float c, float d)
+{
+    return std::max(std::max(a, b), std::max(c, d));
+}
 
 }

--- a/Source/WebCore/rendering/shapes/Shape.cpp
+++ b/Source/WebCore/rendering/shapes/Shape.cpp
@@ -105,7 +105,7 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
         const auto& circle = uncheckedDowncast<BasicShapeCircle>(basicShape);
         float centerX = floatValueForCenterCoordinate(circle.centerX(), boxWidth);
         float centerY = floatValueForCenterCoordinate(circle.centerY(), boxHeight);
-        float radius = circle.floatValueForRadiusInBox(boxWidth, boxHeight, { centerX, centerY });
+        float radius = circle.floatValueForRadiusInBox({ boxWidth, boxHeight }, { centerX, centerY });
         FloatPoint logicalCenter = physicalPointToLogical(FloatPoint(centerX, centerY), logicalBoxSize.height(), writingMode);
         logicalCenter.moveBy(borderBoxOffset);
 
@@ -117,12 +117,11 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
         const auto& ellipse = uncheckedDowncast<BasicShapeEllipse>(basicShape);
         float centerX = floatValueForCenterCoordinate(ellipse.centerX(), boxWidth);
         float centerY = floatValueForCenterCoordinate(ellipse.centerY(), boxHeight);
-        float radiusX = ellipse.floatValueForRadiusInBox(ellipse.radiusX(), centerX, boxWidth);
-        float radiusY = ellipse.floatValueForRadiusInBox(ellipse.radiusY(), centerY, boxHeight);
-        FloatPoint logicalCenter = physicalPointToLogical(FloatPoint(centerX, centerY), logicalBoxSize.height(), writingMode);
+        auto center = FloatPoint { centerX, centerY };
+        auto radius = ellipse.floatSizeForRadiusInBox({ boxWidth, boxHeight }, center);
+        FloatPoint logicalCenter = physicalPointToLogical(center, logicalBoxSize.height(), writingMode);
         logicalCenter.moveBy(borderBoxOffset);
-
-        shape = createEllipseShape(logicalCenter, FloatSize(radiusX, radiusY));
+        shape = createEllipseShape(logicalCenter, radius);
         break;
     }
 

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -196,7 +196,8 @@ public:
     const BasicShapeCenterCoordinate& centerX() const { return m_centerX; }
     const BasicShapeCenterCoordinate& centerY() const { return m_centerY; }
     const BasicShapeRadius& radius() const { return m_radius; }
-    float floatValueForRadiusInBox(float boxWidth, float boxHeight, FloatPoint) const;
+
+    float floatValueForRadiusInBox(FloatSize boxSize, FloatPoint center) const;
 
     void setCenterX(BasicShapeCenterCoordinate centerX) { m_centerX = WTFMove(centerX); }
     void setCenterY(BasicShapeCenterCoordinate centerY) { m_centerY = WTFMove(centerY); }
@@ -234,7 +235,8 @@ public:
     const BasicShapeCenterCoordinate& centerY() const { return m_centerY; }
     const BasicShapeRadius& radiusX() const { return m_radiusX; }
     const BasicShapeRadius& radiusY() const { return m_radiusY; }
-    float floatValueForRadiusInBox(const BasicShapeRadius&, float center, float boxWidthOrHeight) const;
+
+    FloatSize floatSizeForRadiusInBox(FloatSize boxSize, FloatPoint center) const;
 
     void setCenterX(BasicShapeCenterCoordinate centerX) { m_centerX = WTFMove(centerX); }
     void setCenterY(BasicShapeCenterCoordinate centerY) { m_centerY = WTFMove(centerY); }


### PR DESCRIPTION
#### 7f95fb8d4a1f63ad3f96b3e9fdf4ab53f9e14d80
<pre>
Clean up some radial-size logic in shapes and gradients
<a href="https://bugs.webkit.org/show_bug.cgi?id=277558">https://bugs.webkit.org/show_bug.cgi?id=277558</a>
<a href="https://rdar.apple.com/133073530">rdar://133073530</a>

Reviewed by Alan Baradlay.

Share some code between gradients and shapes related to computing the distance to closest
corners and sides, moving some helper functions to GeometryUtilities.

Convert if/else into switch in a couple of places, to prepare for corner-relative values.

* Source/WebCore/platform/graphics/FloatQuad.cpp:
(WebCore::min4): Deleted.
(WebCore::max4): Deleted.
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::distanceToClosestSide):
(WebCore::distanceToFarthestSide):
(WebCore::distanceToClosestCorner):
(WebCore::distanceToFarthestCorner):
* Source/WebCore/platform/graphics/GeometryUtilities.h:
(WebCore::min4):
(WebCore::max4):
* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::Shape::createShape):
* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::BasicShapeCircle::floatValueForRadiusInBox const): Pass FloatSize instead of width and height.
(WebCore::BasicShapeCircle::pathForCenterCoordinate const):
(WebCore::BasicShapeEllipse::floatSizeForRadiusInBox const): Compute x and y in one call, returning a FloatSize
(WebCore::BasicShapeEllipse::pathForCenterCoordinate const):
(WebCore::BasicShapeEllipse::floatValueForRadiusInBox const): Deleted.
* Source/WebCore/rendering/style/BasicShapes.h:
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::findDistanceToClosestCorner): Renamed to avoid conflict with distanceToClosestCorner
(WebCore::findDistanceToFarthestCorner): Renamed to avoid conflict with distanceToFarthestCorner
(WebCore::StyleGradientImage::createGradient const):
(WebCore::distanceToClosestCorner): Deleted.
(WebCore::distanceToFarthestCorner): Deleted.

Canonical link: <a href="https://commits.webkit.org/281778@main">https://commits.webkit.org/281778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43fb5c6ab48d1d1e3dfec961fdb8333be6d4e41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49265 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7966 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62959 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37501 "Found 13 new test failures: editing/deleting/25322-1.html editing/deleting/smart-delete-002.html editing/deleting/smart-delete-paragraph-002.html editing/pasteboard/smart-paste-003-trailing-whitespace.html editing/pasteboard/smart-paste-004.html editing/pasteboard/smart-paste-in-text-control.html editing/pasteboard/smart-paste-paragraph-004.html editing/selection/clear-selection-crash.html editing/selection/doubleclick-whitespace-crash.html editing/selection/ios/change-selection-by-tapping.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10005 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66587 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56627 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56817 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4036 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36089 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->