### PR TITLE
Use cascade alias for box-shadow/-webkit-box-shadow

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -222,7 +222,6 @@ zoom: 1;
 -webkit-box-orient: horizontal;
 -webkit-box-pack: start;
 -webkit-box-reflect: none;
--webkit-box-shadow: none;
 -webkit-column-axis: auto;
 -webkit-font-smoothing: auto;
 -webkit-hyphenate-limit-after: auto;

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -221,7 +221,6 @@ zoom: 1
 -webkit-box-orient: horizontal
 -webkit-box-pack: start
 -webkit-box-reflect: none
--webkit-box-shadow: none
 -webkit-column-axis: auto
 -webkit-font-smoothing: auto
 -webkit-hyphenate-limit-after: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -390,7 +390,6 @@ PASS -webkit-box-ordinal-group
 PASS -webkit-box-orient
 PASS -webkit-box-pack
 PASS -webkit-box-reflect
-PASS -webkit-box-shadow
 PASS -webkit-column-axis
 PASS -webkit-column-progression
 PASS -webkit-cursor-visibility

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -220,7 +220,6 @@ rect: style.getPropertyValue(-webkit-box-ordinal-group) : 1
 rect: style.getPropertyValue(-webkit-box-orient) : horizontal
 rect: style.getPropertyValue(-webkit-box-pack) : start
 rect: style.getPropertyValue(-webkit-box-reflect) : none
-rect: style.getPropertyValue(-webkit-box-shadow) : none
 rect: style.getPropertyValue(-webkit-column-axis) : auto
 rect: style.getPropertyValue(-webkit-font-smoothing) : auto
 rect: style.getPropertyValue(-webkit-hyphenate-limit-after) : auto
@@ -463,7 +462,6 @@ g: style.getPropertyValue(-webkit-box-ordinal-group) : 1
 g: style.getPropertyValue(-webkit-box-orient) : horizontal
 g: style.getPropertyValue(-webkit-box-pack) : start
 g: style.getPropertyValue(-webkit-box-reflect) : none
-g: style.getPropertyValue(-webkit-box-shadow) : none
 g: style.getPropertyValue(-webkit-column-axis) : auto
 g: style.getPropertyValue(-webkit-font-smoothing) : auto
 g: style.getPropertyValue(-webkit-hyphenate-limit-after) : auto

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -148,15 +148,6 @@
         "Whether the property needs to be applied at the end of its priority bucket",
         "in CSS cascading order.",
         "",
-        "* related-property:",
-        "Indicates another property which shares a computed style with the current one.",
-        "Typically used for the prefixed or unprefixed version of the same property, e.g.",
-        "-webkit-box-shadow has box-shadow as the related property, and vice versa.",
-        "Properties with this flag can't be high-priority, they are deferred to be applied",
-        "after low-priority ones, and they are specially handled to apply in parse order.",
-        "So if a declaration block contains both properties, they will be applied in the",
-        "specified order, not alphabetically within their priority bucket as usual.",
-        "",
         "* aliases:",
         "An array of the alternative names for this property. Aliases are folded at",
         "parse time and don't have their own CSSPropertyID.",
@@ -2965,7 +2956,6 @@
                 "inset"
             ],
             "codegen-properties": {
-                "related-property": "-webkit-box-shadow",
                 "custom": "All",
                 "parser-function": "consumeBoxShadow",
                 "parser-function-requires-context": true,
@@ -6797,8 +6787,8 @@
         },
         "-webkit-box-shadow": {
             "codegen-properties": {
-                "related-property": "box-shadow",
-                "custom": "All",
+                "cascade-alias": "box-shadow",
+                "skip-builder": true,
                 "parser-function": "consumeWebkitBoxShadow",
                 "parser-function-requires-context": true,
                 "parser-grammar-unused": "none | <shadow>#",

--- a/Source/WebCore/css/CSSShadowValue.cpp
+++ b/Source/WebCore/css/CSSShadowValue.cpp
@@ -26,7 +26,7 @@
 namespace WebCore {
 
 // Used for text-shadow and box-shadow
-CSSShadowValue::CSSShadowValue(RefPtr<CSSPrimitiveValue>&& x, RefPtr<CSSPrimitiveValue>&& y, RefPtr<CSSPrimitiveValue>&& blur, RefPtr<CSSPrimitiveValue>&& spread, RefPtr<CSSPrimitiveValue>&& style, RefPtr<CSSPrimitiveValue>&& color)
+CSSShadowValue::CSSShadowValue(RefPtr<CSSPrimitiveValue>&& x, RefPtr<CSSPrimitiveValue>&& y, RefPtr<CSSPrimitiveValue>&& blur, RefPtr<CSSPrimitiveValue>&& spread, RefPtr<CSSPrimitiveValue>&& style, RefPtr<CSSPrimitiveValue>&& color, bool isWebkitBoxShadow)
     : CSSValue(ShadowClass)
     , x(WTFMove(x))
     , y(WTFMove(y))
@@ -34,6 +34,7 @@ CSSShadowValue::CSSShadowValue(RefPtr<CSSPrimitiveValue>&& x, RefPtr<CSSPrimitiv
     , spread(WTFMove(spread))
     , style(WTFMove(style))
     , color(WTFMove(color))
+    , isWebkitBoxShadow(isWebkitBoxShadow)
 {
 }
 
@@ -79,7 +80,8 @@ bool CSSShadowValue::equals(const CSSShadowValue& other) const
         && compareCSSValuePtr(y, other.y)
         && compareCSSValuePtr(blur, other.blur)
         && compareCSSValuePtr(spread, other.spread)
-        && compareCSSValuePtr(style, other.style);
+        && compareCSSValuePtr(style, other.style)
+        && isWebkitBoxShadow == other.isWebkitBoxShadow;
 }
 
 }

--- a/Source/WebCore/css/CSSShadowValue.h
+++ b/Source/WebCore/css/CSSShadowValue.h
@@ -35,9 +35,10 @@ public:
         RefPtr<CSSPrimitiveValue>&& blur,
         RefPtr<CSSPrimitiveValue>&& spread,
         RefPtr<CSSPrimitiveValue>&& style,
-        RefPtr<CSSPrimitiveValue>&& color)
+        RefPtr<CSSPrimitiveValue>&& color,
+        bool isWebkitBoxShadow = false)
     {
-        return adoptRef(*new CSSShadowValue(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(style), WTFMove(color)));
+        return adoptRef(*new CSSShadowValue(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(style), WTFMove(color), isWebkitBoxShadow));
     }
 
     String customCSSText() const;
@@ -79,6 +80,7 @@ public:
     RefPtr<CSSPrimitiveValue> spread;
     RefPtr<CSSPrimitiveValue> style;
     RefPtr<CSSPrimitiveValue> color;
+    bool isWebkitBoxShadow { false };
 
 private:
     CSSShadowValue(RefPtr<CSSPrimitiveValue>&& x,
@@ -86,7 +88,8 @@ private:
         RefPtr<CSSPrimitiveValue>&& blur,
         RefPtr<CSSPrimitiveValue>&& spread,
         RefPtr<CSSPrimitiveValue>&& style,
-        RefPtr<CSSPrimitiveValue>&& color);
+        RefPtr<CSSPrimitiveValue>&& color,
+        bool isWebkitBoxShadow);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -979,7 +979,7 @@ Ref<CSSValue> ComputedStyleExtractor::valueForShadow(const ShadowData* shadow, C
         auto spread = propertyID == CSSPropertyTextShadow ? RefPtr<CSSPrimitiveValue>() : adjustLengthForZoom(currShadowData->spread(), style, adjust);
         auto shadowStyle = propertyID == CSSPropertyTextShadow || currShadowData->style() == ShadowStyle::Normal ? RefPtr<CSSPrimitiveValue>() : CSSPrimitiveValue::create(CSSValueInset);
         auto color = cssValuePool.createColorValue(style.colorResolvingCurrentColor(currShadowData->color()));
-        list.append(CSSShadowValue::create(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(shadowStyle), WTFMove(color)));
+        list.append(CSSShadowValue::create(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(shadowStyle), WTFMove(color), currShadowData->isWebkitBoxShadow()));
     }
     list.reverse();
     return CSSValueList::createCommaSeparated(WTFMove(list));

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -289,7 +289,7 @@ RefPtr<CSSValue> consumeFilter(CSSParserTokenRange& range, const CSSParserContex
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-RefPtr<CSSShadowValue> consumeSingleShadow(CSSParserTokenRange& range, const CSSParserContext& context, bool allowInset, bool allowSpread)
+RefPtr<CSSShadowValue> consumeSingleShadow(CSSParserTokenRange& range, const CSSParserContext& context, bool allowInset, bool allowSpread, bool isWebkitBoxShadow)
 {
     RefPtr<CSSPrimitiveValue> style;
     RefPtr<CSSPrimitiveValue> color;
@@ -350,7 +350,7 @@ RefPtr<CSSShadowValue> consumeSingleShadow(CSSParserTokenRange& range, const CSS
     // In order for this to be a valid <shadow>, at least these lengths must be present.
     if (!horizontalOffset || !verticalOffset)
         return nullptr;
-    return CSSShadowValue::create(WTFMove(horizontalOffset), WTFMove(verticalOffset), WTFMove(blurRadius), WTFMove(spreadDistance), WTFMove(style), WTFMove(color));
+    return CSSShadowValue::create(WTFMove(horizontalOffset), WTFMove(verticalOffset), WTFMove(blurRadius), WTFMove(spreadDistance), WTFMove(style), WTFMove(color), isWebkitBoxShadow);
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#predefined-counters
@@ -1766,27 +1766,27 @@ RefPtr<CSSValue> consumeTimingFunction(CSSParserTokenRange& range, const CSSPars
     return nullptr;
 }
 
-static RefPtr<CSSValue> consumeShadow(CSSParserTokenRange& range, const CSSParserContext& context, bool isBoxShadowProperty)
+static RefPtr<CSSValue> consumeShadow(CSSParserTokenRange& range, const CSSParserContext& context, bool isBoxShadowProperty, bool isWebkitBoxShadow)
 {
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
 
-    return consumeCommaSeparatedListWithoutSingleValueOptimization(range, consumeSingleShadow, context, isBoxShadowProperty, isBoxShadowProperty);
+    return consumeCommaSeparatedListWithoutSingleValueOptimization(range, consumeSingleShadow, context, isBoxShadowProperty, isBoxShadowProperty, isWebkitBoxShadow);
 }
 
 RefPtr<CSSValue> consumeTextShadow(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeShadow(range, context, false);
+    return consumeShadow(range, context, false, false);
 }
 
 RefPtr<CSSValue> consumeBoxShadow(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeShadow(range, context, true);
+    return consumeShadow(range, context, true, false);
 }
 
 RefPtr<CSSValue> consumeWebkitBoxShadow(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeShadow(range, context, true);
+    return consumeShadow(range, context, true, true);
 }
 
 RefPtr<CSSValue> consumeTextDecorationLine(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -68,7 +68,7 @@ enum class AllowedFilterFunctions {
 };
 
 RefPtr<CSSValue> consumeFilter(CSSParserTokenRange&, const CSSParserContext&, AllowedFilterFunctions);
-RefPtr<CSSShadowValue> consumeSingleShadow(CSSParserTokenRange&, const CSSParserContext&, bool allowInset, bool allowSpread);
+RefPtr<CSSShadowValue> consumeSingleShadow(CSSParserTokenRange&, const CSSParserContext&, bool allowInset, bool allowSpread, bool isWebkitBoxShadow = false);
 
 struct FontStyleRaw {
     CSSValueID style;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -701,7 +701,7 @@ inline void BuilderCustom::applyTextOrBoxShadowValue(BuilderState& builderState,
         if (shadowValue.color)
             color = builderState.colorFromPrimitiveValue(*shadowValue.color);
 
-        auto shadowData = makeUnique<ShadowData>(LengthPoint(x, y), blur, spread, shadowStyle, property == CSSPropertyWebkitBoxShadow, color);
+        auto shadowData = makeUnique<ShadowData>(LengthPoint(x, y), blur, spread, shadowStyle, shadowValue.isWebkitBoxShadow, color);
         if (property == CSSPropertyTextShadow)
             builderState.style().setTextShadow(WTFMove(shadowData), !isFirstEntry); // add to the list if this is not the first entry
         else
@@ -738,21 +738,6 @@ inline void BuilderCustom::applyInheritBoxShadow(BuilderState& builderState)
 inline void BuilderCustom::applyValueBoxShadow(BuilderState& builderState, CSSValue& value)
 {
     applyTextOrBoxShadowValue<CSSPropertyBoxShadow>(builderState, value);
-}
-
-inline void BuilderCustom::applyInitialWebkitBoxShadow(BuilderState& builderState)
-{
-    applyInitialBoxShadow(builderState);
-}
-
-inline void BuilderCustom::applyInheritWebkitBoxShadow(BuilderState& builderState)
-{
-    applyInheritBoxShadow(builderState);
-}
-
-inline void BuilderCustom::applyValueWebkitBoxShadow(BuilderState& builderState, CSSValue& value)
-{
-    applyTextOrBoxShadowValue<CSSPropertyWebkitBoxShadow>(builderState, value);
 }
 
 inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)


### PR DESCRIPTION
#### e4f270fa0af131f33119d749b1d47c4182480538
<pre>
Use cascade alias for box-shadow/-webkit-box-shadow
<a href="https://bugs.webkit.org/show_bug.cgi?id=277613">https://bugs.webkit.org/show_bug.cgi?id=277613</a>
<a href="https://rdar.apple.com/problem/133171521">rdar://problem/133171521</a>

Reviewed by Tim Nguyen.

Remove the last client of related-property mechanism.

* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/css/CSSProperties.json:

Use cascade-alias.

* Source/WebCore/css/CSSShadowValue.cpp:
(WebCore::CSSShadowValue::CSSShadowValue):

Remember in CSSShadowValue whether this is a legacy -webkit-box-shadow.

(WebCore::CSSShadowValue::equals const):
* Source/WebCore/css/CSSShadowValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForShadow):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeSingleShadow):
(WebCore::CSSPropertyParserHelpers::consumeShadow):
(WebCore::CSSPropertyParserHelpers::consumeTextShadow):
(WebCore::CSSPropertyParserHelpers::consumeBoxShadow):
(WebCore::CSSPropertyParserHelpers::consumeWebkitBoxShadow):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyTextOrBoxShadowValue):

Use the saved bit when creating ShadowData.

(WebCore::Style::BuilderCustom::applyInitialWebkitBoxShadow): Deleted.
(WebCore::Style::BuilderCustom::applyInheritWebkitBoxShadow): Deleted.
(WebCore::Style::BuilderCustom::applyValueWebkitBoxShadow): Deleted.

No need for separate style builder path anymore.

Canonical link: <a href="https://commits.webkit.org/281823@main">https://commits.webkit.org/281823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f51f5cdf326f13d7241a958be6cb3244167c779

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11700 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11975 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30274 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10207 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10612 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56188 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/10502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5098 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57010 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4222 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36316 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->