### PR TITLE
heap-use-after-free | WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope; WebCore::WorkerOrWorkletThread::workerOrWorkletThread; WTF::Thread::entryPoint)

### DIFF
--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-MainThreadPermissionObserver::MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&& permissionStatus, ScriptExecutionContextIdentifier contextIdentifier, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, SingleThreadWeakPtr<Page>&& page, ClientOrigin&& origin)
+MainThreadPermissionObserver::MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&& permissionStatus, ScriptExecutionContextIdentifier contextIdentifier, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page, ClientOrigin&& origin)
     : m_permissionStatus(WTFMove(permissionStatus))
     , m_contextIdentifier(contextIdentifier)
     , m_state(state)

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
@@ -42,7 +42,7 @@ class MainThreadPermissionObserver final : public PermissionObserver {
     WTF_MAKE_NONCOPYABLE(MainThreadPermissionObserver);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&, ClientOrigin&&);
+    MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&, ClientOrigin&&);
     ~MainThreadPermissionObserver();
 
 private:
@@ -52,14 +52,14 @@ private:
     const ClientOrigin& origin() const final { return m_origin; }
     PermissionDescriptor descriptor() const final { return m_descriptor; }
     PermissionQuerySource source() const final { return m_source; }
-    const SingleThreadWeakPtr<Page>& page() const final { return m_page; }
+    const WeakPtr<Page>& page() const final { return m_page; }
 
     ThreadSafeWeakPtr<PermissionStatus> m_permissionStatus;
     ScriptExecutionContextIdentifier m_contextIdentifier;
     PermissionState m_state;
     PermissionDescriptor m_descriptor;
     PermissionQuerySource m_source;
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     ClientOrigin m_origin;
 };
 

--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT static void setSharedController(Ref<PermissionController>&&);
     
     virtual ~PermissionController() = default;
-    virtual void query(ClientOrigin&&, PermissionDescriptor, const SingleThreadWeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
+    virtual void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
     virtual void addObserver(PermissionObserver&) = 0;
     virtual void removeObserver(PermissionObserver&) = 0;
     virtual void permissionChanged(PermissionName, const SecurityOriginData&) = 0;
@@ -60,7 +60,7 @@ public:
     static Ref<DummyPermissionController> create() { return adoptRef(*new DummyPermissionController); }
 private:
     DummyPermissionController() = default;
-    void query(ClientOrigin&&, PermissionDescriptor, const SingleThreadWeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
+    void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
     void addObserver(PermissionObserver&) final { }
     void removeObserver(PermissionObserver&) final { }
     void permissionChanged(PermissionName, const SecurityOriginData&) final { }

--- a/Source/WebCore/Modules/permissions/PermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/PermissionObserver.h
@@ -55,7 +55,7 @@ public:
     virtual const ClientOrigin& origin() const = 0;
     virtual PermissionDescriptor descriptor() const = 0;
     virtual PermissionQuerySource source() const = 0;
-    virtual const SingleThreadWeakPtr<Page>& page() const = 0;
+    virtual const WeakPtr<Page>& page() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -54,14 +54,14 @@ static HashMap<MainThreadPermissionObserverIdentifier, std::unique_ptr<MainThrea
     return map;
 }
 
-Ref<PermissionStatus> PermissionStatus::create(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, SingleThreadWeakPtr<Page>&& page)
+Ref<PermissionStatus> PermissionStatus::create(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page)
 {
     auto status = adoptRef(*new PermissionStatus(context, state, descriptor, source, WTFMove(page)));
     status->suspendIfNeeded();
     return status;
 }
 
-PermissionStatus::PermissionStatus(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, SingleThreadWeakPtr<Page>&& page)
+PermissionStatus::PermissionStatus(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page)
     : ActiveDOMObject(&context)
     , m_state(state)
     , m_descriptor(descriptor)

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -42,7 +42,7 @@ class ScriptExecutionContext;
 class PermissionStatus final : public ActiveDOMObject, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PermissionStatus>, public EventTarget  {
     WTF_MAKE_ISO_ALLOCATED(PermissionStatus);
 public:
-    static Ref<PermissionStatus> create(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&);
+    static Ref<PermissionStatus> create(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&);
     ~PermissionStatus();
 
     PermissionState state() const { return m_state; }
@@ -55,7 +55,7 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
 private:
-    PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&);
+    PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&);
 
     // ActiveDOMObject
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -87,8 +87,10 @@ void AudioDestinationNode::renderQuantum(AudioBus* destinationBus, size_t number
     context().handlePreRenderTasks(outputPosition);
 
     RefPtr<AudioWorkletGlobalScope> workletGlobalScope;
-    if (RefPtr audioWorkletProxy = context().audioWorklet().proxy())
-        workletGlobalScope = audioWorkletProxy->workletThread().globalScope();
+    if (RefPtr audioWorkletProxy = context().audioWorklet().proxy()) {
+        if (Ref workletThread = audioWorkletProxy->workletThread(); workletThread->thread() == &Thread::current())
+            workletGlobalScope = workletThread->globalScope();
+    }
     if (workletGlobalScope)
         workletGlobalScope->handlePreRenderTasks();
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -192,10 +192,9 @@ AudioWorkletThread& AudioWorkletGlobalScope::thread() const
 void AudioWorkletGlobalScope::handlePreRenderTasks()
 {
     // This makes sure that we only drain the MicroTask queue after each render quantum.
-    // It is only safe to grab the lock if we are on the context thread. We might get called on
-    // another thread if audio rendering started before the audio worklet got started.
-    if (isContextThread())
-        m_delayMicrotaskDrainingDuringRendering = script()->vm().drainMicrotaskDelayScope();
+    // It is only safe to grab the lock if we are on the context thread.
+    RELEASE_ASSERT(isContextThread());
+    m_delayMicrotaskDrainingDuringRendering = script()->vm().drainMicrotaskDelayScope();
 }
 
 void AudioWorkletGlobalScope::handlePostRenderTasks(size_t currentFrame)

--- a/Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb
@@ -49,7 +49,7 @@ public:
 <%- end -%>
 
 private:
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
 
 <%- for @setting in @allSettingsSet.settings do -%>
 <%- if @setting.excludeFromInternalSettings == false and @setting.idlType -%>

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
@@ -64,7 +64,7 @@ private:
     static GDBusInterfaceVTable s_socketFunctions;
     static GDBusInterfaceVTable s_componentFunctions;
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     String m_path;
     String m_parentUniqueName;
     String m_parentPath;

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -92,7 +92,7 @@ private:
     HashSet<RefPtr<MutationObserver>> m_activeObservers;
     HashSet<RefPtr<MutationObserver>> m_suspendedObservers;
 
-    SingleThreadWeakHashMap<Page, MonotonicTime> m_pagesWithRenderingOpportunity;
+    WeakHashMap<Page, MonotonicTime> m_pagesWithRenderingOpportunity;
 
     std::unique_ptr<CustomElementQueue> m_customElementQueue;
     bool m_processingBackupElementQueue { false };

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -77,7 +77,7 @@ private:
     Ref<Page> protectedPage() const;
     Ref<BackForwardClient> protectedClient() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     Ref<BackForwardClient> m_client;
 };
 

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -121,7 +121,7 @@ public:
     }
 
 private:
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
 };
 
 void CachedPage::restore(Page& page)

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -64,7 +64,7 @@ public:
     void markForContentsSizeChanged() { m_needsUpdateContentsSize = true; }
 
 private:
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     MonotonicTime m_expirationTime;
     std::unique_ptr<CachedFrame> m_cachedMainFrame;
 #if ENABLE(VIDEO)

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
@@ -90,7 +90,7 @@ private:
     void invalidatePendingResponses();
     ValueOrException evaluateExpression(const String&);
 
-    SingleThreadWeakPtr<Page> m_frontendPage;
+    WeakPtr<Page> m_frontendPage;
     Vector<std::pair<String, EvaluationResultHandler>> m_queuedEvaluations;
     HashMap<Ref<DOMPromise>, EvaluationResultHandler> m_pendingResponses;
     bool m_frontendLoaded { false };

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -145,7 +145,7 @@ private:
     std::optional<bool> evaluationResultToBoolean(InspectorFrontendAPIDispatcher::EvaluationResult);
 
     InspectorController* m_inspectedPageController { nullptr };
-    SingleThreadWeakPtr<Page> m_frontendPage;
+    WeakPtr<Page> m_frontendPage;
     // TODO(yurys): this ref shouldn't be needed.
     RefPtr<InspectorFrontendHost> m_frontendHost;
     std::unique_ptr<InspectorFrontendClientLocal::Settings> m_settings;

--- a/Source/WebCore/inspector/InspectorFrontendHost.h
+++ b/Source/WebCore/inspector/InspectorFrontendHost.h
@@ -187,7 +187,7 @@ private:
     WEBCORE_EXPORT InspectorFrontendHost(InspectorFrontendClient*, Page* frontendPage);
 
     InspectorFrontendClient* m_client;
-    SingleThreadWeakPtr<Page> m_frontendPage;
+    WeakPtr<Page> m_frontendPage;
 #if ENABLE(CONTEXT_MENUS)
     FrontendMenuProvider* m_menuProvider;
 #endif

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -255,7 +255,7 @@ protected:
 
     ~PageLevelForbidScope() = default;
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
 };
 
 struct ForbidPromptsScope : public PageLevelForbidScope {

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -75,7 +75,7 @@ private:
     void progressHeartbeatTimerFired();
     Ref<Page> protectedPage() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     UniqueRef<ProgressTrackerClient> m_client;
     RefPtr<LocalFrame> m_originatingProgressFrame;
     HashMap<ResourceLoaderIdentifier, std::unique_ptr<ProgressItem>> m_progressItems;

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -240,7 +240,7 @@ private:
     void notifyPopupOpeningObservers() const;
     Ref<Page> protectedPage() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     UniqueRef<ChromeClient> m_client;
     Vector<WeakPtr<PopupOpeningObserver>> m_popupOpeningObservers;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -99,7 +99,7 @@ private:
     void performPDFJSAction(LocalFrame&, const String& action);
 #endif
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     UniqueRef<ContextMenuClient> m_client;
     std::unique_ptr<ContextMenu> m_contextMenu;
     RefPtr<ContextMenuProvider> m_menuProvider;

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -82,7 +82,7 @@ protected:
     virtual bool updateRegion() = 0;
     void drawRegion(GraphicsContext&, const Region&, const Color&, const IntRect& dirtyRect);
     
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     std::unique_ptr<Region> m_region;
     Color m_color;

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -76,7 +76,7 @@ private:
     RegionOverlay* regionOverlayForPage(Page&, RegionType) const;
     RegionOverlay& ensureRegionOverlayForPage(Page&, RegionType);
 
-    SingleThreadWeakHashMap<Page, Vector<RefPtr<RegionOverlay>>> m_pageRegionOverlays;
+    WeakHashMap<Page, Vector<RefPtr<RegionOverlay>>> m_pageRegionOverlays;
 
     static DebugPageOverlays* sharedDebugOverlays;
 };

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -149,7 +149,7 @@ private:
     void declareAndWriteDragImage(DataTransfer&, Element&, const URL&, const String& label);
     Ref<Page> protectedPage() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     std::unique_ptr<DragClient> m_client;
 
     RefPtr<Document> m_documentUnderMouse; // The document the mouse was last dragged over.

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -92,6 +92,7 @@ private:
     void recomputeAdjustedElementsIfNeeded();
 
     SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     DeferrableOneShotTimer m_recentAdjustmentClientRectsCleanUpTimer;
     WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_documentsAffectedByVisibilityAdjustment;
     HashMap<ElementIdentifier, IntRect> m_recentAdjustmentClientRects;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4591,7 +4591,10 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
 
 void EventHandler::stopKeyboardScrolling()
 {
-    if (auto animator = m_frame->page()->currentKeyboardScrollingAnimator())
+    RefPtr page = m_frame->page();
+    if (!page)
+        return;
+    if (auto animator = page->currentKeyboardScrollingAnimator())
         animator->handleKeyUpEvent();
 }
 

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -123,7 +123,7 @@ private:
     void focusRepaintTimerFired();
     Ref<Page> protectedPage() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     WeakPtr<Frame> m_focusedFrame;
     bool m_isChangingFocusedFrame;
     OptionSet<ActivityState> m_activityState;

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -129,7 +129,7 @@ private:
     virtual DOMWindow* virtualWindow() const = 0;
     virtual void reinitializeDocumentSecurityContext() = 0;
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     const FrameIdentifier m_frameID;
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -80,7 +80,7 @@ private:
     // FIXME: Refactor the source and target LIDs into either a std::pair<> of strings, or its own named struct.
     String m_sourceLanguageIdentifier;
     String m_targetLanguageIdentifier;
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     Timer m_resumeProcessingTimer;
     WeakHashMap<HTMLImageElement, URL, WeakPtrImplWithEventTargetData> m_queuedElements;
     PriorityQueue<Task, firstIsHigherPriority> m_queue;

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -104,7 +104,7 @@ private:
     RefPtr<Page> protectedPage() const;
     RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForSelection;
     Vector<FloatQuad> m_selectionQuads;

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -121,7 +121,7 @@ private:
 
     bool shouldAllowOpportunisticallyScheduledTasks() const;
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     uint64_t m_imminentlyScheduledWorkCount { 0 };
     uint64_t m_runloopCountAfterBeingScheduled { 0 };
     MonotonicTime m_currentDeadline;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -233,9 +233,9 @@
 
 namespace WebCore {
 
-static HashSet<SingleThreadWeakRef<Page>>& allPages()
+static HashSet<WeakRef<Page>>& allPages()
 {
-    static NeverDestroyed<HashSet<SingleThreadWeakRef<Page>>> set;
+    static NeverDestroyed<HashSet<WeakRef<Page>>> set;
     return set;
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -315,7 +315,7 @@ constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<Render
 };
 
 
-class Page : public RefCounted<Page>, public Supplementable<Page>, public CanMakeSingleThreadWeakPtr<Page> {
+class Page : public RefCounted<Page>, public Supplementable<Page>, public CanMakeWeakPtr<Page> {
     WTF_MAKE_NONCOPYABLE(Page);
     WTF_MAKE_FAST_ALLOCATED;
     friend class SettingsBase;

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -88,7 +88,7 @@ private:
 
     Ref<Page> protectedPage() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -54,7 +54,7 @@ public:
 
     WEBCORE_EXPORT static PageGroup* pageGroup(const String& groupName);
 
-    const SingleThreadWeakHashSet<Page>& pages() const { return m_pages; }
+    const WeakHashSet<Page>& pages() const { return m_pages; }
 
     void addPage(Page&);
     void removePage(Page&);
@@ -70,7 +70,7 @@ public:
 
 private:
     String m_name;
-    SingleThreadWeakHashSet<Page> m_pages;
+    WeakHashSet<Page> m_pages;
 
     unsigned m_identifier;
 

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -132,7 +132,7 @@ private:
     void fadeAnimationTimerFired();
 
     PageOverlayClient& m_client;
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
 
     Timer m_fadeAnimationTimer;
     WallTime m_fadeAnimationStartTime;

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -103,7 +103,7 @@ private:
 
     Ref<Page> protectedPage() const;
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     RefPtr<GraphicsLayer> m_documentOverlayRootLayer;
     RefPtr<GraphicsLayer> m_viewOverlayRootLayer;
 

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -52,7 +52,7 @@ private:
     void processMayBecomeInactiveTimerFired();
     static void updateProcessStateForMemoryPressure();
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
 
     Timer m_postPageLoadCPUUsageTimer;
     std::optional<CPUTime> m_postLoadCPUTime;

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -164,7 +164,7 @@ protected:
     void sampleBufferContentKeySessionSupportEnabledChanged();
 #endif
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
 
     Seconds m_minimumDOMTimerInterval;
 

--- a/Source/WebCore/page/UserContentProvider.h
+++ b/Source/WebCore/page/UserContentProvider.h
@@ -93,7 +93,7 @@ protected:
     WEBCORE_EXPORT void invalidateInjectedStyleSheetCacheInAllFramesInAllPages();
 
 private:
-    SingleThreadWeakHashSet<Page> m_pages;
+    WeakHashSet<Page> m_pages;
     WeakHashSet<UserContentProviderInvalidationClient> m_userMessageHandlerInvalidationClients;
 };
 

--- a/Source/WebCore/page/VisitedLinkStore.h
+++ b/Source/WebCore/page/VisitedLinkStore.h
@@ -50,7 +50,7 @@ public:
     WEBCORE_EXPORT void invalidateStylesForLink(SharedStringHash);
 
 private:
-    SingleThreadWeakHashSet<Page> m_pages;
+    WeakHashSet<Page> m_pages;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -99,7 +99,7 @@ private:
     Page& page() const { return m_page; }
     Ref<Page> protectedPage() const { return m_page.get(); }
 
-    SingleThreadWeakRef<Page> m_page;
+    WeakRef<Page> m_page;
     WeakPtr<PageOverlay> m_servicesOverlay;
 
     RefPtr<DataDetectorHighlight> m_activeHighlight;

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -245,7 +245,7 @@ private:
     EventTrackingRegions absoluteEventTrackingRegionsForFrame(const LocalFrame&) const;
 
     bool m_forceSynchronousScrollLayerPositionUpdates { false };
-    SingleThreadWeakPtr<Page> m_page; // FIXME: ideally this would be a WeakRef but it gets nulled on async teardown.
+    WeakPtr<Page> m_page; // FIXME: ideally this would be a WeakRef but it gets nulled on async teardown.
 
 };
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -161,7 +161,7 @@ private:
 
     RefPtr<Document> document() const;
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
 
     HashMap<WritingTools::Session::ID, std::variant<std::monostate, ProofreadingState, CompositionState>> m_states;
 };

--- a/Source/WebCore/plugins/PluginInfoProvider.h
+++ b/Source/WebCore/plugins/PluginInfoProvider.h
@@ -47,7 +47,7 @@ public:
 private:
     virtual void refreshPlugins() = 0;
 
-    SingleThreadWeakHashSet<Page> m_pages;
+    WeakHashSet<Page> m_pages;
 };
 
 }

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -165,7 +165,7 @@ private:
         bool m_shouldDeactivateAudioSession;
     };
 
-    SingleThreadWeakPtr<Page> m_page;
+    WeakPtr<Page> m_page;
     Backup m_backup;
 };
 

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -195,6 +195,7 @@ SocketProvider* WorkerThread::socketProvider()
 
 WorkerGlobalScope* WorkerThread::globalScope()
 {
+    ASSERT(!thread() || thread() == &Thread::current());
     return downcast<WorkerGlobalScope>(WorkerOrWorkletThread::globalScope());
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -58,7 +58,7 @@ WebPermissionController::~WebPermissionController()
     WebProcess::singleton().removeMessageReceiver(Messages::WebPermissionController::messageReceiverName());
 }
 
-void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, const SingleThreadWeakPtr<WebCore::Page>& page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
+void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, const WeakPtr<WebCore::Page>& page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
 {
     std::optional<WebPageProxyIdentifier> proxyIdentifier;
     if (source == WebCore::PermissionQuerySource::Window || source == WebCore::PermissionQuerySource::DedicatedWorker) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
@@ -56,7 +56,7 @@ private:
     explicit WebPermissionController(WebProcess&);
 
     // WebCore::PermissionController
-    void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, const SingleThreadWeakPtr<WebCore::Page>&, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
+    void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, const WeakPtr<WebCore::Page>&, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
     void addObserver(WebCore::PermissionObserver&) final;
     void removeObserver(WebCore::PermissionObserver&) final;
     void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1340,13 +1340,13 @@ WebCore::HandleUserInputEventResult WebFrame::handleMouseEvent(const WebMouseEve
 
 bool WebFrame::handleKeyEvent(const WebKeyboardEvent& keyboardEvent)
 {
-    auto* coreFrame = coreLocalFrame();
+    RefPtr coreFrame = coreLocalFrame();
     if (!coreFrame)
         return false;
 
     if (keyboardEvent.type() == WebEventType::Char && keyboardEvent.isSystemKey())
-        return coreFrame->eventHandler().handleAccessKey(platform(keyboardEvent));
-    return coreFrame->eventHandler().keyEvent(platform(keyboardEvent));
+        return coreFrame->checkedEventHandler()->handleAccessKey(platform(keyboardEvent));
+    return coreFrame->checkedEventHandler()->keyEvent(platform(keyboardEvent));
 }
 
 bool WebFrame::isFocused() const

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
@@ -58,7 +58,7 @@ private:
     void cloneSessionStorageNamespaceForPage(WebCore::Page&, WebCore::Page&) final;
 
     const String m_localStorageDatabasePath;
-    SingleThreadWeakHashMap<WebCore::Page, HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>>> m_sessionStorageNamespaces;
+    WeakHashMap<WebCore::Page, HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>>> m_sessionStorageNamespaces;
 };
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/WebCoreSupport/PageStorageSessionProvider.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PageStorageSessionProvider.h
@@ -48,5 +48,5 @@ public:
     }
 
 private:
-    SingleThreadWeakPtr<WebCore::Page> m_page;
+    WeakPtr<WebCore::Page> m_page;
 };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -104,7 +104,7 @@ private:
 
     WeakObjCPtr<WebView> m_inspectedWebView;
     RetainPtr<WebNodeHighlighter> m_highlighter;
-    SingleThreadWeakPtr<WebCore::Page> m_frontendPage;
+    WeakPtr<WebCore::Page> m_frontendPage;
     std::unique_ptr<WebInspectorFrontendClient> m_frontendClient;
 };
 

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
@@ -68,7 +68,7 @@ private:
     void playbackTargetPickerWasDismissed(WebCore::PlaybackTargetClientContextIdentifier) final;
     RetainPtr<PlatformView> platformView() const final;
 
-    SingleThreadWeakPtr<WebCore::Page> m_page;
+    WeakPtr<WebCore::Page> m_page;
     WeakObjCPtr<WebView> m_webView;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
@@ -60,8 +60,17 @@ TEST(WebCore, SerializedScriptValueReadRTCCertificate)
     WTF::initializeMainThread();
     JSC::initialize();
     WebCore::Process::identifier();
+    Vector<uint8_t> vector { std::span<uint8_t>(bytes) };
+    const WebCore::ThreadSafeDataBuffer value = WebCore::ThreadSafeDataBuffer::create(WTFMove(vector));
+    WebCore::callOnIDBSerializationThreadAndWait([&](auto& globalObject) {
+        auto jsValue = WebCore::deserializeIDBValueToJSValue(globalObject, value);
+        UNUSED_PARAM(jsValue);
+    });
+}
 
-    std::array<uint8_t, 149> bytes {
+TEST(WebCore, SerializedScriptValueReadRTCCertificate)
+{
+    constexpr auto bytes = std::to_array<uint8_t>({
         0x0d, 0x00, 0x00, 0x00, 0x2c, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0xe7, 0x1b, 0x86, 0xc8, 0xd0, 0xdb, 0x71, 0x6a, 0xac, 0x80, 0xf4,
@@ -75,14 +84,8 @@ TEST(WebCore, SerializedScriptValueReadRTCCertificate)
         0xa8, 0x9f, 0x07, 0xd2, 0x50, 0x03, 0x5e, 0x05, 0x77, 0x4a, 0x56, 0xdd,
         0x1e, 0x68, 0xd3, 0x62, 0x8f, 0x58, 0x7e, 0x7c, 0x1e, 0xc6, 0x0f, 0xcc,
         0x01, 0x6e, 0x88, 0x4b, 0x32
-    };
-
-    Vector<uint8_t> vector { std::span<uint8_t>(bytes) };
-    const WebCore::ThreadSafeDataBuffer value = WebCore::ThreadSafeDataBuffer::create(WTFMove(vector));
-    WebCore::callOnIDBSerializationThreadAndWait([&](auto& globalObject) {
-        auto jsValue = WebCore::deserializeIDBValueToJSValue(globalObject, value);
-        UNUSED_VARIABLE(jsValue);
     });
+    deserializeJSValue(bytes);
 }
 
 TEST(WebCore, SerializedScriptValueArgListMarkedVectorAt)


### PR DESCRIPTION
#### cacaba2c3910815880f27ffc0b6faf3314d3f3cc
<pre>
heap-use-after-free | WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope; WebCore::WorkerOrWorkletThread::workerOrWorkletThread; WTF::Thread::entryPoint)
<a href="https://rdar.apple.com/131127484">rdar://131127484</a>

Reviewed by Ryosuke Niwa.

AudioWorkletGlobalScope is RefCounted so it is unsafe to ref/unref it from various threads.
Before this patch, AudioDestinationNode::renderQuantum may either be called from the audio worklet thread (expected) or the audio rendering thread at init time (unexpected).
This is done to call AudioWorkletGlobalScope::handlePreRenderTasks, which is a no-op if called in another thread than the worklet thread.

To fix the issue, if we are not in the context thread, we do not ref AudioWorkletGlobalScope in AudioDestinationNode::renderQuantum.
AudioWorkletGlobalScope::handlePreRenderTasks will then no longer be called in another thread than the worklet thread.
We update AudioWorkletGlobalScope::handlePreRenderTasks accordingly.

* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::renderQuantum):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::handlePreRenderTasks):
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::globalScope):

Originally-landed-as: f98cf4e20b37. rdar://132955637
</pre>
----------------------------------------------------------------------
#### 1c7b746037eb09aa4713894bddbbeb748af5e4f5
<pre>
Crash in EventHandler::internalKeyEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=275717">https://bugs.webkit.org/show_bug.cgi?id=275717</a>
<a href="https://rdar.apple.com/122024832">rdar://122024832</a>

Reviewed by Chris Dumez.

The crash is likely caused by a WeakPtr to Page&apos;s getting released in a background thread.
Use thread safe WeakPtr to speculatively fix this issue.

Also deploy smart pointers in WebFrame::handleKeyEvent and added a nullptr check for Page
in EventHandler::stopKeyboardScrolling() as further speculative fixes.

* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp:
(WebCore::MainThreadPermissionObserver::MainThreadPermissionObserver):
* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionController.h:
* Source/WebCore/Modules/permissions/PermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::create):
(WebCore::PermissionStatus::PermissionStatus):
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb:
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h:
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/inspector/InspectorFrontendHost.h:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::stopKeyboardScrolling):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/OpportunisticTaskScheduler.h:
* Source/WebCore/page/Page.cpp:
(WebCore::allPages):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageGroup.h:
(WebCore::PageGroup::pages const):
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/UserContentProvider.h:
* Source/WebCore/page/VisitedLinkStore.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/plugins/PluginInfoProvider.h:
* Source/WebCore/testing/InternalSettings.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::handleKeyEvent):
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/WebCoreSupport/PageStorageSessionProvider.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h:

Originally-landed-as: 272448.1090@safari-7618-branch (b2c2a650b7b7). rdar://132955637
</pre>
----------------------------------------------------------------------
#### 2c2bfe2c7efa5db6e6e865d9e31b3ba24930d7e5
<pre>
CloneDeserializer readTerminal crash
<a href="https://rdar.apple.com/126132442">rdar://126132442</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272530">https://bugs.webkit.org/show_bug.cgi?id=272530</a>

Reviewed by Alex Christensen.

Limiting the the depth for serializing/deserializing recursive objects like:
var array = [[[[[....................]]]]]... 2000 times

* Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp:
(TestWebKitAPI::TEST):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneBase::CloneBase):
(WebCore::CloneBase::isSafeToRecurse):
(WebCore::CloneDeserializer::readArrayBufferViewImpl):
(WebCore::CloneDeserializer::readArrayBufferView):
(WebCore::CloneDeserializer::readTerminal):

Originally-landed-as: 272448.946@safari-7618-branch (110ae765d426). rdar://132955637
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cacaba2c3910815880f27ffc0b6faf3314d3f3cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61235 "Failed to checkout and rebase branch from PR 31728") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40596 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13816 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65185 "Hash cacaba2c for PR 31728 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/11784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63365 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48274 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12059 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/65185 "Hash cacaba2c for PR 31728 does not build (failure)") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/11784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63269 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/48274 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/13816 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/65185 "Hash cacaba2c for PR 31728 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/48274 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/13816 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10697 "Hash cacaba2c for PR 31728 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/48274 "Hash cacaba2c for PR 31728 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/13816 "Hash cacaba2c for PR 31728 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/5182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/12059 "Hash cacaba2c for PR 31728 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/5205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/13816 "Hash cacaba2c for PR 31728 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->