### PR TITLE
[fullscreen] Make "Esc" key check for prefixed & unprefixed APIs consistent

### DIFF
--- a/LayoutTests/fullscreen/requestFullscreen-escape-key-expected.txt
+++ b/LayoutTests/fullscreen/requestFullscreen-escape-key-expected.txt
@@ -1,13 +1,1 @@
-Tests that pressing the Escape key cannot be used as user interaction to enter fullscreen.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS document.webkitFullscreenEnabled is true
-Pressing Escape key....
-keydown - Requesting fullscreen
-PASS document.webkitFullscreenElement is null
-PASS successfullyParsed is true
-
-TEST COMPLETE
-
+PASS - Fullscreen through Escape key was rejected.

--- a/LayoutTests/fullscreen/requestFullscreen-escape-key.html
+++ b/LayoutTests/fullscreen/requestFullscreen-escape-key.html
@@ -1,28 +1,24 @@
 <!DOCTYPE html>
 <html>
 <body>
-<script src="../resources/js-test.js"></script>
+<div id="result"></div>
 <script>
-description("Tests that pressing the Escape key cannot be used as user interaction to enter fullscreen.");
-jsTestIsAsync = true;
-
-window.onkeydown = function(e) {
-    debug("keydown - Requesting fullscreen");
-    document.body.webkitRequestFullscreen();
-
-    setTimeout(function() {
-        shouldBeNull("document.webkitFullscreenElement");
-        finishJSTest();
-    }, 0);
-}
-
-onload = function() {
-    shouldBeTrue("document.webkitFullscreenEnabled");
-
-    debug("Pressing Escape key....");
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    addEventListener("keydown", (e) => {
+        const promise = document.documentElement.requestFullscreen().then(() => {
+            result.textContent = "FAIL - Fullscreen through Escape key was allowed.";
+            testRunner.notifyDone();
+        }, () => {
+            result.textContent = "PASS - Fullscreen through Escape key was rejected.";
+            testRunner.notifyDone();
+        });
+        e.preventDefault();
+    });
     if (window.eventSender)
         eventSender.keyDown("escape");
-};
 </script>
 </body>
 </html>

--- a/LayoutTests/fullscreen/webkitRequestFullscreen-escape-key-expected.txt
+++ b/LayoutTests/fullscreen/webkitRequestFullscreen-escape-key-expected.txt
@@ -1,0 +1,13 @@
+Tests that pressing the Escape key cannot be used as user interaction to enter fullscreen.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.webkitFullscreenEnabled is true
+Pressing Escape key...
+keydown - Requesting fullscreen
+PASS document.webkitFullscreenElement is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fullscreen/webkitRequestFullscreen-escape-key.html
+++ b/LayoutTests/fullscreen/webkitRequestFullscreen-escape-key.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that pressing the Escape key cannot be used as user interaction to enter fullscreen.");
+jsTestIsAsync = true;
+
+window.onkeydown = function(e) {
+    debug("keydown - Requesting fullscreen");
+    document.body.webkitRequestFullscreen();
+
+    setTimeout(function() {
+        shouldBeNull("document.webkitFullscreenElement");
+        finishJSTest();
+    }, 0);
+}
+
+onload = function() {
+    shouldBeTrue("document.webkitFullscreenEnabled");
+
+    debug("Pressing Escape key...");
+    if (window.eventSender)
+        eventSender.keyDown("escape");
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -130,22 +130,12 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
         return;
     }
 
-    // This algorithm is not allowed to show a pop-up:
-    //   An algorithm is allowed to show a pop-up if, in the task in which the algorithm is running, either:
-    //   - an activation behavior is currently being processed whose click event was trusted, or
-    //   - the event listener for a trusted click event is being handled.
-    // FIXME: Align prefixed and unprefixed code paths if possible.
-    bool isFromPrefixedAPI = !promise;
-    if (isFromPrefixedAPI) {
-        // We do not allow pressing the Escape key as a user gesture to enter fullscreen since this is the key
-        // to exit fullscreen.
-        if (UserGestureIndicator::processingUserGesture() && UserGestureIndicator::currentUserGesture()->gestureType() == UserGestureType::EscapeKey) {
-            ERROR_LOG(identifier, "Current gesture is EscapeKey; failing.");
-            document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, "The Escape key may not be used as a user gesture to enter fullscreen"_s);
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
-            return;
-        }
+    if (UserGestureIndicator::processingUserGesture() && UserGestureIndicator::currentUserGesture()->gestureType() == UserGestureType::EscapeKey) {
+        ERROR_LOG(identifier, "Current gesture is EscapeKey; failing.");
+        document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, "The Escape key may not be used as a user gesture to enter fullscreen"_s);
+        failedPreflights(WTFMove(element), WTFMove(promise));
+        completionHandler(false);
+        return;
     }
 
     // There is a previously-established user preference, security risk, or platform limitation.


### PR DESCRIPTION
#### 559ec359092079c2bee6b97649eb68cbe7aecb32
<pre>
[fullscreen] Make &quot;Esc&quot; key check for prefixed &amp; unprefixed APIs consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=276852">https://bugs.webkit.org/show_bug.cgi?id=276852</a>
<a href="https://rdar.apple.com/132172599">rdar://132172599</a>

Reviewed by Andy Estes.

Make this check effective for the unprefixed API as well to be consistent with other browsers behavior.

The Esc key always worked as exit fullscreen shortcut and can&apos;t be overriden thanks to other checks,
but let&apos;s prevent it from being used as shortcut to enter fullscreen.

* LayoutTests/fullscreen/requestFullscreen-escape-key-expected.txt:
* LayoutTests/fullscreen/requestFullscreen-escape-key.html:
* LayoutTests/fullscreen/webkitRequestFullscreen-escape-key-expected.txt: Copied from LayoutTests/fullscreen/requestFullscreen-escape-key-expected.txt.
* LayoutTests/fullscreen/webkitRequestFullscreen-escape-key.html: Copied from LayoutTests/fullscreen/requestFullscreen-escape-key.html.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):

Canonical link: <a href="https://commits.webkit.org/281846@main">https://commits.webkit.org/281846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da552915aa092ca45b5787ba93fec0a74a64546b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61222 "Failed to checkout and rebase branch from PR 31697") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/40583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/13803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/11771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63352 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/48260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/12046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/11771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/48260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/13803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/48260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/13803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/10684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/48260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/13803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/5169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/12046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/5192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/13803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9206 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->