### PR TITLE
Deprecate WKSerializedScriptValueRef

### DIFF
--- a/Source/WebKit/Shared/API/c/WKSerializedScriptValue.cpp
+++ b/Source/WebKit/Shared/API/c/WKSerializedScriptValue.cpp
@@ -26,21 +26,17 @@
 #include "config.h"
 #include "WKSerializedScriptValue.h"
 
-#include "APISerializedScriptValue.h"
-#include "WKAPICast.h"
-
 WKTypeID WKSerializedScriptValueGetTypeID()
 {
-    return WebKit::toAPI(API::SerializedScriptValue::APIType);
+    return 0;
 }
 
-WKSerializedScriptValueRef WKSerializedScriptValueCreate(JSContextRef context, JSValueRef value, JSValueRef* exception)
+WKSerializedScriptValueRef WKSerializedScriptValueCreate(JSContextRef, JSValueRef, JSValueRef*)
 {
-    auto serializedValue = API::SerializedScriptValue::create(context, value, exception);
-    return WebKit::toAPI(serializedValue.leakRef());
+    return nullptr;
 }
 
-JSValueRef WKSerializedScriptValueDeserialize(WKSerializedScriptValueRef scriptValueRef, JSContextRef contextRef, JSValueRef* exception)
+JSValueRef WKSerializedScriptValueDeserialize(WKSerializedScriptValueRef, JSContextRef, JSValueRef*)
 {
-    return WebKit::toImpl(scriptValueRef)->deserialize(contextRef, exception);
+    return nullptr;
 }

--- a/Source/WebKit/Shared/API/c/WKSerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/c/WKSerializedScriptValue.h
@@ -28,15 +28,16 @@
 
 #include <JavaScriptCore/JavaScript.h>
 #include <WebKit/WKBase.h>
+#include <WebKit/WKDeprecated.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-WK_EXPORT WKTypeID WKSerializedScriptValueGetTypeID(void);
+WK_EXPORT WKTypeID WKSerializedScriptValueGetTypeID(void) WK_C_API_DEPRECATED;
 
-WK_EXPORT WKSerializedScriptValueRef WKSerializedScriptValueCreate(JSContextRef context, JSValueRef value, JSValueRef* exception);
-WK_EXPORT JSValueRef WKSerializedScriptValueDeserialize(WKSerializedScriptValueRef scriptValue, JSContextRef context, JSValueRef* exception);
+WK_EXPORT WKSerializedScriptValueRef WKSerializedScriptValueCreate(JSContextRef context, JSValueRef value, JSValueRef* exception) WK_C_API_DEPRECATED;
+WK_EXPORT JSValueRef WKSerializedScriptValueDeserialize(WKSerializedScriptValueRef scriptValue, JSContextRef context, JSValueRef* exception) WK_C_API_DEPRECATED;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#### ebea209afc66421f045f69e648b3ac382076b9bf
<pre>
Deprecate WKSerializedScriptValueRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=277594">https://bugs.webkit.org/show_bug.cgi?id=277594</a>
<a href="https://rdar.apple.com/133133034">rdar://133133034</a>

Reviewed by Timothy Hatcher.

Its last use was removed in <a href="https://rdar.apple.com/132943552">rdar://132943552</a>

* Source/WebKit/Shared/API/c/WKSerializedScriptValue.cpp:
(WKSerializedScriptValueGetTypeID):
(WKSerializedScriptValueCreate):
(WKSerializedScriptValueDeserialize):
* Source/WebKit/Shared/API/c/WKSerializedScriptValue.h:

Canonical link: <a href="https://commits.webkit.org/281960@main">https://commits.webkit.org/281960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7903722d16737ea5b73c081ef99b1581c6fa42c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11638 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49385 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34319 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56947 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4173 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9268 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->