### PR TITLE
Image decode failures should not be WebKit internal errors

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm
@@ -55,4 +55,9 @@ ResourceError fileDoesNotExistError(const ResourceResponse& response)
     return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorFileDoesNotExist, response.url()).get());
 }
 
+ResourceError decodeError(const URL& url)
+{
+    return ResourceError(createNSError(NSURLErrorDomain, NSURLErrorCannotDecodeContentData, url).get());
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebErrors.cpp
+++ b/Source/WebKit/Shared/WebErrors.cpp
@@ -99,6 +99,11 @@ ResourceError fileDoesNotExistError(const ResourceResponse& response)
 {
     return ResourceError(API::Error::webKitNetworkErrorDomain(), API::Error::Network::FileDoesNotExist, response.url(), WEB_UI_STRING("File does not exist", "The requested file doesn't exist"));
 }
+
+ResourceError decodeError(const URL&)
+{
+    return { };
+}
 #endif
 
 ResourceError httpsUpgradeRedirectLoopError(const ResourceRequest& request)

--- a/Source/WebKit/Shared/WebErrors.h
+++ b/Source/WebKit/Shared/WebErrors.h
@@ -58,6 +58,8 @@ WebCore::ResourceError downloadCancelledByUserError(const WebCore::ResourceRespo
 WebCore::ResourceError downloadDestinationError(const WebCore::ResourceResponse&, const WTF::String&);
 #endif
 
+WebCore::ResourceError decodeError(const URL&);
+
 #if PLATFORM(GTK)
 WebCore::ResourceError invalidPageRangeToPrint(const URL&);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8299,7 +8299,9 @@ void WebPageProxy::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::o
 {
     if (!hasRunningProcess())
         launchProcess({ }, ProcessLaunchReason::InitialProcess);
-    sendWithAsyncReply(Messages::WebPage::LoadAndDecodeImage(request, sizeConstraint, maximumBytesFromNetwork), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebPage::LoadAndDecodeImage(request, sizeConstraint, maximumBytesFromNetwork), [preventProcessShutdownScope = protectedLegacyMainFrameProcess()->shutdownPreventingScope(), completionHandler = WTFMove(completionHandler)] (std::variant<WebCore::ResourceError, Ref<WebCore::ShareableBitmap>>&& result) mutable {
+        completionHandler(WTFMove(result));
+    });
 }
 
 void WebPageProxy::didChangeContentSize(const IntSize& size)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
@@ -96,8 +96,8 @@ TEST(WebKit, LoadAndDecodeImage)
     EXPECT_EQ(result2->get().size.width, 215);
 
     auto result3 = imageOrError("/not_image"_s);
-    EXPECT_WK_STREQ(result3.error().get().domain, "WebKitErrorDomain");
-    EXPECT_EQ(result3.error().get().code, 300);
+    EXPECT_WK_STREQ(result3.error().get().domain, NSURLErrorDomain);
+    EXPECT_EQ(result3.error().get().code, NSURLErrorCannotDecodeContentData);
 
     auto result4 = imageOrError("/test_png"_s, CGSizeMake(100, 100));
     EXPECT_EQ(result4->get().size.height, 80);


### PR DESCRIPTION
#### cd58fda2512a566be80f30aa8cf43285ff414dda
<pre>
Image decode failures should not be WebKit internal errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=277595">https://bugs.webkit.org/show_bug.cgi?id=277595</a>
<a href="https://rdar.apple.com/133136320">rdar://133136320</a>

Reviewed by Tim Horton.

If an image fails to decode, that should not be reported as an internal error,
it should be a decode error. Otherwise we get these in stderr:
ERROR: WebKit encountered an internal error. This is a WebKit bug.

Also, the process was getting shut down during the message, so in practice
if an image took more than a moment to load it would fail.  I manually verified
that adding preventProcessShutdownScope to the message fixes this issue.

* Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm:
(WebKit::decodeError):
* Source/WebKit/Shared/WebErrors.cpp:
(WebKit::decodeError):
* Source/WebKit/Shared/WebErrors.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadAndDecodeImage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm:
(TestWebKitAPI::TEST(WebKit, LoadAndDecodeImage)):

Canonical link: <a href="https://commits.webkit.org/281813@main">https://commits.webkit.org/281813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a55199c83d896ee39793d59754f47e470e51bfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49370 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8080 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63109 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37629 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10139 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56933 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4161 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9188 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->