### PR TITLE
Add some properties to WKDownload

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.h
@@ -49,6 +49,12 @@ WK_SWIFT_UI_ACTOR
 /* @abstract The delegate that receives progress updates for this download. */
 @property (nonatomic, weak) id <WKDownloadDelegate> delegate;
 
+/* @abstract A boolean value indicating whether this download was initiated by the user. */
+@property (nonatomic, readonly, getter=isUserInitiated) BOOL userInitiated WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/* @abstract The frame that originated this download. */
+@property (nonatomic, readonly) WKFrameInfo *originatingFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 /* @abstract Cancel the download.
  @param completionHandler A block to invoke when cancellation is finished.
  @discussion To attempt to resume the download, call WKWebView resumeDownloadFromResumeData: with the data given to the completionHandler.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -30,6 +30,7 @@
 #import "CompletionHandlerCallChecker.h"
 #import "DownloadProxy.h"
 #import "WKDownloadDelegate.h"
+#import "WKFrameInfoInternal.h"
 #import "WKNSData.h"
 #import "WKNSURLAuthenticationChallenge.h"
 #import "WKWebViewInternal.h"
@@ -201,6 +202,16 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 {
     auto page = _download->originatingPage();
     return page ? page->cocoaView().autorelease() : nil;
+}
+
+- (BOOL)isUserInitiated
+{
+    return _download->wasUserInitiated();
+}
+
+- (WKFrameInfo *)originatingFrame
+{
+    return WebKit::wrapper(_download->frameInfo());
 }
 
 - (id <WKDownloadDelegate>)delegate


### PR DESCRIPTION
#### 6d1954745ba4a691092405c17cc694849d91d8c5
<pre>
Add some properties to WKDownload
<a href="https://rdar.apple.com/120389237">rdar://120389237</a>

Reviewed by Chris Dumez.

Safari uses the originating frame and whether a user gesture was used to start the download.

* Source/WebKit/UIProcess/API/Cocoa/WKDownload.h:
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload isUserInitiated]):
(-[WKDownload originatingFrame]):

Canonical link: <a href="https://commits.webkit.org/281956@main">https://commits.webkit.org/281956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af850d275a31cdd1166b4ef041e362d0401e4627

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49363 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30193 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34301 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56930 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4155 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9266 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36232 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->