### PR TITLE
Add WebExtensionSidebar object to UIProcess.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -93,6 +93,21 @@ inline bool boolForKey(NSDictionary *dictionary, id key, bool defaultValue)
     return value ? value.boolValue : defaultValue;
 }
 
+template<typename T>
+inline std::optional<RetainPtr<T>> toOptional(T *maybeNil)
+{
+    if (maybeNil)
+        return maybeNil;
+    return std::nullopt;
+}
+
+inline std::optional<String> toOptional(NSString *maybeNil)
+{
+    if (maybeNil)
+        return maybeNil;
+    return std::nullopt;
+}
+
 enum class JSONOptions {
     FragmentsAllowed = 1 << 0, /// Allows for top-level scalar types, in addition to arrays and dictionaries.
 };

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -185,6 +185,9 @@ public:
         WebExtensionDataRecord,
         WebExtensionMatchPattern,
         WebExtensionMessagePort,
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+        WebExtensionSidebar,
+#endif
 #endif
         WebResourceLoadStatisticsManager,
         WebsiteDataRecord,

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -155,6 +155,14 @@ static NSString * const externallyConnectableManifestKey = @"externally_connecta
 static NSString * const externallyConnectableMatchesManifestKey = @"matches";
 static NSString * const externallyConnectableIDsManifestKey = @"ids";
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+static NSString * const sidebarActionManifestKey = @"sidebar_action";
+static NSString * const sidePanelManifestKey = @"side_panel";
+static NSString * const sidebarActionTitleManifestKey = @"default_title";
+static NSString * const sidebarActionPathManifestKey = @"default_panel";
+static NSString * const sidePanelPathManifestKey = @"default_path";
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
 static const size_t maximumNumberOfShortcutCommands = 4;
 
 WebExtension::WebExtension(NSBundle *appExtensionBundle, NSError **outError)
@@ -1113,6 +1121,65 @@ void WebExtension::populateActionPropertiesIfNeeded()
     m_displayActionLabel = objectForKey<NSString>(m_actionDictionary, defaultTitleManifestKey);
     m_actionPopupPath = objectForKey<NSString>(m_actionDictionary, defaultPopupManifestKey);
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+CocoaImage *WebExtension::sidebarIcon(CGSize idealSize)
+{
+    // FIXME: <https://webkit.org/b/276833> implement this
+    return nil;
+}
+
+NSString *WebExtension::sidebarDocumentPath()
+{
+    populateSidebarPropertiesIfNeeded();
+    return m_sidebarDocumentPath.get();
+}
+
+NSString *WebExtension::sidebarTitle()
+{
+    populateSidebarPropertiesIfNeeded();
+    return m_sidebarTitle.get();
+}
+
+void WebExtension::populateSidebarPropertiesIfNeeded()
+{
+    if (!manifestParsedSuccessfully())
+        return;
+
+    if (m_parsedManifestSidebarProperties)
+        return;
+
+    // sidePanel documentation: https://developer.chrome.com/docs/extensions/reference/manifest#side-panel
+    // see "Examples" header -> "Side Panel" tab (doesn't mention `default_path` key elsewhere)
+    // sidebarAction documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
+
+    auto sidebarActionDictionary = objectForKey<NSDictionary>(m_manifest, sidebarActionManifestKey);
+    if (sidebarActionDictionary) {
+        populateSidebarActionProperties(sidebarActionDictionary);
+        return;
+    }
+
+    auto sidePanelDictionary = objectForKey<NSDictionary>(m_manifest, sidePanelManifestKey);
+    if (sidePanelDictionary)
+        populateSidePanelProperties(sidePanelDictionary);
+}
+
+void WebExtension::populateSidebarActionProperties(RetainPtr<NSDictionary> sidebarActionDictionary)
+{
+    // FIXME: <https://webkit.org/b/276833> implement sidebar icon parsing
+    m_sidebarIcon = nil;
+    m_sidebarTitle = objectForKey<NSString>(sidebarActionDictionary, sidebarActionTitleManifestKey);
+    m_sidebarDocumentPath = objectForKey<NSString>(sidebarActionDictionary, sidebarActionPathManifestKey);
+}
+
+void WebExtension::populateSidePanelProperties(RetainPtr<NSDictionary> sidePanelDictionary)
+{
+    // Since sidePanel cannot set a default title or icon from the manifest, setting these nil here is intentional
+    m_sidebarIcon = nil;
+    m_sidebarTitle = nil;
+    m_sidebarDocumentPath = objectForKey<NSString>(sidePanelDictionary, sidePanelPathManifestKey);
+}
+#endif
 
 CocoaImage *WebExtension::imageForPath(NSString *imagePath)
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionSidebar.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+#import "CocoaHelpers.h"
+#import "WebExtensionContext.h"
+#import "WebExtensionTab.h"
+#import "WebExtensionWindow.h"
+
+namespace WebKit {
+
+static NSString * const fallbackPath = @"about:blank";
+static NSString * const fallbackTitle = @"";
+
+
+static std::optional<String> getDefaultSidebarTitleFromExtension(WebExtension& extension)
+{
+    return toOptional(extension.sidebarTitle());
+}
+
+static std::optional<String> getDefaultSidebarPathFromExtension(WebExtension& extension)
+{
+    return toOptional(extension.sidebarDocumentPath());
+}
+
+static std::optional<NSDictionary *> getDefaultIconsDictFromExtension(WebExtension& extensions)
+{
+    // FIXME: <https://webkit.org/b/276833> implement this
+    return std::nullopt;
+}
+
+WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, IsDefault isDefault) : WebExtensionSidebar(context, std::nullopt, std::nullopt, isDefault) { };
+
+WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, WebExtensionTab& tab) : WebExtensionSidebar(context, tab, std::nullopt, IsDefault::No) { };
+
+WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, WebExtensionWindow& window) : WebExtensionSidebar(context, std::nullopt, window, IsDefault::No) { };
+
+WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, std::optional<Ref<WebExtensionTab>> tab, std::optional<Ref<WebExtensionWindow>> window, IsDefault isDefault)
+    : m_context(context), m_tab(tab), m_window(window), m_isDefault(isDefault)
+{
+    ASSERT(!(m_tab && m_window));
+
+    // if this is the default action, initialize with default sidebar path / title if present
+    if (isDefaultSidebar()) {
+        auto& extension = context.extension();
+        m_titleOverride = getDefaultSidebarTitleFromExtension(extension);
+        m_sidebarPathOverride = getDefaultSidebarPathFromExtension(extension);
+        m_iconsOverride = getDefaultIconsDictFromExtension(extension);
+    }
+}
+
+std::optional<Ref<WebExtensionContext>> WebExtensionSidebar::extensionContext() const
+{
+    if (m_context.ptr())
+        return m_context.get();
+    return std::nullopt;
+}
+
+const std::optional<Ref<WebExtensionTab>> WebExtensionSidebar::tab() const
+{
+    return m_tab;
+}
+
+const std::optional<Ref<WebExtensionWindow>> WebExtensionSidebar::window() const
+{
+    return m_window;
+}
+
+std::optional<Ref<WebExtensionSidebar>> WebExtensionSidebar::parent() const
+{
+    if (!m_context.ptr() || isDefaultSidebar())
+        return std::nullopt;
+
+    return m_tab.and_then([this](auto const& tab) { return m_context->getSidebar(*tab->window()); })
+        .value_or(m_context->defaultSidebar());
+}
+
+void WebExtensionSidebar::propertiesDidChange()
+{
+    // FIXME: <https://webkit.org/b/277575> notify the delegate that something has changed (implement this)
+}
+
+RetainPtr<CocoaImage> WebExtensionSidebar::icon(CGSize size)
+{
+    if (!extensionContext())
+        return nil;
+
+    const auto largestDim = [](CGSize size) {
+        return size.width > size.height ? size.width : size.height;
+    };
+
+    auto& context = extensionContext().value().get();
+    return m_iconsOverride
+        .and_then([&](RetainPtr<NSDictionary> icons) -> std::optional<RetainPtr<CocoaImage>> {
+            return toOptional(context.extension().bestImageInIconsDictionary(icons.get(), largestDim(size)));
+        })
+        .or_else([&] -> std::optional<RetainPtr<CocoaImage>> {
+            return parent().transform([&](auto const& parent) { return parent.get().icon(size); });
+        })
+        .value_or(context.extension().actionIcon(size));
+}
+
+void WebExtensionSidebar::setIconsDictionary(NSDictionary *icons)
+{
+    if (!icons || !icons.count) {
+        m_iconsOverride = std::nullopt;
+        return;
+    }
+
+    if (m_iconsOverride && [m_iconsOverride.value() isEqualToDictionary:icons])
+        return;
+
+    m_iconsOverride = icons;
+    propertiesDidChange();
+}
+
+String WebExtensionSidebar::title() const
+{
+    return m_titleOverride.value_or(
+        parent().transform([](auto const& parent) { return parent.get().title(); }).value_or(fallbackTitle)
+    );
+}
+
+void WebExtensionSidebar::setTitle(std::optional<String> titleOverride)
+{
+    m_titleOverride = titleOverride;
+    propertiesDidChange();
+}
+
+bool WebExtensionSidebar::isEnabled() const
+{
+    return m_isEnabled;
+}
+
+void WebExtensionSidebar::setEnabled(bool enabled)
+{
+    m_isEnabled = enabled;
+    propertiesDidChange();
+}
+
+bool WebExtensionSidebar::canProgrammaticallyOpenSidebar() const
+{
+    return extensionContext().transform([](auto const& context) -> bool { return !!context.get().extensionController(); })
+        .value_or(false);
+
+    // FIXME: <https://webkit.org/b/277575> also check that the controller delegate responds to whatever selector we use for this
+}
+
+void WebExtensionSidebar::openSidebarWhenReady()
+{
+    // FIXME: <https://webkit.org/b/277575> implement openSidebarWhenReady
+}
+
+bool WebExtensionSidebar::canProgrammaticallyCloseSidebar() const
+{
+    return extensionContext().transform([](auto const& context) -> bool { return !!context.get().extensionController(); })
+        .value_or(false);
+
+    // FIXME: <https://webkit.org/b/277575> also check that the controller delegate responds to whatever selector we use for this
+}
+
+void WebExtensionSidebar::closeSidebarWhenReady()
+{
+    // FIXME: <https://webkit.org/b/277575> implement closeSidebarWhenReady
+}
+
+String WebExtensionSidebar::sidebarPath() const
+{
+    return m_sidebarPathOverride.value_or(
+        parent().transform([](auto const& parent) { return parent.get().sidebarPath(); }).value_or(fallbackPath)
+    );
+}
+
+void WebExtensionSidebar::setSidebarPath(std::optional<String> sidebarPath)
+{
+    m_sidebarPathOverride = sidebarPath;
+    propertiesDidChange();
+}
+
+WKWebView *WebExtensionSidebar::webView()
+{
+    return m_webView.get();
+}
+
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -237,6 +237,12 @@ public:
     bool hasBrowserAction();
     bool hasPageAction();
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    CocoaImage *sidebarIcon(CGSize idealSize);
+    NSString *sidebarDocumentPath();
+    NSString *sidebarTitle();
+#endif
+
     CocoaImage *imageForPath(NSString *);
 
     NSString *pathForBestImageInIconsDictionary(NSDictionary *, size_t idealPixelSize);
@@ -318,6 +324,11 @@ private:
     void populateCommandsIfNeeded();
     void populateDeclarativeNetRequestPropertiesIfNeeded();
     void populateExternallyConnectableIfNeeded();
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    void populateSidebarPropertiesIfNeeded();
+    void populateSidebarActionProperties(RetainPtr<NSDictionary>);
+    void populateSidePanelProperties(RetainPtr<NSDictionary>);
+#endif
 
     std::optional<WebExtension::DeclarativeNetRequestRulesetData> parseDeclarativeNetRequestRulesetDictionary(NSDictionary *, NSError **);
 
@@ -358,6 +369,12 @@ private:
     RetainPtr<NSString> m_displayActionLabel;
     RetainPtr<NSString> m_actionPopupPath;
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    RetainPtr<CocoaImage> m_sidebarIcon;
+    RetainPtr<NSString> m_sidebarDocumentPath;
+    RetainPtr<NSString> m_sidebarTitle;
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
     RetainPtr<NSString> m_contentSecurityPolicy;
 
     RetainPtr<NSArray> m_backgroundScriptPaths;
@@ -386,6 +403,9 @@ private:
     bool m_parsedManifestCommands : 1 { false };
     bool m_parsedManifestDeclarativeNetRequestRulesets : 1 { false };
     bool m_parsedExternallyConnectable : 1 { false };
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    bool m_parsedManifestSidebarProperties : 1 { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -81,6 +81,7 @@
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+#include "WebExtensionSidebar.h"
 #include "WebExtensionSidebarParameters.h"
 #endif
 
@@ -436,6 +437,14 @@ public:
     Ref<WebExtensionAction> getOrCreateAction(WebExtensionWindow*);
     Ref<WebExtensionAction> getOrCreateAction(WebExtensionTab*);
     void performAction(WebExtensionTab*, UserTriggered = UserTriggered::No);
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    WebExtensionSidebar& defaultSidebar();
+    std::optional<Ref<WebExtensionSidebar>> getSidebar(WebExtensionWindow const&);
+    std::optional<Ref<WebExtensionSidebar>> getSidebar(WebExtensionTab const&);
+    std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionWindow&);
+    std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionTab&);
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     const CommandsVector& commands();
     WebExtensionCommand* command(const String& identifier);
@@ -954,6 +963,12 @@ private:
     WeakHashMap<WebExtensionWindow, Ref<WebExtensionAction>> m_actionWindowMap;
     WeakHashMap<WebExtensionTab, Ref<WebExtensionAction>> m_actionTabMap;
     RefPtr<WebExtensionAction> m_defaultAction;
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    WeakHashMap<WebExtensionWindow, Ref<WebExtensionSidebar>> m_sidebarWindowMap;
+    WeakHashMap<WebExtensionTab, Ref<WebExtensionSidebar>> m_sidebarTabMap;
+    RefPtr<WebExtensionSidebar> m_defaultSidebar;
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     PortCountedSet m_ports;
     PageProxyIdentifierPortMap m_pagePortMap;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+#include "APIObject.h"
+#include "CocoaImage.h"
+#include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+OBJC_CLASS WKWebView;
+
+namespace WebKit {
+
+class WebExtensionContext;
+class WebExtensionTab;
+class WebExtensionWindow;
+
+class WebExtensionSidebar : public API::ObjectImpl<API::Object::Type::WebExtensionSidebar>, public CanMakeWeakPtr<WebExtensionSidebar> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionSidebar);
+
+public:
+    enum class IsDefault { No, Yes };
+
+    template<typename... Args>
+    static Ref<WebExtensionSidebar> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionSidebar(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionSidebar(WebExtensionContext&, IsDefault = IsDefault::No);
+    explicit WebExtensionSidebar(WebExtensionContext&, WebExtensionTab&);
+    explicit WebExtensionSidebar(WebExtensionContext&, WebExtensionWindow&);
+
+    bool operator==(const WebExtensionSidebar&) const;
+
+    std::optional<Ref<WebExtensionContext>> extensionContext() const;
+    const std::optional<Ref<WebExtensionTab>> tab() const;
+    const std::optional<Ref<WebExtensionWindow>> window() const;
+    std::optional<Ref<WebExtensionSidebar>> parent() const;
+
+    void propertiesDidChange();
+
+    /// `icon()` will return the overridden icon of this sidebar, or the icon of the first parent sidebar in which the icon is set
+    RetainPtr<CocoaImage> icon(CGSize);
+    void setIconsDictionary(NSDictionary *);
+
+    /// `title()` will return the overridden title of this sidebar, or the title of the first parent sidebar in which the title is set
+    String title() const;
+    void setTitle(std::optional<String>);
+
+    bool isEnabled() const;
+    void setEnabled(bool);
+
+    bool isOpen() const { return m_isOpen; }
+    bool opensSidebar() { return !sidebarPath().isEmpty(); };
+    bool canProgrammaticallyOpenSidebar() const;
+    void openSidebarWhenReady();
+
+    bool canProgrammaticallyCloseSidebar() const;
+    void closeSidebarWhenReady();
+
+    /// `sidebarPath()` will return the overriden path of this sidebar, or the path of the first parent sidebar in which the path is set
+    String sidebarPath() const;
+    void setSidebarPath(std::optional<String>);
+
+    WKWebView *webView();
+
+private:
+    explicit WebExtensionSidebar(WebExtensionContext&, std::optional<Ref<WebExtensionTab>>, std::optional<Ref<WebExtensionWindow>>, IsDefault);
+    bool isDefaultSidebar() const { return m_isDefault == IsDefault::Yes || (!m_window && !m_tab); };
+
+    std::optional<RetainPtr<NSDictionary>> m_iconsOverride;
+    std::optional<String> m_titleOverride;
+    std::optional<String> m_sidebarPathOverride;
+
+    WeakRef<WebExtensionContext> m_context;
+    const std::optional<Ref<WebExtensionTab>> m_tab;
+    const std::optional<Ref<WebExtensionWindow>> m_window;
+
+    bool m_isOpen { false };
+    bool m_opensSidebarWhenReady { false };
+    bool m_sidebarOpened { false };
+    bool m_isEnabled { false };
+    const IsDefault m_isDefault { IsDefault::No };
+
+    RetainPtr<WKWebView> m_webView;
+};
+
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -125,7 +125,9 @@
 		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
 		02660A7C2C4099370074EDC5 /* WebExtensionAPISidebarActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		02660A7E2C4099B50074EDC5 /* WebExtensionAPISidePanelCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		02673A312C583239002878FB /* WebExtensionSidebarCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02673A302C583232002878FB /* WebExtensionSidebarCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		028648C62C3F5A3A00E474D4 /* WebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 028648C52C3F5A2E00E474D4 /* WebExtensionAPISidePanel.h */; };
+		028D30772C616E8A004F4FC6 /* WebExtensionSidebar.h in Headers */ = {isa = PBXBuildFile; fileRef = 028D30762C616E8A004F4FC6 /* WebExtensionSidebar.h */; };
 		029D6BAC2C40609D0068CF99 /* WebExtensionAPISidebarAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAB2C4060920068CF99 /* WebExtensionAPISidebarAction.h */; };
 		029D6BB12C407AA30068CF99 /* JSWebExtensionAPISidePanel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 029D6BB02C407AA30068CF99 /* JSWebExtensionAPISidePanel.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		029D6BB22C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 029D6BAE2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3171,6 +3173,7 @@
 		0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindStringCallbackAggregator.h; sourceTree = "<group>"; };
 		02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPISidebarActionCocoa.mm; sourceTree = "<group>"; };
 		02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPISidePanelCocoa.mm; sourceTree = "<group>"; };
+		02673A302C583232002878FB /* WebExtensionSidebarCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionSidebarCocoa.mm; sourceTree = "<group>"; };
 		02789EF628D3FC3200F77E40 /* WebGPUBufferBindingLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUBufferBindingLayout.serialization.in; sourceTree = "<group>"; };
 		02789EF728D3FF4800F77E40 /* WebGPUCanvasConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUCanvasConfiguration.serialization.in; sourceTree = "<group>"; };
 		02789EF828D4026000F77E40 /* WebGPUColor.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUColor.serialization.in; sourceTree = "<group>"; };
@@ -3186,6 +3189,7 @@
 		02789F0428D44EC800F77E40 /* WebGPUVertexAttribute.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUVertexAttribute.serialization.in; sourceTree = "<group>"; };
 		02789F0528D44ED800F77E40 /* WebGPUVertexBufferLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUVertexBufferLayout.serialization.in; sourceTree = "<group>"; };
 		028648C52C3F5A2E00E474D4 /* WebExtensionAPISidePanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPISidePanel.h; sourceTree = "<group>"; };
+		028D30762C616E8A004F4FC6 /* WebExtensionSidebar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSidebar.h; sourceTree = "<group>"; };
 		029D6BAB2C4060920068CF99 /* WebExtensionAPISidebarAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPISidebarAction.h; sourceTree = "<group>"; };
 		029D6BAD2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPISidebarAction.h; sourceTree = "<group>"; };
 		029D6BAE2C407AA30068CF99 /* JSWebExtensionAPISidebarAction.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPISidebarAction.mm; sourceTree = "<group>"; };
@@ -9947,6 +9951,7 @@
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 				1CC1A36D2B0DCEC900373759 /* WebExtensionMenuItemCocoa.mm */,
 				1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */,
+				02673A302C583232002878FB /* WebExtensionSidebarCocoa.mm */,
 				1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */,
 				1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */,
 				1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */,
@@ -10399,6 +10404,7 @@
 				1C6B84C92B0D6CDF00E885DD /* WebExtensionMenuItem.cpp */,
 				1C6B84CB2B0D6CF500E885DD /* WebExtensionMenuItem.h */,
 				1C73167A2AC1E676007FADA4 /* WebExtensionMessagePort.h */,
+				028D30762C616E8A004F4FC6 /* WebExtensionSidebar.h */,
 				1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */,
 				1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */,
 				1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */,
@@ -17023,6 +17029,7 @@
 				B69E1A682AFF5F0C000FB98E /* WebExtensionRegisteredScriptParameters.h in Headers */,
 				B6D0310A2AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h in Headers */,
 				B624FF1B2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h in Headers */,
+				028D30772C616E8A004F4FC6 /* WebExtensionSidebar.h in Headers */,
 				0237F5EA2C4B40E800AD23EF /* WebExtensionSidebarParameters.h in Headers */,
 				B6B1565E2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h in Headers */,
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
@@ -19975,6 +19982,7 @@
 				1CC1A36C2B0D9A0900373759 /* WebExtensionMenuItem.cpp in Sources */,
 				1CC1A36E2B0DCEC900373759 /* WebExtensionMenuItemCocoa.mm in Sources */,
 				1C73167F2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm in Sources */,
+				02673A312C583239002878FB /* WebExtensionSidebarCocoa.mm in Sources */,
 				1C66BDE22A8C2830009D4452 /* WebExtensionTabCocoa.mm in Sources */,
 				1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */,
 				337822482947FBA5002106BB /* WebExtensionUtilities.mm in Sources */,


### PR DESCRIPTION
#### dd82fa0c239ee137d28c8b225390b0d482d9b401
<pre>
Add WebExtensionSidebar object to UIProcess.
<a href="https://webkit.org/b/277574">https://webkit.org/b/277574</a>
<a href="https://rdar.apple.com/133073139">rdar://133073139</a>

Reviewed by Timothy Hatcher.

This PR adds the WebExtensionSidebar class to UIProcess. The structure
of this class closely mirrors that of WebExtensionAction, except it
prefers to use std::optional over nullable pointers when possible. This
PR also adds several utility methods in WebExtensionContext which will
be used to manage the WebExtensionSidebar objects necessary to service
the sidePanel / sidebarAction APIs for each extensions that utilizes
them.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
 (WebKit::toOptional): Add helper method to convert nulltable T * (where
T is some Cocoa type) to optional&lt;RetainPtr&lt;T&gt;&gt;, where the interior
RetainPtr is guaranteed to be non-null
* Source/WebKit/Shared/API/APIObject.h: Add WebExtensionSidebar to
  API::Object::Type enum
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::sidebarIcon): Getter for current extension&apos;s
default sidebar icon
(WebKit::WebExtension::sidebarDocumentPath): Getter for current
extension&apos;s default document path
(WebKit::WebExtension::sidebarTitle): Getter for current extension&apos;s
default sidebar title
(WebKit::WebExtension::populateSidebarPropertiesIfNeeded): Helper method
to populate sidebar-related properties if needed
(WebKit::WebExtension::populateSidebarActionProperties): Helper method
to populate sidebar-related properties when sidebarAction is detected
(WebKit::WebExtension::populateSidePanelProperties): Helper method to
populate sidebar-related properties when sidePanel is detected
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload): Set m_defaultSidebar to nullptr
on unload
(WebKit::WebExtensionContext::defaultSidebar): Getter for
m_defaultSidebar
(WebKit::WebExtensionContext::getSidebar): Getters for window- or
tab-specific sidebar objects
(WebKit::WebExtensionContext::getOrCreateSidebar): Functions to create
and get window- or tab-specific sidebar objects
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Added.
(WebKit::WebExtensionSidebar::create): Canonical WebKit create method
(WebKit::WebExtensionSidebar::isOpen const): Getter for m_isOpen
(WebKit::WebExtensionSidebar::opensSidebar): Method to check if the
current sidebar has a valid path, enabling it to be opened
(WebKit::WebExtensionSidebar::isDefaultSidebar const): Method to check
if this sidebar object is the default sidebar object
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm: Added.
(WebKit::getDefaultSidebarTitleFromExtension): Utility function to
retrieve the manifest-specified default sidebar title for an extension
(WebKit::getDefaultSidebarPathFromExtension): Utility function to
retrieve the manifest-specified default sidebar path for an extension
(WebKit::WebExtensionSidebar::WebExtensionSidebar): Constructor for
WebExtensionSidebar which populates instance variables and performs a
simple sanity check on the provided window and tab values
(WebKit::WebExtensionSidebar::extensionContext const): Getter for
this sidebar&apos;s context
(WebKit::WebExtensionSidebar::tab const): Getter for this
sidebar&apos;s tab
(WebKit::WebExtensionSidebar::window const): Getter for this
sidebar&apos;s window
(WebKit::WebExtensionSidebar::parent const): Getter for this
sidebar&apos;s parent. It will check the current context for a less-specific
sidebar override if present, otherwise returning the default sidebar. If
this sidebar is the default sidebar, it will return std::nullopt (since
the default sidebar has no parent).
(WebKit::WebExtensionSidebar::propertiesDidChange): Function to notify
the browser through the yet-unimplemented sidebar delegate methods that
the properties of this sidebar have changed.
(WebKit::WebExtensionSidebar::icon): Getter for the icon override of this
sidebar, or this sidebar&apos;s parent if there is no override set.
(WebKit::WebExtensionSidebar::setIconsDictionary): Setter for this
sidebar&apos;s icon override
(WebKit::WebExtensionSidebar::title const): Getter for the title
override of this sidebar, or this sidebar&apos;s parent if there is no
override set.
(WebKit::WebExtensionSidebar::setTitle): Setter for this
sidebar&apos;s title override.
(WebKit::WebExtensionSidebar::isEnabled const): Getter to determine if
this specific sidebar is enabled.
(WebKit::WebExtensionSidebar::setEnabled): Setter to set whether this
specific sidebar is enabled.
(WebKit::WebExtensionSidebar::canProgrammaticallyOpenSidebar const):
Function to check whether it is possible to programmatically open this
sidebar. It ensures that this extension&apos;s context is present, and that
the context contains a valid extension controller object
(WebKit::WebExtensionSidebar::openSidebarWhenReady): Currently
unimplemented method to open this sidebar when the delegate is ready to
do so.
(WebKit::WebExtensionSidebar::canProgrammaticallyCloseSidebar const):
Functino to check whether it is possible to programmatically close this
sidebar. It ensures that this extension&apos;s context is present, and that
the context contains a valid extension controller object.
(WebKit::WebExtensionSidebar::closeSidebarWhenReady): Currently
unimplemented method to close this sidebar when the delegate is ready to
do so.
(WebKit::WebExtensionSidebar::sidebarPath const): Getter for this
sidebar&apos;s path override, or its parent&apos;s if there is no override set.
(WebKit::WebExtensionSidebar::setSidebarPath): Setter for this
particualr sidebar&apos;s path override.
(WebKit::WebExtensionSidebar::webView): Getter for this sidebar&apos;s
WebView.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Add member
  variables to service sidebar management methods, add sidebar
management method declarations.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Add
  WebExtensionSidebar.h and WebExtensionSidebar.mm to the project.

Canonical link: <a href="https://commits.webkit.org/281881@main">https://commits.webkit.org/281881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f445f9bfff502dc4b2258cafcd46dbb979493e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11864 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49539 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34488 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66996 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56911 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57118 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4344 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36480 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37563 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->