### PR TITLE
[Win WebKitTestRunner] Fails to capture a crash log if the crash happens before SetUnhandledExceptionFilter

### DIFF
--- a/Tools/WebKitTestRunner/win/TestControllerWin.cpp
+++ b/Tools/WebKitTestRunner/win/TestControllerWin.cpp
@@ -51,13 +51,6 @@ static const char webProcessCrashingEventName[] = "WebKitTestRunner.WebProcessCr
 static const double maximumWaitForWebProcessToCrash = 60;
 
 
-static LONG WINAPI exceptionFilter(EXCEPTION_POINTERS*)
-{
-    fprintf(stderr, "#CRASHED - WebKitTestRunner (pid %lu)\n", GetCurrentProcessId());
-    fflush(stderr);
-    return EXCEPTION_CONTINUE_SEARCH;
-}
-
 enum RunLoopResult { TimedOut, ObjectSignaled, ConditionSatisfied };
 
 static RunLoopResult runRunLoopUntil(bool& condition, HANDLE object, double timeout)
@@ -112,8 +105,6 @@ void TestController::platformInitialize(const Options&)
     // testing/debugging, as it causes the post-mortem debugger not to be invoked. We reset the
     // error mode here to work around Cygwin's behavior. See <http://webkit.org/b/55222>.
     ::SetErrorMode(0);
-
-    ::SetUnhandledExceptionFilter(exceptionFilter);
 
     _setmode(1, _O_BINARY);
     _setmode(2, _O_BINARY);

--- a/Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp
+++ b/Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp
@@ -77,8 +77,13 @@ int wmain()
         std::wcout << L"CreateProcess failed: " << GetLastError() << std::endl;
         return EXIT_FAILURE;
     }
+    DWORD pid = GetProcessId(processInformation.hProcess);
     WaitForSingleObject(processInformation.hProcess, INFINITE);
     DWORD exitCode;
     GetExitCodeProcess(processInformation.hProcess, &exitCode);
+
+    if (0xC0000000 <= exitCode)
+        fprintf(stderr, "#CRASHED - WebKitTestRunner (pid %lu)\n", pid);
+
     return exitCode;
 }


### PR DESCRIPTION
#### 20b1ec0bfbe1e52d668ae9542715162d0e032b4c
<pre>
[Win WebKitTestRunner] Fails to capture a crash log if the crash happens before SetUnhandledExceptionFilter
<a href="https://bugs.webkit.org/show_bug.cgi?id=277614">https://bugs.webkit.org/show_bug.cgi?id=277614</a>

Reviewed by Ross Kirsling.

After <a href="https://commits.webkit.org/280706@main">https://commits.webkit.org/280706@main</a> introduced
WebKitTestRunnerWS.exe spawning WebKitTestRunner.exe process,
run-webkit-tests scripts failed to capture a crash log of a child
WebKitTestRunner.exe process if the crash happened before calling
SetUnhandledExceptionFilter. For example, crashes in JSC::initialize()
and WebKit::InitializeWebKit2() were not captured.

Instead of using SetUnhandledExceptionFilter in WebKitTestRunner.exe,
output the #CRASH message in WebKitTestRunnerWS.exe.

* Tools/WebKitTestRunner/win/TestControllerWin.cpp:
(WTR::TestController::platformInitialize):
(WTR::exceptionFilter): Deleted.
* Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp:
(wmain):

Canonical link: <a href="https://commits.webkit.org/281821@main">https://commits.webkit.org/281821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fca996ddd63a683db0ecaa08b3385bc1f4313bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49421 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8126 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30251 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10187 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66805 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56794 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56987 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4203 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36292 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->