### PR TITLE
[@page] Add support for jis-b4/jis-b5 sizes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Test setup
+PASS size: 640px 480px
+PASS size: 8.5in 11in
+PASS size: 3in 10in
+PASS size: auto
+PASS size: a5
+PASS size: a4
+PASS size: a3
+PASS size: b5
+PASS size: b4
+PASS size: jis-b5
+PASS size: jis-b4
+PASS size: landscape
+FAIL size: letter assert_equals: for rule 12 expected "letter;" but got "letter portrait;"
+PASS size: legal landscape
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<link rel="help" href="https://drafts.csswg.org/css-page-3/#page-size-prop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@page {
+    size: 640px 480px;
+}
+@page {
+    size: 8.5in 11in;
+}
+@page {
+    size: 3in 10in;
+}
+@page {
+    size: auto;
+}
+@page {
+    size: A5;
+}
+@page {
+    size: A4;
+}
+@page {
+    size: A3;
+}
+@page {
+    size: B5;
+}
+@page {
+    size: B4;
+}
+@page {
+    size: jis-B5;
+}
+@page {
+    size: jis-B4;
+}
+@page {
+    size: landscape;
+}
+@page {
+    size: letter portrait;
+}
+@page {
+    size: legal landscape;
+}
+</style>
+
+<script>
+"use strict";
+
+const expectedSizes = [
+    "640px 480px",
+    "8.5in 11in",
+    "3in 10in",
+    "auto",
+    "a5",
+    "a4",
+    "a3",
+    "b5",
+    "b4",
+    "jis-b5",
+    "jis-b4",
+    "landscape",
+    "letter",
+    "legal landscape"
+];
+const sizePrefix = "size: ";
+
+test(() => {
+    assert_equals(document.styleSheets.length, 1);
+    assert_equals(document.styleSheets[0].rules.length, expectedSizes.length);
+}, "Test setup");
+
+for (let i = 0; i < expectedSizes.length; i++) {
+    test(() => {
+        let cssText = document.styleSheets[0].cssRules[i].style.cssText;
+        assert_true(cssText.startsWith(sizePrefix));
+        cssText = cssText.slice(sizePrefix.length);
+        assert_equals(cssText, expectedSizes[i] + ";", "for rule " + i);
+    }, "size: " + expectedSizes[i]);
+}
+</script>

--- a/LayoutTests/printing/page-format-data-expected.txt
+++ b/LayoutTests/printing/page-format-data-expected.txt
@@ -36,6 +36,10 @@ Test b5
 PASS internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4) is mmSize(176, 250) + pxMargins(1, 2, 3, 4)
 Test b4
 PASS internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4) is mmSize(250, 353) + pxMargins(1, 2, 3, 4)
+Test jis-b5
+PASS internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4) is mmSize(182, 257) + pxMargins(1, 2, 3, 4)
+Test jis-b4
+PASS internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4) is mmSize(257, 364) + pxMargins(1, 2, 3, 4)
 Test letter
 PASS internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4) is inchSize(8.5, 11) + pxMargins(1, 2, 3, 4)
 Test legal

--- a/LayoutTests/printing/page-format-data.html
+++ b/LayoutTests/printing/page-format-data.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head id="head_element">
-<script src="../resources/js-test-pre.js"></script>
-<style>
-</style>
+<head>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -11,11 +9,11 @@
 <script>
     description("This tests page format data");
 
-    function appendStyle(styleString)
+    function appendStyle(style)
     {
-        var styleElement = document.createElement("style");
-        styleElement.innerHTML = styleString;
-        document.getElementById("head_element").appendChild(styleElement);
+        const element = document.createElement("style");
+        element.textContent = style;
+        document.head.appendChild(element);
     }
 
     function inchSize(width, height)
@@ -101,6 +99,14 @@
         debug("Test b4");
         appendStyle("@page {size:b4;}");
         shouldBe("internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4)", "mmSize(250, 353) + pxMargins(1, 2, 3, 4)");
+
+        debug("Test jis-b5");
+        appendStyle("@page {size:jis-b5;}");
+        shouldBe("internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4)", "mmSize(182, 257) + pxMargins(1, 2, 3, 4)");
+
+        debug("Test jis-b4");
+        appendStyle("@page {size:jis-b4;}");
+        shouldBe("internals.pageSizeAndMarginsInPixels(0, 100, 200, 1, 2, 3, 4)", "mmSize(257, 364) + pxMargins(1, 2, 3, 4)");
 
         debug("Test letter");
         appendStyle("@page {size:letter;}");
@@ -188,10 +194,8 @@
 
         debug("");
 
-    } else {
+    } else
         testFailed("This test can be run only with window.testRunner");
-    }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10767,9 +10767,8 @@
             }
         },
         "<page-size>": {
-            "grammar": "A5 | A4 | A3 | B5 | B4 | letter | legal | ledger",
+            "grammar": "A5 | A4 | A3 | B5 | B4 | jis-B5 | jis-B4 | letter | legal | ledger",
             "exported": true,
-            "comment": "FIXME: missing JIS-B5 and JIS-B4",
             "specification": {
                 "category": "css-page",
                 "url": "https://www.w3.org/TR/css-page-3/#typedef-page-size-page-size"

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -606,18 +606,27 @@ full-size-kana
 visible
 //hidden
 collapse
-//
-// Unordered rest
-//
+
+// @page size
 a3
 a4
 a5
+b4
+b5
+jis-b4
+jis-b5
+landscape
+ledger
+legal
+letter
+
+//
+// Unordered rest
+//
 above
 absolute
 always
 avoid
-b4
-b5
 below
 bidi-override
 blink
@@ -637,10 +646,6 @@ plaintext
 -webkit-isolate
 -webkit-isolate-override
 -webkit-plaintext
-landscape
-ledger
-legal
-letter
 level
 line-through
 local

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1197,11 +1197,6 @@ RefPtr<CSSValue> consumeCounterSet(CSSParserTokenRange& range)
     return consumeCounter(range, 0);
 }
 
-static RefPtr<CSSValue> consumePageSize(CSSParserTokenRange& range)
-{
-    return consumeIdent<CSSValueA3, CSSValueA4, CSSValueA5, CSSValueB4, CSSValueB5, CSSValueLedger, CSSValueLegal, CSSValueLetter>(range);
-}
-
 RefPtr<CSSValue> consumeSize(CSSParserTokenRange& range, CSSParserMode mode)
 {
     if (consumeIdentRaw<CSSValueAuto>(range))
@@ -1214,10 +1209,10 @@ RefPtr<CSSValue> consumeSize(CSSParserTokenRange& range, CSSParserMode mode)
         return CSSValuePair::create(width.releaseNonNull(), height.releaseNonNull());
     }
 
-    auto pageSize = consumePageSize(range);
+    auto pageSize = CSSPropertyParsing::consumePageSize(range);
     auto orientation = consumeIdent<CSSValuePortrait, CSSValueLandscape>(range);
     if (!pageSize)
-        pageSize = consumePageSize(range);
+        pageSize = CSSPropertyParsing::consumePageSize(range);
     if (!orientation && !pageSize)
         return nullptr;
     if (pageSize && !orientation)

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -585,6 +585,10 @@ static bool pageSizeFromName(const CSSPrimitiveValue& pageSizeName, const CSSPri
     static NeverDestroyed<Length> b5Height(mmLength(250));
     static NeverDestroyed<Length> b4Width(mmLength(250));
     static NeverDestroyed<Length> b4Height(mmLength(353));
+    static NeverDestroyed<Length> jisB5Width(mmLength(182));
+    static NeverDestroyed<Length> jisB5Height(mmLength(257));
+    static NeverDestroyed<Length> jisB4Width(mmLength(257));
+    static NeverDestroyed<Length> jisB4Height(mmLength(364));
     static NeverDestroyed<Length> letterWidth(inchLength(8.5));
     static NeverDestroyed<Length> letterHeight(inchLength(11));
     static NeverDestroyed<Length> legalWidth(inchLength(8.5));
@@ -612,6 +616,14 @@ static bool pageSizeFromName(const CSSPrimitiveValue& pageSizeName, const CSSPri
     case CSSValueB4:
         width = b4Width;
         height = b4Height;
+        break;
+    case CSSValueJisB5:
+        width = jisB5Width;
+        height = jisB5Height;
+        break;
+    case CSSValueJisB4:
+        width = jisB4Width;
+        height = jisB4Height;
         break;
     case CSSValueLetter:
         width = letterWidth;


### PR DESCRIPTION
#### 500827ca66dce441bc5b1e2a8b0ccecfa14417eb
<pre>
[@page] Add support for jis-b4/jis-b5 sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=277597">https://bugs.webkit.org/show_bug.cgi?id=277597</a>
<a href="https://rdar.apple.com/133138325">rdar://133138325</a>

Reviewed by Darin Adler.

<a href="https://drafts.csswg.org/css-page/#typedef-page-size-page-size">https://drafts.csswg.org/css-page/#typedef-page-size-page-size</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid.html: Added.
* LayoutTests/printing/page-format-data-expected.txt:
* LayoutTests/printing/page-format-data.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeSize):
(WebCore::CSSPropertyParserHelpers::consumePageSize): Deleted.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::pageSizeFromName):

Canonical link: <a href="https://commits.webkit.org/281814@main">https://commits.webkit.org/281814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f62aea55d2993e99fa465c60bce98055d69f6b84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11907 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10147 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56134 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/10442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66752 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56747 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56941 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4169 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9189 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36248 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->