### PR TITLE
Sync `RTCDataChannelInit` as per Web Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxPacketLifeTime-enforce-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxPacketLifeTime-enforce-range-expected.txt
@@ -1,0 +1,19 @@
+
+PASS maxPacketLifeTime with value 0 should succeed
+PASS maxPacketLifeTime with value 1 should succeed
+PASS maxPacketLifeTime with value 1000 should succeed
+PASS maxPacketLifeTime with maximum value 65535 should succeed
+PASS maxPacketLifeTime with value 65534 (max-1) should succeed
+PASS maxPacketLifeTime with value 3 should succeed
+PASS maxPacketLifeTime with value 10 should succeed
+PASS maxPacketLifeTime with value -1 should throw TypeError
+PASS maxPacketLifeTime with value -100 should throw TypeError
+PASS maxPacketLifeTime with value 65536 should throw TypeError
+PASS maxPacketLifeTime with value 100000 should throw TypeError
+PASS maxPacketLifeTime with Infinity should throw TypeError
+PASS maxPacketLifeTime with -Infinity should throw TypeError
+PASS maxPacketLifeTime with NaN should throw TypeError
+PASS maxPacketLifeTime with string "65536" should throw TypeError
+PASS maxPacketLifeTime with numeric string "100" should be converted to 100
+PASS maxPacketLifeTime when omitted should be null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxPacketLifeTime-enforce-range.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxPacketLifeTime-enforce-range.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>RTCDataChannelInit maxPacketLifeTime [EnforceRange] unsigned short tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+// Helper to create a basic RTCPeerConnection
+function createPC() {
+  return new RTCPeerConnection();
+}
+
+// Test valid values within unsigned short range (0-65535)
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 0 });
+  assert_equals(channel.maxPacketLifeTime, 0);
+  pc.close();
+}, 'maxPacketLifeTime with value 0 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 1 });
+  assert_equals(channel.maxPacketLifeTime, 1);
+  pc.close();
+}, 'maxPacketLifeTime with value 1 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 1000 });
+  assert_equals(channel.maxPacketLifeTime, 1000);
+  pc.close();
+}, 'maxPacketLifeTime with value 1000 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 65535 });
+  assert_equals(channel.maxPacketLifeTime, 65535);
+  pc.close();
+}, 'maxPacketLifeTime with maximum value 65535 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 65534 });
+  assert_equals(channel.maxPacketLifeTime, 65534);
+  pc.close();
+}, 'maxPacketLifeTime with value 65534 (max-1) should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 3 });
+  assert_equals(channel.maxPacketLifeTime, 3);
+  pc.close();
+}, 'maxPacketLifeTime with value 3 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: 10 });
+  assert_equals(channel.maxPacketLifeTime, 10);
+  pc.close();
+}, 'maxPacketLifeTime with value 10 should succeed');
+
+// Test [EnforceRange] behavior - values outside range should throw TypeError
+const badValues = [
+  { value: -1, description: 'value -1' },
+  { value: -100, description: 'value -100' },
+  { value: 65536, description: 'value 65536' },
+  { value: 100000, description: 'value 100000' },
+  { value: Infinity, description: 'Infinity' },
+  { value: -Infinity, description: '-Infinity' },
+  { value: NaN, description: 'NaN' },
+  { value: "65536", description: 'string "65536"' }
+];
+
+badValues.forEach(({ value, description }) => {
+  test(() => {
+    const pc = createPC();
+    assert_throws_js(TypeError, () => {
+      pc.createDataChannel('test', { maxPacketLifeTime: value });
+    });
+    pc.close();
+  }, `maxPacketLifeTime with ${description} should throw TypeError`);
+});
+
+// Test numeric strings (should be converted to numbers)
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxPacketLifeTime: "100" });
+  assert_equals(channel.maxPacketLifeTime, 100);
+  pc.close();
+}, 'maxPacketLifeTime with numeric string "100" should be converted to 100');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', {});
+  assert_equals(channel.maxPacketLifeTime, null);
+  pc.close();
+}, 'maxPacketLifeTime when omitted should be null');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxRetransmits-enforce-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxRetransmits-enforce-range-expected.txt
@@ -1,0 +1,19 @@
+
+PASS maxRetransmits with value 0 should succeed
+PASS maxRetransmits with value 1 should succeed
+PASS maxRetransmits with value 1000 should succeed
+PASS maxRetransmits with maximum value 65535 should succeed
+PASS maxRetransmits with value 65534 (max-1) should succeed
+PASS maxRetransmits with value 3 should succeed
+PASS maxRetransmits with value 10 should succeed
+PASS maxRetransmits with value -1 should throw TypeError
+PASS maxRetransmits with value -100 should throw TypeError
+PASS maxRetransmits with value 65536 should throw TypeError
+PASS maxRetransmits with value 100000 should throw TypeError
+PASS maxRetransmits with Infinity should throw TypeError
+PASS maxRetransmits with -Infinity should throw TypeError
+PASS maxRetransmits with NaN should throw TypeError
+PASS maxRetransmits with string "65536" should throw TypeError
+PASS maxRetransmits with numeric string "100" should be converted to 100
+PASS maxRetransmits when omitted should be null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxRetransmits-enforce-range.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxRetransmits-enforce-range.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>RTCDataChannelInit maxRetransmits [EnforceRange] unsigned short tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+// Helper to create a basic RTCPeerConnection
+function createPC() {
+  return new RTCPeerConnection();
+}
+
+// Test valid values within unsigned short range (0-65535)
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 0 });
+  assert_equals(channel.maxRetransmits, 0);
+  pc.close();
+}, 'maxRetransmits with value 0 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 1 });
+  assert_equals(channel.maxRetransmits, 1);
+  pc.close();
+}, 'maxRetransmits with value 1 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 1000 });
+  assert_equals(channel.maxRetransmits, 1000);
+  pc.close();
+}, 'maxRetransmits with value 1000 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 65535 });
+  assert_equals(channel.maxRetransmits, 65535);
+  pc.close();
+}, 'maxRetransmits with maximum value 65535 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 65534 });
+  assert_equals(channel.maxRetransmits, 65534);
+  pc.close();
+}, 'maxRetransmits with value 65534 (max-1) should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 3 });
+  assert_equals(channel.maxRetransmits, 3);
+  pc.close();
+}, 'maxRetransmits with value 3 should succeed');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: 10 });
+  assert_equals(channel.maxRetransmits, 10);
+  pc.close();
+}, 'maxRetransmits with value 10 should succeed');
+
+// Test [EnforceRange] behavior - values outside range should throw TypeError
+const badValues = [
+  { value: -1, description: 'value -1' },
+  { value: -100, description: 'value -100' },
+  { value: 65536, description: 'value 65536' },
+  { value: 100000, description: 'value 100000' },
+  { value: Infinity, description: 'Infinity' },
+  { value: -Infinity, description: '-Infinity' },
+  { value: NaN, description: 'NaN' },
+  { value: "65536", description: 'string "65536"' }
+];
+
+badValues.forEach(({ value, description }) => {
+  test(() => {
+    const pc = createPC();
+    assert_throws_js(TypeError, () => {
+      pc.createDataChannel('test', { maxRetransmits: value });
+    });
+    pc.close();
+  }, `maxRetransmits with ${description} should throw TypeError`);
+});
+
+// Test numeric strings (should be converted to numbers)
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', { maxRetransmits: "100" });
+  assert_equals(channel.maxRetransmits, 100);
+  pc.close();
+}, 'maxRetransmits with numeric string "100" should be converted to 100');
+
+test(() => {
+  const pc = createPC();
+  const channel = pc.createDataChannel('test', {});
+  assert_equals(channel.maxRetransmits, null);
+  pc.close();
+}, 'maxRetransmits when omitted should be null');
+
+</script>

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
@@ -2,7 +2,7 @@
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (C) 2015, 2016 Ericsson AB. All rights reserved.
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,17 +35,18 @@
 
 typedef RTCRtpTransceiverDirection RtpTransceiverDirection;
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled
 ] dictionary RTCDataChannelInit {
     boolean ordered = true;
-    unsigned short maxPacketLifeTime;
-    unsigned short maxRetransmits;
+    [EnforceRange] unsigned short maxPacketLifeTime;
+    [EnforceRange] unsigned short maxRetransmits;
     USVString protocol = "";
     boolean negotiated = false;
     [EnforceRange] unsigned short id;
-    // FIXME 169644: missing priority
+    // FIXME: webkit.org/b/277605 - missing priority
 };
 
 [
@@ -133,11 +134,10 @@ typedef (object or DOMString) AlgorithmIdentifier;
     attribute EventHandler ontrack;
 
     // 6.1 Peer-to-peer data API
+    // https://w3c.github.io/webrtc-pc/#rtcpeerconnection-interface-extensions-0
     readonly attribute RTCSctpTransport? sctp;
-
-    RTCDataChannel createDataChannel(USVString label, optional RTCDataChannelInit options);
+    RTCDataChannel createDataChannel(USVString label, optional RTCDataChannelInit options = {});
     attribute EventHandler ondatachannel;
-
 
     // 8.2 Statistics API
     Promise<RTCStatsReport> getStats(optional MediaStreamTrack? selector = null);


### PR DESCRIPTION
#### 629c47d913460df4effc13f9c1d58333e648be90
<pre>
Sync `RTCDataChannelInit` as per Web Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=277604">https://bugs.webkit.org/show_bug.cgi?id=277604</a>
<a href="https://rdar.apple.com/problem/133630397">rdar://problem/133630397</a>

Reviewed by Youenn Fablet.

This patch aligns &apos;RTCDataChannelInit&apos; with Web Specification [1]:

[1] <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit">https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit</a>

It adds &apos;[EnforceRange]&apos; to &apos;maxPacketLifeTime&apos; and &apos;maxRetransmits&apos;.

Additionally, I just did fly-by fix of adding link of web
specification for easier reference.

NOTE: We match now with Gecko / Firefox as well.

* Source/WebCore/Modules/mediastream/RTCPeerConnection.idl:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxPacketLifeTime-enforce-range-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxPacketLifeTime-enforce-range.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxRetransmits-enforce-range-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannelInit-maxRetransmits-enforce-range.html: Added.

Canonical link: <a href="https://commits.webkit.org/304499@main">https://commits.webkit.org/304499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1e053990102eab236d8f8b84317fcaf2e53783f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143462 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/61a1bb5a-1fd2-4fa3-9de2-9ea32881d9a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/190063a0-1083-4fc7-bcc5-0da366a64033) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84615 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9609d4c-27f6-4333-9462-8db5edc3e15c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3695 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4068 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112101 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5948 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61746 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7859 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36073 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->