### PR TITLE
heap-use-after-free | WebCore::RenderMenuList::setTextFromOption; WebCore::HTMLSelectElement::selectOption; WebCore::Element::didAddAttribute

### DIFF
--- a/LayoutTests/fast/css/container-query-listbox-expected.html
+++ b/LayoutTests/fast/css/container-query-listbox-expected.html
@@ -1,0 +1,17 @@
+<style>
+select {
+    width: 300px;
+}
+
+#option {
+    color: blue;
+}
+</style>
+<p>Test passes if there is the second option is blue.</p>
+<select multiple id="select">
+    <option>A</option>
+    <option id="option">B</option>
+    <option>C</option>
+    <option>D</option>
+</select>
+<script>

--- a/LayoutTests/fast/css/container-query-listbox.html
+++ b/LayoutTests/fast/css/container-query-listbox.html
@@ -1,0 +1,35 @@
+<style>
+#select {
+    width: 100px;
+    container-type: inline-size;
+}
+
+#option {
+    color: red;
+}
+
+@container (min-width: 200px) {
+    #option {
+        color: blue;
+    }
+}
+</style>
+<p>Test passes if there is the second option is blue.</p>
+<select multiple id="select">
+    <option>A</option>
+    <option id="option">B</option>
+    <option>C</option>
+    <option>D</option>
+</select>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+requestAnimationFrame(() => {
+    select.style.width = "300px";
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>

--- a/LayoutTests/fast/forms/select-multiple-changed-with-containment-crash-expected.txt
+++ b/LayoutTests/fast/forms/select-multiple-changed-with-containment-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash.

--- a/LayoutTests/fast/forms/select-multiple-changed-with-containment-crash.html
+++ b/LayoutTests/fast/forms/select-multiple-changed-with-containment-crash.html
@@ -1,0 +1,26 @@
+<style>
+
+select {
+    container: a1 / inline-size;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function load() {
+    options = select.options;
+    options[1] = undefined;
+    select.multiple = true;
+}
+
+</script>
+<body onload=load()>
+<select id="select">
+<option id="first">A</option>
+<option selected="selected">B</option>
+</select>
+<p>PASS if no crash.</p>
+</body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3984,6 +3984,7 @@ imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scro
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional.html [ Failure ]
+fast/css/container-query-listbox.html [ Skip ]
 fast/forms/select/multiselect-in-listbox-mouse-release-outside.html [ Skip ]
 
 # To investigate: might need to relax the tests, or adapt native thumb appearance.

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -496,7 +496,7 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
     const auto& listItems = selectElement().listItems();
     RefPtr listItemElement = listItems[listIndex].get();
 
-    auto itemStyle = listItemElement->computedStyle();
+    auto itemStyle = listItemElement->computedStyleForEditability();
     if (!itemStyle)
         return;
 
@@ -556,7 +556,7 @@ void RenderListBox::paintItemBackground(PaintInfo& paintInfo, const LayoutPoint&
 {
     const auto& listItems = selectElement().listItems();
     RefPtr listItemElement = listItems[listIndex].get();
-    auto itemStyle = listItemElement->computedStyle();
+    auto itemStyle = listItemElement->computedStyleForEditability();
     if (!itemStyle)
         return;
 

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -228,7 +228,7 @@ void RenderMenuList::updateOptionsWidth()
         if (theme().popupOptionSupportsTextIndent()) {
             // Add in the option's text indent.  We can't calculate percentage values for now.
             float optionWidth = 0;
-            if (auto* optionStyle = option->computedStyle())
+            if (auto* optionStyle = option->computedStyleForEditability())
                 optionWidth += minimumValueForLength(optionStyle->textIndent(), 0);
             if (!text.isEmpty()) {
                 const FontCascade& font = style().fontCascade();
@@ -277,7 +277,7 @@ void RenderMenuList::setTextFromOption(int optionIndex)
     if (i >= 0 && i < size) {
         if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*listItems[i])) {
             text = option->textIndentedToRespectGroupLabel();
-            auto* style = option->computedStyle();
+            auto* style = option->computedStyleForEditability();
             m_optionStyle = style ? RenderStyle::clonePtr(*style) : nullptr;
         }
     }
@@ -540,9 +540,12 @@ PopupMenuStyle RenderMenuList::itemStyle(unsigned listIndex) const
     bool itemHasCustomBackgroundColor;
     getItemBackgroundColor(listIndex, itemBackgroundColor, itemHasCustomBackgroundColor);
 
-    auto& style = *element->computedStyle();
-    return PopupMenuStyle(style.visitedDependentColorWithColorFilter(CSSPropertyColor), itemBackgroundColor, style.fontCascade(), style.usedVisibility() == Visibility::Visible,
-        style.display() == DisplayType::None, true, style.textIndent(), style.direction(), isOverride(style.unicodeBidi()),
+    auto* style = element->computedStyleForEditability();
+    if (!style)
+        return menuStyle();
+
+    return PopupMenuStyle(style->visitedDependentColorWithColorFilter(CSSPropertyColor), itemBackgroundColor, style->fontCascade(), style->visibility() == Visibility::Visible,
+        style->display() == DisplayType::None, true, style->textIndent(), style->direction(), isOverride(style->unicodeBidi()),
         itemHasCustomBackgroundColor ? PopupMenuStyle::CustomBackgroundColor : PopupMenuStyle::DefaultBackgroundColor);
 }
 
@@ -556,7 +559,10 @@ void RenderMenuList::getItemBackgroundColor(unsigned listIndex, Color& itemBackg
     }
     HTMLElement* element = listItems[listIndex].get();
 
-    Color backgroundColor = element->computedStyle()->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    Color backgroundColor;
+    if (auto* style = element->computedStyleForEditability())
+        backgroundColor = style->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+
     itemHasCustomBackgroundColor = backgroundColor.isValid() && backgroundColor.isVisible();
     // If the item has an opaque background color, return that.
     if (backgroundColor.isOpaque()) {


### PR DESCRIPTION
#### cd7e28cf47f603ff24c10eae96a5bf8ccbae8713
<pre>
heap-use-after-free | WebCore::RenderMenuList::setTextFromOption; WebCore::HTMLSelectElement::selectOption; WebCore::Element::didAddAttribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=272882">https://bugs.webkit.org/show_bug.cgi?id=272882</a>
<a href="https://rdar.apple.com/126279123">rdar://126279123</a>

Reviewed by Antti Koivisto.

On macOS, `&lt;select&gt;` and `&lt;select multiple&gt;` use `RenderMenuList` and
`RenderMenuList` as their respective renderers. Consequently, whenever the
`multiple` attribute is added, `invalidateStyleAndRenderersForSubtree` is
called and the `RenderMenuList` is marked for destruction.

Additionally, for interoperability, the selected index must be updated when the
`multiple` attribute is added or removed. This update will also trigger an
update on the renderer, in this case, via `RenderMenuList::updateFromElement`.

At this point, the element is `&lt;select multiple&gt;`, but still has a `RenderMenuList`.
Eventually, the update gets into `RenderMenuList::setTextFromOption`, which
calls `computedStyle()` on an `&lt;option&gt;` element. Following 267786@main, when
using containment, this triggers a render tree update, as `Document::resolveStyle`
is called, and `resolver.hasUnresolvedQueryContainers()` is true. The
`RenderMenuList` is then destroyed, as it was previously invalidated, while
inside one of its own methods. Use-after-free is then encountered due to attempted
member variable access.

To fix, take a similar approach as the crash fix in 272334@main and elide a full
style update when a query container with invalid style is encountered.
`fast/css/container-query-listbox.html` has been added to ensure &lt;option&gt;
styling continues to work with container queries. Finally, adopt `CheckedPtr` as
a hardening measure.

Alternatives considered:

1. Call `updateStyleIfNeeded()` in `HTMLSelectElement` prior to entering the
   renderer. This approach was rejected as there are too many entry points, and
   it would be fragile to new entry points.

2. Pass `&lt;option&gt;` style down from `HTMLSelectElement` into the renderer. Again,
   there are too many entry points (including outside of the element). Additionally,
   it is not sufficient to store a single style (for the selected option), as every
   `&lt;option&gt;` participates in width determination.

3. Use `existingComputedStyle()` instead of `computedStyle()`. This resulted in
   paint time regressions where the existing computed style was empty.

* LayoutTests/fast/css/container-query-listbox-expected.html: Added.
* LayoutTests/fast/css/container-query-listbox.html: Added.
* LayoutTests/fast/forms/select-multiple-changed-with-containment-crash-expected.txt: Added.
* LayoutTests/fast/forms/select-multiple-changed-with-containment-crash.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionSelectedByUser):
(WebCore::HTMLSelectElement::selectOption):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::paintItemForeground):
(WebCore::RenderListBox::paintItemBackground):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::updateOptionsWidth):
(RenderMenuList::setTextFromOption):
(RenderMenuList::itemStyle const):
(RenderMenuList::getItemBackgroundColor const):

Originally-landed-as: 272448.982@safari-7618-branch (c4b6c7757697). <a href="https://rdar.apple.com/132958569">rdar://132958569</a>
Canonical link: <a href="https://commits.webkit.org/281864@main">https://commits.webkit.org/281864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd59241f9e18d890f30d198b444b72ab891621fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49487 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8189 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10276 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56859 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57057 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4281 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->