### PR TITLE
Media controls not entirely visible when viewing YouTube fullscreen.

### DIFF
--- a/LayoutTests/compositing/visibility/omitted-hidden-layers-made-visible-expected.html
+++ b/LayoutTests/compositing/visibility/omitted-hidden-layers-made-visible-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+  <div id="container" style="position: absolute; width: 200px; height: 200px;">
+    <div id="visible" style="background: green; visibility:visible; width: 100px; height: 100px; mix-blend-mode: plus-lighter; position:relative"></div>
+    <div style="visibility: hidden; position: relative;" id="hidden-container">
+      <div id="hidden" style="background: blue; visibility:visible; width: 100px; height: 100px; position:relative"></div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/LayoutTests/compositing/visibility/omitted-hidden-layers-made-visible.html
+++ b/LayoutTests/compositing/visibility/omitted-hidden-layers-made-visible.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+  <div id="container" style="position: absolute; width: 200px; height: 200px;">
+    <div id="visible" style="background: green; visibility:visible; width: 100px; height: 100px; mix-blend-mode: plus-lighter; position:relative"></div>
+    <div style="visibility: hidden; position: relative;" id="hidden-container">
+      <div id="hidden" style="background: blue; visibility:hidden; width: 100px; height: 100px; position:relative"></div>
+    </div>
+  </div>
+
+</body>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+window.onload = async () => {
+    await new Promise(requestAnimationFrame);
+    
+    document.getElementById("hidden").style.visibility = "visible";
+    
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -852,6 +852,7 @@ void RenderLayer::setWasOmittedFromZOrderTree()
 
 void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZOrderList, std::unique_ptr<Vector<RenderLayer*>>& negativeZOrderList, OptionSet<Compositing>& accumulatedDirtyFlags)
 {
+    ASSERT(!descendantDependentFlagsAreDirty());
     if (establishesTopLayer())
         return;
 
@@ -1173,13 +1174,10 @@ void RenderLayer::setAncestorChainHasSelfPaintingLayerDescendant()
 void RenderLayer::dirtyAncestorChainHasSelfPaintingLayerDescendantStatus()
 {
     for (RenderLayer* layer = this; layer; layer = layer->parent()) {
-        layer->m_hasSelfPaintingLayerDescendantDirty = true;
-        // If we have reached a self-painting layer, we know our parent should have a self-painting descendant
-        // in this case, there is no need to dirty our ancestors further.
-        if (layer->isSelfPaintingLayer()) {
-            ASSERT(!parent() || parent()->m_hasSelfPaintingLayerDescendantDirty || parent()->hasSelfPaintingLayerDescendant());
+        if (layer->m_hasSelfPaintingLayerDescendantDirty)
             break;
-        }
+
+        layer->m_hasSelfPaintingLayerDescendantDirty = true;
     }
 }
 
@@ -1331,9 +1329,6 @@ void RenderLayer::dirtyAncestorChainHasBlendingDescendants()
             break;
         
         layer->m_hasNotIsolatedBlendingDescendantsStatusDirty = true;
-
-        if (layer->isCSSStackingContext())
-            break;
     }
 }
 
@@ -1643,29 +1638,24 @@ void RenderLayer::updateAncestorDependentState()
 
 void RenderLayer::updateDescendantDependentFlags()
 {
-    if (m_visibleDescendantStatusDirty || m_hasSelfPaintingLayerDescendantDirty || hasNotIsolatedBlendingDescendantsStatusDirty()) {
+    if (m_visibleDescendantStatusDirty || m_hasSelfPaintingLayerDescendantDirty || hasNotIsolatedBlendingDescendantsStatusDirty() || m_hasIntrinsicallyCompositedDescendantsStatusDirty) {
         bool hasVisibleDescendant = false;
         bool hasSelfPaintingLayerDescendant = false;
         bool hasNotIsolatedBlendingDescendants = false;
         bool hasIntrinsicallyCompositedDescendants = false;
 
-        auto firstLayerChild = [&] () -> RenderLayer* {
-            if (renderer().isSkippedContentRoot())
-                return nullptr;
-            return firstChild();
-        }();
-        for (RenderLayer* child = firstLayerChild; child; child = child->nextSibling()) {
+        if (m_hasNotIsolatedBlendingDescendantsStatusDirty) {
+            m_hasNotIsolatedBlendingDescendantsStatusDirty = false;
+            updateSelfPaintingLayer();
+        }
+
+        for (RenderLayer* child = firstChild(); child; child = child->nextSibling()) {
             child->updateDescendantDependentFlags();
 
             hasVisibleDescendant |= child->m_hasVisibleContent || child->m_hasVisibleDescendant;
             hasSelfPaintingLayerDescendant |= child->isSelfPaintingLayer() || child->hasSelfPaintingLayerDescendant();
             hasNotIsolatedBlendingDescendants |= child->hasBlendMode() || (child->hasNotIsolatedBlendingDescendants() && !child->isolatesBlending());
             hasIntrinsicallyCompositedDescendants |= child->isIntrinsicallyComposited() || child->m_hasIntrinsicallyCompositedDescendants;
-
-            bool allFlagsSet = hasVisibleDescendant && hasSelfPaintingLayerDescendant;
-            allFlagsSet &= hasNotIsolatedBlendingDescendants;
-            if (allFlagsSet)
-                break;
         }
 
         m_hasVisibleDescendant = hasVisibleDescendant;
@@ -1676,10 +1666,6 @@ void RenderLayer::updateDescendantDependentFlags()
         m_hasIntrinsicallyCompositedDescendantsStatusDirty = false;
 
         m_hasNotIsolatedBlendingDescendants = hasNotIsolatedBlendingDescendants;
-        if (m_hasNotIsolatedBlendingDescendantsStatusDirty) {
-            m_hasNotIsolatedBlendingDescendantsStatusDirty = false;
-            updateSelfPaintingLayer();
-        }
     }
 
     if (m_visibleContentStatusDirty) {
@@ -1698,6 +1684,8 @@ void RenderLayer::updateDescendantDependentFlags()
         }
         m_visibleContentStatusDirty = false;
     }
+
+    ASSERT(!descendantDependentFlagsAreDirty());
 }
 
 bool RenderLayer::computeHasVisibleContent() const

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -415,7 +415,7 @@ public:
     bool descendantDependentFlagsAreDirty() const
     {
         return m_visibleDescendantStatusDirty || m_visibleContentStatusDirty || m_hasSelfPaintingLayerDescendantDirty
-            || m_hasNotIsolatedBlendingDescendantsStatusDirty;
+            || m_hasNotIsolatedBlendingDescendantsStatusDirty || m_hasIntrinsicallyCompositedDescendantsStatusDirty;
     }
 
     bool isPaintingSVGResourceLayer() const { return m_isPaintingSVGResourceLayer; }


### PR DESCRIPTION
#### fe06a69b5991f95dac3bc6c27b881f61b9505d62
<pre>
Media controls not entirely visible when viewing YouTube fullscreen.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277618">https://bugs.webkit.org/show_bug.cgi?id=277618</a>
&lt;<a href="https://rdar.apple.com/133089532">rdar://133089532</a>&gt;

Reviewed by Simon Fraser.

updateDescendantDependentFlags doesn&apos;t necessarily recurse the entire subtree
(due to the allFlagsSet early return).

This can result in descendants (not direct children) with a visibility change
fail to update the &apos;has visible descendant&apos; on the intermediate layer.

collectLayers then doesn&apos;t recurse through the intermediate layer (which has a
stale &apos;has visible descendant&apos; value), and we never re-add the newly visible
layer.

This changes updateDescendantDependentFlags to always recurse through the dirty
subtrees, since it&apos;s much easier to reason about, and the skipping was
relatively rare (required a mix-blend-mode child).

* LayoutTests/compositing/visibility/omitted-hidden-layers-made-visible-expected.html: Added.
* LayoutTests/compositing/visibility/omitted-hidden-layers-made-visible.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::collectLayers):
(WebCore::RenderLayer::updateDescendantDependentFlags):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/281882@main">https://commits.webkit.org/281882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad82aa1ca734e498aeead9215d7ad187da154ced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49546 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8246 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30384 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57124 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4355 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->