### PR TITLE
Potential 'overread' issue commited to upstream dav1d https://bugs.webkit.org/show_bug.cgi?id=274070 rdar://125547790

### DIFF
--- a/JSTests/stress/regress-119545295.js
+++ b/JSTests/stress/regress-119545295.js
@@ -1,0 +1,23 @@
+function main() {
+    const new_target = (function () { }).bind();
+
+    Object.defineProperty(new_target, 'prototype', {
+        get() {
+            // Make the global object have a bad time during construct.
+            Object.setPrototypeOf(Array.prototype, new Proxy({}, {
+                get() {
+                    return 3;
+                }
+            }));
+        }
+    });
+
+    const array = Reflect.construct(Array, [1.1, 2.2, 3.3], new_target);
+    delete array[0];
+    array[0];
+
+    if ($vm.indexingMode(array) != "ArrayWithSlowPutArrayStorage")
+        throw Error("Unexpected indexing mode")
+}
+
+main();

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-rect-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-rect-expected.txt
@@ -1,4 +1,5 @@
 
 
 PASS Checking invalid rect
+PASS Checking invalid copyTo rect
 

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-rect.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-rect.html
@@ -12,6 +12,7 @@ promise_test(async (t) => {
     myImage.src = 'data:';
     await new Promise(resolve => myImage.onerror = resolve);
     const videoFrame = new VideoFrame(myImage, {timestamp: 0});
+    t.add_cleanup(() => videoFrame.close());
     return promise_rejects_js(t, TypeError,
         videoFrame.copyTo(new ArrayBuffer(72), { rect: {
             y: -2,
@@ -19,7 +20,39 @@ promise_test(async (t) => {
             height: 18
         }})
      );
-  }, "Checking invalid rect");
+}, "Checking invalid rect");
+
+function tryCopy(videoFrame, buffer, overrideRect)
+{
+    const rect = { x: 0, y: 0, width: 1, height: 1 };
+    for (const property in overrideRect)
+        rect[property] = overrideRect[property];
+    return videoFrame.copyTo(buffer, { rect });
+}
+
+promise_test(async (t) => {
+    const data = new ArrayBuffer(4);
+    const videoFrame = new VideoFrame(data, {timestamp: 1, codedHeight: 1, codedWidth: 1, format: 'BGRA'});
+    t.add_cleanup(() => videoFrame.close());
+
+    const output = new Uint32Array(0x8000);
+    const buffer = output.buffer;
+
+    await tryCopy(videoFrame, buffer, { });
+
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { x: -1 }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { x: NaN }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { x: Infinity }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { y: -1 }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { y: NaN }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { y: Infinity }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { width: -1 }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { width: NaN }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { width: Infinity }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { height: -1 }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { height: Infinity }));
+    await promise_rejects_js(t, TypeError, tryCopy(videoFrame, buffer, { height: NaN }));
+}, "Checking invalid copyTo rect");
 </script>
 </body>
 </html>

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -144,6 +144,11 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
     if (UNLIKELY(!targetFunction || !targetFunction->canUseAllocationProfiles())) {
         JSValue prototypeValue = newTarget->get(globalObject, vm.propertyNames->prototype);
         RETURN_IF_EXCEPTION(scope, nullptr);
+        // .prototype getter could have triggered having a bad time so need to recheck array structures.
+        if (UNLIKELY(baseGlobalObject->isHavingABadTime())) {
+            if (baseGlobalObject->isOriginalArrayStructure(baseClass))
+                baseClass = baseGlobalObject->arrayStructureForIndexingTypeDuringAllocation(baseClass->indexingType());
+        }
         if (JSObject* prototype = jsDynamicCast<JSObject*>(prototypeValue)) {
             // This only happens if someone Reflect.constructs our builtin constructor with another builtin constructor or weird .prototype property on a
             // JSFunction as the new.target. Thus, we don't care about the cost of looking up the structure from our hash table every time.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -111,6 +111,8 @@ ExceptionOr<DOMRectInit> parseVisibleRect(const DOMRectInit& defaultRect, const 
 {
     auto sourceRect = defaultRect;
     if (overrideRect) {
+        if (!std::isfinite(overrideRect->width) || !std::isfinite(overrideRect->height) || !std::isfinite(overrideRect->x) || !std::isfinite(overrideRect->y))
+            return Exception { ExceptionCode::TypeError, "overrideRect is not valid"_s };
         if (overrideRect->width <= 0 || overrideRect->height <= 0 || overrideRect->x < 0 || overrideRect->y < 0)
             return Exception { ExceptionCode::TypeError, "overrideRect is not valid"_s };
         if (overrideRect->x + overrideRect->width > codedWidth)

--- a/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/refmvs.c
+++ b/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/refmvs.c
@@ -823,7 +823,9 @@ int dav1d_refmvs_init_frame(refmvs_frame *const rf,
     if (r_stride != rf->r_stride || n_tile_rows != rf->n_tile_rows) {
         if (rf->r) dav1d_freep_aligned(&rf->r);
         const int uses_2pass = n_tile_threads > 1 && n_frame_threads > 1;
-        rf->r = dav1d_alloc_aligned(sizeof(*rf->r) * 35 * r_stride * n_tile_rows * (1 + uses_2pass), 64);
+        /* sizeof(refmvs_block) == 12 but it's accessed using 16-byte loads in asm,
+         * so add 4 bytes of padding to avoid buffer overreads. */
+        rf->r = dav1d_alloc_aligned(sizeof(*rf->r) * 35 * r_stride * n_tile_rows * (1 + uses_2pass) + 4, 64);
         if (!rf->r) return DAV1D_ERR(ENOMEM);
         rf->r_stride = r_stride;
     }

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
@@ -506,8 +506,12 @@ void MediaRecorderPrivateWriter::fetchData(CompletionHandler<void(RefPtr<Fragmen
         m_audioCompressor->flush();
 
     // We hop to the main thread since flushing the video compressor might trigger starting the writer asynchronously.
-    callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() mutable {
-        flushCompressedSampleBuffers([weakThis = WTFMove(weakThis)]() mutable {
+    callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }]() mutable {
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->flushCompressedSampleBuffers([weakThis = WTFMove(weakThis)]() mutable {
             auto protectedThis = weakThis.get();
             if (!protectedThis)
                 return;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -273,6 +273,13 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 
     applySniffingPoliciesAndBindRequestToInferfaceIfNeeded(nsRequest, parameters.contentSniffingPolicy == WebCore::ContentSniffingPolicy::SniffContent && !url.protocolIsFile(), parameters.contentEncodingSniffingPolicy);
 
+    if (url.protocolIs("ws"_s) || url.protocolIs("wss"_s)) {
+        // FIXME: Remove this once configuration._usesNWLoader is always effectively YES.
+        // It will be no longer needed, as verified by the WebSocket.LoadRequestWSS API test.
+        scheduleFailure(FailureType::RestrictedURL);
+        return;
+    }
+
     m_task = [m_sessionWrapper->session dataTaskWithRequest:nsRequest.get()];
 
 #if HAVE(CFNETWORK_HOSTOVERRIDE)


### PR DESCRIPTION
#### b8956add13308d76eff2f87c28f99751af0d26ee
<pre>
Potential &apos;overread&apos; issue commited to upstream dav1d <a href="https://bugs.webkit.org/show_bug.cgi?id=274070">https://bugs.webkit.org/show_bug.cgi?id=274070</a> <a href="https://rdar.apple.com/125547790">rdar://125547790</a>

Reviewed by Youenn Fablet.

The refmvs_block struct is only 12 bytes large but it&apos;s accessed
using 16-byte unaligned loads in asm.

In order to avoid reading past the end of the allocated buffer
we therefore need to pad the allocation size by 4 bytes.
Fix from upstream 076955a1534bb49325a2252f6a1f494674e5363a

* Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/refmvs.c:
(dav1d_refmvs_init_frame):

Originally-landed-as: 272448.1027@safari-7618-branch (17ea9a97d6d4). <a href="https://rdar.apple.com/132954870">rdar://132954870</a>
Canonical link: <a href="https://commits.webkit.org/281794@main">https://commits.webkit.org/281794@main</a>
</pre>
----------------------------------------------------------------------
#### ef46d74db28f933175a36860aae0d4433479fe62
<pre>
WebCodecs VideoFrame Out-Of-Bounds Read
<a href="https://rdar.apple.com/127438135">rdar://127438135</a>

Reviewed by Jean-Yves Avenard.

When passing a NaN, our size error checks would be bypassed as comparing with NaN returns false.
We add finite checks to x, y, width and height and add a corresponding test.

* LayoutTests/http/wpt/webcodecs/videoFrame-rect-expected.txt:
* LayoutTests/http/wpt/webcodecs/videoFrame-rect.html:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::parseVisibleRect):

Originally-landed-as: 272448.1035@safari-7618-branch (9c4e3c807b79). <a href="https://rdar.apple.com/132954751">rdar://132954751</a>
Canonical link: <a href="https://commits.webkit.org/281793@main">https://commits.webkit.org/281793@main</a>
</pre>
----------------------------------------------------------------------
#### 4f4fdbf93a5952a568b92e2b690304aa24825fe2
<pre>
Disallow non-WebSocket use of ws and wss schemes at NetworkDataTaskCocoa level
<a href="https://rdar.apple.com/81997401">rdar://81997401</a>

Reviewed by Brady Eidson.

If you type wss://example.com into the URL bar of Safari, it will call WKWebView.loadRequest
with that URL, and we will give it to CFNetwork, and it will successfully load <a href="https://example.com">https://example.com</a>
but in Chrome and Firefox it fails to load.  We need it to also fail to load.  It used to
successfully load for legacy reasons related to the time before the existence of the
NSURLSessionWebSocketTask API, but now that NSURLSessionWebSocketTask exists it is no longer needed,
so when configuration._usesNWLoader is YES CFNetwork does this for us.  WebKit&apos;s use of NSURLSession
does not need to mix ws/wss and http/https schemes, so we can fail loads before making an
NSURLSessionDataTask and our loading of http/https URLs still works because it uses NSURLSessionDataTask
in the normal way, and our ws/wss URL &quot;loading&quot; still works because we use NSURLSessionWebSocketTask
for those URLs through the JavaScript WebSocket object, the way WebSockets are supposed to be created
from web content.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSocket.mm:
(TestWebKitAPI::TEST):

Originally-landed-as: 272448.1042@safari-7618-branch (0a3f4d58c388). <a href="https://rdar.apple.com/132954656">rdar://132954656</a>
Canonical link: <a href="https://commits.webkit.org/281792@main">https://commits.webkit.org/281792@main</a>
</pre>
----------------------------------------------------------------------
#### 8da2eab7ffa0f22bb36806f41c043a0af5bc0973
<pre>
[JSC] JSGlobalObject::arrayStructureForIndexingTypeDuringAllocation may allow creation of an undecided array with a Proxy object in the prototype chain
<a href="https://bugs.webkit.org/show_bug.cgi?id=274870">https://bugs.webkit.org/show_bug.cgi?id=274870</a>
<a href="https://rdar.apple.com/119545295">rdar://119545295</a>

Reviewed by Keith Miller.

When constructing an array along this particular path, newTarget.prototype could
have a getter that induces a bad time. We need to check for this case and handle
it explicitly since the array isn&apos;t yet fully constructed and thus won&apos;t be handled
by the having a bad time machinery.

* JSTests/stress/regress-119545295.js: Added.
(main.const.new_target):
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::createSubclassStructure):

Originally-landed-as: 272448.1052@safari-7618-branch (d4c5d33ae803). <a href="https://rdar.apple.com/132954559">rdar://132954559</a>
Canonical link: <a href="https://commits.webkit.org/281791@main">https://commits.webkit.org/281791@main</a>
</pre>
----------------------------------------------------------------------
#### b728e584a883c12a86abe5d6932ad5a3715e4ccf
<pre>
heap-use-after-free | WebCore::MediaRecorderPrivateWriter::flushCompressedSampleBuffers; Detail::CallableWrapper::call; WTF::RunLoop::performWork)
<a href="https://rdar.apple.com/129292824">rdar://129292824</a>

Reviewed by Andy Estes.

Adding a weakThis check we missed when adopting ThreadSafefWeakPtr.

* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm:
(WebCore::MediaRecorderPrivateWriter::fetchData):

Originally-landed-as: 272448.1073@safari-7618-branch (891cf8c9dbac). <a href="https://rdar.apple.com/132954379">rdar://132954379</a>
Canonical link: <a href="https://commits.webkit.org/281790@main">https://commits.webkit.org/281790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00f437e1ab32b9a6e822b8608025474c5fe3e74a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49288 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7994 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63019 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37569 "Found 10 new test failures: editing/deleting/smart-delete-002.html editing/deleting/smart-delete-paragraph-002.html editing/pasteboard/smart-paste-003-trailing-whitespace.html editing/pasteboard/smart-paste-004.html editing/pasteboard/smart-paste-in-text-control.html editing/pasteboard/smart-paste-paragraph-004.html editing/selection/clear-selection-crash.html editing/selection/doubleclick-whitespace-crash.html editing/selection/ios/change-selection-by-tapping.html editing/selection/ios/select-text-with-long-press-actions-disabled.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34232 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10046 "Found 1 new test failure: imported/w3c/web-platform-tests/shadow-dom/focus/focus-pseudo-matches-on-shadow-host.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10445 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54087 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66648 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60232 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10184 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56658 "Found 1 new test failure: imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56846 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4079 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81987 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9182 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14284 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38327 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->