### PR TITLE
[fullscreen] Improve error handling

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-cross-origin.https.sub.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-cross-origin.https.sub.tentative-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
 Verifies that element.requestFullscreen() calls from a cross-origin subframe without user activation work if and only if the top frame has user activation and it delegates the capability. https://wicg.github.io/capability-delegation/spec.html See wpt/html/user-activation/propagation*.html for frame tree user activation visibility tests.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
 Verifies that element.requestFullscreen() calls from a same-origin subframe without user activation work if and only if the top frame has user activation, regardless of whether it delegates the capability or not. https://wicg.github.io/capability-delegation/spec.html See wpt/html/user-activation/propagation*.html for frame tree user activation visibility tests.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-anchor.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-anchor.tentative-expected.txt
@@ -9,29 +9,29 @@ PASS Single popover=auto ancestor with dialog, top layer element *is* a popover
 FAIL Single popover=auto ancestor with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
 PASS Single popover=auto ancestor with fullscreen
 PASS Single popover=auto ancestor with fullscreen, top layer element *is* a popover
-FAIL Single popover=auto ancestor with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Single popover=auto ancestor with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Single popover=manual ancestor with dialog
 PASS Single popover=manual ancestor with dialog, top layer element *is* a popover
 FAIL Single popover=manual ancestor with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
 PASS Single popover=manual ancestor with fullscreen
 PASS Single popover=manual ancestor with fullscreen, top layer element *is* a popover
-FAIL Single popover=manual ancestor with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Single popover=manual ancestor with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Nested popover=auto ancestors with dialog
 PASS Nested popover=auto ancestors with dialog, top layer element *is* a popover
 FAIL Nested popover=auto ancestors with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
 PASS Nested popover=auto ancestors with fullscreen
 PASS Nested popover=auto ancestors with fullscreen, top layer element *is* a popover
-FAIL Nested popover=auto ancestors with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Nested popover=auto ancestors with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Nested popover=auto ancestors, target is outer with dialog
 PASS Nested popover=auto ancestors, target is outer with dialog, top layer element *is* a popover
 FAIL Nested popover=auto ancestors, target is outer with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
 PASS Nested popover=auto ancestors, target is outer with fullscreen
 PASS Nested popover=auto ancestors, target is outer with fullscreen, top layer element *is* a popover
-FAIL Nested popover=auto ancestors, target is outer with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Nested popover=auto ancestors, target is outer with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Top layer inside of nested element with dialog
 PASS Top layer inside of nested element with dialog, top layer element *is* a popover
 FAIL Top layer inside of nested element with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
 PASS Top layer inside of nested element with fullscreen
 PASS Top layer inside of nested element with fullscreen, top layer element *is* a popover
-FAIL Top layer inside of nested element with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Top layer inside of nested element with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-expected.txt
@@ -10,7 +10,7 @@ PASS Single popover=auto ancestor with fullscreen
 PASS Single popover=auto ancestor with fullscreen, top layer element *is* a popover
 PASS Single popover=manual ancestor with dialog
 PASS Single popover=manual ancestor with dialog, top layer element *is* a popover
-FAIL Single popover=manual ancestor with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Single popover=manual ancestor with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Single popover=manual ancestor with fullscreen, top layer element *is* a popover
 PASS Nested popover=auto ancestors with dialog
 PASS Nested popover=auto ancestors with dialog, top layer element *is* a popover
@@ -18,7 +18,7 @@ PASS Nested popover=auto ancestors with fullscreen
 PASS Nested popover=auto ancestors with fullscreen, top layer element *is* a popover
 PASS Nested popover=auto ancestors, target is outer with dialog
 PASS Nested popover=auto ancestors, target is outer with dialog, top layer element *is* a popover
-FAIL Nested popover=auto ancestors, target is outer with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Nested popover=auto ancestors, target is outer with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Nested popover=auto ancestors, target is outer with fullscreen, top layer element *is* a popover
 PASS Top layer inside of nested element with dialog
 PASS Top layer inside of nested element with dialog, top layer element *is* a popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.tentative-expected.txt
@@ -10,7 +10,7 @@ PASS Single popover=hint ancestor with fullscreen
 PASS Single popover=hint ancestor with fullscreen, top layer element *is* a popover
 PASS Nested auto/hint ancestors with dialog
 PASS Nested auto/hint ancestors with dialog, top layer element *is* a popover
-FAIL Nested auto/hint ancestors with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Nested auto/hint ancestors with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Nested auto/hint ancestors with fullscreen, top layer element *is* a popover
 FAIL Nested auto/hint ancestors, target is auto with dialog assert_equals: Incorrect behavior expected false but got true
 PASS Nested auto/hint ancestors, target is auto with dialog, top layer element *is* a popover
@@ -18,7 +18,7 @@ FAIL Nested auto/hint ancestors, target is auto with fullscreen assert_equals: I
 PASS Nested auto/hint ancestors, target is auto with fullscreen, top layer element *is* a popover
 FAIL Unrelated hint, target=hint with dialog assert_equals: Incorrect behavior expected true but got false
 PASS Unrelated hint, target=hint with dialog, top layer element *is* a popover
-FAIL Unrelated hint, target=hint with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Unrelated hint, target=hint with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Fullscreen request aborted by a fullscreen request for another element."
 PASS Unrelated hint, target=hint with fullscreen, top layer element *is* a popover
 FAIL Unrelated hint, target=auto with dialog assert_equals: Incorrect behavior expected false but got true
 PASS Unrelated hint, target=auto with dialog, top layer element *is* a popover

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-popup-cross-origin.https.sub.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-popup-cross-origin.https.sub.tentative-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen without transient activation.
 Verifies that element.requestFullscreen() calls from a cross-origin popup without user activation work if and only if the opener has user activation and it delegates the capability. https://wicg.github.io/capability-delegation/spec.html
 
 PASS Fullscreen requests from a cross-origin popup fails without delegation from an opener with no user activation

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -85,64 +85,55 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 {
     auto identifier = LOGIDENTIFIER;
 
-    // If pendingDoc is not fully active, then reject promise with a TypeError exception and return promise.
-    if (promise && !document().isFullyActive()) {
-        promise->reject(Exception { ExceptionCode::TypeError, "Document is not fully active"_s });
-        ERROR_LOG(identifier, "Document is not fully active; failing.");
-        completionHandler(false);
-        return;
-    }
-
-    auto failedPreflights = [this, weakThis = WeakPtr { *this }](Ref<Element>&& element, RefPtr<DeferredPromise>&& promise) mutable {
+    enum class EmitErrorEvent : bool { No, Yes };
+    auto handleError = [this, identifier, weakThis = WeakPtr { *this }](ASCIILiteral message, EmitErrorEvent emitErrorEvent, Ref<Element>&& element, RefPtr<DeferredPromise>&& promise, CompletionHandler<void(bool)>&& completionHandler) mutable {
         if (!weakThis)
             return;
-        Ref document { protectedDocument() };
-        m_fullscreenErrorEventTargetQueue.append(WTFMove(element));
+        ERROR_LOG(identifier, message);
         if (promise)
-            promise->reject(Exception { ExceptionCode::TypeError });
-        document->eventLoop().queueTask(TaskSource::MediaElement, [weakThis = WTFMove(weakThis)]() mutable {
-            if (weakThis)
-                weakThis->notifyAboutFullscreenChangeOrError();
-        });
+            promise->reject(Exception { ExceptionCode::TypeError, message });
+        if (emitErrorEvent == EmitErrorEvent::Yes) {
+            m_fullscreenErrorEventTargetQueue.append(WTFMove(element));
+            protectedDocument()->eventLoop().queueTask(TaskSource::MediaElement, [weakThis = WTFMove(weakThis)]() mutable {
+                if (weakThis)
+                    weakThis->notifyAboutFullscreenChangeOrError();
+            });
+        }
+        completionHandler(false);
     };
+
+    // If pendingDoc is not fully active, then reject promise with a TypeError exception and return promise.
+    if (promise && !document().isFullyActive()) {
+        handleError("Cannot request fullscreen on a document that is not fully active."_s, EmitErrorEvent::No, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
+        return;
+    }
 
     // If any of the following conditions are true, terminate these steps and queue a task to fire
     // an event named fullscreenerror with its bubbles attribute set to true on the context object's
     // node document:
     if (is<HTMLDialogElement>(element)) {
-        ERROR_LOG(identifier, "Element to fullscreen is a <dialog>; failing.");
-        failedPreflights(WTFMove(element), WTFMove(promise));
-        completionHandler(false);
+        handleError("Cannot request fullscreen on a <dialog> element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;
     }
 
     if (element->isPopoverShowing()) {
-        ERROR_LOG(identifier, "Element to fullscreen is an open popover; failing.");
-        failedPreflights(WTFMove(element), WTFMove(promise));
-        completionHandler(false);
+        handleError("Cannot request fullscreen on an open popover."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;
     }
 
     if (!document().domWindow() || !document().domWindow()->consumeTransientActivation()) {
-        ERROR_LOG(identifier, "!hasTransientActivation; failing.");
-        failedPreflights(WTFMove(element), WTFMove(promise));
-        completionHandler(false);
+        handleError("Cannot request fullscreen without transient activation."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;
     }
 
     if (UserGestureIndicator::processingUserGesture() && UserGestureIndicator::currentUserGesture()->gestureType() == UserGestureType::EscapeKey) {
-        ERROR_LOG(identifier, "Current gesture is EscapeKey; failing.");
-        document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, "The Escape key may not be used as a user gesture to enter fullscreen"_s);
-        failedPreflights(WTFMove(element), WTFMove(promise));
-        completionHandler(false);
+        handleError("Cannot request fullscreen with Escape key as current gesture."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;
     }
 
     // There is a previously-established user preference, security risk, or platform limitation.
     if (!page() || !page()->settings().fullScreenEnabled()) {
-        ERROR_LOG(identifier, "!page() or fullscreen not enabled; failing.");
-        failedPreflights(WTFMove(element), WTFMove(promise));
-        completionHandler(false);
+        handleError("Fullscreen API is disabled."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;
     }
 
@@ -153,9 +144,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
         hasKeyboardAccess = false;
 
         if (!page()->chrome().client().supportsFullScreenForElement(element, hasKeyboardAccess)) {
-            ERROR_LOG(identifier, "page does not support fullscreen for element; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Cannot request fullscreen with unsupported element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
     }
@@ -167,7 +156,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
     // We cache the top document here, so we still have the correct one when we exit fullscreen after navigation.
     m_topDocument = document().topDocument();
 
-    protectedDocument()->eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, element = WTFMove(element), promise = WTFMove(promise), completionHandler = WTFMove(completionHandler), checkType, hasKeyboardAccess, failedPreflights, identifier, mode] () mutable {
+    protectedDocument()->eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, element = WTFMove(element), promise = WTFMove(promise), completionHandler = WTFMove(completionHandler), checkType, hasKeyboardAccess, handleError, identifier, mode] () mutable {
         if (!weakThis) {
             if (promise)
                 promise->reject(Exception { ExceptionCode::TypeError });
@@ -178,76 +167,62 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
         // Don't allow fullscreen if it has been cancelled or a different fullscreen element
         // has requested fullscreen.
         if (m_pendingFullscreenElement != element.ptr()) {
-            ERROR_LOG(identifier, "task - pending element mismatch; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Fullscreen request aborted by a fullscreen request for another element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // Don't allow fullscreen if we're inside an exitFullscreen operation.
         if (m_pendingExitFullscreen) {
-            ERROR_LOG(identifier, "task - pending exit fullscreen operation; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Fullscreen request aborted by a request to exit fullscreen."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // Don't allow fullscreen if document is hidden.
         auto document = protectedDocument();
         if (document->hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
-            ERROR_LOG(identifier, "task - document hidden; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Cannot request fullscreen in a hidden document."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // The context object is not in a document.
         if (!element->isConnected()) {
-            ERROR_LOG(identifier, "task - element not in document; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Cannot request fullscreen on a disconnected element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // The element is an open popover.
         if (element->isPopoverShowing()) {
-            ERROR_LOG(identifier, "Element to fullscreen is an open popover; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Cannot request fullscreen on an open popover."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // The context object's node document, or an ancestor browsing context's document does not have
         // the fullscreen enabled flag set.
         if (checkType == EnforceIFrameAllowFullscreenRequirement && !PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::Fullscreen, document)) {
-            ERROR_LOG(identifier, "task - ancestor document does not enable fullscreen; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+            handleError("Fullscreen API is disabled by permissions policy."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // A descendant browsing context's document has a non-empty fullscreen element stack.
-        bool descendentHasNonEmptyStack = false;
+        bool descendantHasNonEmptyStack = false;
         for (RefPtr descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(descendant.get());
             if (!localFrame)
                 continue;
             if (localFrame->document()->fullscreenManager().fullscreenElement()) {
-                descendentHasNonEmptyStack = true;
+                descendantHasNonEmptyStack = true;
                 break;
             }
         }
-        if (descendentHasNonEmptyStack) {
-            ERROR_LOG(identifier, "task - descendent document has non-empty fullscreen stack; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            completionHandler(false);
+        if (descendantHasNonEmptyStack) {
+            handleError("Cannot request fullscreen because a descendant document already has a fullscreen element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
             return;
         }
 
         // 5. Return, and run the remaining steps asynchronously.
         // 6. Optionally, perform some animation.
         m_areKeysEnabledInFullscreen = hasKeyboardAccess;
-        document->eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WTFMove(weakThis), promise = WTFMove(promise), element = WTFMove(element), completionHandler = WTFMove(completionHandler), failedPreflights = WTFMove(failedPreflights), identifier, mode] () mutable {
+        document->eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WTFMove(weakThis), promise = WTFMove(promise), element = WTFMove(element), completionHandler = WTFMove(completionHandler), handleError = WTFMove(handleError), identifier, mode] () mutable {
             if (!weakThis) {
                 if (promise)
                     promise->reject(Exception { ExceptionCode::TypeError });
@@ -257,11 +232,11 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 
             auto page = this->page();
             if (!page || (this->document().hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) || m_pendingFullscreenElement != element.ptr() || !element->isConnected()) {
-                ERROR_LOG(identifier, "task - page, document, or element mismatch; failing.");
-                failedPreflights(WTFMove(element), WTFMove(promise));
-                completionHandler(false);
+                handleError("Invalid state when requesting fullscreen."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
                 return;
             }
+
+            // Reject previous promise, but continue with current operation.
             if (m_pendingPromise) {
                 ERROR_LOG(identifier, "Pending operation cancelled by requestFullscreen() call.");
                 m_pendingPromise->reject(Exception { ExceptionCode::TypeError, "Pending operation cancelled by requestFullscreen() call."_s });


### PR DESCRIPTION
#### bb6320734c7fe75a57c2fd7abdc2673266ac19d1
<pre>
[fullscreen] Improve error handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=248876">https://bugs.webkit.org/show_bug.cgi?id=248876</a>
<a href="https://rdar.apple.com/103073510">rdar://103073510</a>

Reviewed by Darin Adler.

Factor out some repetitive logic and provide useful error messages to web developers.

* LayoutTests/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-cross-origin.https.sub.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-anchor.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.tentative-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-popup-cross-origin.https.sub.tentative-expected.txt:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):

Canonical link: <a href="https://commits.webkit.org/281853@main">https://commits.webkit.org/281853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad95e36328fb901f0e6abb147653f258dc85362d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12066 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34438 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/10285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10704 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53023 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4292 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->