### PR TITLE
Avoid taking a Ref of SOAuthorizationSession in it's destructor

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -120,6 +120,7 @@ private:
     RefPtr<API::NavigationAction> m_navigationAction;
     WeakPtr<WebPageProxy> m_page;
     InitiatingAction m_action;
+    bool m_isInDestructor { false };
 
     RetainPtr<SOAuthorizationViewController> m_viewController;
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 7337e801521b2c8c312d350e4997b867a3cd64b4
<pre>
Avoid taking a Ref of SOAuthorizationSession in it&apos;s destructor
<a href="https://rdar.apple.com/125530945">rdar://125530945</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274121">https://bugs.webkit.org/show_bug.cgi?id=274121</a>

Reviewed by Chris Dumez.

If the window is minimized whenever the destructor of SOAuthorizationSession is called, it can
set up a notification that takes a protectedThis of SOAuthorizationSession. However this is invalid
because we are inside the destructor, making the program crash when this notification is called and
the protectedThis is used. To fix this, we avoid setting up these notifications whenever we are in
the destructor of SOAuthorizationSession.

This issue dates back to whenever this minimize work-around was added in <a href="https://rdar.apple.com/55669065">rdar://55669065</a>.

There have been quite a few attempts to fix this: <a href="https://rdar.apple.com/59672418">rdar://59672418</a>, <a href="https://rdar.apple.com/73477045">rdar://73477045</a>,
<a href="https://rdar.apple.com/72375494">rdar://72375494</a>, and <a href="https://rdar.apple.com/65681530">rdar://65681530</a>, but they didn&apos;t address the root issue.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::~SOAuthorizationSession):
(WebKit::SOAuthorizationSession::becomeCompleted):
(WebKit::SOAuthorizationSession::dismissViewController):

Originally-landed-as: 272448.1025@safari-7618-branch (ee9683422733). <a href="https://rdar.apple.com/132954964">rdar://132954964</a>
Canonical link: <a href="https://commits.webkit.org/281835@main">https://commits.webkit.org/281835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/597038d9cb37cae4885134f29aa042f4876a8b7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11534 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49291 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7996 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34234 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56067 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10354 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_avc (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56660 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56850 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4080 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9201 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36152 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->