### PR TITLE
WebGL context is constructed with window GPU ID if low-power GPU is requested

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -435,7 +435,7 @@ static GraphicsContextGLAttributes resolveGraphicsContextGLAttributes(const WebG
     glAttributes.isWebGL2 = isWebGL2;
 #if PLATFORM(MAC)
     GraphicsClient* graphicsClient = scriptExecutionContext.graphicsClient();
-    if (graphicsClient)
+    if (graphicsClient && attributes.powerPreference == WebGLContextAttributes::PowerPreference::Default)
         glAttributes.windowGPUID = gpuIDForDisplay(graphicsClient->displayID());
 #endif
 #if ENABLE(WEBXR)

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -62,7 +62,7 @@ class Widget;
 
 using PlatformDisplayID = uint32_t;
 
-using PlatformGPUID = uint64_t; // On MAC, MACCATALYST, global IOKit registryID that can identify a GPU across process boundaries.
+using PlatformGPUID = uint64_t; // On MAC, global IOKit registryID that can identify a GPU across process boundaries.
 
 int screenDepth(Widget*);
 int screenDepthPerComponent(Widget*);

--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -43,7 +43,7 @@ enum class GraphicsContextGLSimulatedCreationFailure : uint8_t {
     FailPlatformContextCreation
 };
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC)
 using PlatformGPUID = uint64_t;
 #endif
 
@@ -56,7 +56,7 @@ struct GraphicsContextGLAttributes {
     bool preserveDrawingBuffer { false };
     GraphicsContextGLPowerPreference powerPreference { GraphicsContextGLPowerPreference::Default };
     bool isWebGL2 { false };
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC)
     PlatformGPUID windowGPUID { 0 };
 #endif
 #if ENABLE(WEBXR)

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -117,26 +117,24 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     if (powerPreference == GraphicsContextGLPowerPreference::HighPerformance) {
         displayAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
         displayAttributes.append(EGL_HIGH_POWER_ANGLE);
-    } else {
-        if (powerPreference == GraphicsContextGLPowerPreference::LowPower) {
-            displayAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
-            displayAttributes.append(EGL_LOW_POWER_ANGLE);
-        }
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    } else if (powerPreference == GraphicsContextGLPowerPreference::LowPower) {
+        displayAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
+        displayAttributes.append(EGL_LOW_POWER_ANGLE);
+    }
+#if PLATFORM(MAC)
+    else if (attrs.windowGPUID) {
         ASSERT(strstr(clientExtensions, "EGL_ANGLE_platform_angle_device_id"));
         // If the power preference is default, use the GPU the context window is on.
         // If the power preference is low power, and we know which GPU the context window is on,
         // most likely the lowest power is the GPU that drives the context window, as that GPU
         // is anyway already powered on.
-        if (attrs.windowGPUID) {
-            // EGL_PLATFORM_ANGLE_DEVICE_ID_*_ANGLE is the IOKit registry id on EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE.
-            displayAttributes.append(EGL_PLATFORM_ANGLE_DEVICE_ID_HIGH_ANGLE);
-            displayAttributes.append(static_cast<EGLAttrib>(attrs.windowGPUID >> 32));
-            displayAttributes.append(EGL_PLATFORM_ANGLE_DEVICE_ID_LOW_ANGLE);
-            displayAttributes.append(static_cast<EGLAttrib>(attrs.windowGPUID));
-        }
-#endif
+        // EGL_PLATFORM_ANGLE_DEVICE_ID_*_ANGLE is the IOKit registry id on EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE.
+        displayAttributes.append(EGL_PLATFORM_ANGLE_DEVICE_ID_HIGH_ANGLE);
+        displayAttributes.append(static_cast<EGLAttrib>(attrs.windowGPUID >> 32));
+        displayAttributes.append(EGL_PLATFORM_ANGLE_DEVICE_ID_LOW_ANGLE);
+        displayAttributes.append(static_cast<EGLAttrib>(attrs.windowGPUID));
     }
+#endif
     ASSERT(strstr(clientExtensions, "EGL_ANGLE_feature_control"));
     displayAttributes.append(EGL_FEATURE_OVERRIDES_DISABLED_ANGLE);
     displayAttributes.append(reinterpret_cast<EGLAttrib>(disabledANGLEMetalFeatures));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2939,7 +2939,7 @@ struct WebCore::GraphicsContextGLAttributes {
     bool preserveDrawingBuffer;
     WebCore::GraphicsContextGLPowerPreference powerPreference;
     bool isWebGL2;
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC)
     uint64_t windowGPUID;
 #endif
 #if ENABLE(WEBXR)


### PR DESCRIPTION
#### 23375c07162cd579617a30a98114a8b30a798542
<pre>
WebGL context is constructed with window GPU ID if low-power GPU is requested
<a href="https://bugs.webkit.org/show_bug.cgi?id=277629">https://bugs.webkit.org/show_bug.cgi?id=277629</a>
<a href="https://rdar.apple.com/133211880">rdar://133211880</a>

Reviewed by Dan Glastonbury.

If the page asks for low-power GPU, only use this as the instantiation
criteria.
Also remove macCatalyst ifdefs in some places. On macCatalyst, the code
does not populate the GPUID of the window in the first place.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::resolveGraphicsContextGLAttributes):
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::initializeEGLDisplay):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/281988@main">https://commits.webkit.org/281988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/180d13f59759fe664a3171c2c8596f838e6db9bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49579 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8279 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34529 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10389 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10836 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56952 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4393 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36539 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->