### PR TITLE
[cocoa] Add Continue button on warning view

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3673,7 +3673,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_showWarningViewWithURL:(NSURL *)url title:(NSString *)title warning:(NSString *)warning detailsWithLinks:(NSAttributedString *)details completionHandler:(void(^)(BOOL, NSURL *))completionHandler
 {
     THROW_IF_SUSPENDED;
-    auto safeBrowsingWarning = WebKit::BrowsingWarning::create(url, title, warning, details);
+    auto safeBrowsingWarning = WebKit::BrowsingWarning::create(url, title, warning, details, WebKit::BrowsingWarning::SafeBrowsingWarningData { });
     auto wrapper = [completionHandler = makeBlockPtr(completionHandler)] (std::variant<WebKit::ContinueUnsafeLoad, URL>&& variant) {
         switchOn(variant, [&] (WebKit::ContinueUnsafeLoad continueUnsafeLoad) {
             switch (continueUnsafeLoad) {

--- a/Source/WebKit/UIProcess/BrowsingWarning.h
+++ b/Source/WebKit/UIProcess/BrowsingWarning.h
@@ -55,9 +55,9 @@ public:
     }
 #endif
 #if PLATFORM(COCOA)
-    static Ref<BrowsingWarning> create(URL&& url, String&& title, String&& warning, RetainPtr<NSAttributedString>&& details)
+    static Ref<BrowsingWarning> create(URL&& url, String&& title, String&& warning, RetainPtr<NSAttributedString>&& details, Data&& data)
     {
-        return adoptRef(*new BrowsingWarning(WTFMove(url), WTFMove(title), WTFMove(warning), WTFMove(details)));
+        return adoptRef(*new BrowsingWarning(WTFMove(url), WTFMove(title), WTFMove(warning), WTFMove(details), WTFMove(data)));
     }
 #endif
 
@@ -68,6 +68,7 @@ public:
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> details() const { return m_details; }
 #endif
+    const Data& data() const { return m_data; }
 
     static NSURL *visitUnsafeWebsiteSentinel();
     static NSURL *confirmMalwareSentinel();
@@ -77,7 +78,7 @@ private:
     BrowsingWarning(const URL&, bool, Data&&);
 #endif
 #if PLATFORM(COCOA)
-    BrowsingWarning(URL&&, String&&, String&&, RetainPtr<NSAttributedString>&&);
+    BrowsingWarning(URL&&, String&&, String&&, RetainPtr<NSAttributedString>&&, Data&&);
 #endif
 
     URL m_url;
@@ -87,6 +88,7 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> m_details;
 #endif
+    const Data m_data;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -196,15 +196,17 @@ BrowsingWarning::BrowsingWarning(const URL& url, bool forMainFrameNavigation, Da
     , m_warning(browsingWarningText(data))
     , m_forMainFrameNavigation(forMainFrameNavigation)
     , m_details(browsingDetailsText(url, data))
+    , m_data(WTFMove(data))
 {
 }
 #endif
 
-BrowsingWarning::BrowsingWarning(URL&& url, String&& title, String&& warning, RetainPtr<NSAttributedString>&& details)
+BrowsingWarning::BrowsingWarning(URL&& url, String&& title, String&& warning, RetainPtr<NSAttributedString>&& details, Data&& data)
     : m_url(WTFMove(url))
     , m_title(WTFMove(title))
     , m_warning(WTFMove(warning))
     , m_details(WTFMove(details))
+    , m_data(WTFMove(data))
 {
 }
 


### PR DESCRIPTION
#### c82e784731d3ce16ffdb4d3e9f3158618184760f
<pre>
[cocoa] Add Continue button on warning view
<a href="https://bugs.webkit.org/show_bug.cgi?id=277529">https://bugs.webkit.org/show_bug.cgi?id=277529</a>
<a href="https://rdar.apple.com/133037364">rdar://133037364</a>

Reviewed by Alex Christensen.

Adds support for a &quot;Continue&quot; button in the same place as the current &quot;Show
Details&quot; button when the warning is for a HTTPSNavigationFailure.

As part of this change, I&apos;m storing the BrowsingWarning&apos;s Data parameter and
providing an accessor for it so we can identify the desired warning.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _showWarningViewWithURL:title:warning:detailsWithLinks:completionHandler:]):

This patch now requires explicitly declaring the warning type.

* Source/WebKit/UIProcess/BrowsingWarning.h:
(WebKit::BrowsingWarning::create):
(WebKit::BrowsingWarning::data const):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::BrowsingWarning::BrowsingWarning):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(colorForItem):
(makeButton):
(-[_WKWarningView addContent]):
(-[_WKWarningView continueClicked]):

Canonical link: <a href="https://commits.webkit.org/281796@main">https://commits.webkit.org/281796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7efa22bc1dbadcacf300c60c99b48c2320eb82ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11533 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49290 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7995 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34233 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10446 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66649 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56849 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4084 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9183 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38328 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->