### PR TITLE
In AXIsolatedTree::resolveAppends(), m_unresolvedPendingAppends can be added to while being iterated, potentially causing memory safety issues

### DIFF
--- a/LayoutTests/fast/css/font-size-adjust-from-style-invalid-value-expected.txt
+++ b/LayoutTests/fast/css/font-size-adjust-from-style-invalid-value-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash on release/debug builds for empty font-size-adjust value

--- a/LayoutTests/fast/css/font-size-adjust-from-style-invalid-value.html
+++ b/LayoutTests/fast/css/font-size-adjust-from-style-invalid-value.html
@@ -1,0 +1,11 @@
+<style>
+.class9 { font:0em/0 serif; font-size-adjust:from-font; }
+</style>
+<body>
+<li contenteditable="plaintext-only" class="class9" autofocus="autofocus" Zv">
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>
+<div>This test should not crash on release/debug builds for empty font-size-adjust value</div>
+</body>

--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -116,6 +116,10 @@ public:
 
     template<typename Predicate> iterator findIf(const Predicate&);
     template<typename Predicate> const_iterator findIf(const Predicate&) const;
+    template<typename Predicate> bool containsIf(const Predicate& predicate) const
+    {
+        return findIf(predicate) != end();
+    }
 
 private:
     friend class DequeIteratorBase<T, inlineCapacity>;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2102,22 +2102,16 @@ void AccessibilityObject::clearChildren()
     m_childrenInitialized = false;
 }
 
-AccessibilityObject* AccessibilityObject::anchorElementForNode(Node* node)
+AccessibilityObject* AccessibilityObject::anchorElementForNode(Node& node)
 {
-    RenderObject* obj = node->renderer();
-    if (!obj)
+    CheckedPtr renderer = node.renderer();
+    if (!renderer)
         return nullptr;
 
-    RefPtr<AccessibilityObject> axObj = obj->document().axObjectCache()->getOrCreate(*obj);
-    Element* anchor = axObj->anchorElement();
-    if (!anchor)
-        return nullptr;
-    
-    RenderObject* anchorRenderer = anchor->renderer();
-    if (!anchorRenderer)
-        return nullptr;
-    
-    return anchorRenderer->document().axObjectCache()->getOrCreate(*anchorRenderer);
+    WeakPtr cache = renderer->document().axObjectCache();
+    RefPtr axObject = cache ? cache->getOrCreate(renderer.get()) : nullptr;
+    auto* anchor = axObject ? axObject->anchorElement() : nullptr;
+    return anchor ? cache->getOrCreate(anchor->renderer()) : nullptr;
 }
 
 AccessibilityObject* AccessibilityObject::headingElementForNode(Node* node)

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -428,7 +428,7 @@ public:
 
     AXObjectCache* axObjectCache() const override;
 
-    static AccessibilityObject* anchorElementForNode(Node*);
+    static AccessibilityObject* anchorElementForNode(Node&);
     static AccessibilityObject* headingElementForNode(Node*);
     virtual Element* anchorElement() const { return nullptr; }
     virtual RefPtr<Element> popoverTargetElement() const { return nullptr; }

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -203,14 +203,14 @@ RetainPtr<NSArray> AccessibilityObject::contentForRange(const SimpleRange& range
         if (it.text().length()) {
             auto listMarkerText = listMarkerTextForNodeAndPosition(&node, makeContainerOffsetPosition(it.range().start));
             if (!listMarkerText.isEmpty()) {
-                if (auto attrString = attributedStringCreate(&node, listMarkerText, it.range(), SpellCheck::No))
+                if (auto attrString = attributedStringCreate(node, listMarkerText, it.range(), SpellCheck::No))
                     [result addObject:attrString.get()];
             }
 
-            if (auto attrString = attributedStringCreate(&node, it.text(), it.range(), spellCheck))
+            if (auto attrString = attributedStringCreate(node, it.text(), it.range(), spellCheck))
                 [result addObject:attrString.get()];
         } else {
-            if (Node* replacedNode = it.node()) {
+            if (RefPtr replacedNode = it.node()) {
                 auto* cache = axObjectCache();
                 if (auto* object = cache ? cache->getOrCreate(replacedNode->renderer()) : nullptr)
                     addObjectWrapperToArray(*object, result.get());

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -272,10 +272,10 @@ static void attributedStringSetCompositionAttributes(NSMutableAttributedString *
 #endif // HAVE(INLINE_PREDICTIONS)
 }
 
-RetainPtr<NSAttributedString> attributedStringCreate(Node* node, StringView text, const SimpleRange&, AXCoreObject::SpellCheck)
+RetainPtr<NSAttributedString> attributedStringCreate(Node& node, StringView text, const SimpleRange&, AXCoreObject::SpellCheck)
 {
     // Skip invisible text.
-    auto* renderer = node->renderer();
+    CheckedPtr renderer = node.renderer();
     if (!renderer)
         return nil;
 
@@ -283,10 +283,10 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node* node, StringView text
     NSRange range = NSMakeRange(0, [result length]);
 
     // Set attributes.
-    attributeStringSetStyle(result.get(), renderer, range);
-    attributeStringSetBlockquoteLevel(result.get(), renderer, range);
-    attributeStringSetLanguage(result.get(), renderer, range);
-    attributedStringSetCompositionAttributes(result.get(), renderer);
+    attributeStringSetStyle(result.get(), renderer.get(), range);
+    attributeStringSetBlockquoteLevel(result.get(), renderer.get(), range);
+    attributeStringSetLanguage(result.get(), renderer.get(), range);
+    attributedStringSetCompositionAttributes(result.get(), renderer.get());
 
     return result;
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -393,7 +393,10 @@ Vector<AXIsolatedTree::NodeChange> AXIsolatedTree::resolveAppends()
     double counter = 0;
     Vector<NodeChange> resolvedAppends;
     resolvedAppends.reserveInitialCapacity(m_unresolvedPendingAppends.size());
-    for (const auto& unresolvedAppend : m_unresolvedPendingAppends) {
+    // The process of resolving appends can add more IDs to m_unresolvedPendingAppends as we iterate over it, so
+    // iterate over an exchanged map instead. Any late-appended IDs will get picked up in the next cycle.
+    auto unresolvedPendingAppends = std::exchange(m_unresolvedPendingAppends, { });
+    for (const auto& unresolvedAppend : unresolvedPendingAppends) {
         if (m_replacingTree) {
             ++counter;
             if (MonotonicTime::now() - lastFeedbackTime > CreationFeedbackInterval) {
@@ -408,7 +411,6 @@ Vector<AXIsolatedTree::NodeChange> AXIsolatedTree::resolveAppends()
         }
     }
     resolvedAppends.shrinkToFit();
-    m_unresolvedPendingAppends.clear();
 
     if (m_replacingTree)
         m_replacingTree->reportLoadingProgress(1);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -53,7 +53,7 @@ void attributedStringSetNumber(NSMutableAttributedString *, NSString *, NSNumber
 void attributedStringSetFont(NSMutableAttributedString *, CTFontRef, const NSRange&);
 void attributedStringSetSpelling(NSMutableAttributedString *, Node&, StringView, const NSRange&);
 void attributedStringSetNeedsSpellCheck(NSMutableAttributedString *, Node&);
-RetainPtr<NSAttributedString> attributedStringCreate(Node*, StringView, const SimpleRange&, AXCoreObject::SpellCheck);
+RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const SimpleRange&, AXCoreObject::SpellCheck);
 }
 
 @interface WebAccessibilityObjectWrapperBase : NSObject {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -371,6 +371,10 @@ static Ref<CSSValue> fontSizeAdjustFromStyle(const RenderStyle& style)
 
     auto metric = fontSizeAdjust.metric;
     auto value = fontSizeAdjust.shouldResolveFromFont() ? fontSizeAdjust.resolve(style.computedFontSize(), style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
+
+    if (!value)
+        return CSSPrimitiveValue::create(CSSValueNone);
+
     if (metric == FontSizeAdjust::Metric::ExHeight)
         return CSSPrimitiveValue::create(*value);
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -31,6 +31,7 @@
 #include "RemoteCommandListener.h"
 #include "Timer.h"
 #include <wtf/AggregateLogger.h>
+#include <wtf/CancellableTask.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -83,7 +84,7 @@ public:
     WEBCORE_EXPORT static void setMediaCapabilityGrantsEnabled(bool);
 #endif
 
-    virtual ~PlatformMediaSessionManager() = default;
+    virtual ~PlatformMediaSessionManager();
 
     virtual void scheduleSessionStatusUpdate() { }
 
@@ -227,6 +228,7 @@ protected:
     std::optional<bool> supportsSpatialAudioPlayback() { return m_supportsSpatialAudioPlayback; }
 
     void nowPlayingMetadataChanged(const NowPlayingMetadata&);
+    void enqueueTaskOnMainThread(Function<void()>&&);
 
 private:
     friend class Internals;
@@ -260,6 +262,7 @@ private:
     bool m_hasScheduledSessionStateUpdate { false };
 
     WeakHashSet<NowPlayingMetadataObserver> m_nowPlayingMetadataObservers;
+    TaskCancellationGroup m_taskGroup;
 
 #if ENABLE(WEBM_FORMAT_READER)
     static bool m_webMFormatReaderEnabled;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -270,7 +270,7 @@ String MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorre
 
 void MediaSessionManagerCocoa::scheduleSessionStatusUpdate()
 {
-    callOnMainThread([this] () mutable {
+    enqueueTaskOnMainThread([this] () mutable {
         m_nowPlayingManager->setSupportsSeeking(computeSupportsSeeking());
         updateNowPlayingInfo();
 
@@ -329,7 +329,7 @@ void MediaSessionManagerCocoa::sessionWillEndPlayback(PlatformMediaSession& sess
 {
     PlatformMediaSessionManager::sessionWillEndPlayback(session, delayCallingUpdateNowPlaying);
 
-    callOnMainThread([weakSession = WeakPtr { session }] {
+    enqueueTaskOnMainThread([weakSession = WeakPtr { session }] {
         if (weakSession)
             weakSession->updateMediaUsageIfChanged();
     });
@@ -337,7 +337,7 @@ void MediaSessionManagerCocoa::sessionWillEndPlayback(PlatformMediaSession& sess
     if (delayCallingUpdateNowPlaying == DelayCallingUpdateNowPlaying::No)
         updateNowPlayingInfo();
     else {
-        callOnMainThread([this] {
+        enqueueTaskOnMainThread([this] {
             updateNowPlayingInfo();
         });
     }

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -70,6 +70,9 @@ constexpr Seconds largeOutgoingMessageQueueTimeThreshold { 20_s };
 
 std::atomic<unsigned> UnboundedSynchronousIPCScope::unboundedSynchronousIPCCount = 0;
 
+enum class MessageIdentifierType { };
+using MessageIdentifier = AtomicObjectIdentifier<MessageIdentifierType>;
+
 #if ENABLE(UNFAIR_LOCK)
 static UnfairLock s_connectionMapLock;
 #else
@@ -110,14 +113,20 @@ public:
     // waiting for a reply to a synchronous message.
     bool processIncomingMessage(Connection& connectionForLockCheck, UniqueRef<Decoder>&) WTF_REQUIRES_LOCK(connectionForLockCheck.m_incomingMessagesLock);
 
-    // Dispatch pending sync messages.
+    // Dispatch pending messages that should be dispatched while waiting for a sync reply.
     void dispatchMessages(Function<void(MessageName, uint64_t)>&& willDispatchMessage = { });
+
+    // Dispatch pending messages that should be dispatched while waiting for a sync reply,
+    // up until the message with the provided identifier.
+    void dispatchMessagesUntil(MessageIdentifier lastMessageToDispatch);
 
     // Add matching pending messages to the provided MessageReceiveQueue.
     void enqueueMatchingMessages(Connection&, MessageReceiveQueue&, const ReceiverMatcher&);
 
     // Dispatch pending sync messages for given connection.
     void dispatchMessagesAndResetDidScheduleDispatchMessagesForConnection(Connection&);
+
+    std::optional<MessageIdentifier> identifierOfLastMessageToDispatchWhileWaitingForSyncReply();
 
 private:
     explicit SyncMessageState(SerialFunctionDispatcher& dispatcher)
@@ -142,6 +151,7 @@ private:
     struct ConnectionAndIncomingMessage {
         Ref<Connection> connection;
         UniqueRef<Decoder> message;
+        MessageIdentifier identifier { MessageIdentifier::generate() };
 
         void dispatch()
         {
@@ -245,7 +255,7 @@ void Connection::SyncMessageState::dispatchMessages(Function<void(MessageName, u
             m_messagesBeingDispatched = std::exchange(m_messagesToDispatchWhileWaitingForSyncReply, { });
         else {
             while (!m_messagesToDispatchWhileWaitingForSyncReply.isEmpty())
-                m_messagesBeingDispatched.append(m_messagesToDispatchWhileWaitingForSyncReply.takeLast());
+                m_messagesBeingDispatched.append(m_messagesToDispatchWhileWaitingForSyncReply.takeFirst());
         }
     }
 
@@ -255,6 +265,33 @@ void Connection::SyncMessageState::dispatchMessages(Function<void(MessageName, u
             willDispatchMessage(messageToDispatch.message->messageName(), messageToDispatch.message->destinationID());
         messageToDispatch.dispatch();
     }
+}
+
+void Connection::SyncMessageState::dispatchMessagesUntil(MessageIdentifier lastMessageToDispatch)
+{
+    assertIsCurrent(m_dispatcher);
+    {
+        Locker locker { m_lock };
+        if (!m_messagesToDispatchWhileWaitingForSyncReply.containsIf([&](auto& message) { return message.identifier == lastMessageToDispatch; }))
+            return; // This message has already been dispatched.
+
+        while (!m_messagesToDispatchWhileWaitingForSyncReply.isEmpty()) {
+            m_messagesBeingDispatched.append(m_messagesToDispatchWhileWaitingForSyncReply.takeFirst());
+            if (m_messagesBeingDispatched.last().identifier == lastMessageToDispatch)
+                break;
+        }
+    }
+
+    while (!m_messagesBeingDispatched.isEmpty())
+        m_messagesBeingDispatched.takeFirst().dispatch();
+}
+
+std::optional<MessageIdentifier> Connection::SyncMessageState::identifierOfLastMessageToDispatchWhileWaitingForSyncReply()
+{
+    Locker locker { m_lock };
+    if (m_messagesToDispatchWhileWaitingForSyncReply.isEmpty())
+        return std::nullopt;
+    return m_messagesToDispatchWhileWaitingForSyncReply.last().identifier;
 }
 
 void Connection::SyncMessageState::dispatchMessagesAndResetDidScheduleDispatchMessagesForConnection(Connection& connection)
@@ -286,6 +323,10 @@ struct Connection::PendingSyncReply {
     // The reply decoder, will be null if there was an error processing the sync
     // message on the other side.
     std::unique_ptr<Decoder> replyDecoder;
+
+    // To make sure we maintain message ordering, we keep track of the last message (that returns true for shouldDispatchMessageWhenWaitingForSyncReply())
+    // and that was received *before* the sync reply. This is to make sure that we dispatch messages up until this one, before dispatching the sync reply.
+    std::optional<MessageIdentifier> identifierOfLastMessageToDispatchBeforeSyncReply;
 
     PendingSyncReply() = default;
 
@@ -912,8 +953,18 @@ auto Connection::waitForSyncReply(SyncRequestID syncRequestID, MessageName messa
             ASSERT_UNUSED(syncRequestID, pendingSyncReply.syncRequestID == syncRequestID);
 
             // We found the sync reply.
-            if (pendingSyncReply.replyDecoder)
-                return makeUniqueRefFromNonNullUniquePtr(WTFMove(pendingSyncReply.replyDecoder));
+            if (pendingSyncReply.replyDecoder) {
+                auto replyDecoder = std::exchange(pendingSyncReply.replyDecoder, nullptr);
+                if (auto identifierOfLastMessageToDispatchBeforeSyncReply = pendingSyncReply.identifierOfLastMessageToDispatchBeforeSyncReply) {
+                    locker.unlockEarly();
+
+                    // Dispatch messages (that return true for shouldDispatchMessageWhenWaitingForSyncReply()) that
+                    // were received before this sync reply, in order to maintain ordering.
+                    m_syncState->dispatchMessagesUntil(*identifierOfLastMessageToDispatchBeforeSyncReply);
+                }
+
+                return makeUniqueRefFromNonNullUniquePtr(WTFMove(replyDecoder));
+            }
 
             // The connection was closed.
             if (!m_shouldWaitForSyncReplies)
@@ -960,6 +1011,11 @@ void Connection::processIncomingSyncReply(UniqueRef<Decoder> decoder)
             ASSERT(!pendingSyncReply.replyDecoder);
 
             pendingSyncReply.replyDecoder = decoder.moveToUniquePtr();
+
+            // Keep track of the last message (that returns true for shouldDispatchMessageWhenWaitingForSyncReply())
+            // we've received before this sync reply. This is to make sure that we dispatch all messages up to this
+            // one, before the sync reply, to maintain ordering.
+            pendingSyncReply.identifierOfLastMessageToDispatchBeforeSyncReply = m_syncState->identifierOfLastMessageToDispatchWhileWaitingForSyncReply();
 
             // We got a reply to the last send message, wake up the client run loop so it can be processed.
             if (i == m_pendingSyncReplies.size()) {


### PR DESCRIPTION
#### 6e72e0b7776655d2f98d62318ba18d959b9f6a0d
<pre>
In AXIsolatedTree::resolveAppends(), m_unresolvedPendingAppends can be added to while being iterated, potentially causing memory safety issues
<a href="https://rdar.apple.com/127694319">rdar://127694319</a>

Reviewed by Andres Gonzalez.

Avoid this using std::exchange to put the HashMap on the stack before iterating over it. Anything subsequently added
to m_unresolvedPendingAppends will be processed in the next go-around of resolveAppends().

This patch also fixes several nullptr crashes found by ASAN in various tests.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::anchorElementForNode):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::AccessibilityObject::contentForRange const):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::attributedStringCreate):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::resolveAppends):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::attributedStringSetHeadingLevel):
(WebCore::attributedStringSetBlockquoteLevel):
(WebCore::attributedStringSetExpandedText):
(WebCore::shouldHaveAnySpellCheckAttribute):
(WebCore::attributedStringCreate):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:

Originally-landed-as: 272448.996@safari-7618-branch (50eaa40540f2). <a href="https://rdar.apple.com/132958115">rdar://132958115</a>
Canonical link: <a href="https://commits.webkit.org/281802@main">https://commits.webkit.org/281802@main</a>
</pre>
----------------------------------------------------------------------
#### 472726cd0306b8e15efddf187463cb78a4d8a272
<pre>
Sync IPC messages may get processed out of order with async messages sent with the DispatchMessageEvenWhenWaitingForSyncReply option
<a href="https://bugs.webkit.org/show_bug.cgi?id=274597">https://bugs.webkit.org/show_bug.cgi?id=274597</a>
<a href="https://rdar.apple.com/127810844">rdar://127810844</a>

Reviewed by Geoffrey Garen and Ryosuke Niwa.

When doing a sendSync() call, the caller waits until the remote process responds to the sync IPC.
When receiving this sync IPC, the remote process may itself decide to send sync IPC back (or async
IPC with the DispatchMessageEvenWhenWaitingForSyncReply option) to the other process, *before*
responding to the sync IPC. In such cases, one would expect those intermediate IPC to be processed
*before* the reply to the sync message, to maintain ordering. Unfortunately, our IPC logic was racy
and it was possible that the order wasn&apos;t maintained to such cases. This could lead to logic bugs,
which sometimes translate into security bugs.

In particular, this impacted the following scenario, as proven in the radar:
1. The WebProcess sends a `WebPageProxy::ExecuteUndoRedo` sync IPC to the UIProcess
2. The UIProcess receives the `WebPageProxy::ExecuteUndoRedo` IPC
3. The UIProcess sends an `WebPage::UnapplyEditCommand` / `WebPage::ReapplyEditCommand` async
   IPC to the WebProcess with the DispatchMessageEvenWhenWaitingForSyncReply option.
4. The UIProcess calls the completion handler for the `WebPageProxy::ExecuteUndoRedo` sync IPC,
   thus finally responding to the WebProcess.
5. The WebProcess processes the `WebPage::UnapplyEditCommand` / `WebPage::ReapplyEditCommand`
   IPC
6. The WebProcess processes the reply to its `WebPageProxy::ExecuteUndoRedo` sync IPC and returns
   from its `sendSync()` call.

This is what normally happens. However, due to a race in our logic for handling sync IPC responses,
steps 5 &amp; 6 would sometimes be swapped, leading to crashes.

The race was due to the logic in Connection::waitForSyncReply(), which runs on the main thread.
We would do the following:
  1. Call `m_syncState-&gt;dispatchMessages()` to dispatch sync messages and async messages sent with
     the DispatchMessageEvenWhenWaitingForSyncReply option
  2. Check if we received a response to our sync IPC, return it if we do
  3. Go back to step 1

This code is racy because messages are processed on the IPC receive queue and this code runs on the
main thread. This means that in between step 1 and step 2, we could receive messages that should
have been processed *before* processing the sync IPC reply.

To address the issue, whenever we receive a sync IPC reply on the IPC receive queue, we save (with
the reply) the identifiers of the IPC messages that were received *before* the sync reply and that
should be processed before to maintain ordering. When we process the sync reply later on, on the main
thread, we make sure to dispatch these messages *before* we return the sync reply.

This patch also fixes a bug in SyncMessageState::dispatchMessages() that could cause ordering issues.
The code wanted to merge 2 Deque containers and kept calling takeLast() on the second container
instead of takeFirst(). This was essentially reversing the order of messages in the second Deque.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::dispatchMessages):
(IPC::Connection::SyncMessageState::identifiersOfMessagesToDispatchWhileWaitingForSyncReply):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::processIncomingSyncReply):

Originally-landed-as: 272448.1041@safari-7618-branch (047893baba32). <a href="https://rdar.apple.com/132957900">rdar://132957900</a>
Canonical link: <a href="https://commits.webkit.org/281801@main">https://commits.webkit.org/281801@main</a>
</pre>
----------------------------------------------------------------------
#### e73dfba967ee3b8d87afc74425a343cac523845b
<pre>
Add support for CancellableTasks to PlatformMediaSessionManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=275117">https://bugs.webkit.org/show_bug.cgi?id=275117</a>
<a href="https://rdar.apple.com/127612016">rdar://127612016</a>

Reviewed by Andy Estes.

Pass a CancellableTask into callOnMainThread() rather than a raw Function,
to allow the task to be cancelled before executing.

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::~PlatformMediaSessionManager):
(WebCore::PlatformMediaSessionManager::sessionCanProduceAudioChanged):
(WebCore::PlatformMediaSessionManager::scheduleUpdateSessionState):
(WebCore::PlatformMediaSessionManager::enqueueTaskOnMainThread):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::scheduleSessionStatusUpdate):
(WebCore::MediaSessionManagerCocoa::sessionWillEndPlayback):

Originally-landed-as: 272448.1079@safari-7618-branch (2131bc756e54). <a href="https://rdar.apple.com/132957816">rdar://132957816</a>
Canonical link: <a href="https://commits.webkit.org/281800@main">https://commits.webkit.org/281800@main</a>
</pre>
----------------------------------------------------------------------
#### ff621791b629fa47447f8ce9264d54544486547a
<pre>
WebCore::fontSizeAdjustFromStyle; WebCore::ComputedStyleExtractor::valueForPropertyInStyle; WebCore::ComputedStyleExtractor::propertyValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=272821">https://bugs.webkit.org/show_bug.cgi?id=272821</a>
<a href="https://rdar.apple.com/126112927">rdar://126112927</a>

Reviewed by Sihui Liu and Darin Adler.

Crash happens in fontSizeAdjustFromStyle API due to invalid &apos;value&apos; (float:NaN).
Added check to validate the &apos;value&apos;.

* LayoutTests/fast/css/font-size-adjust-from-style-invalid-value-expected.txt: Added.
* LayoutTests/fast/css/font-size-adjust-from-style-invalid-value.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle):

Originally-landed-as: 272448.951@safari-7618-branch (5e92cb84fde1). <a href="https://rdar.apple.com/132957136">rdar://132957136</a>
Canonical link: <a href="https://commits.webkit.org/281799@main">https://commits.webkit.org/281799@main</a>
</pre>
----------------------------------------------------------------------
#### 467a48b3e198a8ee382fb052d54c6992e9d1cfb7
<pre>
[WebAuthn] Ensure conditional mediation paused when another page is focused
<a href="https://bugs.webkit.org/show_bug.cgi?id=274998">https://bugs.webkit.org/show_bug.cgi?id=274998</a>
<a href="https://rdar.apple.com/128955691">rdar://128955691</a>

Reviewed by Brent Fulgham.

In the situation where a page gets unpaused, the activeConditionalMediationProxy does not
get set. This later causes that page to fail to pause, which can cause an unrelated page
to have conditional mediation while the page that started it is not focused.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::pauseConditionalAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::unpauseConditionalAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::makeActiveConditionalAssertion):

Originally-landed-as: 272448.1062@safari-7618-branch (2e232301da1e). <a href="https://rdar.apple.com/132956983">rdar://132956983</a>
Canonical link: <a href="https://commits.webkit.org/281798@main">https://commits.webkit.org/281798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ce1c98debb619e24de42a58e87f064c28323c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49311 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8009 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10454 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54098 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60241 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56677 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4091 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81996 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36159 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14286 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->