### PR TITLE
Update platforms from mac-monterey to mac-ventura

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -82,8 +82,8 @@
     { "name": "ews124", "platform": "ios-simulator-17" },
     { "name": "ews125", "platform": "ios-simulator-17" },
     { "name": "ews126", "platform": "ios-simulator-17" },
-    { "name": "ews127", "platform": "mac-monterey" },
-    { "name": "ews128", "platform": "mac-monterey" },
+    { "name": "ews127", "platform": "mac-ventura" },
+    { "name": "ews128", "platform": "mac-ventura" },
     { "name": "ews130", "platform": "*" },
     { "name": "ews131", "platform": "ios-17" },
     { "name": "ews132", "platform": "*" },
@@ -171,11 +171,11 @@
     { "name": "ews228", "platform": "visionos-simulator-1" },
     { "name": "ews229", "platform": "visionos-simulator-1" },
     { "name": "ews230", "platform": "visionos-simulator-1" },
-    { "name": "webkit-cq-01", "platform": "mac-monterey" },
-    { "name": "webkit-cq-02", "platform": "mac-monterey" },
-    { "name": "webkit-cq-03", "platform": "mac-monterey" },
-    { "name": "webkit-cq-04", "platform": "mac-monterey" },
-    { "name": "webkit-cq-05", "platform": "mac-monterey" }
+    { "name": "webkit-cq-01", "platform": "mac-ventura" },
+    { "name": "webkit-cq-02", "platform": "mac-ventura" },
+    { "name": "webkit-cq-03", "platform": "mac-ventura" },
+    { "name": "webkit-cq-04", "platform": "mac-ventura" },
+    { "name": "webkit-cq-05", "platform": "mac-ventura" }
   ],
   "builders": [
     {
@@ -355,7 +355,7 @@
     },
     {
       "name": "JSC-Tests-EWS", "shortname": "jsc", "icon": "buildAndTest",
-      "factory": "JSCBuildAndTestsFactory", "platform": "mac-monterey",
+      "factory": "JSCBuildAndTestsFactory", "platform": "mac-ventura",
       "configuration": "release", "runTests": "true",
       "workernames": ["ews127", "ews128"]
     },
@@ -426,19 +426,19 @@
     },
     {
       "name": "Commit-Queue", "shortname": "commit", "icon": "buildAndTest",
-      "factory": "CommitQueueFactory", "platform": "mac-monterey",
+      "factory": "CommitQueueFactory", "platform": "mac-ventura",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-05"]
     },
     {
       "name": "Merge-Queue", "shortname": "merge", "icon": "buildAndTest",
-      "factory": "MergeQueueFactory", "platform": "mac-monterey",
+      "factory": "MergeQueueFactory", "platform": "mac-ventura",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-05"]
     },
     {
       "name": "Unsafe-Merge-Queue", "shortname": "unsafe-merge", "icon": "buildAndTest",
-      "factory": "UnsafeMergeQueueFactory", "platform": "mac-monterey",
+      "factory": "UnsafeMergeQueueFactory", "platform": "mac-ventura",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-04", "webkit-cq-05"]
     },


### PR DESCRIPTION
#### 3e82ae87999da05fb39da2da5166dacd2f1e1925
<pre>
Update platforms from mac-monterey to mac-ventura
<a href="https://bugs.webkit.org/show_bug.cgi?id=277582">https://bugs.webkit.org/show_bug.cgi?id=277582</a>
<a href="https://rdar.apple.com/133099292">rdar://133099292</a>

Reviewed by Timothy Hatcher and Aakash Jain.

Updates platforms for workers and queues.

* Tools/CISupport/ews-build/config.json:

Canonical link: <a href="https://commits.webkit.org/281843@main">https://commits.webkit.org/281843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f2df5986deb0857736beafd5a8f02dd6ba18ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49317 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8032 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10084 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10473 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66677 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56688 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/60703 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4104 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36178 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37261 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->