### PR TITLE
[ios] Prioritize text/plain content type over suggested xhtml MIME type

### DIFF
--- a/LayoutTests/http/tests/mime/resources/.htaccess
+++ b/LayoutTests/http/tests/mime/resources/.htaccess
@@ -5,6 +5,14 @@ Header always set Content-Type ""
 <Files xml-with-html.xml>
 ForceType "text/plain"
 </Files>
+<Files xhtml-with-html.xhtml>
+ForceType "text/plain"
+</Files>
+<Files xhtml-with-html-with-content-disposition>
+ForceType "text/plain"
+Header always set Content-Disposition "inline; filename=\"xhtml-with-html-with-content-disposition.xhtml\""
+Header always set X-Content-Type-Options "nosniff"
+</Files>
 <Files svg-with-html.svg>
 ForceType "text/plain"
 </Files>

--- a/LayoutTests/http/tests/mime/resources/xhtml-with-html-with-content-disposition
+++ b/LayoutTests/http/tests/mime/resources/xhtml-with-html-with-content-disposition
@@ -1,0 +1,4 @@
+<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<html xmlns:html="http://www.w3.org/1999/xhtml">
+<html:script>console.log("Fail");</html:script>
+</html>

--- a/LayoutTests/http/tests/mime/resources/xhtml-with-html.xhtml
+++ b/LayoutTests/http/tests/mime/resources/xhtml-with-html.xhtml
@@ -1,0 +1,4 @@
+<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<html xmlns:html="http://www.w3.org/1999/xhtml">
+<html:script>console.log("Fail");</html:script>
+</html>

--- a/LayoutTests/http/tests/mime/xhtml-with-html-expected.txt
+++ b/LayoutTests/http/tests/mime/xhtml-with-html-expected.txt
@@ -1,0 +1,2 @@
+xhtml-with-html.xhtml has MIME type text/plain
+

--- a/LayoutTests/http/tests/mime/xhtml-with-html-with-content-disposition-expected.txt
+++ b/LayoutTests/http/tests/mime/xhtml-with-html-with-content-disposition-expected.txt
@@ -1,0 +1,2 @@
+xhtml-with-html-with-content-disposition has MIME type text/plain
+

--- a/LayoutTests/http/tests/mime/xhtml-with-html-with-content-disposition.html
+++ b/LayoutTests/http/tests/mime/xhtml-with-html-with-content-disposition.html
@@ -1,0 +1,24 @@
+<html>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpResourceResponseMIMETypes();
+    testRunner.dumpAsText();
+}
+</script>
+<body>
+<script>
+function runTests() {
+    let iframe = document.createElement("iframe");
+    iframe.src = 'resources/xhtml-with-html-with-content-disposition';
+    if (window.testRunner) {
+        iframe.onerror = testRunner.notifyDone();
+        iframe.onload = testRunner.notifyDone();
+    }
+    document.body.appendChild(iframe);
+}
+runTests();
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/mime/xhtml-with-html.html
+++ b/LayoutTests/http/tests/mime/xhtml-with-html.html
@@ -1,0 +1,24 @@
+<html>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpResourceResponseMIMETypes();
+    testRunner.dumpAsText();
+}
+</script>
+<body>
+<script>
+function runTests() {
+    let iframe = document.createElement("iframe");
+    iframe.src = 'resources/xhtml-with-html.xhtml';
+    if (window.testRunner) {
+        iframe.onerror = testRunner.notifyDone();
+        iframe.onload = testRunner.notifyDone();
+    }
+    document.body.appendChild(iframe);
+}
+runTests();
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
+++ b/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
@@ -40,7 +40,7 @@ namespace WebCore {
 
 static inline bool shouldPreferTextPlainMIMEType(const String& mimeType, const String& proposedMIMEType)
 {
-    return ("text/plain"_s == mimeType) && ((proposedMIMEType == "text/xml"_s) || (proposedMIMEType == "application/xml"_s) || (proposedMIMEType == "image/svg+xml"_s));
+    return ("text/plain"_s == mimeType) && ((proposedMIMEType == "text/xml"_s) || (proposedMIMEType == "application/xhtml+xml"_s) || (proposedMIMEType == "application/xml"_s) || (proposedMIMEType == "image/svg+xml"_s));
 }
 
 void adjustMIMETypeIfNecessary(CFURLResponseRef response, IsMainResourceLoad isMainResourceLoad, IsNoSniffSet isNoSniffSet)


### PR DESCRIPTION
#### f9a7dd12bbf77919866f72097b381a51cebdf56b
<pre>
[ios] Prioritize text/plain content type over suggested xhtml MIME type
<a href="https://bugs.webkit.org/show_bug.cgi?id=273805">https://bugs.webkit.org/show_bug.cgi?id=273805</a>
<a href="https://rdar.apple.com/126768293">rdar://126768293</a>

Reviewed by David Kilzer.

Prefer text/plain when it is requested, instead of guessing the best MIME type
from a xhtml file extension or the content disposition.

* LayoutTests/http/tests/mime/resources/.htaccess:
* LayoutTests/http/tests/mime/resources/xhtml-with-html-with-content-disposition: Added.
* LayoutTests/http/tests/mime/resources/xhtml-with-html.xhtml: Added.
* LayoutTests/http/tests/mime/xhtml-with-html-expected.txt: Added.
* LayoutTests/http/tests/mime/xhtml-with-html-with-content-disposition-expected.txt: Added.
* LayoutTests/http/tests/mime/xhtml-with-html-with-content-disposition.html: Added.
* LayoutTests/http/tests/mime/xhtml-with-html.html: Added.
* Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm:
(WebCore::shouldPreferTextPlainMIMEType):

Originally-landed-as: 272448.1013@safari-7618-branch (efaf5e842f10). <a href="https://rdar.apple.com/132955068">rdar://132955068</a>
Canonical link: <a href="https://commits.webkit.org/281836@main">https://commits.webkit.org/281836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/458db168c0dcb4d373b5372d8c0ec5191154270b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49293 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8000 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34236 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10056 "Found 2 new test failures: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66652 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4933 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10186 "Found 1 new test failure: http/tests/media/media-element-frame-destroyed-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56868 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4086 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->