### PR TITLE
Add check in AudioBufferSourceNode::renderFromBuffer() when detune is set to large negative value

### DIFF
--- a/LayoutTests/fast/css/cssom-insertrule-crash-expected.html
+++ b/LayoutTests/fast/css/cssom-insertrule-crash-expected.html
@@ -1,0 +1,6 @@
+<style>
+  div {
+   color: green;
+  }
+</style>
+<div id=om>div { color: green; baz { } bar { } foo { } }</div>

--- a/LayoutTests/fast/css/cssom-insertrule-crash.html
+++ b/LayoutTests/fast/css/cssom-insertrule-crash.html
@@ -1,0 +1,19 @@
+<style>
+  div {
+   color: red;
+  }
+</style>
+<div id=om></div>
+
+<script>
+var stylesheet = document.styleSheets.item(0);
+var rule = stylesheet.cssRules.item(0);
+rule.insertRule("foo { }");
+rule.insertRule("bar { }");
+rule = stylesheet.cssRules.item(0);
+rule.insertRule("baz { }");
+var s = rule.style;
+s.color = "green";
+om.textContent = rule.cssText;
+</script>
+

--- a/LayoutTests/fast/css/grid-template-rule-no-crash-expected.txt
+++ b/LayoutTests/fast/css/grid-template-rule-no-crash-expected.txt
@@ -1,0 +1,2 @@
+Test passes if no crash.
+

--- a/LayoutTests/fast/css/grid-template-rule-no-crash.html
+++ b/LayoutTests/fast/css/grid-template-rule-no-crash.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+grid {
+  display: grid;
+  grid-template: "test" 100px / 100px;
+  grid-template-rows: subgrid;
+}
+</style>
+</head>
+<body>
+Test passes if no crash.
+<grid></grid>
+</body>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  document.styleSheets[0].cssRules[0].cssText
+</script>
+</html>

--- a/LayoutTests/fast/scrolling/scrollIntoView-destroy-renderer-for-meter-element-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/scrollIntoView-destroy-renderer-for-meter-element-crash-expected.txt
@@ -1,0 +1,2 @@
+PASS if no crash.
+

--- a/LayoutTests/fast/scrolling/scrollIntoView-destroy-renderer-for-meter-element-crash.html
+++ b/LayoutTests/fast/scrolling/scrollIntoView-destroy-renderer-for-meter-element-crash.html
@@ -1,0 +1,29 @@
+<style>
+    :root {
+        offset-path: path('M 0 -1 0 0 Z');
+    }
+    * {
+        background-position: inherit;
+        border-image-source: url(data:image/gif;base64);
+        contain: size;
+        grid-template-columns: 0vw;
+    }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function jsfuzzer() {
+        try { /* */ var00209 = document.createElement("object"); } catch (e) { }
+        try { document.alinkColor = String.fromCharCode(93, 98); } catch (e) { }
+        try { /* */ var00261 = htmlvar00015.insertAdjacentElement("afterEnd", var00209); } catch (e) { }
+        try { htmlvar00022.scrollIntoView(); } catch (e) { }
+        try { var00209.data = String.fromCharCode(63, 109) } catch (e) { }
+    }
+</script>
+PASS if no crash.
+<body onload=jsfuzzer()>
+    <table frame="border">
+        <colgroup id="htmlvar00015" char="i"></colgroup>
+        <meter id="htmlvar00022" accept="audio/*"></meter>
+    </table>
+</body>

--- a/LayoutTests/http/tests/local/blob/resolve-response-with-custom-then-expected.txt
+++ b/LayoutTests/http/tests/local/blob/resolve-response-with-custom-then-expected.txt
@@ -1,0 +1,3 @@
+Test passes if the load succeeds.
+
+

--- a/LayoutTests/http/tests/local/blob/resolve-response-with-custom-then.html
+++ b/LayoutTests/http/tests/local/blob/resolve-response-with-custom-then.html
@@ -1,0 +1,25 @@
+<body>
+<p>Test passes if the load succeeds.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    setTimeout(() => testRunner.notifyDone(), 500);
+}
+
+const f = document.body.appendChild(document.createElement('iframe'));
+f.srcdoc = `<script>
+    function fetchBlob() {
+        Object.prototype.__defineGetter__('then', (r) => {
+            window.frameElement.remove();
+            $vm.edenGC();
+            location = r;
+        });
+        const response = new Response(new Blob(['/dne.html']));
+        response.blob();
+    }
+    setTimeout(fetchBlob);
+</` + `script>`;
+
+</script>
+</body>

--- a/LayoutTests/webaudio/audiobuffersourcenode-detune-crash-expected.txt
+++ b/LayoutTests/webaudio/audiobuffersourcenode-detune-crash-expected.txt
@@ -1,0 +1,10 @@
+Attempting to create a AudioBufferSourceNode with a large negative detune value should not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Test passed because it did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/audiobuffersourcenode-detune-crash.html
+++ b/LayoutTests/webaudio/audiobuffersourcenode-detune-crash.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <script src="../resources/js-test-pre.js"></script>
+    <script src="resources/audio-testing.js"></script>
+    </head>
+    <body>
+        <script>
+            description("Attempting to create a AudioBufferSourceNode with a large negative detune value should not crash.");
+
+            jsTestIsAsync = true;
+
+            var context = new AudioContext();
+            var src = context.createBufferSource();
+            var buffer = context.createBuffer(1, 256, 44100);
+            src.buffer = buffer;
+            src.start(undefined, 1);
+            src.connect(context.listener.positionX, 0);
+            var panner = context.createPanner();
+            src.detune.value = -0xffffff;
+            panner.connect(context.destination);
+            setTimeout(() => {
+                testPassed("Test passed because it did not crash.");
+                finishJSTest();
+            }, 100);
+        </script>
+
+        <script src="../resources/js-test-post.js"></script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -299,6 +299,9 @@ void FetchBodyOwner::blobLoadingSucceeded()
     }
 
     m_body->loadingSucceeded(contentType());
+    if (!m_blobLoader)
+        return;
+
     finishBlobLoading();
 }
 
@@ -337,6 +340,12 @@ void FetchBodyOwner::BlobLoader::didFail(const ResourceError&)
     // didFail might be called within FetchLoader::start call.
     if (loader->isStarted())
         owner.blobLoadingFailed();
+}
+
+void FetchBodyOwner::BlobLoader::didSucceed(const NetworkLoadMetrics&)
+{
+    Ref protectedOwner = Ref { owner };
+    protectedOwner->blobLoadingSucceeded();
 }
 
 ExceptionOr<RefPtr<ReadableStream>> FetchBodyOwner::readableStream(JSC::JSGlobalObject& state)

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -125,7 +125,7 @@ private:
         void didReceiveResponse(const ResourceResponse&) final;
         void didReceiveData(const SharedBuffer& buffer) final { owner.blobChunk(buffer); }
         void didFail(const ResourceError&) final;
-        void didSucceed(const NetworkLoadMetrics&) final { owner.blobLoadingSucceeded(); }
+        void didSucceed(const NetworkLoadMetrics&) final;
 
         FetchBodyOwner& owner;
         std::unique_ptr<FetchLoader> loader;

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -328,9 +328,16 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
         virtualReadIndex = readIndex;
     } else if (!pitchRate) {
         unsigned readIndex = static_cast<unsigned>(virtualReadIndex);
+        int deltaFrames = static_cast<int>(virtualDeltaFrames);
+        maxFrame = static_cast<unsigned>(virtualMaxFrame);
+
+        if (readIndex >= maxFrame)
+            readIndex -= deltaFrames;
 
         for (unsigned i = 0; i < numberOfChannels; ++i)
             std::fill_n(destinationChannels[i] + writeIndex, framesToProcess, sourceChannels[i][readIndex]);
+
+        virtualReadIndex = readIndex;
     } else if (reverse) {
         unsigned maxFrame = static_cast<unsigned>(virtualMaxFrame);
         unsigned minFrame = static_cast<unsigned>(floorf(virtualMinFrame));

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -168,8 +168,6 @@ RefPtr<StyleRuleWithNesting> CSSGroupingRule::prepareChildStyleRuleForNesting(St
         if (rules[i].ptr() == &styleRule) {
             auto styleRuleWithNesting = StyleRuleWithNesting::create(WTFMove(styleRule));
             rules[i] = styleRuleWithNesting;
-            if (auto* styleSheet = parentStyleSheet())
-                styleSheet->contents().setHasNestingRules();
             return styleRuleWithNesting;
         }        
     }

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -182,7 +182,7 @@ Node* CSSStyleSheet::ownerNode() const
     return m_ownerNode.get();
 }
 
-RefPtr<StyleRuleWithNesting> CSSStyleSheet::prepareChildStyleRuleForNesting(StyleRule&& styleRule)
+RefPtr<StyleRuleWithNesting> CSSStyleSheet::prepareChildStyleRuleForNesting(StyleRule& styleRule)
 {
     RuleMutationScope scope(this);
     auto& rules = m_contents->m_childRules;
@@ -190,7 +190,6 @@ RefPtr<StyleRuleWithNesting> CSSStyleSheet::prepareChildStyleRuleForNesting(Styl
         if (rules[i].ptr() == &styleRule) {
             auto styleRuleWithNesting = StyleRuleWithNesting::create(WTFMove(styleRule));
             rules[i] = styleRuleWithNesting;
-            m_contents->setHasNestingRules();
             return styleRuleWithNesting;
         }        
     }

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -121,7 +121,7 @@ public:
 
     bool hadRulesMutation() const { return m_mutatedRules; }
     void clearHadRulesMutation() { m_mutatedRules = false; }
-    RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&&);
+    RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
 
     enum RuleMutationType { OtherMutation, RuleInsertion, KeyframesRuleMutation, RuleReplace };
     enum class ContentsClonedForMutation : bool { No, Yes };

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1170,16 +1170,15 @@ String ShorthandSerializer::serializeGridTemplate() const
         return hasAtLeastOneTrackSize;
     };
 
-    // For the rows we need to return early if the value of grid-template-rows is none because otherwise
-    // we will iteratively build up that portion of the shorthand and check to see if the value is a valid
-    // <track-size> at the appropriate position in the shorthand. For the columns we must check the entire
-    // value of grid-template-columns beforehand because we append the value as a whole to the shorthand
-    if (isLonghandValueNone(rowsIndex) || (!isLonghandValueNone(columnsIndex) && !isValidExplicitTrackList(longhandValue(columnsIndex))))
+    Ref rowTrackSizes = longhandValue(rowsIndex);
+
+    // Make sure the longhands can be expressed in this version of the shorthand.
+    if (!rowTrackSizes->isValueList() || (!isLonghandValueNone(columnsIndex) && !isValidExplicitTrackList(longhandValue(columnsIndex))))
         return String();
 
     StringBuilder result;
     unsigned row = 0;
-    for (auto& currentValue : downcast<CSSValueList>(longhandValue(rowsIndex))) {
+    for (auto& currentValue : downcast<CSSValueList>(rowTrackSizes).get()) {
         if (!result.isEmpty())
             result.append(' ');
         if (auto lineNames = dynamicDowncast<CSSGridLineNamesValue>(currentValue))

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -94,6 +94,7 @@ StyleSheetContents::StyleSheetContents(const StyleSheetContents& o)
     , m_loadCompleted(true)
     , m_hasSyntacticallyValidCSSHeader(o.m_hasSyntacticallyValidCSSHeader)
     , m_usesStyleBasedEditability(o.m_usesStyleBasedEditability)
+    , m_hasNestingRulesCache(o.m_hasNestingRulesCache)
     , m_parserContext(o.m_parserContext)
 {
     ASSERT(o.isCacheable());
@@ -139,7 +140,7 @@ bool StyleSheetContents::isCacheable() const
     // FIXME: Valid mime type avoids the check too.
     if (!m_hasSyntacticallyValidCSSHeader)
         return false;
-    if (m_hasNestingRules)
+    if (hasNestingRules())
         return false;
     return true;
 }
@@ -530,6 +531,20 @@ bool StyleSheetContents::traverseRules(const Function<bool(const StyleRuleBase&)
             return true;
     }
     return traverseRulesInVector(m_childRules, handler);
+}
+
+bool StyleSheetContents::hasNestingRules() const
+{
+    if (m_hasNestingRulesCache)
+        return *m_hasNestingRulesCache;
+
+    m_hasNestingRulesCache = traverseRulesInVector(m_childRules, [&] (auto& rule) {
+        if (rule.isStyleRuleWithNesting())
+            return true;
+        return false;
+    });
+
+    return *m_hasNestingRulesCache;
 }
 
 bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "CSSParserContext.h"
+#include <optional>
 #include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
@@ -145,8 +146,8 @@ public:
     bool isMutable() const { return m_isMutable; }
     void setMutable() { m_isMutable = true; }
 
-    bool hasNestingRules() const { return m_hasNestingRules; }
-    void setHasNestingRules() { m_hasNestingRules = true; }
+    bool hasNestingRules() const;
+    void clearHasNestingRulesCache() { m_hasNestingRulesCache = { }; }
 
     bool isInMemoryCache() const { return m_inMemoryCacheCount; }
     void addedToMemoryCache();
@@ -186,7 +187,7 @@ private:
     bool m_didLoadErrorOccur { false };
     bool m_usesStyleBasedEditability { false };
     bool m_isMutable { false };
-    bool m_hasNestingRules { false };
+    mutable std::optional<bool> m_hasNestingRulesCache;
     unsigned m_inMemoryCacheCount { 0 };
 
     CSSParserContext m_parserContext;

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -698,8 +698,6 @@ Vector<Ref<StyleRuleBase>> CSSParserImpl::consumeNestedGroupRules(CSSParserToken
                 // property declarations.
                 rules.append(createNestingParentRule());
 
-                protectedStyleSheet()->setHasNestingRules();
-
                 if (m_observerWrapper)
                     m_observerWrapper->observer().markRuleBodyContainsImplicitlyNestedProperties();
             }
@@ -1356,6 +1354,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
     if (mutableSelectorList.isEmpty())
         return nullptr; // Parse error, invalid selector list
 
+    // FIXME: We should pass the ancestor rule type also for CSSSOM.
     if (!m_ancestorRuleTypeStack.isEmpty()) {
         // https://drafts.csswg.org/css-nesting/#cssom
         // Relative selector should be absolutized (only when not "nest-containing" for the descendant one),
@@ -1386,10 +1385,8 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
         // We save memory by creating a simple StyleRule instead of a heavier StyleRuleWithNesting when we don't need the CSS Nesting features.
         if (nestedRules.isEmpty() && !selectorList.hasExplicitNestingParent() && !isNestedContext())
             styleRule = StyleRule::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, WTFMove(selectorList));
-        else {
+        else
             styleRule = StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, WTFMove(selectorList), WTFMove(nestedRules));
-            protectedStyleSheet()->setHasNestingRules();
-        }
     });
 
     return styleRule;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1078,7 +1078,7 @@ inline ScrollAlignment toScrollAlignmentForBlockDirection(std::optional<ScrollLo
     }
 }
 
-static std::optional<std::pair<CheckedRef<RenderElement>, LayoutRect>> listBoxElementScrollIntoView(const Element& element)
+static std::optional<std::pair<SingleThreadWeakPtr<RenderElement>, LayoutRect>> listBoxElementScrollIntoView(const Element& element)
 {
     auto owningSelectElement = [](const Element& element) -> HTMLSelectElement* {
         if (auto* optionElement = dynamicDowncast<HTMLOptionElement>(element))
@@ -1105,7 +1105,7 @@ static std::optional<std::pair<CheckedRef<RenderElement>, LayoutRect>> listBoxEl
         itemIndex = 0;
 
     auto itemLocalRect = renderListBox->itemBoundingBoxRect({ }, itemIndex);
-    return std::pair<CheckedRef<RenderElement>, LayoutRect> { renderListBox.releaseNonNull(), itemLocalRect };
+    return std::pair<SingleThreadWeakPtr<RenderElement>, LayoutRect> { renderListBox.releaseNonNull(), itemLocalRect };
 }
 
 void Element::scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOptions>>&& arg)
@@ -1115,7 +1115,7 @@ void Element::scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOpti
 
     document->updateLayoutIgnorePendingStylesheets(LayoutOptions::UpdateCompositingLayers);
 
-    CheckedPtr<RenderElement> renderer;
+    SingleThreadWeakPtr<RenderElement> renderer;
     bool insideFixed = false;
     LayoutRect absoluteBounds;
 


### PR DESCRIPTION
#### 0b2843995193ff7b5bab822c5456a69de24a326c
<pre>
Add check in AudioBufferSourceNode::renderFromBuffer() when detune is set to large negative value
<a href="https://bugs.webkit.org/show_bug.cgi?id=275273">https://bugs.webkit.org/show_bug.cgi?id=275273</a>
<a href="https://rdar.apple.com/125617842">rdar://125617842</a>

Reviewed by Eric Carlson.

* LayoutTests/webaudio/audiobuffersourcenode-detune-crash-expected.txt: Added.
* LayoutTests/webaudio/audiobuffersourcenode-detune-crash.html: Added.
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):

Originally-landed-as: 272448.1080@safari-7618-branch (64c9479d6f29). <a href="https://rdar.apple.com/132954227">rdar://132954227</a>
Canonical link: <a href="https://commits.webkit.org/281789@main">https://commits.webkit.org/281789@main</a>
</pre>
----------------------------------------------------------------------
#### 0fb943e26c18e22794acd8d70df013944f50b9dd
<pre>
Extend the lifetime of the Fetch body owner
<a href="https://bugs.webkit.org/show_bug.cgi?id=275122">https://bugs.webkit.org/show_bug.cgi?id=275122</a>
<a href="https://rdar.apple.com/128250783">rdar://128250783</a>

Reviewed by Youenn Fablet and Simon Fraser.

This patch extends the lifetime of the FetchBodyOwner while we resolve the
body. In some cases, the body can be prematurely freed if its only reference
is held by a JavaScript object.

* LayoutTests/http/tests/local/blob/resolve-response-with-custom-then-expected.txt: Added.
* LayoutTests/http/tests/local/blob/resolve-response-with-custom-then.html: Added.
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::blobLoadingSucceeded):
(WebCore::FetchBodyOwner::BlobLoader::didSucceed):
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:

Originally-landed-as: 272448.1095@safari-7618-branch (2ba62228e7b8). <a href="https://rdar.apple.com/132954026">rdar://132954026</a>
Canonical link: <a href="https://commits.webkit.org/281788@main">https://commits.webkit.org/281788@main</a>
</pre>
----------------------------------------------------------------------
#### eeccf9681be2753e654655d799635ca94f48845a
<pre>
Bad downcast in ShorthandSerializer::serializeGridTemplate
<a href="https://bugs.webkit.org/show_bug.cgi?id=275863">https://bugs.webkit.org/show_bug.cgi?id=275863</a>
<a href="https://rdar.apple.com/121949510">rdar://121949510</a>

Reviewed by Brent Fulgham and Tim Nguyen.

When attempting to parse the more complex version of the grid-template syntax,
the ShorthandSerializer assumes that the value for the grid-template-rows longhand
will be a CSSValueList. This may not be true as demonstrated in the testcase which
ends up returning a CSSSubgridValue for the longhand value.

Instead of just blindly downcasting, let&apos;s replace the erroneous
isLonghandValueNone(rowsIndex) with !rowTrackSizes-&gt;isValueList() to make sure we return
a null string if the value of grid-template-rows is not a CSSValueList and as a result
cannot be expressed in the shorthand, which is similar to what we do for the
grid-template-columns case. Also rephrase the comment to just say this instead of the
lengthy and confusing description.

* LayoutTests/fast/css/grid-template-rule-no-crash-expected.txt: Added.
* LayoutTests/fast/css/grid-template-rule-no-crash.html: Added.
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeGridTemplate const):

Originally-landed-as: 272448.1096@safari-7618-branch (32cdb1b7a376). <a href="https://rdar.apple.com/132953407">rdar://132953407</a>
Canonical link: <a href="https://commits.webkit.org/281787@main">https://commits.webkit.org/281787@main</a>
</pre>
----------------------------------------------------------------------
#### d9047878322f6a875050f942e56cc38c5f82088a
<pre>
ASAN_ILL | WebCore::RenderMeter::~RenderMeter;
<a href="https://bugs.webkit.org/show_bug.cgi?id=275944">https://bugs.webkit.org/show_bug.cgi?id=275944</a>
<a href="https://rdar.apple.com/126113504">rdar://126113504</a>

Reviewed by Alan Baradlay.

The test case produces a crash case where the checkedPtr renderer within Element::scrollIntoView
will be destroryed, even we called updateLayoutIgnorePendingStylesheets right before it.
During LocalFrameView::scrollRectToVisible, layout is triggered because:
    1. pre-layout: willDoLayout() -&gt; adjustScrollbarsForLayout() turns the vertical scrollbar to be on
    2. during/after layout the scrollbar is updated ONLY when content size has changed: LocalFrameView::setContentsSize
    3. when content size is unchanged the vertical scrollbar remains on,
    4. LocalFrameView::scrollRectToVisible -&gt; updateScrollbars checked the scrollbar has changed,
       decided to trigger layout with updateContentsSize().
The fix is to make renderer as WeakPtr instead of CheckedPtr.

This patch also fixes build failuer for CHECKED_POINTER_DEBUG in SU branch.

* LayoutTests/fast/scrolling/scrollIntoView-destroy-renderer-for-meter-element-crash-expected.txt: Added.
* LayoutTests/fast/scrolling/scrollIntoView-destroy-renderer-for-meter-element-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::listBoxElementScrollIntoView):
(WebCore::Element::scrollIntoView):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::registerCheckedPtr const): Deleted.
(WebCore::TreeScope::copyCheckedPtr const): Deleted.
(WebCore::TreeScope::moveCheckedPtr const): Deleted.
(WebCore::TreeScope::unregisterCheckedPtr const): Deleted.

Originally-landed-as: 272448.1097@safari-7618.3.11.10-branch (a7082f8505ae). <a href="https://rdar.apple.com/132944916">rdar://132944916</a>
Canonical link: <a href="https://commits.webkit.org/281786@main">https://commits.webkit.org/281786@main</a>
</pre>
----------------------------------------------------------------------
#### d9acfd1b770df4d87991f92cbd2dcf9526cb0d9c
<pre>
[CSSOM] Fix insertion of rule inside non nested style rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=275129">https://bugs.webkit.org/show_bug.cgi?id=275129</a>
<a href="https://rdar.apple.com/126112807">rdar://126112807</a>

Reviewed by Antti Koivisto.

The CSS parser should not change the &quot;hasNestingRules&quot; status
of a stylesheet (which makes the CoW mechanism fails and a bunch of other issues).

This patch changes when the CoW will copy the rules to allow mutation
and makes the cache mechanism internal to StyleSheetContent class.

* LayoutTests/fast/css/cssom-insertrule-crash-expected.html: Added.
* LayoutTests/fast/css/cssom-insertrule-crash.html: Added.
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::prepareChildStyleRuleForNesting):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::insertRule):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::prepareChildStyleRuleForNesting):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::StyleSheetContents):
(WebCore::StyleSheetContents::isCacheable const):
(WebCore::StyleSheetContents::hasNestingRules):
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeNestedGroupRules):
(WebCore::CSSParserImpl::consumeStyleRule):

Originally-landed-as: 272448.1086@safari-7618-branch (d3f4fe14288c). <a href="https://rdar.apple.com/132959061">rdar://132959061</a>
Canonical link: <a href="https://commits.webkit.org/281785@main">https://commits.webkit.org/281785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd2264e3390bd3d7f2237246e9ba98f2c547b0e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64914 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49289 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7992 "Found 1 new test failure: fast/css/cssom-insertrule-crash.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63016 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37568 "Found 12 new test failures: editing/deleting/25322-1.html editing/deleting/smart-delete-002.html editing/deleting/smart-delete-paragraph-002.html editing/pasteboard/smart-paste-003-trailing-whitespace.html editing/pasteboard/smart-paste-004.html editing/pasteboard/smart-paste-in-text-control.html editing/pasteboard/smart-paste-paragraph-004.html editing/selection/clear-selection-crash.html editing/selection/doubleclick-whitespace-crash.html editing/selection/ios/change-selection-by-tapping.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52840 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30117 "Found 1 new API test failure: /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10054 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10442 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66645 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56656 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56845 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4077 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9181 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38324 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->