### PR TITLE
[iOS] Add an internal setting to allow the keyboard to dismiss after tapping

### DIFF
--- a/LayoutTests/fast/forms/ios/dismiss-keyboard-after-tapping-expected.txt
+++ b/LayoutTests/fast/forms/ios/dismiss-keyboard-after-tapping-expected.txt
@@ -1,0 +1,11 @@
+
+Verifies that tapping over a large element with a click handler dismisses the keyboard when keyboardDismissalGestureEnabled is enabled, even if the event handler prevents default. Requires WebKitTestRunner
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS initialKeyboardWillHideCount is keyboardWillHideCountAfterTap
+PASS Dismissed keyboard after tap
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/dismiss-keyboard-after-tapping.html
+++ b/LayoutTests/fast/forms/ios/dismiss-keyboard-after-tapping.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true KeyboardDismissalGestureEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    text-align: center;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+.container {
+    margin: 1em auto;
+}
+
+.outer-container {
+    width: 100%;
+    border: solid 1px lightgray;
+    padding: 100px 0;
+    box-sizing: border-box;
+}
+
+input {
+    font-size: 16px;
+    border: 1px solid lightgray;
+    border-radius: 22px;
+    width: 250px;
+    height: 24px;
+    padding: 1em;
+    outline: none;
+}
+
+.name-container {
+    margin-bottom: 1em;
+}
+</style>
+</head>
+<body>
+<div class="outer-container">
+    <div class="name-container"><input type="text" class="top" autocomplete="none" spellcheck="false" placeholder="Name"></div>
+    <input type="text" class="bottom" autocomplete="none" spellcheck="false" placeholder="Address">
+</div>
+<pre id="description"></pre>
+<pre id="console"></pre>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that tapping over a large element with a click handler dismisses the keyboard when <code>keyboardDismissalGestureEnabled</code> is enabled, even if the event handler prevents default. Requires WebKitTestRunner");
+
+    const topTextField = document.querySelector("input.top");
+    const bottomTextField = document.querySelector("input.bottom");
+    const container = document.querySelector(".outer-container");
+    for (const event of ["touchend", "mousedown", "click"]) {
+        container.addEventListener(event, event => {
+            if (event.target?.tagName !== "INPUT")
+                event.preventDefault();
+        });
+    }
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await UIHelper.activateElementAndWaitForInputSession(topTextField);
+    initialKeyboardWillHideCount = await UIHelper.keyboardWillHideCount();
+
+    // Tapping another text field again should not dismiss the keyboard.
+    await UIHelper.activateElement(bottomTextField);
+    await UIHelper.waitForDoubleTapDelay();
+    keyboardWillHideCountAfterTap = await UIHelper.keyboardWillHideCount();
+    shouldBe("initialKeyboardWillHideCount", "keyboardWillHideCountAfterTap");
+
+    // Tapping outside of the text field should dismiss the keyboard.
+    await UIHelper.tapAt(10, 100);
+    await UIHelper.waitForKeyboardToHide();
+    testPassed("Dismissed keyboard after tap");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3699,6 +3699,18 @@ JavaScriptRuntimeFlags:
     WebCore:
       default: '{ }'
 
+KeyboardDismissalGestureEnabled:
+  type: bool
+  status: internal
+  webcoreBinding: none
+  condition: PLATFORM(IOS_FAMILY)
+  humanReadableName: "Keyboard Dismissal Gesture"
+  humanReadableDescription: "Enable the keyboard dismissal gesture"
+  defaultValue:
+    WebKit:
+      "PLATFORM(APPLETV)" : true
+      default: false
+
 LargeImageAsyncDecodingEnabled:
   type: bool
   status: embedder

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -521,6 +521,7 @@ UIProcess/ios/WKMouseInteraction.mm
 UIProcess/ios/WKPasswordView.mm
 UIProcess/ios/WKPDFView.mm
 UIProcess/ios/WKScrollView.mm
+UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm
 UIProcess/ios/WKStylusDeviceObserver.mm
 UIProcess/ios/WKSyntheticFlagsChangedWebEvent.mm
 UIProcess/ios/WKSyntheticTapGestureRecognizer.mm

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1077,6 +1077,8 @@ public:
 
     void insertionPointColorDidChange();
 
+    void shouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint, CompletionHandler<void(bool)>&&);
+
 #if ENABLE(DRAG_SUPPORT)
     void didHandleDragStartRequest(bool started);
     void didHandleAdditionalDragItemsRequest(bool added);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -345,6 +345,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<UITapGestureRecognizer> _doubleTapGestureRecognizerForDoubleClick;
     RetainPtr<UITapGestureRecognizer> _twoFingerDoubleTapGestureRecognizer;
     RetainPtr<UITapGestureRecognizer> _twoFingerSingleTapGestureRecognizer;
+    RetainPtr<WKScrollViewTrackingTapGestureRecognizer> _keyboardDismissalGestureRecognizer;
     RetainPtr<WKInspectorNodeSearchGestureRecognizer> _inspectorNodeSearchGestureRecognizer;
 
     RetainPtr<WKTouchActionGestureRecognizer> _touchActionGestureRecognizer;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1133,6 +1133,7 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
     [_doubleTapGestureRecognizer setDelegate:self];
     [self addGestureRecognizer:_doubleTapGestureRecognizer.get()];
     [_singleTapGestureRecognizer requireGestureRecognizerToFail:_doubleTapGestureRecognizer.get()];
+    [_keyboardDismissalGestureRecognizer requireGestureRecognizerToFail:_doubleTapGestureRecognizer.get()];
 }
 
 - (void)_createAndConfigureHighlightLongPressGestureRecognizer
@@ -1368,6 +1369,13 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
     // FIXME: This should be called when we get notified that loading has completed.
     [self setUpTextSelectionAssistant];
 
+    _keyboardDismissalGestureRecognizer = adoptNS([[WKScrollViewTrackingTapGestureRecognizer alloc] initWithTarget:self action:@selector(_keyboardDismissalGestureRecognized:)]);
+    [_keyboardDismissalGestureRecognizer setNumberOfTapsRequired:1];
+    [_keyboardDismissalGestureRecognizer setDelegate:self];
+    [_keyboardDismissalGestureRecognizer setName:@"Keyboard dismissal tap gesture"];
+    [_keyboardDismissalGestureRecognizer setEnabled:_page->preferences().keyboardDismissalGestureEnabled()];
+    [self addGestureRecognizer:_keyboardDismissalGestureRecognizer.get()];
+
 #if HAVE(UI_PASTE_CONFIGURATION)
     self.pasteConfiguration = adoptNS([[UIPasteConfiguration alloc] initWithAcceptableTypeIdentifiers:[&] {
         if (_page->preferences().attachmentElementEnabled())
@@ -1493,6 +1501,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_lookupGestureRecognizer setDelegate:nil];
     [self removeGestureRecognizer:_lookupGestureRecognizer.get()];
 #endif
+
+    [_keyboardDismissalGestureRecognizer setDelegate:nil];
+    [self removeGestureRecognizer:_keyboardDismissalGestureRecognizer.get()];
 
     [_singleTapGestureRecognizer setDelegate:nil];
     [_singleTapGestureRecognizer setGestureIdentifiedTarget:nil action:nil];
@@ -1632,6 +1643,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self removeGestureRecognizer:_touchActionRightSwipeGestureRecognizer.get()];
     [self removeGestureRecognizer:_touchActionUpSwipeGestureRecognizer.get()];
     [self removeGestureRecognizer:_touchActionDownSwipeGestureRecognizer.get()];
+    [self removeGestureRecognizer:_keyboardDismissalGestureRecognizer.get()];
 }
 
 - (void)_addDefaultGestureRecognizers
@@ -1657,6 +1669,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self addGestureRecognizer:_touchActionRightSwipeGestureRecognizer.get()];
     [self addGestureRecognizer:_touchActionUpSwipeGestureRecognizer.get()];
     [self addGestureRecognizer:_touchActionDownSwipeGestureRecognizer.get()];
+    [self addGestureRecognizer:_keyboardDismissalGestureRecognizer.get()];
 }
 
 - (void)_didChangeLinkPreviewAvailability
@@ -2916,6 +2929,9 @@ static inline bool isSamePair(UIGestureRecognizer *a, UIGestureRecognizer *b, UI
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
+    if (gestureRecognizer == _keyboardDismissalGestureRecognizer || otherGestureRecognizer == _keyboardDismissalGestureRecognizer)
+        return YES;
+
     for (WKDeferringGestureRecognizer *gesture in self.deferringGestures) {
         if (isSamePair(gestureRecognizer, otherGestureRecognizer, _touchEventGestureRecognizer.get(), gesture))
             return YES;
@@ -3245,11 +3261,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     CGPoint point = [gestureRecognizer locationInView:self];
 
-    if (gestureRecognizer == _singleTapGestureRecognizer) {
+    auto shouldAcknowledgeTap = [&](WKScrollViewTrackingTapGestureRecognizer *tapGesture) {
         if ([self _shouldToggleSelectionCommandsAfterTapAt:point])
             return NO;
-        auto scrollView = [_singleTapGestureRecognizer lastTouchedScrollView];
+        auto scrollView = tapGesture.lastTouchedScrollView;
         return ![self _isPanningScrollViewOrAncestor:scrollView] && ![self _isInterruptingDecelerationForScrollViewOrAncestor:scrollView];
+    };
+
+    if (gestureRecognizer == _singleTapGestureRecognizer)
+        return shouldAcknowledgeTap(_singleTapGestureRecognizer.get());
+
+    if (gestureRecognizer == _keyboardDismissalGestureRecognizer) {
+        return self._hasFocusedElement
+            && !self.hasHiddenContentEditable
+            && !CGRectContainsPoint(self.selectionClipRect, point)
+            && shouldAcknowledgeTap(_keyboardDismissalGestureRecognizer.get());
     }
 
     if (gestureRecognizer == _doubleTapGestureRecognizerForDoubleClick) {
@@ -3663,6 +3689,26 @@ static void cancelPotentialTapIfNecessary(WKContentView* contentView)
 
     if (!_isTapHighlightIDValid)
         [self _fadeTapHighlightViewIfNeeded];
+}
+
+- (void)_keyboardDismissalGestureRecognized:(UITapGestureRecognizer *)gestureRecognizer
+{
+    ASSERT(gestureRecognizer == _keyboardDismissalGestureRecognizer);
+
+    if (!self._hasFocusedElement)
+        return;
+
+    _page->shouldDismissKeyboardAfterTapAtPoint([gestureRecognizer locationInView:self], [weakSelf = WeakObjCPtr<WKContentView>(self), element = _focusedElementInformation.elementContext](bool shouldDismiss) {
+        if (!shouldDismiss)
+            return;
+
+        RetainPtr strongSelf = weakSelf.get();
+        if (![strongSelf _hasFocusedElement] || !strongSelf->_focusedElementInformation.elementContext.isSameElement(element))
+            return;
+
+        RELEASE_LOG(ViewGestures, "Dismissing keyboard after tap (%p, pageProxyID=%llu)", strongSelf.get(), strongSelf->_page->identifier().toUInt64());
+        [strongSelf _elementDidBlur];
+    });
 }
 
 - (void)_doubleTapDidFail:(UITapGestureRecognizer *)gestureRecognizer
@@ -9791,6 +9837,9 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
         // if it has already failed; otherwise, we will incorrectly defer other gestures in the web view, such as scroll view pinching.
         return NO;
     }
+
+    if (gestureRecognizer == _keyboardDismissalGestureRecognizer)
+        return NO;
 
     auto webView = _webView.getAutoreleased();
     auto view = gestureRecognizer.view;

--- a/Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #if PLATFORM(IOS_FAMILY)
 
-#import "WKScrollViewTrackingTapGestureRecognizer.h"
+#import <UIKit/UIKit.h>
 
-@class WKTouchEventsGestureRecognizer;
+@interface WKScrollViewTrackingTapGestureRecognizer : UITapGestureRecognizer
 
-// The purpose of this class is to call a target/action when
-// the gesture is recognized, as well as the typical time when
-// a gesture should be handled. This allows it to be used while
-// it is waiting for another gesture recognizer to fail.
-@interface WKSyntheticTapGestureRecognizer : WKScrollViewTrackingTapGestureRecognizer
-- (void)setGestureIdentifiedTarget:(id)target action:(SEL)action;
-- (void)setGestureFailedTarget:(id)target action:(SEL)action;
-- (void)setResetTarget:(id)target action:(SEL)action;
-@property (nonatomic, weak) WKTouchEventsGestureRecognizer *supportingTouchEventsGestureRecognizer;
-@property (nonatomic, readonly) NSNumber *lastActiveTouchIdentifier;
+@property (nonatomic, readonly, weak) UIScrollView *lastTouchedScrollView;
+
 @end
 
-#endif
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if PLATFORM(IOS_FAMILY)
-
+#import "config.h"
 #import "WKScrollViewTrackingTapGestureRecognizer.h"
 
-@class WKTouchEventsGestureRecognizer;
+#if PLATFORM(IOS_FAMILY)
 
-// The purpose of this class is to call a target/action when
-// the gesture is recognized, as well as the typical time when
-// a gesture should be handled. This allows it to be used while
-// it is waiting for another gesture recognizer to fail.
-@interface WKSyntheticTapGestureRecognizer : WKScrollViewTrackingTapGestureRecognizer
-- (void)setGestureIdentifiedTarget:(id)target action:(SEL)action;
-- (void)setGestureFailedTarget:(id)target action:(SEL)action;
-- (void)setResetTarget:(id)target action:(SEL)action;
-@property (nonatomic, weak) WKTouchEventsGestureRecognizer *supportingTouchEventsGestureRecognizer;
-@property (nonatomic, readonly) NSNumber *lastActiveTouchIdentifier;
+#import "UIKitUtilities.h"
+
+@implementation WKScrollViewTrackingTapGestureRecognizer
+
+- (void)reset
+{
+    [super reset];
+
+    _lastTouchedScrollView = nil;
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+
+    if (auto scrollView = WebKit::scrollViewForTouches(touches))
+        _lastTouchedScrollView = scrollView;
+}
+
 @end
 
-#endif
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
@@ -41,7 +41,6 @@
     __weak id _resetTarget;
     SEL _resetAction;
     RetainPtr<NSNumber> _lastActiveTouchIdentifier;
-    __weak UIScrollView *_lastTouchedScrollView;
 }
 
 - (void)setGestureIdentifiedTarget:(id)target action:(SEL)action
@@ -74,17 +73,9 @@
 - (void)reset
 {
     [super reset];
+
     [_resetTarget performSelector:_resetAction withObject:self];
     _lastActiveTouchIdentifier = nil;
-    _lastTouchedScrollView = nil;
-}
-
-- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    [super touchesBegan:touches withEvent:event];
-
-    if (auto scrollView = WebKit::scrollViewForTouches(touches))
-        _lastTouchedScrollView = scrollView;
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -101,11 +92,6 @@
             break;
         }
     }
-}
-
-- (UIScrollView *)lastTouchedScrollView
-{
-    return _lastTouchedScrollView;
 }
 
 - (NSNumber*)lastActiveTouchIdentifier

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1578,6 +1578,14 @@ void WebPageProxy::insertionPointColorDidChange()
     legacyMainFrameProcess().send(Messages::WebPage::SetInsertionPointColor(protectedPageClient()->insertionPointColor()), webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::shouldDismissKeyboardAfterTapAtPoint(FloatPoint point, CompletionHandler<void(bool)>&& completion)
+{
+    if (!hasRunningProcess())
+        return completion(false);
+
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::ShouldDismissKeyboardAfterTapAtPoint(point), WTFMove(completion), webPageIDInMainFrameProcess());
+}
+
 Color WebPageProxy::platformUnderPageBackgroundColor() const
 {
     if (auto contentViewBackgroundColor = protectedPageClient()->contentViewBackgroundColor(); contentViewBackgroundColor.isValid())

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2513,6 +2513,7 @@
 		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F40C3B712AB401C5007A3567 /* WKDatePickerPopoverController.h in Headers */ = {isa = PBXBuildFile; fileRef = F40C3B6F2AB40167007A3567 /* WKDatePickerPopoverController.h */; };
+		F416F1C02C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */; };
 		F41795A62AC61B78007F5F12 /* CompactContextMenuPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */; };
 		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
 		F42D634122A0EFDF00D2FB3A /* WebAutocorrectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */; };
@@ -8176,6 +8177,8 @@
 		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
 		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
 		F410A19329AAC81E0082D554 /* RemoteGPURequestAdapterResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGPURequestAdapterResponse.h; sourceTree = "<group>"; };
+		F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKScrollViewTrackingTapGestureRecognizer.h; path = ios/WKScrollViewTrackingTapGestureRecognizer.h; sourceTree = "<group>"; };
+		F416F1BF2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKScrollViewTrackingTapGestureRecognizer.mm; path = ios/WKScrollViewTrackingTapGestureRecognizer.mm; sourceTree = "<group>"; };
 		F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CompactContextMenuPresenter.h; path = ios/CompactContextMenuPresenter.h; sourceTree = "<group>"; };
 		F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = CompactContextMenuPresenter.mm; path = ios/CompactContextMenuPresenter.mm; sourceTree = "<group>"; };
 		F425374F2AF9A25A00873864 /* InteractionInformationRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationRequest.serialization.in; path = ios/InteractionInformationRequest.serialization.in; sourceTree = "<group>"; };
@@ -11187,6 +11190,8 @@
 				A1046EA02079263100F0C5D8 /* WKPDFView.mm */,
 				0FCB4E4418BBE044000FCFC9 /* WKScrollView.h */,
 				0FCB4E4518BBE044000FCFC9 /* WKScrollView.mm */,
+				F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */,
+				F416F1BF2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.mm */,
 				445979382BBB8E9A00087EBC /* WKSTextAnimationManager.h */,
 				9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */,
 				9593675E252E5E3100D3F0A0 /* WKStylusDeviceObserver.mm */,
@@ -17539,6 +17544,7 @@
 				5109099723DACBF2003B1E4C /* WKScriptMessageHandlerWithReply.h in Headers */,
 				7CC99A3618EF7CBC0048C8B4 /* WKScriptMessageInternal.h in Headers */,
 				0FCB4E5418BBE044000FCFC9 /* WKScrollView.h in Headers */,
+				F416F1C02C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h in Headers */,
 				51CD1C651B34B9D400142CA5 /* WKSecurityOrigin.h in Headers */,
 				51CD1C671B34B9DF00142CA5 /* WKSecurityOriginInternal.h in Headers */,
 				519261782950EA3F00A975D1 /* WKSecurityOriginPrivate.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1287,6 +1287,8 @@ public:
     void updateStringForFind(const String&);
 
     bool canShowWhileLocked() const { return m_page && m_page->canShowWhileLocked(); }
+
+    void shouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint, CompletionHandler<void(bool)>&&);
 #endif
 
 #if ENABLE(META_VIEWPORT)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -771,6 +771,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     RequestTextExtraction(std::optional<WebCore::FloatRect> collectionRectInRootView) -> (struct WebCore::TextExtraction::Item item)
 
+#if PLATFORM(IOS_FAMILY)
+    ShouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint point) -> (bool shouldDismiss)
+#endif
+
 #if ENABLE(EXTENSION_CAPABILITIES)
     SetMediaEnvironment(String mediaEnvironment)
 #endif


### PR DESCRIPTION
#### 26bb7484b4f6853b76ff5d3b2b843668f38ab019
<pre>
[iOS] Add an internal setting to allow the keyboard to dismiss after tapping
<a href="https://bugs.webkit.org/show_bug.cgi?id=277551">https://bugs.webkit.org/show_bug.cgi?id=277551</a>
<a href="https://rdar.apple.com/130552664">rdar://130552664</a>

Reviewed by Aditya Keerthi.

Add an internal setting to make it possible to dismiss the keyboard by tapping over the page,
regardless of whether the page prevents default on touch, mouse or click events. See below for more
details.

Test: fast/forms/ios/dismiss-keyboard-after-tapping.html

* LayoutTests/fast/forms/ios/dismiss-keyboard-after-tapping-expected.txt: Added.
* LayoutTests/fast/forms/ios/dismiss-keyboard-after-tapping.html: Added.

Add a test case to verify that after focusing a text field with the new flag enabled:

1.  Tapping within the focused field does not dismiss the keyboard.
2.  Tapping another text field keeps the keyboard up.
3.  Tapping an empty part of the page that prevents `touchend`, `mousedown` and `click` dismisses
    the keyboard.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _createAndConfigureDoubleTapGestureRecognizer]):
(-[WKContentView setUpInteraction]):
(-[WKContentView cleanUpInteraction]):

Add a new gesture, `_keyboardDismissalGestureRecognizer`, that&apos;s only enabled when the new setting
is enabled, and whose only purpose is to drive keyboard dismissal. This is a new gesture recognizer
because:

a.  We should recognize a tap regardless of whether default was prevented, so we can&apos;t key off of
    the synthetic click gesture.

b.  We should not recognize in the case where the user is double tapping the page to zoom out (i.e.
    single tap recognition should be delayed by double tap).

(-[WKContentView _removeDefaultGestureRecognizers]):
(-[WKContentView _addDefaultGestureRecognizers]):
(-[WKContentView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKContentView gestureRecognizerShouldBegin:]):

Bail early from the keyboard dismissal gesture if any of the following are true:
1. The keyboard is not shown.
2. The tap is inside of the focused element.
3. A hidden contenteditable element has focus.
4. The tap gesture is used to stop momentum scrolling.

(-[WKContentView _keyboardDismissalGestureRecognized:]):

Asynchronously check if a tap at this location should result in keyboard dismissal using
`shouldDismissKeyboardAfterTapAtPoint` (see below).

(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
* Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.h: Copied from Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.h.
* Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm: Copied from Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.h.
(-[WKScrollViewTrackingTapGestureRecognizer reset]):
(-[WKScrollViewTrackingTapGestureRecognizer touchesBegan:withEvent:]):

Split out logic to keep track of the last touched scroll view out into a separate class, which we
use for the new gesture recognizer. This allows us to check whether the keyboard dismissal tap
gesture was recognized while momentum scrolling, in which case we don&apos;t allow it to recognize.

* Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm:
(-[WKSyntheticTapGestureRecognizer reset]):
(-[WKSyntheticTapGestureRecognizer touchesBegan:withEvent:]): Deleted.
(-[WKSyntheticTapGestureRecognizer lastTouchedScrollView]): Deleted.
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::shouldDismissKeyboardAfterTapAtPoint):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::shouldDismissKeyboardAfterTapAtPoint):

Only dismiss the keyboard if the tap is either:
- Over a very large element responding to click events, or
- Not over an element responding to click events.

This makes it likely that the user will be able to dismiss the keyboard by tapping over blank areas
of the page, even if the page installs click handlers over a large container element, while making
it unlikely that the keyboard would unintentionally dismiss when tapping (for instance) a small,
text editing control to bold or italicize text.

Canonical link: <a href="https://commits.webkit.org/281844@main">https://commits.webkit.org/281844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e318cf22f657609921258a11a26f114e12937d19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11743 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49471 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10246 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10656 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54298 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56223 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/10541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66875 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60442 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5141 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56843 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57040 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13639 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4256 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82197 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36359 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14343 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->