### PR TITLE
[WGSL] Type::alignment should work for primitive structs

### DIFF
--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -417,8 +417,11 @@ unsigned Type::alignment() const
         [&](const Struct& structure) -> unsigned {
             return structure.structure.alignment();
         },
-        [&](const PrimitiveStruct&) -> unsigned {
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const PrimitiveStruct& structure) -> unsigned {
+            unsigned alignment = 0;
+            for (auto* type : structure.values)
+                alignment = std::max(alignment, type->alignment());
+            return alignment;
         },
         [&](const Function&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebGPU/WGSL/tests/valid/array-primitive-struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-primitive-struct.wgsl
@@ -1,0 +1,7 @@
+// RUN: %metal-compile main
+
+enable f16;
+@compute @workgroup_size(1)
+fn main(){
+    var x = array(modf(2h));
+}


### PR DESCRIPTION
#### 846b4dcaed697bf586d0a250ff23e658b6081777
<pre>
[WGSL] Type::alignment should work for primitive structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277634">https://bugs.webkit.org/show_bug.cgi?id=277634</a>
<a href="https://rdar.apple.com/132479662">rdar://132479662</a>

Reviewed by Mike Wyrzykowski.

The alignment was only used for global variables, so the alignment would never
be computed for primitive structs. Since we started using alignment and size
for computing the limit of local variables, it needs to support primitive
structs as well.

* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/tests/valid/array-primitive-struct.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/281889@main">https://commits.webkit.org/281889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ddc1c6d73f4effe7b69b6181aa580c1b2a29b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11742 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49469 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8170 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34403 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4251 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36358 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->