### PR TITLE
[JSC] putDirectWithReify() should not cache putting `prototype` to a JSFunction

### DIFF
--- a/JSTests/stress/regress-125602977.js
+++ b/JSTests/stress/regress-125602977.js
@@ -1,0 +1,51 @@
+function main() {
+    Function.prototype.__proto__ = new Proxy({}, {});
+
+    const object = {
+        nonConstructor() {
+
+        }
+    };
+
+    function target() {
+
+    }
+
+    Function.prototype.__proto__ = Object.prototype;
+
+    const nonConstructor = object.nonConstructor;
+
+    nonConstructor.x = 1;
+    target.x = 1;
+
+    function returnArgument(a) {
+        return a;
+    }
+
+    class A extends returnArgument {
+        prototype = {};
+
+        constructor(a) {
+            super(a);
+        }
+    }
+
+    new A(nonConstructor);
+    new A(target);
+
+    target.__defineGetter__('prototype', () => {
+
+    });
+
+    target.prototype.x = 1;
+}
+
+var errString = "<no error>";
+try {
+    main();
+} catch (err) {
+    errString = err.toString();
+}
+
+if (errString !== "TypeError: Attempting to change configurable attribute of unconfigurable property.")
+    throw new Error(`Bad error: ${errString}`);

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -180,7 +180,15 @@ static ALWAYS_INLINE void putDirectWithReify(VM& vm, JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool isJSFunction = baseObject->inherits<JSFunction>();
     if (isJSFunction) {
-        jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
+        JSFunction* jsFunction = jsCast<JSFunction*>(baseObject);
+
+        if (propertyName == vm.propertyNames->prototype) {
+            slot.disableCaching();
+            if (FunctionRareData* rareData = jsFunction->rareData())
+                rareData->clear("Store to prototype property of a function");
+        }
+
+        jsFunction->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
         RETURN_IF_EXCEPTION(scope, void());
     }
 
@@ -201,16 +209,18 @@ static ALWAYS_INLINE void putDirectWithReify(VM& vm, JSGlobalObject* globalObjec
 
 static ALWAYS_INLINE void putDirectAccessorWithReify(VM& vm, JSGlobalObject* globalObject, JSObject* baseObject, PropertyName propertyName, GetterSetter* accessor, unsigned attribute)
 {
+    // baseObject is either JSFinalObject during object literal construction, or a userland JSFunction class
+    // constructor, both of which are guaranteed to be extensible and without non-configurable |propertyName|.
+    // Please also note that static "prototype" accessor in a `class` literal is a syntax error.
+
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool isJSFunction = baseObject->inherits<JSFunction>();
     if (isJSFunction) {
+        ASSERT(propertyName != vm.propertyNames->prototype);
         jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
         RETURN_IF_EXCEPTION(scope, void());
     }
 
-    // baseObject is either JSFinalObject during object literal construction, or a userland JSFunction class
-    // constructor, both of which are guaranteed to be extensible and without non-configurable |propertyName|.
-    // Please also note that static "prototype" accessor in a `class` literal is a syntax error.
     ASSERT(canPutDirectFast(vm, originalStructureBeforePut(baseObject), propertyName, isJSFunction));
     scope.release();
     baseObject->putDirectAccessor(globalObject, propertyName, accessor, attribute);


### PR DESCRIPTION
#### 536ac3a29fccd9f597f47ed43377a4ad70f22ba2
<pre>
[JSC] putDirectWithReify() should not cache putting `prototype` to a JSFunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=273580">https://bugs.webkit.org/show_bug.cgi?id=273580</a>
&lt;<a href="https://rdar.apple.com/125602977">rdar://125602977</a>&gt;

Reviewed by Yusuke Suzuki.

Before this change, putDirectWithReify() used for direct op_put_by_id could still cache putting of
`prototype` properties. Leveraging the cache, one could put a configurable `prototype` property onto
a JSFunction with mayHaveNonReifiedPrototype() returning true. And because of configurability, it could
have been turned into a GetterSetter and leaked via getDirect() in JSFunction::getOwnPropertySlot(),
breaking the method&apos;s assumption that the `prototype` a JSFunction with thruthy mayHaveNonReifiedPrototype()
must be a value.

This change prevents put slot from being cached, and clears FunctionRareData like it&apos;s done in other
methods that put `prototype` property.

* JSTests/stress/regress-125602977.js: Added.
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::putDirectWithReify):
(JSC::CommonSlowPaths::putDirectAccessorWithReify):

Originally-landed-as: 272448.1012@safari-7618-branch (283802946dcc). <a href="https://rdar.apple.com/133089383">rdar://133089383</a>
Canonical link: <a href="https://commits.webkit.org/281897@main">https://commits.webkit.org/281897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06bf41d1650a8a5a002f20e8e250057400bf7282

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11764 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49480 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8185 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10266 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10677 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54319 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66896 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60463 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57051 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4270 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82218 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9231 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36380 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14350 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->