### PR TITLE
Integer truncation in FragmentedSharedBuffer::tryCreateArrayBuffer can lead to a buffer overflow

### DIFF
--- a/LayoutTests/editing/undo/redo-reapply-edit-command-crash-expected.txt
+++ b/LayoutTests/editing/undo/redo-reapply-edit-command-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/editing/undo/redo-reapply-edit-command-crash.html
+++ b/LayoutTests/editing/undo/redo-reapply-edit-command-crash.html
@@ -1,0 +1,39 @@
+<style>
+*:read-only,*::cue,#x49:only-child { border-bottom-left-radius: 100% 0.16em;-webkit-user-modify: read-write-plaintext-only;caret-color: auto;column-break-after: auto;justify-self: last baseline;border-top-color: green;border-image-source: conic-gradient(at 100% 0.04em,transparent);font-variant: small-caps;padding-top: auto;image-rendering: smooth;border-right-width: var(--css-line-width);border-bottom-width: thick;grid-row-start: auto;overflow-x: hidden;user-zoom: fixed;text-decoration-style: dotted;outline-offset: 10px;-webkit-shape-outside: repeating-linear-gradient(rgba(215,83,81,206));position: fixed;-webkit-box-lines: single }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function main() {
+    try { document.execCommand("redo",false,null); } catch (e) { }
+    document.write('Test passes if it does not crash.');
+}
+function f1() {
+    var x6 = document.getElementById("x9");
+    try { x29.before(x6); } catch (e) { }
+    try { document.execCommand("undo",false,null); } catch (e) { }
+}
+function f4() {
+try { document.onreadystatechange = f4; } catch (e) { }
+try { document.execCommand("forwardDelete",false,null); } catch (e) { }
+try { document.execCommand("selectAll",false,null); } catch (e) { }
+try { x20.toBlob(f1); } catch (e) { }
+try { document.execCommand("insertText",false," "); } catch (e) { }
+}
+</script>
+<body onload="main()">
+<img id="x6" importance="low" align="left" src="x">
+<link id="x29" href="">
+<template id="x9" onclick="f4()">
+</template>
+<cite id="x5" translate="yes" accesskey="1" dir="rtl" onfocusin="f1()">
+</cite>
+<h3 id="x10">
+<iframe id="x27" align="left" importance="auto" src="x" hidden="" marginwidth="0" loading="lazy">
+</iframe>
+<canvas id="x20" onfocusin="f1()" onfocus="f4()"></canvas>
+</h3>
+<pre id="x1">
+<details open="" ontoggle="f4()">
+</body>

--- a/LayoutTests/webaudio/crashtest/audioworklet-concurrent-resampler-crash-expected.txt
+++ b/LayoutTests/webaudio/crashtest/audioworklet-concurrent-resampler-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webaudio/crashtest/audioworklet-concurrent-resampler-crash.html
+++ b/LayoutTests/webaudio/crashtest/audioworklet-concurrent-resampler-crash.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+    <script>
+        let worklet_source = `
+            class Processor extends AudioWorkletProcessor {
+                process(inputs, outputs, parameters) {
+                    return true;
+                }
+            }
+            registerProcessor('P2', Processor);
+        `;
+
+        let blob = new Blob([worklet_source], { type: 'application/javascript' });
+        let worklet = URL.createObjectURL(blob);
+
+        var ctx = new AudioContext({ sampleRate: 44100});
+        const dest = ctx.destination;
+        dest.channelCountMode = "max";
+
+        async function main() {
+            await ctx.audioWorklet.addModule(worklet);
+            var script_processor = ctx.createScriptProcessor();
+            script_processor.onaudioprocess = function() {
+                dest.channelCount = 1;
+                audio_worklet.disconnect();
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }
+            var audio_worklet = new AudioWorkletNode(ctx, "P2");
+            script_processor.connect(audio_worklet);
+            audio_worklet.connect(dest);
+        }
+    </script>
+</head>
+<body onload="main()">
+    <p>This test passes if it does not crash.</p>
+    <script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+    </script>
+</body>
+</html>

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/SeparateCompoundExpressions.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/SeparateCompoundExpressions.cpp
@@ -262,8 +262,10 @@ class Separator : public TIntermRebuild
         }
         auto &bindingMap = getCurrBindingMap();
         const Name name  = mIdGen.createNewName();
-        auto *var =
-            new TVariable(&mSymbolTable, name.rawName(), &newExpr.getType(), name.symbolType());
+        TType *newType   = new TType(newExpr.getType());
+        newType->setQualifier(EvqTemporary);
+        newType->setInterfaceBlock(nullptr);
+        auto *var  = new TVariable(&mSymbolTable, name.rawName(), newType, name.symbolType());
         auto *decl = new TIntermDeclaration(var, &newExpr);
         pushStmt(*decl);
         mExprMap[&oldExpr] = new TIntermSymbol(var);

--- a/Source/WebCore/PAL/ThirdParty/libavif/src/obu.c
+++ b/Source/WebCore/PAL/ThirdParty/libavif/src/obu.c
@@ -439,12 +439,14 @@ avifBool avifSequenceHeaderParse(avifSequenceHeader * header, const avifROData *
             return AVIF_FALSE;
 
         if (obu_type == 1) { // Sequence Header
+            avifBits seqHdrBits;
+            avifBitsInit(&seqHdrBits, obus.data + init_byte_pos, obu_size);
             switch (codecType) {
                 case AVIF_CODEC_TYPE_AV1:
-                    return parseAV1SequenceHeader(&bits, header);
+                    return parseAV1SequenceHeader(&seqHdrBits, header);
 #if defined(AVIF_CODEC_AVM)
                 case AVIF_CODEC_TYPE_AV2:
-                    return parseAV2SequenceHeader(&bits, header);
+                    return parseAV2SequenceHeader(&seqHdrBits, header);
 #endif
                 default:
                     return AVIF_FALSE;

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -296,8 +296,10 @@ void EditCommandComposition::reapply()
     if (!document->editor().willReapplyEditing(*this))
         return;
 
-    for (auto& command : m_commands)
+    for (size_t i = 0; i < m_commands.size(); ++i) {
+        RefPtr command = m_commands[i].get();
         command->doReapply();
+    }
 
     document->editor().reappliedEditing(*this);
 
@@ -334,8 +336,10 @@ void EditCommandComposition::setRangeDeletedByUnapply(const VisiblePositionIndex
 #ifndef NDEBUG
 void EditCommandComposition::getNodesInCommand(HashSet<Ref<Node>>& nodes)
 {
-    for (auto& command : m_commands)
+    for (size_t i = 0; i < m_commands.size(); ++i) {
+        RefPtr command = m_commands[i].get();
         command->getNodesInCommand(nodes);
+    }
 }
 #endif
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1272,6 +1272,7 @@ void Editor::appliedEditing(CompositeEditCommand& command)
 
 bool Editor::willUnapplyEditing(const EditCommandComposition& composition) const
 {
+    TypingCommand::closeTyping(protectedDocument());
     return dispatchBeforeInputEvents(composition.startingRootEditableElement(), composition.endingRootEditableElement(), "historyUndo"_s, IsInputMethodComposing::No);
 }
 

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -247,6 +247,10 @@ String FragmentedSharedBuffer::toHexString() const
 
 RefPtr<ArrayBuffer> FragmentedSharedBuffer::tryCreateArrayBuffer() const
 {
+    if (size() > std::numeric_limits<unsigned>::max()) {
+        WTFLogAlways("SharedBuffer::tryCreateArrayBuffer Unable to create buffer. Requested size is too large (%zu)\n", size());
+        return nullptr;
+    }
     auto arrayBuffer = ArrayBuffer::tryCreateUninitialized(static_cast<unsigned>(size()), 1);
     if (!arrayBuffer) {
         WTFLogAlways("SharedBuffer::tryCreateArrayBuffer Unable to create buffer. Requested size was %zu\n", size());

--- a/Source/WebCore/platform/audio/MultiChannelResampler.cpp
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.cpp
@@ -42,19 +42,8 @@ namespace WebCore {
 MultiChannelResampler::MultiChannelResampler(double scaleFactor, unsigned numberOfChannels, unsigned requestFrames, Function<void(AudioBus*, size_t framesToProcess)>&& provideInput)
     : m_numberOfChannels(numberOfChannels)
     , m_provideInput(WTFMove(provideInput))
-    , m_multiChannelBus(AudioBus::create(numberOfChannels, requestFrames, false))
+    , m_multiChannelBus(AudioBus::create(numberOfChannels, requestFrames))
 {
-    // As an optimization, we will use the buffer passed to provideInputForChannel() as channel memory for the first channel so we
-    // only need to allocate memory if there is more than one channel.
-    if (numberOfChannels > 1) {
-        m_channelsMemory = Vector<std::unique_ptr<AudioFloatArray>>(numberOfChannels - 1, [&](size_t i) {
-            size_t channelIndex = i + 1;
-            auto floatArray = makeUnique<AudioFloatArray>(requestFrames);
-            m_multiChannelBus->setChannelMemory(channelIndex, floatArray->data(), requestFrames);
-            return floatArray;
-        });
-    }
-
     // Create each channel's resampler.
     m_kernels = Vector<std::unique_ptr<SincResampler>>(numberOfChannels, [&](size_t channelIndex) {
         return makeUnique<SincResampler>(scaleFactor, requestFrames, std::bind(&MultiChannelResampler::provideInputForChannel, this, std::placeholders::_1, std::placeholders::_2, channelIndex));
@@ -93,16 +82,10 @@ void MultiChannelResampler::process(AudioBus* destination, size_t framesToProces
 void MultiChannelResampler::provideInputForChannel(std::span<float> buffer, size_t framesToProcess, unsigned channelIndex)
 {
     ASSERT(channelIndex < m_multiChannelBus->numberOfChannels());
-    ASSERT(framesToProcess == m_multiChannelBus->length());
+    ASSERT(framesToProcess <= m_multiChannelBus->length());
 
-    if (!channelIndex) {
-        // As an optimization, we use the provided buffer as memory for the first channel in the AudioBus. This avoids
-        // having to memcpy() for the first channel.
-        RELEASE_ASSERT(framesToProcess <= buffer.size());
-        m_multiChannelBus->setChannelMemory(0, buffer.data(), framesToProcess);
+    if (!channelIndex)
         m_provideInput(m_multiChannelBus.get(), framesToProcess);
-        return;
-    }
 
     // Copy the channel data from what we received from m_multiChannelProvider.
     memcpySpan(buffer, m_multiChannelBus->channel(channelIndex)->span().first(framesToProcess));

--- a/Source/WebCore/platform/audio/MultiChannelResampler.h
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.h
@@ -29,7 +29,6 @@
 #ifndef MultiChannelResampler_h
 #define MultiChannelResampler_h
 
-#include "AudioArray.h"
 #include <memory>
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
@@ -62,7 +61,6 @@ private:
     size_t m_outputFramesReady { 0 };
     Function<void(AudioBus*, size_t framesToProcess)> m_provideInput;
     RefPtr<AudioBus> m_multiChannelBus;
-    Vector<std::unique_ptr<AudioFloatArray>> m_channelsMemory;
 };
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -30,6 +30,7 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
@@ -211,4 +212,41 @@ TEST(WebKit, LoadHTMLStringWithInvalidBaseURL)
     EXPECT_WK_STREQ([webView URL].absoluteString, "invalid");
 
     EXPECT_FALSE(didCrash);
+}
+
+TEST(WebKit, LoadMoreThan4GB)
+{
+    constexpr auto html = "<script>"
+    "async function main() {"
+    "    const response = await fetch('/bigdata');"
+    "    await response.arrayBuffer();"
+    "}"
+    "main().catch(e => {"
+    "    alert('caught error ' + e);"
+    "}).finally(() => {"
+    "    alert('did not catch error');"
+    "});"
+    "</script>"_s;
+
+    using namespace TestWebKitAPI;
+    auto longData = dataFromVector(Vector<uint8_t>(static_cast<size_t>(0x10000000), [] (size_t) {
+        return static_cast<uint8_t>('a');
+    }));
+
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        if (path == "/"_s)
+            co_await connection.awaitableSend(HTTPResponse(html).serialize());
+        else {
+            co_await connection.awaitableSend("HTTP/1.1 200 OK\r\nContent-type: application/octet-stream\r\n\r\n"_s);
+            for (size_t i = 0; i < 16; ++i)
+                co_await connection.awaitableSend(RetainPtr { longData.get() });
+            connection.terminate();
+        }
+    } });
+
+    RetainPtr webView = adoptNS([WKWebView new]);
+    [webView loadRequest:server.request()];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "caught error RangeError: Out of memory");
 }

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -129,6 +129,7 @@ public:
     void send(RetainPtr<dispatch_data_t>&&, CompletionHandler<void(bool)>&& = nullptr) const;
     SendOperation awaitableSend(Vector<uint8_t>&&);
     SendOperation awaitableSend(String&&);
+    SendOperation awaitableSend(RetainPtr<dispatch_data_t>&&);
     void sendAndReportError(Vector<uint8_t>&&, CompletionHandler<void(bool)>&&) const;
     void receiveBytes(CompletionHandler<void(Vector<uint8_t>&&)>&&, size_t minimumSize = 1) const;
     void receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&&, Vector<char>&& buffer = { }) const;
@@ -261,6 +262,8 @@ private:
 };
 
 } // namespace H2
+
+RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&&);
 
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -336,7 +336,7 @@ static RetainPtr<dispatch_data_t> dataFromString(String&& s)
     }));
 }
 
-static RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&& v)
+RetainPtr<dispatch_data_t> dataFromVector(Vector<uint8_t>&& v)
 {
     auto bufferSize = v.size();
     auto rawPointer = v.releaseBuffer().leakPtr();
@@ -514,6 +514,11 @@ SendOperation Connection::awaitableSend(Vector<uint8_t>&& message)
 SendOperation Connection::awaitableSend(String&& message)
 {
     return { dataFromString(WTFMove(message)), *this };
+}
+
+SendOperation Connection::awaitableSend(RetainPtr<dispatch_data_t>&& data)
+{
+    return { WTFMove(data), *this };
 }
 
 void Connection::send(String&& message, CompletionHandler<void()>&& completionHandler) const


### PR DESCRIPTION
#### a4eefa9bf62946ba7a32da8aedfa0dff2e8ae816
<pre>
Integer truncation in FragmentedSharedBuffer::tryCreateArrayBuffer can lead to a buffer overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=276381">https://bugs.webkit.org/show_bug.cgi?id=276381</a>
<a href="https://rdar.apple.com/131369305">rdar://131369305</a>

Reviewed by Alex Christensen.

Make sure the size fits in an `unsigned` type before casting it.

Including an API test that Alex Christensen wrote.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::tryCreateArrayBuffer const):

Originally-landed-as: 0d4ba4017ef3. <a href="https://rdar.apple.com/132955526">rdar://132955526</a>
Canonical link: <a href="https://commits.webkit.org/281842@main">https://commits.webkit.org/281842@main</a>
</pre>
----------------------------------------------------------------------
#### 25eedd143edb3a68d58b8995159bdeb806a9d8b0
<pre>
Fix array OOB due to a bug in comma expression processing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=xxxxx">https://bugs.webkit.org/show_bug.cgi?id=xxxxx</a>
<a href="https://rdar.apple.com/128873925">rdar://128873925</a>

Reviewed by Dan Glastonbury.

A pre-pass of the ANGLE compiler separates compound expressions into single
expressions with temporary values. (i.e. x=A+B+C can become tmp1 = b+C,
x=A+tmp1;). When creating a temporary variable, we previously would copy
the entire type. However, the type constructor also lead to copying
qualifiers, such as &apos;uniform&apos; and &apos;interface block&apos; markers: Qualifiers
that can belong to an original type, but shouldn&apos;t ever be applied to
temporary variables. (Fix and explanation by Kyle Piddington.)

* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/SeparateCompoundExpressions.cpp:
(sh::Separator::pushBinding):

Originally-landed-as: 5a66ef38bf19. <a href="https://rdar.apple.com/132955470">rdar://132955470</a>
Canonical link: <a href="https://commits.webkit.org/281841@main">https://commits.webkit.org/281841@main</a>
</pre>
----------------------------------------------------------------------
#### 42190b9e1320b2ef71e165fefaf8263d5924281d
<pre>
Always copy all audio channels to the AudioBus to guarantee data lifetime.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273176">https://bugs.webkit.org/show_bug.cgi?id=273176</a>
<a href="https://rdar.apple.com/125166710">rdar://125166710</a>

Reviewed by Chris Dumez.

Following 275262@main, a task is dispatched on the audio render thread.
This task dispatch takes a reference to the source and destination AudioBus
however when a MultiChannelResampler is in use, the source AudioBus may
contain a raw pointer to the resampled&apos;s AudioArray and the lifetime of
this object may be shorter than the AudioBus.

In 232182@main, a speed and memory optimisation was added by passed-in buffer
as memory for the first channel in the AudioBus.
We revert this change for now and copy all channels&apos; data to the AudioBus.

Added test.

* LayoutTests/webaudio/crashtest/audioworklet-concurrent-resampler-crash-expected.txt: Added.
* LayoutTests/webaudio/crashtest/audioworklet-concurrent-resampler-crash.html: Added.
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::MultiChannelResampler):
(WebCore::MultiChannelResampler::provideInputForChannel):
* Source/WebCore/platform/audio/MultiChannelResampler.h:

Originally-landed-as: 272448.960@safari-7618-branch (b7ccdb65258e). <a href="https://rdar.apple.com/132955432">rdar://132955432</a>
Canonical link: <a href="https://commits.webkit.org/281840@main">https://commits.webkit.org/281840@main</a>
</pre>
----------------------------------------------------------------------
#### 4dfdeb7f6ab6f19c3af8d9b1276d65a89d3f3cec
<pre>
heap-use-after-free | WebCore::EditCommandComposition::reapply
<a href="https://rdar.apple.com/126683181">rdar://126683181</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273237">https://bugs.webkit.org/show_bug.cgi?id=273237</a>

Reviewed by Ryosuke Niwa.

Close TypingCommand when about to undo any command to avoid mutate
m_commands of TypingCommand (during undo &amp; redo).
Make iteration for m_commands safe in EditCommandComposition::reapply
when more commands appended and its capacity needs to expand.

* LayoutTests/editing/undo/redo-reapply-edit-command-crash-expected.txt: Added.
* LayoutTests/editing/undo/redo-reapply-edit-command-crash.html: Added.
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::EditCommandComposition::reapply):
(WebCore::EditCommandComposition::getNodesInCommand):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::willUnapplyEditing const):

Originally-landed-as: 272448.968@safari-7618-branch (39a32d378220). <a href="https://rdar.apple.com/132955348">rdar://132955348</a>
Canonical link: <a href="https://commits.webkit.org/281839@main">https://commits.webkit.org/281839@main</a>
</pre>
----------------------------------------------------------------------
#### 1e99eb3b139ea79efd03877bd2053df972dad45f
<pre>
[LibAVIF Downstream] Potential &apos;over-read&apos; issue committed to upstream libavif
<a href="https://bugs.webkit.org/show_bug.cgi?id=273636">https://bugs.webkit.org/show_bug.cgi?id=273636</a>
<a href="https://rdar.apple.com/127409431">rdar://127409431</a>

Reviewed by Tim Horton.

When trying to parse a sequence header, parse only obu_size bytes.

The current code ignores obu_size and parses as long as it sees
data and could end up over-reading into other obus.

Commit URL: <a href="https://github.com/AOMediaCodec/libavif/commit/4c7f0f40c3c3c1c362cef47379220041d61fd2af">https://github.com/AOMediaCodec/libavif/commit/4c7f0f40c3c3c1c362cef47379220041d61fd2af</a>

* Source/WebCore/PAL/ThirdParty/libavif/src/obu.c:
(avifSequenceHeaderParse):

Originally-landed-as: 272448.981@safari-7618-branch (4f3b41b6047a). <a href="https://rdar.apple.com/132955262">rdar://132955262</a>
Canonical link: <a href="https://commits.webkit.org/281838@main">https://commits.webkit.org/281838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9493b7a754979b7e343f9bd64089ab0019970103

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11814 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49310 "Found 1 new test failure: webaudio/crashtest/audioworklet-concurrent-resampler-crash.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8001 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66656 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4936 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10188 "Found 1 new test failure: http/tests/media/media-element-frame-destroyed-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56674 "Found 1 new test failure: webaudio/crashtest/audioworklet-concurrent-resampler-crash.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56859 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4087 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9203 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36157 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->