### PR TITLE
[JSC] Use bucketOwnerType() instead of MapIteratorObjectUse / SetIteratorObjectUse

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3591,8 +3591,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* mapIterator = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            UseKind useKind = intrinsic == JSMapIteratorNextIntrinsic ? MapIteratorObjectUse : SetIteratorObjectUse;
-            Node* storage = addToGraph(MapIteratorNext, Edge(mapIterator, useKind));
+            BucketOwnerType type = intrinsic == JSMapIteratorNextIntrinsic ? BucketOwnerType::Map : BucketOwnerType::Set;
+            Node* storage = addToGraph(MapIteratorNext, OpInfo(type), Edge(mapIterator, CellUse));
             setResult(storage);
             return CallOptimizationResult::Inlined;
         }
@@ -3603,8 +3603,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* mapIterator = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            UseKind useKind = intrinsic == JSMapIteratorKeyIntrinsic ? MapIteratorObjectUse : SetIteratorObjectUse;
-            Node* storage = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(mapIterator, useKind));
+            BucketOwnerType type = intrinsic == JSMapIteratorKeyIntrinsic ? BucketOwnerType::Map : BucketOwnerType::Set;
+            Node* storage = addToGraph(MapIteratorKey, OpInfo(type), OpInfo(prediction), Edge(mapIterator, CellUse));
             setResult(storage);
             return CallOptimizationResult::Inlined;
         }
@@ -3614,7 +3614,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* mapIterator = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            Node* storage = addToGraph(MapIteratorValue, OpInfo(0), OpInfo(prediction), Edge(mapIterator, MapIteratorObjectUse));
+            Node* storage = addToGraph(MapIteratorValue, OpInfo(BucketOwnerType::Map), OpInfo(prediction), Edge(mapIterator, CellUse));
             setResult(storage);
             return CallOptimizationResult::Inlined;
         }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2108,7 +2108,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case MapIteratorNext: {
         Edge& mapIteratorEdge = node->child1();
-        AbstractHeapKind heap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapIteratorFields : JSSetIteratorFields;
+        AbstractHeapKind heap = node->bucketOwnerType() == BucketOwnerType::Map ? JSMapIteratorFields : JSSetIteratorFields;
         read(heap);
         write(heap);
         def(HeapLocation(MapIteratorNextLoc, heap, mapIteratorEdge), LazyNode(node));
@@ -2116,14 +2116,14 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     }
     case MapIteratorKey: {
         Edge& mapIteratorEdge = node->child1();
-        AbstractHeapKind heap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapIteratorFields : JSSetIteratorFields;
+        AbstractHeapKind heap = node->bucketOwnerType() == BucketOwnerType::Map ? JSMapIteratorFields : JSSetIteratorFields;
         read(heap);
         def(HeapLocation(MapIteratorKeyLoc, heap, mapIteratorEdge), LazyNode(node));
         return;
     }
     case MapIteratorValue: {
         Edge& mapIteratorEdge = node->child1();
-        AbstractHeapKind heap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapIteratorFields : JSSetIteratorFields;
+        AbstractHeapKind heap = node->bucketOwnerType() == BucketOwnerType::Map ? JSMapIteratorFields : JSSetIteratorFields;
         read(heap);
         def(HeapLocation(MapIteratorValueLoc, heap, mapIteratorEdge), LazyNode(node));
         return;

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2785,17 +2785,6 @@ private:
             fixEdge<CellUse>(node->child1());
             break;
 
-        case MapIteratorNext:
-        case MapIteratorKey:
-        case MapIteratorValue:
-            if (node->child1().useKind() == MapIteratorObjectUse)
-                fixEdge<MapIteratorObjectUse>(node->child1());
-            else if (node->child1().useKind() == SetIteratorObjectUse)
-                fixEdge<SetIteratorObjectUse>(node->child1());
-            else
-                RELEASE_ASSERT_NOT_REACHED();
-            break;
-
         case MapHash: {
 #if USE(JSVALUE64)
             if (node->child1()->shouldSpeculateBoolean()) {
@@ -3279,6 +3268,9 @@ private:
         case MakeAtomString:
         case CallCustomAccessorGetter:
         case CallCustomAccessorSetter:
+        case MapIteratorNext:
+        case MapIteratorKey:
+        case MapIteratorValue:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3413,7 +3413,18 @@ public:
 
     bool hasBucketOwnerType()
     {
-        return op() == MapIterationNext || op() == MapIterationEntry || op() == MapIterationEntryKey || op() == MapIterationEntryValue || op() == MapStorage;
+        switch (op()) {
+        case MapIteratorNext:
+        case MapIteratorKey:
+        case MapIteratorValue:
+        case MapIterationNext:
+        case MapIterationEntry:
+        case MapIterationEntryKey:
+        case MapIterationEntryValue:
+            return true;
+        default:
+            return false;
+        }
     }
 
     unsigned numberOfBoundArguments()

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -72,8 +72,6 @@ public:
         case DateObjectUse:
         case MapObjectUse:
         case SetObjectUse:
-        case MapIteratorObjectUse:
-        case SetIteratorObjectUse:
         case WeakMapObjectUse:
         case WeakSetObjectUse:
         case DataViewObjectUse:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1918,10 +1918,6 @@ public:
     void speculateMapObject(Edge, GPRReg cell);
     void speculateSetObject(Edge);
     void speculateSetObject(Edge, GPRReg cell);
-    void speculateMapIteratorObject(Edge);
-    void speculateMapIteratorObject(Edge, GPRReg cell);
-    void speculateSetIteratorObject(Edge);
-    void speculateSetIteratorObject(Edge, GPRReg cell);
     void speculateWeakMapObject(Edge);
     void speculateWeakMapObject(Edge, GPRReg cell);
     void speculateWeakSetObject(Edge);

--- a/Source/JavaScriptCore/dfg/DFGUseKind.cpp
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.cpp
@@ -116,12 +116,6 @@ void printInternal(PrintStream& out, UseKind useKind)
     case SetObjectUse:
         out.print("SetObject");
         return;
-    case MapIteratorObjectUse:
-        out.print("MapIteratorObject");
-        return;
-    case SetIteratorObjectUse:
-        out.print("SetIteratorObject");
-        return;
     case WeakMapObjectUse:
         out.print("WeakMapObject");
         return;

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -73,8 +73,6 @@ enum UseKind : uint8_t {
     DateObjectUse,
     MapObjectUse,
     SetObjectUse,
-    MapIteratorObjectUse,
-    SetIteratorObjectUse,
     WeakMapObjectUse,
     WeakSetObjectUse,
     DataViewObjectUse,
@@ -177,9 +175,6 @@ inline SpeculatedType typeFilterFor(UseKind useKind)
         return SpecMapObject;
     case SetObjectUse:
         return SpecSetObject;
-    case MapIteratorObjectUse:
-    case SetIteratorObjectUse:
-        return SpecObjectOther;
     case WeakMapObjectUse:
         return SpecWeakMapObject;
     case WeakSetObjectUse:
@@ -276,8 +271,6 @@ inline bool isCell(UseKind kind)
     case DateObjectUse:
     case MapObjectUse:
     case SetObjectUse:
-    case MapIteratorObjectUse:
-    case SetIteratorObjectUse:
     case WeakMapObjectUse:
     case WeakSetObjectUse:
     case DataViewObjectUse:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -555,9 +555,7 @@ CapabilityLevel canCompile(Graph& graph)
                 case HeapBigIntUse:
                 case DateObjectUse:
                 case MapObjectUse:
-                case MapIteratorObjectUse:
                 case SetObjectUse:
-                case SetIteratorObjectUse:
                 case WeakMapObjectUse:
                 case WeakSetObjectUse:
                 case DataViewObjectUse:


### PR DESCRIPTION
#### 8ccf46466dc2969b2d71dd5eec1d8d190f7b2409
<pre>
[JSC] Use bucketOwnerType() instead of MapIteratorObjectUse / SetIteratorObjectUse
<a href="https://bugs.webkit.org/show_bug.cgi?id=277560">https://bugs.webkit.org/show_bug.cgi?id=277560</a>
&lt;<a href="https://rdar.apple.com/problem/133079173">rdar://problem/133079173</a>&gt;

Reviewed by NOBODY (OOPS!).

Currently, ToThis hinder proper type speculation propagation. However, if it&apos;s removed (by just commenting
out emitToThis() or webkit.org/b/225397), running JSTests/microbenchmarks/set-for-of.js &amp; friends in
FTL-eager mode results in a crash in LowerDFGToB3::speculate() with:

  Unsupported speculation use kind for MapIteratorObjectUse / SetIteratorObjectUse

If speculateMapIteratorObject() / speculateSetIteratorObject() are added, the same test crashes in
DFG AI&apos;s verifyEdge() with:

  Edge verification error: D@65-&gt;Check:SetIteratorObject:D@232 was expected to have type OtherObj but has type MapObject

  --&gt; next#&lt;no-hash&gt;:&lt;0x11315c6d0 (StrictMode), bc#72, Call, known callee: Object: 0x113028ac0 with butterfly 0x0(base=0xfffffffffffffff8) (Structure %AG:Function)
    D@76:&lt;!0:-&gt; CheckNotEmpty(Check:Untyped:D@232, MustGen, Exits, bc#4, exit: bc#67, ExitValid)
   D@225:&lt; 2:-&gt; IsCellWithType(Cell:D@232, Boolean|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, Bool, JSTypeRange { JSSetIteratorType, JSSetIteratorType }, Exits, bc#4, exit: bc#67, ExitValid)
    D@65:&lt;!0:-&gt; Check(Check:SetIteratorObject:D@232, MustGen, Exits, bc#21, exit: bc#67, ExitValid, WasHoisted)
  &lt;-- next#&lt;no-hash&gt;:&lt;0x11315c6d0 (StrictMode), bc#72, Call, known callee: Object: 0x113028ac0 with butterfly 0x0(base=0xfffffffffffffff8) (Structure %AG:Function)

I believe the lack of 1:1 correspondence between a UseKind and a SpeculatedType is what confuses the
validator. All other UseKinds, including SetObjectUse / MapObjectUse, seem to rely on the exact
SpeculatedType, and not a SpecObjectOther.

Instead of adding SpecMapIteratorObject / SpecSetIteratorObject, which won&apos;t be useful, this change
aligns MapIteratorNext / MapIteratorKey DFG nodes with MapIteration* to use bucketOwnerType().

No new tests, no behavior change.

* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasBucketOwnerType):
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::SafeToExecuteEdge::operator()):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGUseKind.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGUseKind.h:
(JSC::DFG::typeFilterFor):
(JSC::DFG::isCell):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ccf46466dc2969b2d71dd5eec1d8d190f7b2409

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11489 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49270 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37515 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52796 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.GrandfatherCallback (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10015 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10402 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54044 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66604 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60189 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56638 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4048 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81944 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36106 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14278 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->