### PR TITLE
[JSC] Fix speculation for JSMap/SetIterator in DFG and FTL

### DIFF
--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -706,6 +706,9 @@ std::optional<SpeculatedType> speculationFromJSType(JSType type)
         return SpecWeakSetObject;
     case DataViewType:
         return SpecDataViewObject;
+    case JSMapIteratorType:
+    case JSSetIteratorType:
+        return SpecObjectOther;
     default:
         return std::nullopt;
     }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21535,6 +21535,12 @@ IGNORE_CLANG_WARNINGS_END
         case MiscUse:
             speculateMisc(edge);
             break;
+        case MapIteratorObjectUse:
+            speculateMapIteratorObject(edge);
+            break;
+        case SetIteratorObjectUse:
+            speculateSetIteratorObject(edge);
+            break;
         default:
             DFG_CRASH(m_graph, m_node, "Unsupported speculation use kind");
         }
@@ -22160,7 +22166,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void speculateMapIteratorObject(Edge edge)
     {
-        speculateMapObject(edge, lowCell(edge));
+        speculateMapIteratorObject(edge, lowCell(edge));
     }
 
     void speculateSetObject(Edge edge, LValue cell)
@@ -22182,7 +22188,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void speculateSetIteratorObject(Edge edge)
     {
-        speculateMapObject(edge, lowCell(edge));
+        speculateSetIteratorObject(edge, lowCell(edge));
     }
 
     void speculateWeakMapObject(Edge edge, LValue cell)


### PR DESCRIPTION
#### 959410e0ccfa1db00275b4c1f9412dc45f3ac033
<pre>
[JSC] Fix speculation for JSMap/SetIterator in DFG and FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=277576">https://bugs.webkit.org/show_bug.cgi?id=277576</a>
<a href="https://rdar.apple.com/133097257">rdar://133097257</a>

Reviewed by Alexey Shvayka and Yusuke Suzuki.

The speculation of speculateMap(Set)IteratorObject is
definitely wrong. This patch fix all speculations for
JSMap/SetIterator in DFG and FTL.

* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromJSType):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/281810@main">https://commits.webkit.org/281810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b6d674dcce5281ea8c40c9a065577fc2898f09d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11548 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49313 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10068 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10461 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54105 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66665 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60248 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56681 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56870 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4096 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82003 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36166 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14288 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37249 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->