### PR TITLE
Remove related-property mechanism and rename deferred properties to logical group properties

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -562,8 +562,6 @@ void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVe
         auto& rule = ruleData.styleRule();
 
         // If the rule has no properties to apply, then ignore it in the non-debug mode.
-        // Note that if we get null back here, it means we have a rule with deferred properties,
-        // and that means we always have to consider it.
         if (rule.properties().isEmpty() && !m_shouldIncludeEmptyRules)
             continue;
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -89,7 +89,7 @@ void PropertyCascade::buildCascade()
         addImportantMatches(cascadeLevel);
     }
 
-    sortDeferredPropertyIDs();
+    sortLogicalGroupPropertyIDs();
 }
 
 void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
@@ -112,7 +112,7 @@ void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, 
 void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
 {
     ASSERT(!CSSProperty::isInLogicalPropertyGroup(id));
-    ASSERT(id < firstDeferredProperty);
+    ASSERT(id < firstLogicalGroupProperty);
 
     ASSERT(id < m_propertyIsPresent.size());
     if (id == CSSPropertyCustom) {
@@ -135,18 +135,18 @@ void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedPro
     setPropertyInternal(property, id, cssValue, matchedProperties, cascadeLevel);
 }
 
-void PropertyCascade::setDeferred(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
+void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)
 {
-    ASSERT(id >= firstDeferredProperty);
-    ASSERT(id <= lastDeferredProperty);
+    ASSERT(id >= firstLogicalGroupProperty);
+    ASSERT(id <= lastLogicalGroupProperty);
 
     auto& property = m_properties[id];
-    if (!hasDeferredProperty(id)) {
+    if (!hasLogicalGroupProperty(id)) {
         property.cssValue = { };
-        m_lowestSeenDeferredProperty = std::min(m_lowestSeenDeferredProperty, id);
-        m_highestSeenDeferredProperty = std::max(m_highestSeenDeferredProperty, id);
+        m_lowestSeenLogicalGroupProperty = std::min(m_lowestSeenLogicalGroupProperty, id);
+        m_highestSeenLogicalGroupProperty = std::max(m_highestSeenLogicalGroupProperty, id);
     }
-    setDeferredPropertyIndex(id, ++m_lastIndexForDeferred);
+    setLogicalGroupPropertyIndex(id, ++m_lastIndexForLogicalGroup);
     setPropertyInternal(property, id, cssValue, matchedProperties, cascadeLevel);
 }
 
@@ -154,30 +154,28 @@ bool PropertyCascade::hasProperty(CSSPropertyID propertyID, const CSSValue& valu
 {
     if (propertyID == CSSPropertyCustom)
         return hasCustomProperty(downcast<CSSCustomPropertyValue>(value).name());
-    return propertyID < firstDeferredProperty ? hasNormalProperty(propertyID) : hasDeferredProperty(propertyID);
+    return propertyID < firstLogicalGroupProperty ? hasNormalProperty(propertyID) : hasLogicalGroupProperty(propertyID);
 }
 
-const PropertyCascade::Property* PropertyCascade::lastDeferredPropertyResolvingRelated(CSSPropertyID propertyID, TextDirection direction, WritingMode writingMode) const
+const PropertyCascade::Property* PropertyCascade::lastPropertyResolvingLogicalPropertyPair(CSSPropertyID propertyID, TextDirection direction, WritingMode writingMode) const
 {
-    auto relatedID = [&] {
-        if (!CSSProperty::isInLogicalPropertyGroup(propertyID))
-            return relatedProperty(propertyID);
+    ASSERT(CSSProperty::isInLogicalPropertyGroup(propertyID));
+
+    auto pairID = [&] {
         if (CSSProperty::isDirectionAwareProperty(propertyID))
             return CSSProperty::resolveDirectionAwareProperty(propertyID, direction, writingMode);
         return CSSProperty::unresolvePhysicalProperty(propertyID, direction, writingMode);
     }();
-    if (relatedID == CSSPropertyInvalid) {
-        ASSERT_NOT_REACHED();
-        return hasDeferredProperty(propertyID) ? &deferredProperty(propertyID) : nullptr;
-    }
-    auto indexForPropertyID = deferredPropertyIndex(propertyID);
-    auto indexForRelatedID = deferredPropertyIndex(relatedID);
-    if (indexForPropertyID > indexForRelatedID)
-        return &deferredProperty(propertyID);
-    if (indexForPropertyID < indexForRelatedID)
-        return &deferredProperty(relatedID);
-    ASSERT(!hasDeferredProperty(propertyID));
-    ASSERT(!hasDeferredProperty(relatedID));
+    ASSERT(pairID != CSSPropertyInvalid);
+
+    auto indexForPropertyID = logicalGroupPropertyIndex(propertyID);
+    auto indexForPairID = logicalGroupPropertyIndex(pairID);
+    if (indexForPropertyID > indexForPairID)
+        return &logicalGroupProperty(propertyID);
+    if (indexForPropertyID < indexForPairID)
+        return &logicalGroupProperty(pairID);
+    ASSERT(!hasLogicalGroupProperty(propertyID));
+    ASSERT(!hasLogicalGroupProperty(pairID));
     return nullptr;
 }
 
@@ -242,8 +240,8 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             if (m_includedProperties.contains(PropertyType::NonInherited) && !current.isInherited())
                 return true;
 
-            // Apply all deferred properties if we have applied any. They may override the ones we already applied.
-            if (propertyID >= firstDeferredProperty && m_lastIndexForDeferred)
+            // Apply all logical group properties if we have applied any. They may override the ones we already applied.
+            if (propertyID >= firstLogicalGroupProperty && m_lastIndexForLogicalGroup)
                 return true;
 
             return false;
@@ -252,10 +250,10 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
         if (!shouldIncludeProperty)
             continue;
 
-        if (propertyID < firstDeferredProperty)
+        if (propertyID < firstLogicalGroupProperty)
             set(propertyID, *current.value(), matchedProperties, cascadeLevel);
         else
-            setDeferred(propertyID, *current.value(), matchedProperties, cascadeLevel);
+            setLogicalGroupProperty(propertyID, *current.value(), matchedProperties, cascadeLevel);
     }
 
     return hasImportantProperties;
@@ -375,18 +373,18 @@ void PropertyCascade::addImportantMatches(CascadeLevel cascadeLevel)
         addMatch(matchedDeclarations[match.index], cascadeLevel, IsImportant::Yes);
 }
 
-void PropertyCascade::sortDeferredPropertyIDs()
+void PropertyCascade::sortLogicalGroupPropertyIDs()
 {
-    auto begin = m_deferredPropertyIDs.begin();
+    auto begin = m_logicalGroupPropertyIDs.begin();
     auto end = begin;
-    for (uint16_t id = m_lowestSeenDeferredProperty; id <= m_highestSeenDeferredProperty; ++id) {
+    for (uint16_t id = m_lowestSeenLogicalGroupProperty; id <= m_highestSeenLogicalGroupProperty; ++id) {
         auto propertyID = static_cast<CSSPropertyID>(id);
-        if (hasDeferredProperty(propertyID))
+        if (hasLogicalGroupProperty(propertyID))
             *end++ = propertyID;
     }
-    m_seenDeferredPropertyCount = end - begin;
+    m_seenLogicalGroupPropertyCount = end - begin;
     std::sort(begin, end, [&](auto id1, auto id2) {
-        return deferredPropertyIndex(id1) < deferredPropertyIndex(id2);
+        return logicalGroupPropertyIndex(id1) < logicalGroupPropertyIndex(id2);
     });
 }
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -132,8 +132,8 @@ void Builder::applyNonHighPriorityProperties()
 
 void Builder::applyDeferredProperties()
 {
-    for (auto id : m_cascade.deferredPropertyIDs())
-        applyCascadeProperty(m_cascade.deferredProperty(id));
+    for (auto id : m_cascade.logicalGroupPropertyIDs())
+        applyCascadeProperty(m_cascade.logicalGroupProperty(id));
 }
 
 void Builder::applyProperties(int firstProperty, int lastProperty)
@@ -335,13 +335,13 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
                         return;
                     }
                 }
-            } else if (id < firstDeferredProperty) {
+            } else if (id < firstLogicalGroupProperty) {
                 if (rollbackCascade->hasNormalProperty(id)) {
                     auto& property = rollbackCascade->normalProperty(id);
                     applyRollbackCascadeProperty(property, linkMatchMask);
                     return;
                 }
-            } else if (auto* property = rollbackCascade->lastDeferredPropertyResolvingRelated(id, style.direction(), style.writingMode())) {
+            } else if (auto* property = rollbackCascade->lastPropertyResolvingLogicalPropertyPair(id, style.direction(), style.writingMode())) {
                 applyRollbackCascadeProperty(*property, linkMatchMask);
                 return;
             }


### PR DESCRIPTION
#### f91f78d77fdb532f75393779cbb34bf301fcb73b
<pre>
Remove related-property mechanism and rename deferred properties to logical group properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=277623">https://bugs.webkit.org/show_bug.cgi?id=277623</a>
<a href="https://rdar.apple.com/133203218">rdar://133203218</a>

Reviewed by Tim Nguyen.

The related-property mechanism has no clients left. It is also the only user of
&quot;deferred properties&quot; besides logical group properties. We can now remove this confusing
non-spec term from the codebase.

* Source/WebCore/css/process-css-properties.py:
(StylePropertyCodeGenProperties):
(StylePropertyCodeGenProperties.from_json):
(StylePropertyCodeGenProperties.is_logical):
(StyleProperty.perform_fixups_for_longhands):
(StyleProperty.perform_fixups):
(StyleProperties._sort_by_descending_priority_and_name):
(DescriptorCodeGenProperties.__init__):
(GenerateCSSPropertyNames):
(StylePropertyCodeGenProperties.is_deferred): Deleted.
(StyleProperty.perform_fixups_for_related_properties): Deleted.
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::buildCascade):
(WebCore::Style::PropertyCascade::set):
(WebCore::Style::PropertyCascade::setLogicalGroupProperty):
(WebCore::Style::PropertyCascade::hasProperty):
(WebCore::Style::PropertyCascade::lastPropertyResolvingLogicalPropertyPair const):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::sortLogicalGroupPropertyIDs):
(WebCore::Style::PropertyCascade::setDeferred): Deleted.
(WebCore::Style::PropertyCascade::lastDeferredPropertyResolvingRelated const): Deleted.
(WebCore::Style::PropertyCascade::sortDeferredPropertyIDs): Deleted.
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::isEmpty const):
(WebCore::Style::PropertyCascade::hasNormalProperty const):
(WebCore::Style::PropertyCascade::logicalGroupPropertyIndex const):
(WebCore::Style::PropertyCascade::setLogicalGroupPropertyIndex):
(WebCore::Style::PropertyCascade::hasLogicalGroupProperty const):
(WebCore::Style::PropertyCascade::logicalGroupProperty const):
(WebCore::Style::PropertyCascade::logicalGroupPropertyIDs const):
(WebCore::Style::PropertyCascade::deferredPropertyIndex const): Deleted.
(WebCore::Style::PropertyCascade::setDeferredPropertyIndex): Deleted.
(WebCore::Style::PropertyCascade::hasDeferredProperty const): Deleted.
(WebCore::Style::PropertyCascade::deferredProperty const): Deleted.
(WebCore::Style::PropertyCascade::deferredPropertyIDs const): Deleted.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyDeferredProperties):
(WebCore::Style::Builder::applyProperty):

Canonical link: <a href="https://commits.webkit.org/281834@main">https://commits.webkit.org/281834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1dea95d1b54e342b7a7513b537382cf4547dc37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49455 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56828 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57023 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4236 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->