### PR TITLE
[WebGPU] Validation error when instanceCount overflows

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277642-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277642-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277642.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277642.html
@@ -1,0 +1,6357 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: ['depth-clip-control', 'depth32float-stencil8', 'indirect-first-instance', 'bgra8unorm-storage'],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxDynamicStorageBuffersPerPipelineLayout: 4,
+    maxUniformBufferBindingSize: 7300529,
+    maxStorageBufferBindingSize: 169320268,
+    maxUniformBuffersPerShaderStage: 12,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u7cb4\ua587\ucf97\u42c3'});
+let texture0 = device0.createTexture({
+  label: '\u5543\u8774\u59e7\u8fa9\u{1f64d}\ud4df\u{1fd2b}\u6a56\u0063',
+  size: {width: 40},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u3bd3\u{1f961}\u013a\u0857\u0450\u0801',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\u05b1\u5a93\u{1fe86}\u{1fce0}\u66f3\u8a67\uba9a\u{1f6f2}'});
+try {
+renderBundleEncoder0.insertDebugMarker('\u761c');
+} catch {}
+let buffer0 = device0.createBuffer({
+  label: '\u0807\u{1fc22}\u{1f93a}',
+  size: 25628,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u3641\ud5a5\u5a68\u3957'});
+try {
+buffer0.unmap();
+} catch {}
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u0cb4\u17d3\u5bc9\u{1f7fa}\ud4d8\u03f0\u{1f6ce}',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u0b6d\u09d2\u0c69\u60f9\u8ab4\u081c'});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 5_432, 6_660);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer0, 0, 1_217);
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder({label: '\uef4d\u08b4\u0d00\u898a\uedc3\uf052\u89e5\u0422\u{1f6f8}\uacc8\u{1f7d1}'});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 10124, new DataView(new ArrayBuffer(5610)), 2332, 624);
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0009\u{1f7f7}\u0680\u8d05\u081e',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u{1fdbe}\uba88\u02d9\u0e9e\u0488\u{1fa74}\ucdd7\u004a\u01b8'});
+let imageData0 = new ImageData(12, 52);
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 75});
+let computePassEncoder2 = commandEncoder1.beginComputePass();
+let textureView0 = texture0.createView({label: '\u0d87\uc8b0\u09bd\u7e51\u{1f63e}\u089b'});
+let querySet1 = device0.createQuerySet({label: '\u0d35\u{1ff39}\u076f\u00eb\u0522\ue847\u0cbd', type: 'occlusion', count: 769});
+let texture1 = device0.createTexture({
+  label: '\u7947\u8624\uef10\u{1fef5}\u0969\uff59',
+  size: {width: 40, height: 20, depthOrArrayLayers: 488},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint16', 2_704, 3_996);
+} catch {}
+let video0 = await videoWithData();
+let commandEncoder2 = device0.createCommandEncoder({});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\u4932\u0932\u0b93\u{1fcd9}\ue5b2\u{1f84d}\u038e\u0b92'});
+let commandEncoder3 = device0.createCommandEncoder({label: '\u1491\u98f5\u7476\u9493\ue490\u0ad3\u39ad\u1f93'});
+let commandBuffer0 = commandEncoder2.finish({label: '\ua306\ue4be\u{1fcf0}\u{1f8c8}\u{1f7c3}\u03bc\u8a53\ub4f6\u1bb5\u0b07'});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 195},
+  aspect: 'all',
+}, new ArrayBuffer(1_717_958), /* required buffer size: 1_717_958 */
+{offset: 18, bytesPerRow: 176, rowsPerImage: 119}, {width: 4, height: 4, depthOrArrayLayers: 83});
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fca7}\u02a4\u{1f7c2}\ub20a\uac10\uc31a\ud9fb\u3f0c\u2a8d\u0ccf'});
+let commandBuffer1 = commandEncoder4.finish({label: '\ucb25\u0862\u4df9\u420c\u3783\u0ef0\u{1fe00}\u{1f7f4}'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint16', 1_376, 6_926);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(4, buffer0);
+} catch {}
+document.body.prepend(video0);
+let computePassEncoder3 = commandEncoder3.beginComputePass();
+try {
+computePassEncoder2.end();
+} catch {}
+let commandBuffer2 = commandEncoder1.finish();
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 280, 6_787);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 9_172, 5_526);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+video0.height = 31;
+let commandEncoder5 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder5.finish();
+let renderBundle4 = renderBundleEncoder2.finish({});
+let renderBundle5 = renderBundleEncoder2.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 2, y: 1, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(114_266), /* required buffer size: 114_266 */
+{offset: 185, bytesPerRow: 115, rowsPerImage: 55}, {width: 1, height: 3, depthOrArrayLayers: 19});
+} catch {}
+let renderBundle6 = renderBundleEncoder1.finish({label: '\u5f76\u{1f749}\u297c\u{1f606}\u91c0\u8e0d\u03bb\u{1ff63}\u109e\u{1fb07}\u5d4c'});
+let renderBundle7 = renderBundleEncoder2.finish({});
+document.body.prepend(video0);
+let imageBitmap0 = await createImageBitmap(imageData0);
+let texture2 = device0.createTexture({
+  label: '\u{1ff86}\u089f\ued49\u09ed\u444f\u{1fb90}\ucd76\ua89c\u02ef\u{1fe44}',
+  size: {width: 20, height: 10, depthOrArrayLayers: 17},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle8 = renderBundleEncoder0.finish({});
+let img0 = await imageWithData(54, 8, '#0e686a29', '#9b40efdb');
+try {
+buffer0.unmap();
+} catch {}
+let img1 = await imageWithData(46, 20, '#54000b32', '#f72901ef');
+document.body.prepend(video0);
+await gc();
+let commandEncoder6 = device0.createCommandEncoder();
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u940c\u3c0f\u0c05\ubbab\u2b69\u{1f7df}\ubaa1',
+  entries: [{binding: 48, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let sampler0 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.06,
+  compare: 'never',
+  maxAnisotropy: 3,
+});
+try {
+commandEncoder6.resolveQuerySet(querySet1, 324, 122, buffer0, 7936);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u{1fee4}\u01bf\udaa8', bindGroupLayouts: [bindGroupLayout0]});
+let buffer1 = device0.createBuffer({
+  label: '\u{1f7d2}\u{1f95f}\u14f5\u0d35\u{1fa34}\u8792',
+  size: 3685,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler1 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 9.620,
+  lodMaxClamp: 91.17,
+  compare: 'not-equal',
+});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let commandEncoder7 = device0.createCommandEncoder();
+let commandBuffer4 = commandEncoder7.finish({label: '\u{1fbc3}\uf809\u8add\u{1ff86}\u{1fa74}\u75ec\u0eec\u{1f663}\u2cdb\u4a1c'});
+let renderBundle9 = renderBundleEncoder2.finish({});
+try {
+commandEncoder6.copyBufferToBuffer(buffer1, 576, buffer0, 13160, 312);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(80_554), /* required buffer size: 80_554 */
+{offset: 181, bytesPerRow: 73, rowsPerImage: 122}, {width: 0, height: 4, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+let commandBuffer5 = commandEncoder8.finish({});
+let shaderModule0 = device0.createShaderModule({
+  label: '\u340f\u0041\u{1fe41}\u065b',
+  code: `@group(0) @binding(48) var et0: texture_external;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et0, vec2u());
+}
+
+struct S0 {
+  @location(14) f0: i32,
+  @location(11) f1: i32,
+  @location(5) f2: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: i32
+}
+
+@fragment
+fn fragment0(@location(8) a0: u32, @location(7) a1: vec3<i32>, a2: S0, @location(10) a3: vec3<f16>) -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(11) f0: i32,
+  @location(10) f1: vec3<f16>,
+  @builtin(position) f2: vec4<f32>,
+  @location(5) f3: vec2<i32>,
+  @location(7) f4: vec3<i32>,
+  @location(8) f5: u32,
+  @location(14) f6: i32
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, @location(12) a1: vec2<f16>, @location(6) a2: f32, @location(2) a3: vec2<f16>) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture3 = device0.createTexture({
+  label: '\u2005\u0e1e\u{1fbf5}\u0c19\u{1ff28}',
+  size: {width: 5, height: 2, depthOrArrayLayers: 61},
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder4 = commandEncoder6.beginComputePass();
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 366 */
+  offset: 366,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder3.insertDebugMarker('\u0ad5');
+} catch {}
+let commandBuffer6 = commandEncoder3.finish({label: '\u7604\u0313\u0f4b\u71d5\u{1fd9c}\u7839\u00fb\u362b\u{1f9da}\u9466\ub9a0'});
+let renderBundle10 = renderBundleEncoder0.finish({label: '\ua410\u52fe\u{1fac6}\u2d0e\uc380\u1e96\u0872\u{1fb60}'});
+let commandEncoder9 = device0.createCommandEncoder({label: '\uf688\ud7d6\u0944\u0920\u67d2\u{1fc9a}\u{1fafe}'});
+let commandBuffer7 = commandEncoder9.finish();
+let textureView1 = texture0.createView({label: '\ub362\u03eb\ue3ff\u{1f95d}\u{1fce7}'});
+let commandEncoder10 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder10.finish({label: '\u0a0d\u08af\u0cea\u0004\u4fb1'});
+let pipeline0 = device0.createComputePipeline({
+  label: '\u5e3e\u3ce9\u0517\u{1f785}\u0046\ucb33\uebab\u6fb7\u{1f94a}\u{1fa6a}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u2963\ubd1c\u3395\uf8ed\ub81a\u001f',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandBuffer9 = commandEncoder0.finish({label: '\u4dbd\uf664\u4bdf\u713f\udba4'});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({label: '\u088d\u9cad\u0a3e'});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u9cc2\ud60b\u7947\u0bad\u4801\u{1f848}\u2156\u01a2\uc8d3',
+  size: 14068,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({label: '\u2bd8\u0ee2', colorFormats: ['r8sint'], depthReadOnly: true});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(img1);
+let commandEncoder12 = device0.createCommandEncoder();
+let commandBuffer10 = commandEncoder12.finish({});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer2, 0, 85);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 486 */
+  offset: 486,
+  bytesPerRow: 0,
+  rowsPerImage: 123,
+  buffer: buffer0,
+}, {width: 0, height: 2, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({});
+let commandBuffer11 = commandEncoder11.finish({});
+let externalTexture0 = device0.importExternalTexture({label: '\u02a4\u2cdf\u7912', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4348, new DataView(new ArrayBuffer(22292)), 1281, 3320);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0286\u0ace'});
+let commandBuffer12 = commandEncoder13.finish({label: '\u{1f8dc}\u1e82\ub5f0'});
+let renderBundle11 = renderBundleEncoder1.finish({label: '\ua264\u065f\u3fcf\u0184\ua253\u{1f6c7}\u{1f9d6}\u88a1\u0c99\u009f\u49bc'});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer2, 'uint16', 20, 1_216);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, buffer2, 0);
+} catch {}
+let commandBuffer13 = commandEncoder6.finish();
+let texture4 = device0.createTexture({
+  label: '\u3c2a\u3e61\u07d7\u{1f82d}\u0f8c\u0ae8\u0189',
+  size: [30, 2, 207],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(2, buffer2);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 9},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let imageData1 = new ImageData(16, 16);
+let promise2 = adapter0.requestAdapterInfo();
+let bindGroup0 = device0.createBindGroup({
+  label: '\uec6e\u8aa9\u0720\u1cb0\u9cdc',
+  layout: bindGroupLayout0,
+  entries: [{binding: 48, resource: externalTexture0}],
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u0c7a\u350a\ue2c0\u3e03\u{1fdee}'});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 344, 52);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1072, new DataView(new ArrayBuffer(5341)), 716, 1424);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  label: '\u{1fe12}\u0918',
+  layout: bindGroupLayout0,
+  entries: [{binding: 48, resource: externalTexture0}],
+});
+let commandBuffer14 = commandEncoder14.finish({label: '\ucf90\u0f14\uab0a\u7d26'});
+try {
+commandEncoder15.resolveQuerySet(querySet1, 93, 96, buffer0, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1, commandBuffer0, commandBuffer5, commandBuffer12]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer15 = commandEncoder15.finish();
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup1, new Uint32Array(1369), 167, 0);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]});
+let texture5 = device0.createTexture({
+  label: '\u3f11\u5d18\u02cf\u{1fc14}\ucd55\u{1fe84}\ub44f\u{1ff69}\u4903',
+  size: {width: 40, height: 20, depthOrArrayLayers: 488},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+device0.label = '\ub1c2\u1aa7\u{1fabc}\uc208\u{1f626}\u15ad\u{1f883}';
+} catch {}
+try {
+window.someLabel = renderBundle3.label;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer2, 'uint16', 2_472, 84);
+} catch {}
+let computePassEncoder5 = commandEncoder16.beginComputePass();
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1ff25}\u{1fc47}\u37d6\u{1f89e}\u0dd8\ubb53\u4c5b\u7f9a\u5524',
+  colorFormats: ['r8sint'],
+  stencilReadOnly: true,
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 854, 521);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, buffer2, 0, 453);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer1, 432, buffer0, 3804, 72);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet0, 9, 2, buffer0, 6400);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let imageData2 = new ImageData(36, 12);
+let renderBundle12 = renderBundleEncoder3.finish({label: '\u43c3\u0c04\u{1fb53}\u96f2\u5fd8\u0f70\u02d9'});
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(144), 9, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14, commandBuffer11, commandBuffer4]);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({label: '\u4dae\u0308\ueb60\u{1f678}\u5857\ubd51\u{1f7a2}\u{1f75f}'});
+let texture6 = device0.createTexture({
+  size: [5, 2, 5],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder6 = commandEncoder18.beginComputePass({label: '\u087a\u{1fd0c}\u{1f6e8}\ub6c2\u03f8\u3b78\u{1ff44}\u{1fe5c}'});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 2_488, 4_191);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1612 */
+  offset: 1612,
+  bytesPerRow: 0,
+  rowsPerImage: 28,
+  buffer: buffer0,
+}, {width: 0, height: 2, depthOrArrayLayers: 22});
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `@group(0) @binding(48) var et1: texture_external;
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et1, vec2u());
+}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec2<u32>) -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f7: vec4<f32>,
+  @location(14) f8: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<u32>, @location(12) a1: vec4<u32>, @location(6) a2: vec4<f16>, @builtin(vertex_index) a3: u32, @location(3) a4: vec4<u32>) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder20 = device0.createCommandEncoder({});
+let computePassEncoder7 = commandEncoder18.beginComputePass();
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+let commandBuffer16 = commandEncoder17.finish();
+let externalTexture1 = device0.importExternalTexture({label: '\u{1ff67}\ue83e\ud4e2\uc5ad', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer2, 'uint16', 1_536, 4_900);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4_294_967_294, undefined, 433_793_208, 1_316_411_699);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.pushDebugGroup('\uea00');
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer2, 'uint16', 236, 2_349);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer1, 136, buffer0, 25304, 200);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1224, new BigUint64Array(12147), 2233, 976);
+} catch {}
+await gc();
+let commandEncoder21 = device0.createCommandEncoder({label: '\u3b43\u0fa9'});
+let renderBundle13 = renderBundleEncoder4.finish({});
+try {
+commandEncoder16.clearBuffer(buffer0);
+} catch {}
+try {
+externalTexture1.label = '\ub51a\u02d1\ud230\u1809\u75a2\ue350\u{1f6e5}\ue087\u{1fde9}\u{1fcb9}';
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\ubb9c\u{1f6e3}\u0744\u0d57\u3162\u0a48\uabfa\u{1fea7}\u0db9',
+  code: `@group(3) @binding(48) var et5: texture_external;
+@group(0) @binding(48) var et2: texture_external;
+@group(2) @binding(48) var et4: texture_external;
+@group(1) @binding(48) var et3: texture_external;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et5, vec2u());
+r += textureLoad(et2, vec2u());
+r += textureLoad(et4, vec2u());
+r += textureLoad(et3, vec2u());
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(3) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec4<f32>, @location(14) a1: vec2<u32>, @location(8) a2: vec2<f32>, @builtin(vertex_index) a3: u32, @location(7) a4: vec3<u32>) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder22 = device0.createCommandEncoder({label: '\u{1f7ce}\u39ee\u{1f70e}\u45d2'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u00e3\u92d5\uc770\ud50e\u0957\uaccc\u0b30\u0501\u8468',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle14 = renderBundleEncoder5.finish({label: '\u025b\ue405\u096b\u0bee\u{1f7ed}'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0, new Uint32Array(1981), 1067, 0);
+} catch {}
+try {
+window.someLabel = commandEncoder12.label;
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\ue213\u5f2e\u91d4\u3b10\u71ea\u02bc\u78e8',
+  size: 53,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder23 = device0.createCommandEncoder({label: '\u4466\u07f2\u0b69\ud3a5\u05ed\u0fcf\u0e4d\u0790\u{1fe5c}\u7438\u1a24'});
+let textureView2 = texture3.createView({label: '\u6acb\u8d79\u4473\ue15e\u5e55\u05e0\uf55a'});
+let computePassEncoder8 = commandEncoder19.beginComputePass({label: '\u71e5\u278f\u0b82'});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u{1fd65}\udc9b\u{1f9b0}\u3db1\u6b9c\u7254\u{1fdd6}\u7c3c',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder24 = device0.createCommandEncoder({});
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer1, 2_844);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+  label: '\u028a\uc5c9\ubd72\uab58\u390b\u0692',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, constants: {}},
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u08e8\u35d1\u010e\u0bf3\u001e'});
+let commandBuffer17 = commandEncoder24.finish({label: '\u0378\u{1fd7e}\u523a\ub434\u054c\u35d7\u9342\u9531\u4770'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0, new Uint32Array(5244), 1858, 0);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let renderBundle15 = renderBundleEncoder4.finish({label: '\ua451\ua54a\u08d7'});
+let sampler2 = device0.createSampler({
+  label: '\u{1fc0f}\u{1fe05}\u56c7\ube65\ucc98\u{1ff21}\ucb1f\u9519',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 25.36,
+  lodMaxClamp: 92.74,
+});
+try {
+commandEncoder26.pushDebugGroup('\u5b5e');
+} catch {}
+try {
+commandEncoder19.popDebugGroup();
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\ubddb\u5865\u{1fe02}\uf3cd\u{1f79c}\ue1cb\u{1f9d8}\u21f0\ub885',
+  code: `@group(1) @binding(48) var et7: texture_external;
+@group(2) @binding(48) var et8: texture_external;
+@group(0) @binding(48) var et6: texture_external;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et7, vec2u());
+r += textureLoad(et8, vec2u());
+r += textureLoad(et6, vec2u());
+}
+
+
+
+@fragment
+fn fragment0() -> @location(200) vec2<i32> {
+var r: vec4f;
+return vec2<i32>();
+}
+
+struct VertexOutput0 {
+  @location(6) f9: vec3<i32>,
+  @location(10) f10: vec4<f32>,
+  @location(4) f11: vec4<f32>,
+  @location(9) f12: vec4<i32>,
+  @location(8) f13: vec4<i32>,
+  @builtin(position) f14: vec4<f32>,
+  @location(5) f15: i32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer18 = commandEncoder20.finish({label: '\u05e6\u8855\u0cb9\u4d37\ud237\u08c1\u34d5\u{1fd9a}\u{1ffb8}\u{1f683}'});
+let renderBundle16 = renderBundleEncoder1.finish({label: '\ue6ed\ua131\ua76b\u085e\u5bbe\u{1f68b}\u8851\u056e\uaa39\u9790'});
+try {
+commandEncoder25.insertDebugMarker('\u0650');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle17 = renderBundleEncoder1.finish({label: '\u6721\u{1fc57}'});
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 4952, buffer0, 19048, 292);
+} catch {}
+let promise4 = adapter0.requestAdapterInfo();
+let renderBundle18 = renderBundleEncoder0.finish();
+try {
+commandEncoder26.pushDebugGroup('\u23d6');
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({label: '\u0674\u6390\u5756\ua53c\u0a1e\u66fd\u0e6d\u1eb6\u8059\u2052'});
+let renderBundle19 = renderBundleEncoder1.finish({label: '\u0990\u911d\ue88e\ua2cf'});
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 59},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 25});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer0);
+} catch {}
+try {
+window.someLabel = textureView1.label;
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\u97de\u0fbc\ub13c\u42b0\u0dc3\u645f\u6985\u07ac\uc494',
+  layout: bindGroupLayout0,
+  entries: [{binding: 48, resource: externalTexture0}],
+});
+let buffer4 = device0.createBuffer({
+  size: 6515,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder28 = device0.createCommandEncoder();
+let externalTexture2 = device0.importExternalTexture({label: '\uaa0f\ufcf2\u3b64\u0680', source: video0, colorSpace: 'display-p3'});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u{1fb02}\u0868\uc8f2\u757b\u043a\u{1fd34}\u{1f843}\u0416'});
+let computePassEncoder9 = commandEncoder28.beginComputePass({label: '\u789c\u0fc7\u2a6e\u0fcf\u6340\uc0ca\u045d\ue5a1\ua576\u44b6'});
+let pipeline2 = device0.createComputePipeline({
+  label: '\u9942\u{1fdc5}\u25fe\u94ff\u98a6\u1970\u7997\uf381',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0},
+});
+try {
+  await promise4;
+} catch {}
+let imageData3 = new ImageData(20, 80);
+let shaderModule4 = device0.createShaderModule({
+  code: `@group(1) @binding(48) var et10: texture_external;
+@group(0) @binding(48) var et9: texture_external;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et10, vec2u());
+r += textureLoad(et9, vec2u());
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(7) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer19 = commandEncoder23.finish({label: '\u2d46\u4584\u8033\u0109\ub2ca\u0abd'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 243 */
+  offset: 243,
+  buffer: buffer2,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer20 = commandEncoder16.finish({label: '\u{1ffe6}\u{1f769}\u08e1\u0830\ubdab'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup2);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+let pipeline3 = device0.createRenderPipeline({
+  label: '\uec45\ud97e\ubb7c\u94f9\ufed8\u{1f6b3}\u00ee\u0124\uc676',
+  layout: pipelineLayout0,
+  multisample: {mask: 0xc92c9384},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'r8sint'}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'keep', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilWriteMask: 1001462619,
+    depthBias: 0,
+    depthBiasSlopeScale: -26.167798653007452,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 236,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 8, shaderLocation: 0},
+          {format: 'float32x2', offset: 16, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 156, attributes: [{format: 'unorm8x2', offset: 18, shaderLocation: 6}]},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 376, attributes: []},
+      {arrayStride: 344, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 46, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandBuffer21 = commandEncoder29.finish({});
+let renderBundle20 = renderBundleEncoder1.finish();
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+commandEncoder18.pushDebugGroup('\ucda3');
+} catch {}
+let texture7 = device0.createTexture({
+  label: '\u{1fe0e}\ue3cc\u0767\u5707',
+  size: {width: 30},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17, commandBuffer10, commandBuffer3, commandBuffer13]);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let commandBuffer22 = commandEncoder21.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 18},
+  aspect: 'all',
+}, new ArrayBuffer(126_800), /* required buffer size: 126_800 */
+{offset: 17, bytesPerRow: 30, rowsPerImage: 128}, {width: 3, height: 3, depthOrArrayLayers: 34});
+} catch {}
+let texture8 = device0.createTexture({
+  size: [40, 20, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle21 = renderBundleEncoder4.finish({});
+try {
+buffer0.unmap();
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  label: '\u09f7\ue875\u0b02\u2ce7',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'greater', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 1266432053,
+    stencilWriteMask: 2464984387,
+    depthBias: -1923872125,
+    depthBiasSlopeScale: 717.3898096832172,
+  },
+  vertex: {module: shaderModule3, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+  await promise3;
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\u4f97\u091b\u056c'});
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 22},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder18.popDebugGroup();
+} catch {}
+let computePassEncoder10 = commandEncoder30.beginComputePass();
+let externalTexture3 = device0.importExternalTexture({label: '\u04a4\ud554\u884f\u0a91\u{1fcb3}\u9632\ud016', source: video0, colorSpace: 'srgb'});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder26.popDebugGroup();
+} catch {}
+let renderBundle22 = renderBundleEncoder5.finish({label: '\u0f55\u0989\u{1f9cc}\u00c2'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup0, new Uint32Array(1582), 199, 0);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet0, 59, 0, buffer0, 6144);
+} catch {}
+await gc();
+let bindGroup3 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 48, resource: externalTexture0}]});
+let commandEncoder33 = device0.createCommandEncoder({label: '\u7160\u{1fcf3}\ud339\udbdb\u0f39\u4615\u{1ffec}\u{1fced}\ufc3e\u2863\u595b'});
+let commandBuffer23 = commandEncoder33.finish();
+let renderBundle23 = renderBundleEncoder1.finish({label: '\u95fe\u0a59'});
+try {
+buffer0.unmap();
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule2, constants: {}}});
+let buffer5 = device0.createBuffer({
+  label: '\u0816\u0465',
+  size: 347,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder34 = device0.createCommandEncoder();
+let commandEncoder35 = device0.createCommandEncoder();
+let computePassEncoder11 = commandEncoder25.beginComputePass({label: '\u0d58\u0a0c\u5bee\u{1f705}'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u4bf1\u842b\u{1f9e9}\ud82a\u{1fc50}\u{1f956}\u0e06\u073b\u4c2e',
+  entries: [{binding: 210, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let querySet2 = device0.createQuerySet({label: '\u8590\u0ad1\u7a8d\u4fe1\u{1fef1}\u01cb\u0471', type: 'occlusion', count: 562});
+let textureView3 = texture8.createView({label: '\u3df8\u{1f790}\u{1ff54}\u24a3', mipLevelCount: 1});
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u311b\u0943\u0c0f\ubb7f\u6248\u0533\u75e1\u0656\u9093',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandBuffer24 = commandEncoder18.finish({});
+let computePassEncoder12 = commandEncoder27.beginComputePass({label: '\u0fd7\u1449\u{1f9a8}'});
+let renderPassEncoder0 = commandEncoder35.beginRenderPass({
+  label: '\uadf6\ue12f\u{1fceb}\u0536\u04f9\u49b6\u{1feb4}',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 708.6, g: 313.1, b: 870.0, a: 980.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer3, 4);
+} catch {}
+let commandBuffer25 = commandEncoder28.finish({});
+let texture9 = device0.createTexture({
+  label: '\uac54\udc28',
+  size: {width: 60, height: 4, depthOrArrayLayers: 19},
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder1 = commandEncoder31.beginRenderPass({
+  label: '\u22f3\u0174\u340f\u0c61\u{1f832}\u0c94\ud279',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 380.2, g: -971.7, b: -691.2, a: -382.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({label: '\u042b\u1daf\u18d8\uab58', colorFormats: ['r8sint'], depthReadOnly: true});
+let sampler3 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.27,
+  lodMaxClamp: 87.82,
+  compare: 'equal',
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 340, new Float32Array(45), 4, 8);
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder();
+let renderPassEncoder2 = commandEncoder36.beginRenderPass({
+  label: '\u57f4\u06fb\u{1f9cc}\u2049\u0f84\ubc7e\u5480',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 64.78, g: 68.78, b: -151.7, a: 259.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderBundleEncoder6.setIndexBuffer(buffer0, 'uint16', 594, 3_147);
+} catch {}
+try {
+commandEncoder22.resolveQuerySet(querySet1, 46, 229, buffer4, 0);
+} catch {}
+try {
+commandEncoder26.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({label: '\u9d09\u3738\u0ec2\uaadd\ub7de\u643f'});
+let renderPassEncoder3 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 159535487,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer5, 'uint32', 60, 66);
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\u0b7d');
+} catch {}
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u{1fb94}\u{1ff16}\u0edd\ud2c2\u1a97\ud9eb\u{1f666}\u0137\u2344\u0bfe\u0d12',
+  colorFormats: ['r8sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer2, 'uint32', 4, 565);
+} catch {}
+let commandBuffer26 = commandEncoder26.finish({label: '\u229d\u0495'});
+let renderPassEncoder4 = commandEncoder19.beginRenderPass({
+  label: '\ue567\u{1f963}\ue54b\ubf5d\u0123',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 67.30, g: 974.1, b: -514.7, a: 855.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer5, 'uint16', 12, 0);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4743 */
+  offset: 4743,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+  label: '\uaf22\u0503\u09bc\u0117\u0797\u0b7e\u0675\ubc16\ub869\u76f5\u{1ff9c}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, constants: {}},
+});
+let promise5 = adapter0.requestAdapterInfo();
+let textureView4 = texture4.createView({label: '\u0d0a\uaa6c\u304f\u2227\uc0d8\u066c\u96ac\u2f08\u0036\u{1f724}'});
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer0, 0, 2_316);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+try {
+computePassEncoder10.setBindGroup(2, bindGroup1, new Uint32Array(1043), 247, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(391), 76, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer2, 'uint32', 11_412, 149);
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer4, 64, 2084);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\u0156');
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -165.6, g: 236.4, b: 624.9, a: -30.58, });
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer1, 4, buffer0, 12308, 4);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer4, 308, 504);
+} catch {}
+video0.width = 15;
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u0be8\uf624\u{1ff7b}\u7ab0\ua6f9\ua1b0\u3775', bindGroupLayouts: [bindGroupLayout0]});
+let commandBuffer27 = commandEncoder32.finish({label: '\u0f32\u3ee4\u{1f69a}\ua4a9\uba88\u0ae4\ua00a\uf176'});
+try {
+renderPassEncoder3.setIndexBuffer(buffer0, 'uint32', 7_340, 1_852);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer2);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3635 */
+  offset: 3635,
+  bytesPerRow: 0,
+  rowsPerImage: 11,
+  buffer: buffer2,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 3});
+} catch {}
+try {
+adapter0.label = '\u{1f994}\u{1f978}\u5602';
+} catch {}
+let commandBuffer28 = commandEncoder37.finish({label: '\uf40c\u02a0\u28c8\u{1f9f1}\uf8b0\uaff0'});
+let computePassEncoder13 = commandEncoder38.beginComputePass();
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer0, 996, 650);
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\u9a27\ue106\u085b\u022d\ue806\u7b74\u78be'});
+let externalTexture4 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup2, new Uint32Array(651), 22, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer2, 6_004);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer2, 'uint32', 1_120, 4_426);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer0, 0, 1_368);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27, commandBuffer20, commandBuffer18]);
+} catch {}
+let commandBuffer29 = commandEncoder39.finish();
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer5, 'uint16', 190, 19);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer0);
+} catch {}
+try {
+computePassEncoder12.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+commandEncoder25.insertDebugMarker('\ua6e3');
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  label: '\u8982\ub4ba\ubd76\uc417\ufd29\u07f8\u067b\u8a2c\ua2e2',
+  layout: bindGroupLayout1,
+  entries: [{binding: 210, resource: externalTexture0}],
+});
+let commandBuffer30 = commandEncoder25.finish({label: '\u0be2\u{1f716}\u9206\u91ea\ua885\u{1fbe2}'});
+let texture10 = device0.createTexture({
+  size: {width: 20, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView5 = texture8.createView({label: '\u0309\ud8e1\u4071\uce64\u6f51\ubdb5\u062d\ufab7\u085b\uc65c\uc2f4'});
+let renderPassEncoder5 = commandEncoder34.beginRenderPass({
+  label: '\ua816\uab18\u06cd\u{1f621}\u0fe9\u5ab2\u07ec',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 65,
+  clearValue: { r: 313.6, g: 138.0, b: -802.7, a: -848.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({});
+let textureView6 = texture1.createView({
+  label: '\u{1f77a}\udc55\u87f6\ueaec\u0f23\u01c0\u4cc2\u{1fdb9}',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(437);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer3, 24);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 284, 8_966);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4, buffer3, 0, 2);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({label: '\u3936\u{1fc3c}\u4554\u{1f6b1}\u0ff6\u0572\u{1fdfd}\u0dc6'});
+let renderPassEncoder6 = commandEncoder40.beginRenderPass({
+  label: '\ufa16\u641e',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -8.653, g: -38.86, b: 907.0, a: -495.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 286648819,
+});
+let renderBundle24 = renderBundleEncoder6.finish({label: '\ucf88\uc15c\u{1ffbe}\u83f5\u0936\u{1f954}\u{1f944}\ud807\ub8f6\u{1f99b}\u0300'});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer3, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer2, 0, 5_521);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet2, 127, 26, buffer0, 2048);
+} catch {}
+let textureView7 = texture0.createView({label: '\ub5d0\u9960\ud586\u283c\ud25d\u0f47', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({label: '\u4046\u0c6d\u057b\u0d7d', colorFormats: ['r8sint'], depthReadOnly: true});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer2, 'uint16', 1_348, 4_716);
+} catch {}
+document.body.prepend(video0);
+let commandBuffer31 = commandEncoder41.finish({label: '\u0313\u0390\ua899\u{1f92f}\u0494\u0fe0\u{1fe27}\u681b'});
+let texture11 = device0.createTexture({
+  size: {width: 7, height: 1, depthOrArrayLayers: 51},
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer5);
+} catch {}
+let texture12 = device0.createTexture({
+  label: '\u2faa\u{1fcee}\u0e60\ucdcb\u5630\ud518\u{1fd81}\u0938',
+  size: [20, 10, 244],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle25 = renderBundleEncoder8.finish({label: '\u{1fbe7}\u8410\uae39\u6185\u3c31\u029f\u0929\u003e\u67a6'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup0);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule1, constants: {}}});
+document.body.prepend(video0);
+let texture13 = device0.createTexture({
+  label: '\u{1f788}\u6ea4\ub611\u{1feb7}',
+  size: {width: 10},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler4 = device0.createSampler({
+  label: '\u7040\u835c\u61f2\u{1fea1}\u{1f68c}\u9be6\u350e',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 81.14,
+  lodMaxClamp: 87.86,
+});
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer5, 0, 14);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer4, 0, 342);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(70_994), /* required buffer size: 70_994 */
+{offset: 11, bytesPerRow: 210, rowsPerImage: 167}, {width: 3, height: 5, depthOrArrayLayers: 3});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u6170\u{1f853}'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer3);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(3601), 978, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageBitmap0);
+let commandEncoder43 = device0.createCommandEncoder({label: '\u0d7b\u{1fdb5}\u4a95\u9ab7'});
+let computePassEncoder14 = commandEncoder43.beginComputePass({label: '\u{1f7e9}\u8a11\u{1fec6}\u29f2\u9279\uda70\u{1fcf1}\u{1f903}\u9bad\u53d6'});
+let renderPassEncoder7 = commandEncoder42.beginRenderPass({
+  label: '\u0b3a\u0ed0\u{1f61b}\u466f\u085b\u{1fbd2}\u57a7\u0cec\u5cb2',
+  colorAttachments: [{view: textureView4, depthSlice: 22, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+});
+let renderBundle26 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 6_364, 3_067);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u4e78\u{1f63e}\u4b38\u0169\u3d4b\u0317',
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+try {
+renderPassEncoder7.executeBundles([renderBundle14, renderBundle8, renderBundle4]);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(1, bindGroup1, new Uint32Array(193), 116, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer2, 'uint32', 1_768, 415);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer3, 20, 3);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+let commandBuffer32 = commandEncoder44.finish({});
+try {
+computePassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(746), 59, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer3, 'uint16', 12, 12);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer0);
+} catch {}
+let externalTexture5 = device0.importExternalTexture({
+  label: '\u{1fe1f}\u02cc\u0c1e\uf5de\u0332\ua559\u{1ff99}\u0484\u{1fd68}\ud12f',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1451);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer2);
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({});
+let textureView8 = texture6.createView({label: '\u7294\u{1f684}\ue8fa\u885a', baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder45.beginComputePass({label: '\u{1f7d6}\u{1f99f}\u{1f9fb}\uf0e2\u0c47\u03e8\u0895'});
+try {
+computePassEncoder10.dispatchWorkgroupsIndirect(buffer2, 2_652);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+window.someLabel = textureView3.label;
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({label: '\u04ab\u{1fe67}\u06c8\u0a9a\u0dd7\u89d2\ud833\u84d6\u0c09'});
+let computePassEncoder16 = commandEncoder46.beginComputePass({label: '\u0877\u31cb\u46e0\u{1fcd1}'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u{1fa28}\u3baf\u{1fb5b}\u005a\u6cbd\u{1fc4f}\u{1feff}\u0743',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint16', 17_696, 123);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer0, 364, 2_219);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 12_012, 5_271);
+} catch {}
+let textureView9 = texture12.createView({label: '\u4e57\u9e79\uab42\ufeec\u775f', baseMipLevel: 1});
+try {
+computePassEncoder10.dispatchWorkgroups(3, 1, 1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup1, new Uint32Array(4297), 8, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer5, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer16, commandBuffer31]);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let querySet3 = device0.createQuerySet({label: '\u0caf\u{1fda6}', type: 'occlusion', count: 1449});
+let sampler5 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 31.15,
+  lodMaxClamp: 83.07,
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer2, 'uint32', 444, 1_045);
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({label: '\u08e8\u1907\u04e2\u790e\u67a5\u0692\u02d4\u0e15\u8c36\u0567'});
+let commandBuffer33 = commandEncoder47.finish();
+let texture14 = device0.createTexture({
+  label: '\u{1fa43}\u4689\u0205\u6e98',
+  size: [5, 2, 5],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle27 = renderBundleEncoder6.finish();
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer3, 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 172, new BigUint64Array(9731), 3986, 20);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\u0c61\u{1fa81}\u{1fa3e}\u0a53\u7f01\u5df6\u{1fcac}\ufdc7\u{1fb72}\u457c\uc79d'});
+let renderPassEncoder8 = commandEncoder48.beginRenderPass({
+  label: '\uf718\u{1fc15}\u0373\u{1fd81}\u0b9c\u{1f98b}\ub734\u{1f9f0}',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 195,
+  clearValue: { r: 612.7, g: 146.9, b: 534.2, a: 109.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 198932690,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup1, new Uint32Array(660), 108, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer5, 0, 17);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer4, 0, 447);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let video1 = await videoWithData();
+let querySet4 = device0.createQuerySet({
+  label: '\ue8c2\u{1f6ea}\u04d3\u{1f8fd}\u2054\ud38d\u0619\u{1f65b}\u1ea4\u{1ff52}',
+  type: 'occlusion',
+  count: 729,
+});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer2, 'uint16', 388, 3_338);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer3);
+} catch {}
+let texture15 = device0.createTexture({
+  label: '\u07c0\u0ded\u0e8e\u02ed\u{1f93b}\u7778\u{1fc62}\u{1fe17}',
+  size: {width: 7, height: 1, depthOrArrayLayers: 1},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer3, 'uint32', 12, 4);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer2, 'uint32', 3_008, 1_563);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer5, 0, 36);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise7;
+} catch {}
+video1.width = 70;
+try {
+computePassEncoder16.setBindGroup(1, bindGroup4, new Uint32Array(353), 70, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(8, 0, 4, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer2, 'uint16', 1_950, 2_341);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer5, 0, 6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer33, commandBuffer28]);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({label: '\u0e05\uffae\u3b31\u5cd6'});
+let commandBuffer34 = commandEncoder49.finish({});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer0, 'uint16', 8_340, 198);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer4, 1_444, 53);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let imageData4 = new ImageData(8, 44);
+let querySet5 = device0.createQuerySet({label: '\u3849\uc0ce\u{1f727}\ube81\ua071\u{1fa6c}\u2fe9\u0c22\uda9a', type: 'occlusion', count: 258});
+let renderBundle28 = renderBundleEncoder5.finish({label: '\u1eb1\u1812\u03b4\u4b43\ua4d7\u0bfd\u168c\u{1f97c}'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(277);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer0, 3_976);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let texture16 = device0.createTexture({
+  size: {width: 5, height: 2, depthOrArrayLayers: 17},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup4, new Uint32Array(236), 30, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer24, commandBuffer8]);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({label: '\u98e9\ucd5c\uff60'});
+let commandBuffer35 = commandEncoder50.finish({label: '\ub7cd\u06f2\u{1fb3e}\ubdff\ufba1\u1002\u0895\u0cc7\ub591\u045b\u0a1b'});
+let computePassEncoder17 = commandEncoder46.beginComputePass();
+let renderBundle29 = renderBundleEncoder5.finish({label: '\u{1f7bf}\u03c8\u0249\u1d0d\u035d\u696f\ufe2a'});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup0, new Uint32Array(434), 113, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer5, 'uint32', 108, 9);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  label: '\u21dd\u094d\uefc1\uedb1\u28f2\u0581\u{1fa29}\ue60e\u{1f6e6}',
+  layout: pipelineLayout4,
+  multisample: {mask: 0x8a68527f},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule3, buffers: []},
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer2);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 804, new DataView(new ArrayBuffer(15940)));
+} catch {}
+let textureView10 = texture0.createView({label: '\u{1fae5}\u0e5b\u05da\ued5b\u{1fb3c}'});
+let renderPassEncoder9 = commandEncoder27.beginRenderPass({
+  label: '\u1c81\u18be\ucacb\u0da0',
+  colorAttachments: [{view: textureView5, loadOp: 'load', storeOp: 'discard'}],
+});
+let sampler6 = device0.createSampler({
+  label: '\u9c91\u0ba9\ub609\u{1fe93}\u0a7e\u0f84\u{1fba8}\u07f4',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 34.50,
+  lodMaxClamp: 63.06,
+});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -843.1, g: 771.6, b: -19.83, a: -904.1, });
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(1227);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer3, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({label: '\ubc93\u{1fcf8}\u9db3\u1fb3\u0b43\u040c\u0b8d\u070b\u48c1\u{1fab9}\u5043'});
+let texture17 = device0.createTexture({
+  label: '\ua244\uc3e6\ube35\u02d6\u4550\u0582',
+  size: [20, 10, 244],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 80, 13);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer0);
+} catch {}
+await gc();
+let imageData5 = new ImageData(8, 120);
+let commandEncoder52 = device0.createCommandEncoder({label: '\u{1f7d6}\u019b\u0452\u{1fd38}\u0f61\u24b1'});
+let commandBuffer36 = commandEncoder51.finish({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup3, new Uint32Array(66), 7, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer0, 0, 370);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup1);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let bindGroup5 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 48, resource: externalTexture4}]});
+let commandBuffer37 = commandEncoder52.finish({label: '\u0758\u0ca1\u{1fdb2}\u0fdd\u7b78\uccb7\u023f\u{1fd24}\u0b0a'});
+let renderBundle30 = renderBundleEncoder7.finish();
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 652.4, g: -854.3, b: -711.0, a: 412.0, });
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer3, 'uint16', 18, 2);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+await gc();
+let imageData6 = new ImageData(24, 20);
+let commandEncoder53 = device0.createCommandEncoder({label: '\u{1f993}\ucb25\u04f7\u0d83\udb51\uf059\u7045\uf99b'});
+let computePassEncoder18 = commandEncoder53.beginComputePass({label: '\u{1fefa}\u7d5a\u066d'});
+try {
+renderPassEncoder7.setViewport(9.32669521528845, 1.0125959101426791, 9.254744917962341, 0.9348270086375281, 0.05295022781642922, 0.2763455573480518);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer0, 8_440, 2_366);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup3);
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({label: '\u9aa5\u9939\u2c98\u08a8\u7201\uf4b4\u8b02\u004e\u5034'});
+let renderPassEncoder10 = commandEncoder54.beginRenderPass({
+  label: '\u6a3f\ue22a\u5939\u31a3\u6b15\u0165\u{1fb63}\u0a20',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 16,
+  clearValue: { r: 265.0, g: 845.2, b: -907.4, a: -436.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup4, new Uint32Array(896), 18, 0);
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({label: '\u779b\u33cc\u{1f6a5}\u0608\u29b1\u{1f60f}'});
+let commandBuffer38 = commandEncoder55.finish({label: '\u03b5\uf14f'});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(731);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle11, renderBundle24, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer2, 'uint16', 102, 1_928);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer0, 'uint32', 3_956, 1_626);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let buffer6 = device0.createBuffer({
+  label: '\u{1f72a}\ue97b\u{1f8cc}',
+  size: 4305,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder56 = device0.createCommandEncoder();
+let commandBuffer39 = commandEncoder56.finish({label: '\u9f44\u0c3f\ue50d\u0923\u0503'});
+let textureView11 = texture11.createView({label: '\uc3f1\u751e\u0f26\u{1f88b}\u0f75\u97a8\u{1facb}\ud497\u{1fa6f}\u89d9'});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2, new Uint32Array(1352), 185, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer0, 1_600, 12_346);
+} catch {}
+let buffer7 = device0.createBuffer({label: '\uf2b2\u{1f766}', size: 7689, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u04d6\ucf95\u{1feb0}\u516c\u{1fbdb}\u0c9b\u0aad\u0920\u0014\u{1fa25}\ub410'});
+let commandBuffer40 = commandEncoder57.finish({label: '\u{1fd9d}\u8323\u23c1\u347e\u0d3f\u215e\u004a\uf95f\u1f8a\u151a\u0e84'});
+let textureView12 = texture1.createView({label: '\u{1fb04}\u63aa', baseMipLevel: 3});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle21, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer6, 'uint16', 350, 745);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer4, 1_148, 1_038);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+  label: '\ua44b\u001a\u41b4',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video1);
+let promise10 = adapter0.requestAdapterInfo();
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer5);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer3, 'uint16', 2, 4);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\u1c3f\u0e3a\u{1f6c6}\u3916\u0a2f\ud60a\u067c\u2956\u00a1',
+  layout: bindGroupLayout2,
+  entries: [{binding: 41, resource: sampler1}],
+});
+let renderBundle31 = renderBundleEncoder6.finish();
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer6, 1_212, 125);
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({label: '\ub4b2\u{1fc10}\u060d\u0ea7\u68c6\u31aa\u{1f74d}\u0b65'});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup4, new Uint32Array(400), 67, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1448, new Int16Array(43557), 8274, 504);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({});
+let commandBuffer41 = commandEncoder58.finish({});
+let computePassEncoder19 = commandEncoder59.beginComputePass({label: '\u{1ff39}\u8301\u7f38\u0d40\u910e\u{1f7a6}\uabba\u3a4f'});
+try {
+computePassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer0, 'uint16', 8_140, 1_225);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise9;
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({
+  label: '\uca8d\uefbb\u5a1d\u78b6\u{1f8db}\u607d\udd94\u{1fb40}\u6d15',
+  size: {width: 10},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 3444, new BigUint64Array(1054));
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  multisample: {mask: 0xec4d5114},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 1203970098,
+    stencilWriteMask: 4294967295,
+    depthBias: 0,
+    depthBiasClamp: 988.2797111681696,
+  },
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 844, stepMode: 'vertex', attributes: []},
+      {arrayStride: 228, attributes: [{format: 'uint8x2', offset: 56, shaderLocation: 12}]},
+      {arrayStride: 236, stepMode: 'instance', attributes: []},
+      {arrayStride: 600, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 476,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32', offset: 120, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32x3', offset: 596, shaderLocation: 3},
+          {format: 'uint8x2', offset: 98, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: false},
+});
+try {
+  await promise10;
+} catch {}
+let commandBuffer42 = commandEncoder60.finish({});
+try {
+computePassEncoder14.dispatchWorkgroups(2, 2, 1);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer6, 'uint16', 482, 901);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1964, new Float32Array(16594), 1034, 60);
+} catch {}
+let pipeline11 = device0.createComputePipeline({label: '\u72a4\u3182\u134e\ua573', layout: pipelineLayout5, compute: {module: shaderModule0}});
+let commandEncoder61 = device0.createCommandEncoder({label: '\u5556\u0f70'});
+let commandBuffer43 = commandEncoder61.finish();
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint32', 16, 17);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder19.insertDebugMarker('\u01a9');
+} catch {}
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({label: '\u{1fda7}\udf13\u{1f7e4}\uabb5\u{1ffc3}', colorFormats: ['r8sint']});
+try {
+computePassEncoder14.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer3, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(802);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer6, 0, 5);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer7, 'uint16', 1_006, 471);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u0a86\u{1ff0b}\uc2e2\u{1fda6}\u{1f802}\u1c73\u2bfc\u06db\u7b96\u7902\u0ed9',
+  entries: [
+    {binding: 87, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 110, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 130,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 234,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer8 = device0.createBuffer({
+  label: '\u0086\u0b4d\u0d3d\u037c\u093d',
+  size: 45988,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+let commandBuffer44 = commandEncoder62.finish({label: '\u{1fa82}\u0f7e\u9336\ufa8f\u{1fc09}\u0b83\u{1fbf5}\u05d5\u0f76\u0499\u3147'});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer2, 0, 131);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.draw(347, 234, 685_841_266, 175_788_035);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(41, 50, 46, 750_174_561, 794_305_492);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4256, new DataView(new ArrayBuffer(27571)), 8294, 840);
+} catch {}
+let querySet6 = device0.createQuerySet({label: '\u{1f9df}\ue042\u248e\u0a9d\u6f43\u8652\u0b0f', type: 'occlusion', count: 196});
+let renderBundle32 = renderBundleEncoder3.finish({label: '\u9f15\u7f86\u{1f6fd}\u{1f74c}\u812b\ufb8d\u{1fe35}\u0767\u{1fa2a}\ua06c'});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup3, new Uint32Array(706), 111, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder2.setViewport(31.479214294140256, 3.3830681320533884, 5.762749392286582, 2.9766431672374782, 0.7198956147237534, 0.8097158196136607);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer2, 1_128);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(44, 45, 71, -1_096_896_670, 407_774_958);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer1, 1_784);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer2, 3_052, 1_507);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\u5fcb');
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({
+  label: '\u0176\u02e3\u{1ff24}\u8bc9\u663e\u{1f657}\u{1fc57}\ubbf0\u{1f9a0}',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, constants: {}},
+});
+let imageData7 = new ImageData(104, 40);
+let commandEncoder63 = device0.createCommandEncoder({label: '\u{1fd4b}\u5513\u0bdf\u0bd3\ueb4b\u058b\u0bbb\uc597\u1bac\u0ee7'});
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer2);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(24, 175, 68, 187_538_505, 1_551_698_042);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer6, 996, buffer8, 4744, 256);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+video1.width = 4;
+let commandEncoder64 = device0.createCommandEncoder({label: '\uf6f0\u0843\u4f11\u010e\u{1f866}\u{1ffa9}\u{1fcda}\u3549'});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup1, new Uint32Array(4365), 447, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle9, renderBundle22, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint32', 20, 141);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer2, 172);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer6, 'uint32', 2_396, 62);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let computePassEncoder20 = commandEncoder45.beginComputePass({label: '\u43d6\u424c\u07ff\u01b4\u2499\u8df7\u901f\uc7a3\u01d3'});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.draw(160, 237, 1_027_852_861, 169_707_892);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer2, 'uint32', 4_120, 1_181);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(21, 52, 72, 337_813_172, 225_812_642);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer2, 3_452, 6_178);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u{1fb51}');
+} catch {}
+try {
+computePassEncoder20.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(12, 92, 81, 152_713_505, 628_200_655);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer1, 88);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer6, 1836, buffer8, 5128, 240);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 27 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2108 */
+  offset: 1825,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 189},
+  aspect: 'all',
+}, {width: 27, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let querySet7 = device0.createQuerySet({label: '\u{1f766}\u0b41\u{1f9f7}\u5297\u8788\u4908\ue9ea\u27bd\u0289', type: 'occlusion', count: 737});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup0, new Uint32Array(763), 284, 0);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder5.draw(220, 29, 472_276_638, 1_298_197_580);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer7);
+} catch {}
+try {
+renderBundleEncoder9.draw(154, 49, 741_153_814, 1_011_749_678);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(12, 133, 15, 97_874_457, 124_364_766);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer0, 0, 1_736);
+} catch {}
+try {
+device0.queue.submit([commandBuffer35]);
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({label: '\u7e72\u4b8a\u0436'});
+let texture19 = device0.createTexture({
+  label: '\u73e6\ua331\u009a',
+  size: [10],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView13 = texture19.createView({label: '\u43ca\uf930\u059a\ue26e', mipLevelCount: 1});
+try {
+renderPassEncoder5.beginOcclusionQuery(185);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer6, 0, 738);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(20, 352, 4, 351_272_891, 1_629_990_086);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer7, 880, 2_765);
+} catch {}
+let commandBuffer45 = commandEncoder64.finish();
+let textureView14 = texture10.createView({label: '\uf231\u07f6\u{1fb42}', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder21 = commandEncoder65.beginComputePass({});
+let renderBundle33 = renderBundleEncoder2.finish();
+try {
+computePassEncoder14.dispatchWorkgroupsIndirect(buffer2, 2_620);
+} catch {}
+try {
+renderPassEncoder5.draw(18, 80, 1_209_513_393, 356_886_857);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer5, 'uint16', 68, 11);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer0, 0);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 8, y: 4, z: 47},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 3196, new BigUint64Array(3434), 99);
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  label: '\u0245\u0a13\u02e1\u{1f6a7}\u{1f74e}\u00b8\u0bc9\u5ddd',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule4, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder67 = device0.createCommandEncoder({label: '\u{1ffc7}\u9330\u5def\u{1fde1}\u8502\u294f\u0803\u2e98\uda5b\u0075'});
+let commandBuffer46 = commandEncoder66.finish({label: '\u{1f7e3}\uccb9\u1ba7\u{1f90a}'});
+try {
+renderPassEncoder10.setStencilReference(3640);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(97, 59, 2, 181_037_858, 438_265_374);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({label: '\u4753\u060e\ud9bc\u0325\ua0a1\u{1fe36}'});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u{1fd72}\ucd1f\ub838\u54da\u4bc8\u4805\u{1fd21}\u3c97\u8274',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup4, new Uint32Array(10000), 3255, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer6, 'uint32', 132, 630);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer7, 0, 1_006);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(40, 11, 1, 946_779_910, 596_452_301);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer0, 'uint32', 9_552, 5_233);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet4, 58, 157, buffer4, 1792);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let pipeline14 = device0.createRenderPipeline({
+  label: '\u031a\uaf03\u{1fe33}\u0234\u{1fa70}\u{1ff3b}\u0c5e\u{1fe04}\u{1fcf0}\ud475',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2350067159,
+    depthBias: 632709939,
+  },
+  vertex: {module: shaderModule3, buffers: []},
+});
+let buffer9 = device0.createBuffer({label: '\u{1f7d3}\u{1fe87}', size: 21684, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u{1ff60}\u8b7c'});
+let commandBuffer47 = commandEncoder67.finish({label: '\u01f1\u086a\uc712\u{1f7ef}\u5821\u047e\ubb0f\u{1f7e6}'});
+try {
+computePassEncoder14.dispatchWorkgroupsIndirect(buffer1, 20);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup3, new Uint32Array(2526), 803, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(71, 222, 22, 4_397_813, 2_556_987_007);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer2, 2_056);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(66, 274, 34, 133_252_270, 330_533_344);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer1, 676);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer2, 1584, buffer4, 676, 740);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer4, 760, 2184);
+} catch {}
+try {
+device0.queue.submit([commandBuffer34]);
+} catch {}
+let buffer10 = device0.createBuffer({
+  size: 6219,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle34 = renderBundleEncoder5.finish({label: '\u90bc\u{1fc78}\u02b6'});
+try {
+renderPassEncoder5.draw(350, 204, 740_604_103, 1_341_957_580);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(27, 148, 35, 322_432_040, 739_392_958);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(335, 553, 61, 87_652_155, 765_321_735);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer2, 800);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 95},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder();
+let commandBuffer48 = commandEncoder69.finish({label: '\u0f6e\uca22\ube95\u{1f905}\ubb61\uca2b\u0022'});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder14.dispatchWorkgroupsIndirect(buffer1, 924);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup6, new Uint32Array(115), 12, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(71, 23, 1_148_225_188, 1_382_280_681);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer1, 308);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.draw(80, 362, 417_951_207, 60_747_024);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(216, 264, 64, 53_313_583, 92_609_530);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer2, 420);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer1, 28);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(3, buffer2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer37, commandBuffer25]);
+} catch {}
+let pipeline15 = device0.createRenderPipeline({
+  label: '\u0ae9\u0306\u{1f6aa}\u2b2c\u{1feeb}\uf99b\u0825\u{1f704}\ud075\u0211',
+  layout: pipelineLayout4,
+  multisample: {mask: 0x50f6a6f8},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule3, buffers: []},
+});
+let buffer11 = device0.createBuffer({
+  label: '\u0690\u0f44\uee94\u0f2f',
+  size: 7876,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let textureView15 = texture5.createView({label: '\ubc54\u090a\ua874\uf081\ubb36\u9797', baseMipLevel: 1});
+try {
+computePassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5, new Uint32Array(304), 32, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(4, 7, 21, -2_117_883_411, 498_130_039);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer1, 512);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint32', 1_204, 41);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer6, 'uint32', 444, 18);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer6, 1720, buffer10, 292, 584);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video1);
+let texture20 = device0.createTexture({
+  label: '\u{1f93b}\u08cb',
+  size: {width: 5, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder10.draw(112, 332, 2_127_331_611, 93_042_035);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer1, 288);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer2, 8_124);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint16', 4, 20);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(182, 632, 403, 406_969_617, 412_545_014);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer1, 268);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer3, 8, 6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 7856, new DataView(new ArrayBuffer(2037)), 625);
+} catch {}
+await gc();
+let commandEncoder71 = device0.createCommandEncoder({});
+let commandBuffer49 = commandEncoder71.finish({});
+let computePassEncoder22 = commandEncoder63.beginComputePass({label: '\u5aa2\u0882\uf6da\u0912\udf37\u919d'});
+let renderPassEncoder11 = commandEncoder68.beginRenderPass({
+  label: '\u{1f849}\u5687\u01b1\u{1fde3}\ubd4a\u0c06\u0706\u{1fc8d}\ubfbd\ud7c0\u5fa5',
+  colorAttachments: [{
+  view: textureView15,
+  depthSlice: 219,
+  clearValue: { r: 423.2, g: -64.19, b: 209.5, a: 429.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler7 = device0.createSampler({
+  label: '\u{1fc8c}\u{1f9a0}\ub0a9\u32d0\u0444\ub623\u{1fb5d}\u06f9\u{1f92c}\u0011',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.21,
+  lodMaxClamp: 76.50,
+  compare: 'always',
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder7.beginOcclusionQuery(61);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(13, 196, 5, 247_412_557, 590_234_637);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer11, 12);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(188, 181, 135, -1_916_106_076, 212_313_450);
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({label: '\u{1fe6f}\u0365\u{1f8a9}\u53d5'});
+let commandBuffer50 = commandEncoder59.finish({label: '\u936a\uded8\uc5e2\ub1d9\u{1fde6}\u{1fff0}\u0b0c\u0b9a\u7eea'});
+try {
+computePassEncoder10.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(558, 69, 23_481_608, 545_046_577);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(1, 364, 58, -1_307_924_757, 25_107_968);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer6, 0, 386);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 968);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer1, 232);
+} catch {}
+let video2 = await videoWithData();
+try {
+externalTexture6.label = '\ubdd2\u303c\uaf73\u205a';
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({label: '\u{1f6df}\ubded\u588e\u{1fc52}\u{1ff8e}\u0aab\u2570\u02c0\u{1fe23}'});
+let commandBuffer51 = commandEncoder45.finish({label: '\ub2af\u09a6\u{1f600}\u7d74\u6ced\u0b23\u{1f691}'});
+let texture21 = device0.createTexture({
+  label: '\u9114\u{1f9c8}\u15b0\u7513\ue2e8\ueb4c\u0e17',
+  size: {width: 40, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView16 = texture9.createView({label: '\u0e26\u66e7\ub540\udcf3\uc643\u{1fbcb}\u{1f6ea}', dimension: '2d', mipLevelCount: 1});
+let computePassEncoder23 = commandEncoder70.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(25.444041959081883, 0.28390017414036794, 2.3049121683803975, 1.0821998112529232, 0.516536505931347, 0.9115155347813266);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer5, 8, 10);
+} catch {}
+try {
+renderBundleEncoder9.draw(32, 257, 1_178_942_773, 253_628_326);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer2, 408);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer2, 8_652);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer5, 'uint16', 12, 45);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer5, 0, 224);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 37},
+  aspect: 'all',
+}, new ArrayBuffer(686_181), /* required buffer size: 686_181 */
+{offset: 197, bytesPerRow: 52, rowsPerImage: 194}, {width: 0, height: 1, depthOrArrayLayers: 69});
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u{1fd40}\u0331\u{1ffbd}',
+  entries: [
+    {
+      binding: 18,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let querySet8 = device0.createQuerySet({
+  label: '\ud7fa\u63d3\ueb6d\u05d8\u0b07\u0f5a\u0f26\ud690\uab21\u8833\u289e',
+  type: 'occlusion',
+  count: 88,
+});
+let renderBundle35 = renderBundleEncoder10.finish({label: '\u3c62\u{1f7f9}'});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(191, 224, 32_697_987, 839_395_987);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer11, 1_332);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 56);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 20);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 331 */
+  offset: 331,
+  bytesPerRow: 0,
+  rowsPerImage: 19,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 10});
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\uc2a4');
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u0d94\u020b\u{1fa25}\u{1f6b2}\u0e60\u57a2\u6986\u9682'});
+let renderPassEncoder12 = commandEncoder74.beginRenderPass({
+  label: '\u{1fa9f}\u014c\ua5bf',
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: 984.1, g: -346.1, b: 269.6, a: 718.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder7.setIndexBuffer(buffer2, 'uint32', 684, 3_964);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder9.draw(255, 219, 996_851_587, 202_561_899);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(656, 47, 24, -2_058_213_203, 1_378_853_253);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(85_750), /* required buffer size: 85_750 */
+{offset: 38, bytesPerRow: 44, rowsPerImage: 278}, {width: 0, height: 3, depthOrArrayLayers: 8});
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({label: '\ue7c7\u0bb2\u178c\u01e4\uf26d\ub380\u0299'});
+let commandBuffer52 = commandEncoder72.finish({});
+let renderBundle36 = renderBundleEncoder9.finish({label: '\u0c41\u07f8\u0fed\ub10b\u096b\u538a\u{1ff64}\u8054\u{1fdbe}\u9508'});
+try {
+renderPassEncoder10.drawIndexed(2, 125, 7, 698_335_943, 1_036_171_501);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer2, 4_900);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer11, 1_444);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint32', 4, 48);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer4, 0);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet7, 105, 12, buffer4, 768);
+} catch {}
+try {
+device0.queue.submit([commandBuffer52, commandBuffer29]);
+} catch {}
+document.body.prepend(video2);
+let commandBuffer53 = commandEncoder75.finish({label: '\u{1f757}\u0f17\uf20b\u{1faae}\ue45e\u29d3'});
+let renderPassEncoder13 = commandEncoder73.beginRenderPass({
+  label: '\u3a4c\u60f2\u4104\u{1ffb6}\uf377\u{1f631}\u0b3b\u5cb1\u15af',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -87.68, g: 477.4, b: -919.0, a: 364.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 216788344,
+});
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.draw(237, 34, 1_122_404_032, 551_642_266);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(101, 463, 19, 286_498_004, 1_146_515_847);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer2, 172);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer1, 476);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer4, 880, 830);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder({label: '\u962f\uf61b\u{1fe34}\u{1ffae}\u{1fdd7}'});
+let commandBuffer54 = commandEncoder76.finish({label: '\uddb1\u{1fbb5}\u{1f693}\u154c\u{1fd4a}'});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(199, 3, 11, -1_905_116_845, 678_683_464);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer2, 1_472);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer1, 1_528);
+} catch {}
+let textureView17 = texture12.createView({label: '\ud0e5\u8286\u33ec', baseMipLevel: 1});
+let sampler8 = device0.createSampler({
+  label: '\ue279\u3b3f\u{1f614}\u0b3b\u2809',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.65,
+  lodMaxClamp: 77.43,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer11, 472);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup3, new Uint32Array(2353), 1, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer11, 968);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u3ce1');
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({label: '\u00a6\u0fb9\ue1ab\u076c\u2061\u031b\u42fe\u0c51\u{1ff83}\ud4ef'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer2, 5_324);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer11, 2_688);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer0, 'uint32', 3_140, 22_050);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  label: '\u2e9f\u{1fdd6}\ue04b\uc4d4\u0e68\u{1fe68}\uda48\u0d6c\u6d00\u{1fb3c}',
+  layout: pipelineLayout0,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 264,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 20, shaderLocation: 0}],
+      },
+      {arrayStride: 544, stepMode: 'instance', attributes: []},
+      {arrayStride: 264, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, stepMode: 'instance', attributes: []},
+      {arrayStride: 20, stepMode: 'instance', attributes: []},
+      {arrayStride: 120, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 16,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x2', offset: 4, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 2},
+          {format: 'float16x2', offset: 0, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+try {
+  await promise12;
+} catch {}
+let textureView18 = texture21.createView({label: '\u9814\u08c4\ueb04\uf786\u6aee', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup3, new Uint32Array(924), 97, 0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 196);
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 692);
+} catch {}
+try {
+device0.queue.submit([commandBuffer23, commandBuffer43, commandBuffer50]);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({label: '\ub41a\u{1fb31}\u24b1\u8b4b', entries: []});
+let commandBuffer55 = commandEncoder77.finish({});
+let renderBundle37 = renderBundleEncoder10.finish({label: '\u8c11\u0b75\u0e36\uf7d1\u{1f673}\u9ec0\u0dd3\u{1f98d}\u0fde\u540d\u01ee'});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(41, 34, 35, -2_095_726_503, 602_862_168);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 10628, new DataView(new ArrayBuffer(11780)));
+} catch {}
+let computePassEncoder24 = commandEncoder43.beginComputePass({label: '\u762c\u04df'});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.draw(125, 90, 5_919_580, 329_354_623);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(1, 75, 13, 139_321_103, 834_685_114);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer11, 520);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer1, 136);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer2, 0, 3_263);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(85), /* required buffer size: 85 */
+{offset: 85, rowsPerImage: 230}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  label: '\u4a9e\u47c0\u{1f6c0}\ua26d\u0931\u01e9\u56d7\uc0f9\u641d\u92e2',
+  layout: bindGroupLayout2,
+  entries: [{binding: 41, resource: sampler7}],
+});
+try {
+computePassEncoder10.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer11, 636);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer6, 60, 429);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(147), /* required buffer size: 147 */
+{offset: 147, rowsPerImage: 69}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer1, 864);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 620);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer3, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer55, commandBuffer40]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2764, new BigUint64Array(3960), 174, 12);
+} catch {}
+let pipeline17 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: [{format: 'r8sint'}]},
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {arrayStride: 796, stepMode: 'vertex', attributes: []},
+      {arrayStride: 332, attributes: []},
+      {arrayStride: 104, attributes: []},
+      {arrayStride: 128, attributes: []},
+      {
+        arrayStride: 192,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 24, shaderLocation: 8}],
+      },
+      {arrayStride: 28, attributes: []},
+      {arrayStride: 432, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 40,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 7},
+          {format: 'uint8x2', offset: 10, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.draw(190, 382, 657_528_487, 351_656_334);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer5, 'uint32', 40, 89);
+} catch {}
+let arrayBuffer0 = buffer11.getMappedRange(5448);
+try {
+renderPassEncoder9.insertDebugMarker('\u0043');
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  label: '\udff9\u{1f6a5}\ua00e\u{1f9d2}\u1677\u{1fd73}\u0ce5\u542e\u2e25',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 596,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 12, shaderLocation: 12}],
+      },
+      {arrayStride: 252, attributes: []},
+      {arrayStride: 88, attributes: []},
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 12, shaderLocation: 8},
+          {format: 'uint32x2', offset: 68, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 36, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let textureView19 = texture18.createView({label: '\u966f\udce1\u{1f8b8}\u089f\u560c\u08d9\u{1f6c7}\u6861\u1acf\u{1fce5}'});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer42, commandBuffer19]);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.draw(77, 109, 443_836_243, 485_396_903);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+await gc();
+let imageBitmap2 = await createImageBitmap(imageData3);
+let commandEncoder78 = device0.createCommandEncoder();
+let texture22 = device0.createTexture({
+  label: '\u2f04\u0517\u470d\u{1f8c1}',
+  size: [20, 10, 76],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder14 = commandEncoder78.beginRenderPass({
+  label: '\ue86e\u8928\uc980\u{1f992}',
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -208.5, g: 257.0, b: 948.2, a: 358.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 150248185,
+});
+let renderBundle38 = renderBundleEncoder7.finish({label: '\u07af\u3215\uc3c4\u{1fb52}\u58dc\u3337\u01ce\u{1fa05}'});
+try {
+computePassEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 24);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer6, 356, 312);
+} catch {}
+document.body.prepend(video0);
+let textureView20 = texture12.createView({label: '\u{1ffdf}\u{1f767}\u{1fcd8}', baseMipLevel: 1});
+try {
+computePassEncoder24.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(3, 742, 0, 305_196_656, 65_598_016);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(173, 137, 39_167_028, 90_075_741);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer3, 4, 7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(14_144), /* required buffer size: 14_144 */
+{offset: 102, bytesPerRow: 119, rowsPerImage: 59}, {width: 0, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData1);
+try {
+renderPassEncoder5.draw(37, 368, 108_647_986, 30_824_591);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.submit([commandBuffer45, commandBuffer38, commandBuffer51]);
+} catch {}
+try {
+commandBuffer0.label = '\u0eeb\u29f4';
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder();
+let commandBuffer56 = commandEncoder79.finish({label: '\u0cff\u022a\u0a53\u6881\u0a1d\ua183\u{1fc11}\u0d2f\ue30e\u{1fac0}\u69c2'});
+let textureView21 = texture8.createView({label: '\u{1f7ba}\u4d27\uadb6\u5901\u{1fe22}', arrayLayerCount: 1});
+let renderBundle39 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 905.3, g: 429.3, b: -750.5, a: -93.28, });
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint32', 0, 28);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder7.draw(0, 431, 851_208_205, 9_781_003);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 80);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer6, 'uint32', 3_752, 441);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\ue3a2');
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({label: '\u0411\u0134\ua052\ucd24\u6701\udf06\uef9d\u0d45\u{1fddb}\ud203'});
+try {
+computePassEncoder17.dispatchWorkgroups(1, 2, 1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder7.draw(7, 342, 552_318_124, 161_139_818);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let video3 = await videoWithData();
+let commandEncoder81 = device0.createCommandEncoder({label: '\u9928\u75a4'});
+try {
+computePassEncoder24.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder5.draw(105, 30, 519_353_758, 4_294_967_295);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 932);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint32', 432, 334);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 1792, 7168);
+} catch {}
+try {
+computePassEncoder24.pushDebugGroup('\ua15b');
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({label: '\ud8fd\uaa82\u2fe4\u0e76\u0f6e\u0b1c'});
+let querySet9 = device0.createQuerySet({label: '\u3385\u0e03', type: 'occlusion', count: 68});
+let commandBuffer57 = commandEncoder81.finish();
+let renderBundle40 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup7, new Uint32Array(86), 35, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(183);
+} catch {}
+try {
+renderPassEncoder8.setViewport(4.924489987914363, 0.36602808305785905, 6.425414389544024, 0.22960051338486884, 0.5489580932034491, 0.7207652525594651);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 21, 0, -2_007_849_046, 169_290_728);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint32', 356, 813);
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({label: '\u08fe\u7a8f\ub615\u{1f6f9}\u0e78\u0a9d\u1b07\u0853'});
+let computePassEncoder25 = commandEncoder83.beginComputePass({label: '\ub310\ua026\ufef2\u70e7\u1c54\u{1fa67}\u0fdc'});
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(11.780252138508217, 1.746595394325876, 12.073384110049547, 0.012595482618606244, 0.33885886424823974, 0.7298152169120139);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(29, 227, 82, 322_961_513, 1_627_158_799);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer11, 960);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer1, 864, buffer10, 368, 392);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(querySet0, 1, 1, buffer0, 2048);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4036, new Float32Array(4043));
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.draw(46, 150, 88_416_032, 441_718_296);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let pipeline19 = await device0.createComputePipelineAsync({label: '\ucd5f\u0377', layout: pipelineLayout5, compute: {module: shaderModule1, constants: {}}});
+try {
+  await promise11;
+} catch {}
+await gc();
+let texture23 = device0.createTexture({
+  label: '\u5b77\u14c0\u0d4a\uc64f\u32cd\ud004\u0806\u08e8',
+  size: [15, 1, 103],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder25.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let videoFrame0 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let commandEncoder84 = device0.createCommandEncoder({label: '\u7556\ue42d\u3a9e\u0c5c\ue4a8'});
+let commandBuffer58 = commandEncoder82.finish({label: '\u953f\u08ba\u5fde\ue4e6\u0c77'});
+let texture24 = device0.createTexture({
+  label: '\u0079\u0926\u{1f733}\u613a\u066b',
+  size: {width: 5, height: 2, depthOrArrayLayers: 61},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder26 = commandEncoder84.beginComputePass();
+try {
+computePassEncoder24.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(27, 551, 1_347_089_026, 1_303_619_156);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer11, 880);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint16', 464, 195);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u561b');
+} catch {}
+try {
+device0.queue.submit([commandBuffer30, commandBuffer9]);
+} catch {}
+let imageData8 = new ImageData(16, 84);
+let commandEncoder85 = device0.createCommandEncoder();
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(31, 537, 4, -1_356_311_638, 979_525_491);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer3, 'uint32', 0, 6);
+} catch {}
+let arrayBuffer1 = buffer11.getMappedRange(1808, 200);
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 332,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder86 = device0.createCommandEncoder({label: '\u0094\u{1f8d8}'});
+let commandBuffer59 = commandEncoder86.finish();
+let renderPassEncoder15 = commandEncoder85.beginRenderPass({
+  label: '\u0be6\u0a49\u{1f70a}\u{1f884}\u2163\u0b49\ub54a\u{1fa40}',
+  colorAttachments: [{
+  view: textureView20,
+  depthSlice: 82,
+  clearValue: { r: 823.0, g: -398.2, b: -0.3636, a: -106.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder18.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder5.draw(142, 130, 239_478_526, 60_495_737);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer1, 1_004);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline16);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer22, commandBuffer44, commandBuffer49]);
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder();
+let commandBuffer60 = commandEncoder87.finish({label: '\u0659\u{1ff9a}\u{1fef9}\u36af\u{1f84a}\u49ba\u0a85'});
+let renderPassEncoder16 = commandEncoder80.beginRenderPass({
+  label: '\u36d0\u63c8',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 35,
+  clearValue: { r: 220.9, g: -329.3, b: -425.6, a: -830.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle28, renderBundle24, renderBundle30, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder5.draw(424, 164, 728_587_804, 194_710_084);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(28, 29, 244, 185_305_823, 1_210_215_966);
+} catch {}
+let pipeline20 = await device0.createRenderPipelineAsync({
+  label: '\ub1a0\u0ac1\u{1f608}\u1d3d\uc5fe\u2fe9\u5fdb\uf792\u1084\u9dcd\ue78f',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x1d6ecc35},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'never', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'keep', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 4269055647,
+    depthBias: 1529212644,
+    depthBiasSlopeScale: 679.0966700989084,
+    depthBiasClamp: 989.6189471923119,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 228, attributes: []},
+      {arrayStride: 920, attributes: []},
+      {arrayStride: 68, stepMode: 'vertex', attributes: []},
+      {arrayStride: 316, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 212,
+        attributes: [
+          {format: 'float32x2', offset: 24, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 60, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 100, attributes: []},
+      {arrayStride: 296, attributes: []},
+      {
+        arrayStride: 176,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 12, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.prepend(img1);
+let imageData9 = new ImageData(120, 40);
+let commandEncoder88 = device0.createCommandEncoder({label: '\u50d5\u0883\u{1f818}\ub01e\u080a\uf6ac\u022e\u944c'});
+let commandBuffer61 = commandEncoder88.finish({label: '\u06df\u{1f625}\uccc4\ua865\u0509\u91fc'});
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer1, 176);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 620);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({label: '\u059e\u11c0\u{1fbc3}\u087e\u13f6\uef33\u05a1\uf78b\u{1ff8c}\ud7c1'});
+let commandBuffer62 = commandEncoder89.finish({label: '\u{1ff58}\ucb3e\uf791\u5fbc\u1147\uc529\u0728\u{1f6fd}\u0c66'});
+let textureView22 = texture2.createView({label: '\u05b7\uba92\u{1f753}', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 692);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 528);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(14, 306, 30, 228_901_707, 401_210_290);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer11, 132);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 304);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder24.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer46]);
+} catch {}
+let renderBundle41 = renderBundleEncoder10.finish({label: '\uff07\ued8f\u{1fe15}\u3e5f\ue2fe\u0bfa\u4eb5\u1a05\u0237\u6e4a\ued9d'});
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer11, 1_220);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer3, 'uint32', 0, 2);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline15);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({});
+let commandBuffer63 = commandEncoder90.finish({label: '\u{1fa2d}\u9930\u{1fcf2}\u034a\u1132\u7e0c\udea3'});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup7, new Uint32Array(962), 83, 0);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 992.5, g: -409.5, b: 106.6, a: 755.4, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1585);
+} catch {}
+let renderBundle42 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder7.draw(165, 354, 241_856_459, 323_335_951);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 520);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u0f7b');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1080, new Int16Array(37189), 6665, 376);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle43 = renderBundleEncoder4.finish({label: '\u{1fe3b}\u{1f9b3}\u53ac\u7969\u0af9\u000f\u217b\u0ce4\u7a5b\u139f\u6fe9'});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 796);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer10);
+} catch {}
+let img2 = await imageWithData(2, 43, '#e6ba02e9', '#4e939538');
+let commandEncoder91 = device0.createCommandEncoder({});
+let commandBuffer64 = commandEncoder91.finish({label: '\u0412\u{1f77e}\uc7c0\u{1f6a0}\ue405\u4bc5\uccbd\u{1f6db}\u0414\u47b9'});
+let computePassEncoder27 = commandEncoder65.beginComputePass({label: '\u54fe\uc5e4\uf7e0\u0321\u886a\u{1fb4f}\u{1f814}\u2bc4'});
+try {
+computePassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 856);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline16);
+} catch {}
+let renderBundle44 = renderBundleEncoder8.finish({label: '\u0b30\u1d51\uad99\u{1f79c}\u9003\u0698\u0d86'});
+try {
+renderPassEncoder11.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 55, 24, 1_167_960_182, 169_938_851);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer1, 1_016);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 344);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer6, 'uint32', 416, 1_541);
+} catch {}
+document.body.prepend(video0);
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer2, 7_516);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer7, 'uint16', 1_126, 665);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\ue631\u0141\u{1fbf7}\u0422\u0b81\u0cf4\uc045',
+  entries: [
+    {
+      binding: 393,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 303,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder92 = device0.createCommandEncoder({label: '\u05a2\u{1fc3d}\u5e7e\u0090\u9391\u{1f796}\u4b4f'});
+let querySet10 = device0.createQuerySet({label: '\uf7a2\u3e5d\u{1fc52}\u730c\u{1f8e7}\u00da\u39e8', type: 'occlusion', count: 625});
+let computePassEncoder28 = commandEncoder92.beginComputePass({label: '\u09d7\u1926\u0b2d\u951d\u5387\u8b77\u088a\u708b\u4896\u{1fbd0}'});
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.draw(138, 13, 232_394_616, 765_905_912);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(9, 21, 1, 150_981_237, 953_041_076);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer6, 'uint32', 136, 247);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer3, 0, 7);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder();
+let renderBundle45 = renderBundleEncoder9.finish({label: '\u054b\u0d90\u074b\u5112\u000b'});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle32]);
+} catch {}
+try {
+renderPassEncoder5.draw(569, 146, 612_256_876, 1_208_870_789);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(170, 267, 58, 206_118_062, 1_478_640_856);
+} catch {}
+let commandBuffer65 = commandEncoder93.finish({});
+let textureView23 = texture21.createView({
+  label: '\u0da7\ua3c7\uc773\ucfb1',
+  dimension: '2d-array',
+  format: 'rgba32uint',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let externalTexture7 = device0.importExternalTexture({label: '\u312b\u854f\uf0f5\u2227', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder17.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(11, 795, 28, 251_393_287, 1_778_384_991);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let imageData10 = new ImageData(20, 32);
+try {
+computePassEncoder24.setBindGroup(0, bindGroup3, new Uint32Array(376), 40, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(57, 97, 542_829_586, 231_555_273);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer3, 'uint16', 6, 2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+texture19.label = '\ubc41\u1c07\u099e\u7be3\u{1fa17}\u0576';
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 1_876);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer11, 1_200);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer2, 2_220, 3_693);
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u04ef\u0c37',
+  size: 1604,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder94 = device0.createCommandEncoder({label: '\u039a\udb9d\u{1fcde}\u{1fd8f}\u3647\u{1f7de}'});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.draw(180, 126, 664_578_935, 762_125_739);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 19, 0, 1_467_559_883, 399_309_190);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 136);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline16);
+} catch {}
+let arrayBuffer2 = buffer11.getMappedRange(2792, 44);
+let promise14 = device0.queue.onSubmittedWorkDone();
+let shaderModule5 = device0.createShaderModule({
+  code: `@group(1) @binding(48) var et12: texture_external;
+@group(2) @binding(48) var et13: texture_external;
+@group(0) @binding(48) var et11: texture_external;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et12, vec2u());
+r += textureLoad(et13, vec2u());
+r += textureLoad(et11, vec2u());
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(7) f1: i32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder7.draw(177, 275, 3_233_650_143, 235_910_840);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 1_348);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer0, 'uint32', 292, 3_542);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer10, 2236, buffer4, 3892, 628);
+} catch {}
+try {
+device0.queue.submit([commandBuffer54, commandBuffer56, commandBuffer62]);
+} catch {}
+let computePassEncoder29 = commandEncoder94.beginComputePass({label: '\u0a0c\ua0d0\u0671\ua983'});
+try {
+computePassEncoder24.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(2, 134, 1, 174_795_427, 355_064_360);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 276);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer4, 0, 1_765);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -719.5, g: -538.1, b: -522.2, a: -103.7, });
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer0, 'uint32', 2_472, 4_221);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.submit([commandBuffer39, commandBuffer60]);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer7, 0, 1_330);
+} catch {}
+let video4 = await videoWithData();
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\u0891\ucdaa\u4898\u0263\u3952\ua8f8\ub888\u0c87',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout5, bindGroupLayout1, bindGroupLayout4],
+});
+let externalTexture8 = device0.importExternalTexture({label: '\u{1f67e}\u56a8\u0106\u{1ff09}', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setScissorRect(1, 3, 12, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(270, 350, 138_450_565, 1_920_470_128);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(6, 152, 19, 548_739_540, 517_879_181);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 332);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer5, 'uint32', 52, 81);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer7, 956);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer61]);
+} catch {}
+try {
+  await promise14;
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(4, 28, 40, -2_122_878_384, 405_854_763);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 376);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 148);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 336, new Int16Array(16140), 4635, 4920);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({label: '\u4e8b\u0a18\uf8ad\u1ef3'});
+let renderPassEncoder17 = commandEncoder63.beginRenderPass({
+  label: '\u087f\u{1fa50}',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 185.7, g: -807.5, b: 460.0, a: -218.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder24.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle11, renderBundle34]);
+} catch {}
+try {
+renderPassEncoder5.draw(54, 267, 73_808_613, 15_531_204);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 1_372);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+adapter0.label = '\u4e43\udcf2\ufc02\u7a48\u6b63\uf35a\u0486\u7ec1\u02a5';
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({
+  label: '\u02ee\u{1f634}\u0fcf\u07c8\u0cfe\u{1ff98}\u8811\uac3d\uedd2\u063b',
+  type: 'occlusion',
+  count: 823,
+});
+let texture25 = device0.createTexture({
+  label: '\u8d12\u0cde\u{1fa1a}\u2573\u50ed\u0622\u2db2\u035c\u5d61\u0348',
+  size: [30, 2, 6],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder18.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder7.draw(136, 49, 14_662_136, 122_924_712);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer11, 72);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer7, 'uint16', 816, 987);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer0, 7_744, 7_259);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({label: '\u0388\u{1fc88}'});
+let commandBuffer66 = commandEncoder95.finish({label: '\u36cf\u086f\u9999\u{1f85a}'});
+let renderBundle46 = renderBundleEncoder7.finish({label: '\u74a5\u2254\ua52e\u0b71\u{1f902}\u0194\u2725\u628e\u{1f83e}\uf6ad'});
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 279, 0, 479_650_440, 1_071_141_913);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer1, 12);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer2, 3764, buffer0, 5832, 1696);
+} catch {}
+let commandEncoder98 = device0.createCommandEncoder({label: '\u{1f8b1}\ua24b\uf7b7\u4a1f\u3015\u3c4c\u0707\u970e\u0549\u3fa3'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup3, new Uint32Array(1069), 120, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer11, 1_956);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer1, 624);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer3, 'uint16', 18, 1);
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker('\u5366');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2916, new DataView(new ArrayBuffer(46635)), 6240, 1120);
+} catch {}
+let imageData11 = new ImageData(8, 4);
+let commandEncoder99 = device0.createCommandEncoder();
+let commandBuffer67 = commandEncoder97.finish({label: '\u{1fdf2}\u08e2'});
+let renderPassEncoder18 = commandEncoder99.beginRenderPass({
+  label: '\u{1fcf0}\u0a5d\u0ceb\u0721',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 116,
+  clearValue: { r: 315.5, g: -397.1, b: -958.4, a: -665.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder7.draw(34, 160, 44_622_439, 418_508_594);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer11, 2_768);
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 268 */
+  offset: 268,
+  buffer: buffer6,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer65, commandBuffer67, commandBuffer58, commandBuffer36]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let renderPassEncoder19 = commandEncoder98.beginRenderPass({
+  label: '\u0389\u1e8b\uea4d\uc2b5\u8d23\u6565\u{1fdf6}\u0ad6\ucbd7\ua895\u7237',
+  colorAttachments: [{view: textureView5, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup6, new Uint32Array(352), 153, 0);
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(3);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(23, 308, 8, 150_847_745, 182_334_455);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 4_432);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer5, 0, 8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer53, commandBuffer64]);
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({
+  label: '\u361f\u4f99\u85a4\u{1fc11}\uf3f3\u{1f802}\u0338\u98b7\u{1fa17}',
+  type: 'occlusion',
+  count: 84,
+});
+let commandBuffer68 = commandEncoder96.finish({label: '\u36d2\u{1f821}\ua6a2\u0f03\u0003\u437b\u{1f823}'});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder5.draw(37, 330, 819_687_298, 671_218_476);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer2, 1_388);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer7, 'uint32', 1_184, 105);
+} catch {}
+try {
+device0.queue.submit([commandBuffer59, commandBuffer68]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 46},
+  aspect: 'all',
+}, new ArrayBuffer(2_255_469), /* required buffer size: 2_255_469 */
+{offset: 27, bytesPerRow: 258, rowsPerImage: 186}, {width: 6, height: 1, depthOrArrayLayers: 48});
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+  label: '\u64ef\u8df0',
+  layout: pipelineLayout0,
+  multisample: {mask: 0xc482c2d2},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {arrayStride: 164, stepMode: 'instance', attributes: []},
+      {arrayStride: 1352, attributes: []},
+      {arrayStride: 816, attributes: []},
+      {arrayStride: 216, stepMode: 'instance', attributes: []},
+      {arrayStride: 112, stepMode: 'instance', attributes: []},
+      {arrayStride: 80, stepMode: 'instance', attributes: []},
+      {arrayStride: 76, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 96,
+        attributes: [
+          {format: 'uint16x4', offset: 0, shaderLocation: 12},
+          {format: 'float16x2', offset: 12, shaderLocation: 6},
+          {format: 'uint32', offset: 40, shaderLocation: 3},
+          {format: 'uint8x2', offset: 24, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', unclippedDepth: false},
+});
+document.body.prepend(video4);
+await gc();
+let commandEncoder101 = device0.createCommandEncoder({label: '\u1435\uea2b\u{1f946}\u{1fb0d}\u01da'});
+try {
+renderPassEncoder2.setViewport(27.71427747232691, 3.3581457484259514, 3.3798826248106306, 14.915660450909819, 0.33817231469721465, 0.9724462720478646);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(17, 46, 21, -735_186_453, 264_315_360);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer1, 432);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 112);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint32', 2_052, 324);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline15);
+} catch {}
+let imageData12 = new ImageData(8, 28);
+let commandEncoder102 = device0.createCommandEncoder();
+let commandBuffer69 = commandEncoder101.finish({label: '\u0e3d\u08fe\u0462\u0bdd\u{1fdac}\u2842\u0e82\u01f6'});
+let renderPassEncoder20 = commandEncoder100.beginRenderPass({
+  label: '\u47c1\u1812\u032f\u1adb\u4f2e',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 4,
+  clearValue: { r: 579.7, g: -80.46, b: 428.0, a: -639.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle47 = renderBundleEncoder1.finish({label: '\u0726\u{1fb70}\u3054'});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(6, 76, 19, -2_051_428_859, 126_177_234);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline16);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1306 */
+  offset: 1306,
+  bytesPerRow: 0,
+  rowsPerImage: 27,
+  buffer: buffer10,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.submit([commandBuffer69, commandBuffer32]);
+} catch {}
+let imageData13 = new ImageData(100, 48);
+let promise15 = adapter0.requestAdapterInfo();
+try {
+canvas1.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder();
+let commandBuffer70 = commandEncoder103.finish();
+let textureView24 = texture3.createView({label: '\ube01\ucc53\u46f4\u0888\u6b9c\u5a2f'});
+let renderBundle48 = renderBundleEncoder9.finish();
+try {
+computePassEncoder25.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 358, 0, 373_005_682, 126_484_741);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer3, 'uint16', 10, 7);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder({});
+let renderPassEncoder21 = commandEncoder104.beginRenderPass({
+  label: '\u0bee\udcdd',
+  colorAttachments: [{view: textureView17, depthSlice: 95, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 145057631,
+});
+try {
+renderPassEncoder19.beginOcclusionQuery(100);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(7, 68, 10, -2_034_098_382, 19_070_224);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer2, 2_256);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer10, 1_324, 54);
+} catch {}
+try {
+commandEncoder102.resolveQuerySet(querySet9, 1, 3, buffer0, 1536);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({label: '\u0c72\u{1feea}'});
+let renderBundle49 = renderBundleEncoder5.finish({label: '\u{1fc44}\ubeb3\ue2c0\u5797'});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+computePassEncoder25.dispatchWorkgroupsIndirect(buffer2, 792);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(11, 2, 2, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(11, 218, 28, 533_133_812, 322_453_052);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer11, 908);
+} catch {}
+let textureView25 = texture9.createView({
+  label: '\u0d06\ub10e\u{1f72c}\u0ca3\u32b1\u{1f780}\u085a\ud3df\u0a57',
+  format: 'r8sint',
+  baseMipLevel: 1,
+  baseArrayLayer: 18,
+});
+try {
+renderPassEncoder19.setPipeline(pipeline16);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u{1f91e}');
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({label: '\u0a42\u0a05\u9cd8\u8678\udb58\u0ca6\u09ef'});
+let renderBundle50 = renderBundleEncoder3.finish();
+let sampler9 = device0.createSampler({
+  label: '\ud8a2\u1005\u{1f866}\u0c04\ubd32\u07af\ucacf\u894f\u00ce',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 38.49,
+  lodMaxClamp: 97.14,
+});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(1, bindGroup4, new Uint32Array(1613), 306, 0);
+} catch {}
+try {
+computePassEncoder24.dispatchWorkgroupsIndirect(buffer11, 68);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 200);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandBuffer71 = commandEncoder106.finish({label: '\uf132\u9dfe\u90a8'});
+let textureView26 = texture6.createView({label: '\u0211\ub3e6\u{1ff13}\u{1fbac}', dimension: '2d'});
+let renderBundle51 = renderBundleEncoder3.finish({label: '\u0970\u6eb8'});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup5, new Uint32Array(4070), 788, 0);
+} catch {}
+try {
+computePassEncoder17.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup0, new Uint32Array(189), 8, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle6, renderBundle51, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder5.draw(17, 137, 173_720_970, 1_010_563);
+} catch {}
+let arrayBuffer3 = buffer11.getMappedRange(2112, 68);
+document.body.prepend(canvas1);
+let offscreenCanvas0 = new OffscreenCanvas(467, 47);
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({label: '\ucebb\uc721\u5ad9\u0998\u0937\ufc4a\u06b4\u8375'});
+let commandBuffer72 = commandEncoder105.finish({label: '\u0c22\u058a\u4d23\ue6fd\u{1f6f1}'});
+try {
+computePassEncoder25.dispatchWorkgroupsIndirect(buffer1, 4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(3723), 3723, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 1_684);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet7, 161, 21, buffer4, 2048);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({label: '\u668c\u{1fc5d}\u0c46\u{1fdf8}\u0862\u4960\u{1f70c}\u0a54\u98e2\u8449'});
+let commandBuffer73 = commandEncoder107.finish({label: '\u40b0\ua6bb\u0b7a\u{1fe91}\ue59b\u0801\u5311\uc384\u9371'});
+let renderBundle52 = renderBundleEncoder3.finish({label: '\u4917\u3b9a\uaf5c'});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3, new Uint32Array(3157), 439, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(417, 258, 74_631_727, 613_817_834);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 59, 0, 544_396_073, 388_939_590);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 304);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\uabe0\u6d2c\u0cd8\u3f27\uebf7\u0edb\u{1f776}\u{1f661}\u6315',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout2],
+});
+let commandBuffer74 = commandEncoder108.finish({});
+let computePassEncoder30 = commandEncoder102.beginComputePass({label: '\ua7fc\u{1faf3}\ue645\u618d'});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup1, new Uint32Array(2031), 396, 0);
+} catch {}
+let arrayBuffer4 = buffer11.getMappedRange(2888, 296);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer47]);
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({label: '\u4fe5\u{1ffc3}\u0ada\uec6f\uce5a\u0b1b\u4f85\u0833\u{1f6d3}\u8e8b'});
+let renderPassEncoder22 = commandEncoder109.beginRenderPass({
+  label: '\ub79d\u7a3b\u504a\u0416\u251c\u0e98\u15bf\u0e5e',
+  colorAttachments: [{view: textureView17, depthSlice: 84, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 192161715,
+});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet3, 17, 90, buffer0, 6656);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let commandEncoder110 = device0.createCommandEncoder({label: '\u0147\u970b\uade4\u87c8\u{1f62c}\u0b91'});
+let commandBuffer75 = commandEncoder83.finish({});
+let computePassEncoder31 = commandEncoder110.beginComputePass();
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.draw(100, 29, 308_207_475, 226_379_618);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(15, 4, 21, -2_097_721_332, 23_994_270);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 192);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer6, 'uint16', 690, 1_583);
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 122, 0, 120_474_725, 1_829_199_144);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 244);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer5, 'uint16', 28, 22);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1936, new BigUint64Array(14815), 2966, 60);
+} catch {}
+document.body.prepend(video2);
+let commandEncoder111 = device0.createCommandEncoder({});
+let commandBuffer76 = commandEncoder111.finish({label: '\u{1f98f}\u9313\u{1f768}\uc753\ubc64\u1e58\u0e6b'});
+let renderBundle53 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 692);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer12);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+externalTexture3.label = '\u{1f745}\ufab0\u6eda\ua30a\u754f\u0744\u072f\u{1fd70}\u0d65\u0913';
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.draw(125, 211, 1_158_249_059, 574_769_074);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(2, 162, 0, -1_940_619_192, 105_095_767);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline21);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageData7);
+let texture26 = device0.createTexture({
+  size: {width: 15},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 4_716);
+} catch {}
+try {
+device0.queue.submit([commandBuffer41, commandBuffer72]);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u0d6c\u063c\u{1f634}\u0c2b\u{1fb97}\ua3a5\u2ff0\u7c21\u7d0d',
+  entries: [
+    {
+      binding: 209,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let renderPassEncoder23 = commandEncoder46.beginRenderPass({
+  label: '\uccd0\u0544\u1fcb\u1837\u{1f752}\u{1f6b2}\ud6b9\u04da\u9255',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 86,
+  clearValue: { r: -457.7, g: 369.5, b: 954.4, a: 271.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder24.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 312, 3, 134_779_628, 418_581_482);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline21);
+} catch {}
+let buffer13 = device0.createBuffer({
+  label: '\u{1fa25}\u4a0a\u04d6\uad6f\u933d\u07b2\u1f0b\ue796\uf5eb\uafb9\ucbf5',
+  size: 22126,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let querySet13 = device0.createQuerySet({label: '\ua11a\u4285\u6f85\u{1f7b1}\ue3fe\u0713\u0ea6\ub4da\u2c88', type: 'occlusion', count: 441});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(53, 161, 662_682_815, 823_467_159);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 100, 1, 57_643_727, 448_898_120);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 2_304);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline17);
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle39, renderBundle18, renderBundle29, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(36, 217, 17, -2_142_448_877, 529_173_847);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer2, 84, buffer4, 264, 624);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let commandBuffer77 = commandEncoder112.finish({label: '\u{1fc93}\u08b7\u06a9\u0aea\u{1f648}\u{1fed3}\uad50'});
+let renderBundle54 = renderBundleEncoder10.finish({label: '\u3c66\u71e9\u0bc7\u{1fe26}\u{1ff6c}'});
+try {
+renderPassEncoder7.draw(115, 344, 1_892_522_667, 343_794_584);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(3, 293, 1, 1_119_561_799, 1_028_721_579);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer11, 468);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer4, 0, 2_062);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer6, 596, buffer13, 172, 56);
+} catch {}
+try {
+commandEncoder110.insertDebugMarker('\u{1f718}');
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let renderBundle55 = renderBundleEncoder6.finish();
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer13, 1_792);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandBuffer78 = commandEncoder110.finish({label: '\u{1f756}\u82e0\u0193\u6928\u{1fdd0}\u9fe5'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\u8b21\u0496', colorFormats: ['r8sint']});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer11, 968);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer2, 1_540);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer6, 0, 180);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({label: '\u0a64\u6797\uba45\uf53a\u{1f706}\u{1fa8a}'});
+let renderBundle56 = renderBundleEncoder3.finish();
+try {
+computePassEncoder23.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer13, 1_680);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup5);
+} catch {}
+canvas0.width = 1257;
+let commandEncoder114 = device0.createCommandEncoder({});
+let computePassEncoder32 = commandEncoder113.beginComputePass();
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer13, 1_368);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(253, 287, 257, 400_050_342, 1_678_524_451);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer6, 'uint32', 356, 338);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, undefined, 145_769_064, 297_240_611);
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet1, 85, 5, buffer0, 1024);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\uce19');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer78, commandBuffer63, commandBuffer73, commandBuffer48, commandBuffer66]);
+} catch {}
+let commandBuffer79 = commandEncoder114.finish();
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.draw(35, 281, 156_639_843, 1_431_794_834);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(277, 77, 79, -742_071_919, 73_485_928);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint16', 152, 26);
+} catch {}
+try {
+computePassEncoder28.insertDebugMarker('\u{1f98b}');
+} catch {}
+try {
+adapter0.label = '\u{1f6e8}\ubc5d\u7606\u09b4\u020a\uc385\u3ae8\ue38f\u0716\u0891';
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(2, 3);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint32', 188, 2);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer5, 4, 8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer57, commandBuffer74]);
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({
+  label: '\u{1f957}\u7254\u{1fe15}\u17a7\u8eb0\u1c2a\u0abc\u0516\u3ef6\u0cdd\u{1ff10}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+renderPassEncoder7.draw(441, 18, 343_985_802, 642_934_086);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer4, 0, 177);
+} catch {}
+let texture27 = device0.createTexture({
+  label: '\u0662\u090e\u24fa\uaba1\u9e50\u02e5\u{1fe41}\u08e7\u5471\u8450',
+  size: {width: 60, height: 4, depthOrArrayLayers: 36},
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle19, renderBundle2, renderBundle13, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer5, 'uint16', 58, 18);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline18);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer2, 1_908);
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageData13);
+let texture28 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup1, new Uint32Array(2055), 500, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(3, 318, 0, 416_548_838, 2_757_409_049);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 548);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint16', 0, 15);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer7, 0, 2_809);
+} catch {}
+await gc();
+let bindGroup8 = device0.createBindGroup({
+  label: '\u{1fa8d}\u{1fced}\u323c\u0170\u{1f818}\u{1f6cc}\u181f',
+  layout: bindGroupLayout0,
+  entries: [{binding: 48, resource: externalTexture7}],
+});
+try {
+renderPassEncoder15.draw(182, 164, 1_109_175_257, 198_392_817);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 148, 1, -1_591_271_112, 203_905_785);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 584);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup4, []);
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({label: '\u17f6\u048f\ub25d'});
+let commandBuffer80 = commandEncoder115.finish({label: '\u0c88\ue58b\u{1fd34}\u{1fa7d}'});
+let texture29 = device0.createTexture({
+  label: '\ub540\u{1fbe6}\ueae6\udd37\u{1fc01}\u4781\u6574\u08e1\u{1f92d}\u05b0\uc875',
+  size: {width: 7, height: 1, depthOrArrayLayers: 8},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup6, new Uint32Array(387), 76, 0);
+} catch {}
+try {
+renderPassEncoder15.draw(303, 402, 263_097_178, 4_202_421);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(51, 339, 86, -243_503_766, 1_134_656_209);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\uba15');
+} catch {}
+let imageData14 = new ImageData(8, 116);
+let buffer14 = device0.createBuffer({
+  label: '\u00c1\u91c9\u5bb2',
+  size: 15920,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let texture30 = device0.createTexture({
+  size: {width: 7},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder7.draw(332, 83, 35_099_438, 22_468_115);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(52, 96, 141, -2_045_183_510, 115_242_202);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint32', 328, 842);
+} catch {}
+try {
+renderPassEncoder15.draw(24, 224, 617_715_281, 128_075_467);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(83, 131, 138, -2_080_235_998, 290_687_015);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 860);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer4, 0, 2_680);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas1.width = 366;
+let renderBundle57 = renderBundleEncoder11.finish({label: '\u3111\u2430'});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup2, new Uint32Array(49), 1, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup1, new Uint32Array(4189), 13, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer14, 516);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 3_460);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 708, new Float32Array(2190), 37, 600);
+} catch {}
+offscreenCanvas0.height = 736;
+try {
+renderPassEncoder6.setStencilReference(3135);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer1, 488);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer2, 1_132);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 784, new BigUint64Array(370), 10, 100);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({label: '\u0dbf\ue0c8\u135e\u{1fa78}\ud9b5'});
+try {
+computePassEncoder24.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(185);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(3228);
+} catch {}
+try {
+renderPassEncoder5.draw(86, 0, 520_187_043);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(2, 520, 0, 132_222_774, 206_203_890);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer14, 1_388);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device0.createComputePipeline({label: '\u66b8\u95f1\u{1fe8a}', layout: pipelineLayout0, compute: {module: shaderModule1}});
+let renderPassEncoder24 = commandEncoder116.beginRenderPass({
+  label: '\uae85\u5ced\u3e9f\u011a\u0918\u08d8\uc6d4\u5d42\u712b',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 184,
+  clearValue: { r: -771.8, g: 345.5, b: 991.1, a: -590.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle58 = renderBundleEncoder0.finish({label: '\u09c4\ud0e6\uef9b'});
+try {
+computePassEncoder24.dispatchWorkgroupsIndirect(buffer2, 732);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup7, new Uint32Array(189), 12, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer1, 104);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer1, 396);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21, commandBuffer26]);
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder({label: '\u4330\u{1f75c}\uc77e\u58f8\uf379\u0713\ud24a\ud3b7\u6754\u0c62\u0170'});
+try {
+renderPassEncoder15.setIndexBuffer(buffer0, 'uint32', 616, 9_106);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 7724, new BigUint64Array(621), 82, 100);
+} catch {}
+let imageData15 = new ImageData(12, 32);
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer3, 'uint16', 0, 5);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(7, buffer3, 0);
+} catch {}
+await gc();
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\ud7f0\ucbef\u0208\u{1fffc}\u{1fad3}\u0f8d\uffb9\u{1feaf}\u72e5\u{1f8fb}',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout8],
+});
+let commandBuffer81 = commandEncoder117.finish({label: '\u{1f901}\u0a67\u7a31\u582c\u0b46'});
+let renderBundle59 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder24.executeBundles([renderBundle13, renderBundle27, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder7.draw(37, 173, 2_241_870_502, 201_878_998);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let texture31 = device0.createTexture({
+  label: '\u{1f84f}\u00fe\u9f3c\u{1fea3}\u{1fd3a}\u{1fab1}',
+  size: [10, 5, 1],
+  mipLevelCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8'],
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setViewport(17.455554226939892, 6.833247297747683, 13.361927445912256, 9.989448651798307, 0.492082265078682, 0.6219346059283896);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer7);
+} catch {}
+let renderBundle60 = renderBundleEncoder9.finish({label: '\u9bd8\ub418\u2a4c\u{1f6c7}\u{1fab6}\u{1fa6d}\u9b45\u58aa\ubc3f\u022b'});
+try {
+renderPassEncoder15.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(401, 0, 424_566_458, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 12, 0, 444_461_110, 1_266_853_854);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer13, 960);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer0, 'uint16', 3_328, 1_846);
+} catch {}
+let video5 = await videoWithData();
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup7, new Uint32Array(2408), 28, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.draw(0, 288, 0, 2_689_433_849);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 25, 2, 146_902_308, 379_496_819);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer11, 3_200);
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder();
+let textureView27 = texture22.createView({label: '\u0ddf\u0b06\u{1fbd2}\u3694\u7530', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 24});
+let renderPassEncoder25 = commandEncoder118.beginRenderPass({
+  label: '\u34e2\u{1fec6}\u{1ff1c}\u0556\u{1f6e8}\u{1fd21}\uc153\u7f61\uda3c\u2fee\u09f2',
+  colorAttachments: [{view: textureView27, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 33424941,
+});
+let renderBundle61 = renderBundleEncoder5.finish();
+try {
+computePassEncoder27.setBindGroup(1, bindGroup2, new Uint32Array(2656), 41, 0);
+} catch {}
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.draw(307, 86, 79_177_579, 140_974_151);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer11, 1_648);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer7, 'uint32', 2_472, 831);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let commandEncoder119 = device0.createCommandEncoder({label: '\u05b4\u0f35\u0848\u01c6\uc0e0\u8223\ua670\u{1f7d0}'});
+let textureView28 = texture7.createView({});
+let renderPassEncoder26 = commandEncoder119.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -697.9, g: -112.0, b: 159.3, a: -749.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+});
+let renderBundle62 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder5.draw(6, 0, 1_355_132_998);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 6, 0, 331_172_573, 488_677_498);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer11, 652);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer0, 'uint16', 582, 4_466);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(7, buffer7, 0, 1_689);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({label: '\u0410\u0615'});
+let renderPassEncoder27 = commandEncoder120.beginRenderPass({
+  label: '\u{1fad8}\u{1f79b}\u0c0d\u444b\u{1fb78}',
+  colorAttachments: [{
+  view: textureView15,
+  depthSlice: 168,
+  clearValue: { r: -5.249, g: -13.72, b: -296.9, a: 192.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder23.dispatchWorkgroups(1, 2, 1);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder23.pushDebugGroup('\u2b13');
+} catch {}
+try {
+device0.queue.submit([commandBuffer71]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(209_266), /* required buffer size: 209_266 */
+{offset: 164, bytesPerRow: 179, rowsPerImage: 146}, {width: 30, height: 1, depthOrArrayLayers: 9});
+} catch {}
+let texture32 = device0.createTexture({
+  label: '\uf68b\ud61f\u{1fbd4}',
+  size: {width: 20, height: 10, depthOrArrayLayers: 1},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.drawIndexed(11, 184, 0, 735_490_812, 1_888_390_924);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer14, 'uint32', 1_092, 585);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u5c99\uf3ef\uf021\u09e8\u076e\u{1f823}',
+  entries: [
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture33 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle63 = renderBundleEncoder0.finish();
+try {
+computePassEncoder24.setBindGroup(0, bindGroup3, new Uint32Array(1610), 237, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(5, 192, 1, 143_377_962, 357_188_850);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer4, 0, 859);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 28);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer2, 'uint32', 948, 2_553);
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder({label: '\u0c11\u4608\u{1f76d}'});
+let commandBuffer82 = commandEncoder121.finish({label: '\u0151\u2a5e\u{1fdb5}\u0959\u{1f801}\u3829'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer0, 1_936);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let renderBundle64 = renderBundleEncoder3.finish({label: '\ue123\u{1fc6f}\u0106'});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup0, new Uint32Array(917), 109, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup8, new Uint32Array(103), 16, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer2, 4_904);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer2, 368);
+} catch {}
+try {
+device0.queue.submit([commandBuffer77, commandBuffer70]);
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder({});
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle44, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer11, 340);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer14, 'uint16', 2_316, 419);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder29.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(0, bindGroup4, new Uint32Array(643), 20, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(149, 0, 91_062_875);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(4, 0, 26, 637_745_288);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer11, 40);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer13, 56);
+} catch {}
+offscreenCanvas0.width = 815;
+let renderBundle65 = renderBundleEncoder6.finish({label: '\u0682\ud82c\u724c\u6b67\u965c\u9239\ubee6\u984e'});
+try {
+renderPassEncoder8.draw(0, 176, 0, 1_739_494_381);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(31, 0, 2, 592_875_048);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer2, 2_236);
+} catch {}
+let textureView29 = texture9.createView({label: '\u{1fa86}\udbcb\uafd6\u28af\udb7e\ud15f\ua618\u853d', baseMipLevel: 1, arrayLayerCount: 4});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup3, new Uint32Array(1843), 592, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle30]);
+} catch {}
+try {
+renderPassEncoder22.setViewport(2.5076659303482405, 3.7909764127643317, 6.765985086745709, 0.9814369561378387, 0.23777932807666047, 0.7847400404271898);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 1624, 2340);
+} catch {}
+try {
+renderPassEncoder23.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandBuffer83 = commandEncoder113.finish({label: '\u4775\u41ef\u3da6'});
+let renderBundle66 = renderBundleEncoder9.finish({label: '\u{1fe04}\u{1f773}\u0038\ucd64\u7df1\u034c\u57b3\u9ea1'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup5, new Uint32Array(1424), 45, 0);
+} catch {}
+try {
+renderPassEncoder22.setViewport(2.4613521365445012, 0.7043883498608633, 0.459796815528915, 3.2854788217368336, 0.39056694861888785, 0.8625536890066094);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 0, 80, 156_889_540);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer7);
+} catch {}
+let arrayBuffer5 = buffer9.getMappedRange(1624, 940);
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let videoFrame1 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let commandBuffer84 = commandEncoder122.finish({label: '\u220f\u0208'});
+try {
+computePassEncoder27.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder5.draw(268, 0, 929_549_941);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 0, 24, 25_252_627);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer11, 172);
+} catch {}
+try {
+device0.queue.submit([commandBuffer80]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 728, new Int16Array(40519), 947, 364);
+} catch {}
+canvas0.height = 1259;
+let bindGroup9 = device0.createBindGroup({label: '\u0cfd\ub436\ue32e\uaccd\u49b7', layout: bindGroupLayout5, entries: []});
+let texture34 = device0.createTexture({
+  label: '\ub4a6\u1605\u0ac4\u0a37\u7bb2\u9f36\u406e',
+  size: {width: 5, height: 2, depthOrArrayLayers: 30},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer2, 256);
+} catch {}
+try {
+renderPassEncoder5.draw(182, 0, 962_838_880);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer14, 1_488);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint16', 498, 2_127);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 5488, new DataView(new ArrayBuffer(11465)), 4032, 732);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let videoFrame2 = new VideoFrame(video3, {timestamp: 0});
+try {
+  await promise19;
+} catch {}
+canvas1.height = 891;
+let imageBitmap6 = await createImageBitmap(imageData3);
+try {
+window.someLabel = renderBundle42.label;
+} catch {}
+await gc();
+let videoFrame3 = new VideoFrame(imageBitmap2, {timestamp: 0});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let promise20 = navigator.gpu.requestAdapter({});
+let offscreenCanvas1 = new OffscreenCanvas(285, 25);
+try {
+adapter0.label = '\u0d6c\u07f8\u1e7a\u0201';
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+video5.height = 24;
+document.body.prepend(canvas0);
+document.body.prepend(video3);
+await gc();
+let promise21 = adapter0.requestAdapterInfo();
+try {
+  await promise21;
+} catch {}
+let imageData16 = new ImageData(8, 36);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+video1.height = 102;
+await gc();
+canvas1.height = 2198;
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+externalTexture4.label = '\u067f\ubb1f\u{1f653}\u{1ffdf}\u960e\u81a9\u90c8\u948c';
+} catch {}
+try {
+bindGroupLayout9.label = '\u00ca\u83c1\u14b8';
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+externalTexture8.label = '\u2a20\u{1ff3d}\ufb30\u9aac\u0168\u{1fd7a}\u0ee0\u0470';
+} catch {}
+let videoFrame4 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData17 = new ImageData(20, 8);
+canvas0.height = 1459;
+try {
+commandEncoder7.label = '\u{1fb31}\u7627\u0b35\u{1f9f6}\ua549\ub378\uac0e\u5f71\u{1fb51}\u76ce\u{1f87b}';
+} catch {}
+video0.height = 6;
+try {
+adapter0.label = '\u4c82\u4adc';
+} catch {}
+let imageBitmap7 = await createImageBitmap(imageData2);
+try {
+adapter0.label = '\u0994\u8c1d\u{1ff8e}';
+} catch {}
+let imageData18 = new ImageData(36, 8);
+await gc();
+let imageData19 = new ImageData(8, 84);
+let img3 = await imageWithData(31, 133, '#0100b3fb', '#4c3d2753');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\ufe01\u{1f71a}\u6822\u0954\u0d37\u{1f6a7}\u8a9e\u42ef\u0014\u0262';
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(img3);
+await gc();
+let canvas2 = document.createElement('canvas');
+document.body.prepend(video3);
+try {
+externalTexture5.label = '\u{1f98d}\u366c\u68f1\u03ac\u{1fd3f}\uf45f\u{1f90c}\u6b71\u0732\u6970';
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+adapter0.label = '\u91fc\u31b3\u045c\uea00\u0cb5\u33aa';
+} catch {}
+try {
+commandBuffer3.label = '\u24f9\u{1f8ad}\u0cea\u9852\u07f8';
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(105, 390);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas2.getContext('webgpu');
+let video6 = await videoWithData();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+offscreenCanvas1.height = 862;
+video1.height = 8;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+try {
+textureView16.label = '\u12be\u{1facb}';
+} catch {}
+let videoFrame5 = new VideoFrame(imageBitmap5, {timestamp: 0});
+try {
+adapter0.label = '\u346f\ub568\u{1f724}\u{1f90d}\uc8c9\u424e\u{1fdc0}\u{1fd75}';
+} catch {}
+let video7 = await videoWithData();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+video4.height = 92;
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let imageData20 = new ImageData(132, 32);
+try {
+window.someLabel = renderPassEncoder15.label;
+} catch {}
+document.body.prepend(video3);
+video0.height = 5;
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+adapter0.label = '\u0d34\u{1f69e}\u662f';
+} catch {}
+video7.height = 99;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let promise22 = adapter0.requestAdapterInfo();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.prepend(video5);
+try {
+  await promise22;
+} catch {}
+let imageData21 = new ImageData(132, 56);
+document.body.prepend(canvas2);
+let promise23 = adapter0.requestAdapterInfo();
+document.body.prepend(video0);
+try {
+  await promise23;
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+canvas1.width = 579;
+document.body.prepend(img3);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData22 = new ImageData(4, 24);
+offscreenCanvas1.width = 2019;
+await gc();
+canvas1.height = 1004;
+let imageData23 = new ImageData(24, 48);
+let videoFrame6 = new VideoFrame(imageBitmap3, {timestamp: 0});
+document.body.prepend(video6);
+let imageData24 = new ImageData(56, 172);
+let canvas3 = document.createElement('canvas');
+let gpuCanvasContext5 = canvas3.getContext('webgpu');
+document.body.prepend(video7);
+let offscreenCanvas3 = new OffscreenCanvas(130, 92);
+document.body.prepend(video6);
+let offscreenCanvas4 = new OffscreenCanvas(198, 232);
+let imageData25 = new ImageData(124, 24);
+offscreenCanvas0.height = 796;
+let gpuCanvasContext6 = offscreenCanvas4.getContext('webgpu');
+try {
+window.someLabel = pipeline5.label;
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas3.getContext('webgpu');
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+canvas2.height = 895;
+let imageData26 = new ImageData(28, 4);
+video1.height = 251;
+let video8 = await videoWithData();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(529, 49);
+offscreenCanvas5.width = 1137;
+let imageData27 = new ImageData(84, 68);
+try {
+adapter0.label = '\uec6e\ubf02\u175f\u0575\u0279\u627d\u9dd6\u0c1c\u0a95\u0201\u43e9';
+} catch {}
+try {
+window.someLabel = renderPassEncoder4.label;
+} catch {}
+try {
+adapter0.label = '\uca1e\u{1fb46}\ud308\u06f1\ua99b\u3285\u0db8\uefd9\u4700\u{1fbaf}\u502c';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(img1);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas5.getContext('webgpu');
+try {
+commandEncoder103.label = '\u{1f82a}\u15c4\u0e45';
+} catch {}
+let imageData28 = new ImageData(24, 40);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img4 = await imageWithData(34, 17, '#c15d0f83', '#edf15f5a');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+offscreenCanvas2.height = 77;
+let video9 = await videoWithData();
+let imageData29 = new ImageData(28, 16);
+await gc();
+try {
+window.someLabel = commandEncoder25.label;
+} catch {}
+let imageData30 = new ImageData(28, 20);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+offscreenCanvas4.height = 604;
+await gc();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+document.body.prepend(video6);
+let img5 = await imageWithData(193, 69, '#158aa99b', '#794e4e97');
+let promise24 = adapter0.requestAdapterInfo();
+try {
+window.someLabel = externalTexture7.label;
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+  await promise24;
+} catch {}
+await gc();
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+offscreenCanvas4.height = 848;
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+await gc();
+await gc();
+offscreenCanvas0.height = 30;
+let imageData31 = new ImageData(56, 8);
+canvas2.width = 299;
+document.body.prepend(canvas2);
+video7.width = 9;
+try {
+device0.label = '\u64e5\u{1f789}\u0913\u{1f934}\u{1ff5e}\u2a49\u{1fe00}';
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u5bb3\u{1fccf}\u0bbf\ud240\u3880\u1cd7\ua7fe';
+} catch {}
+let videoFrame7 = new VideoFrame(canvas2, {timestamp: 0});
+try {
+adapter0.label = '\u0207\ub7a6\u989f';
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let adapter1 = await promise20;
+try {
+renderBundle14.label = '\u5101\ud542\u{1f794}\u{1fab7}\u345b';
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let imageBitmap8 = await createImageBitmap(imageData27);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+externalTexture7.label = '\u{1fe21}\u8ae7\u4ad5\u7d1e\u0c7f\u{1f9de}\u0a0d';
+} catch {}
+let imageData32 = new ImageData(20, 120);
+let promise25 = adapter0.requestAdapterInfo();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+document.body.prepend(img3);
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame7.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -594,7 +594,7 @@ void RenderPassEncoder::draw(uint32_t vertexCount, uint32_t instanceCount, uint3
     if (!executePreDrawCommands())
         return;
     runVertexBufferValidation(vertexCount, instanceCount, firstVertex, firstInstance);
-    if (!instanceCount || !vertexCount)
+    if (!instanceCount || !vertexCount || instanceCount + firstInstance < firstInstance || vertexCount + firstVertex < firstVertex)
         return;
 
     [renderCommandEncoder()


### PR DESCRIPTION
#### 0a1091a6b8660672f2b145174045c62e35073aa8
<pre>
[WebGPU] Validation error when instanceCount overflows
<a href="https://bugs.webkit.org/show_bug.cgi?id=277642">https://bugs.webkit.org/show_bug.cgi?id=277642</a>
<a href="https://rdar.apple.com/133222357">rdar://133222357</a>

Reviewed by Tadeu Zagallo.

Validation layer crashes when counts exceed UINT32_MAX.

* LayoutTests/fast/webgpu/nocrash/fuzz-277642-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277642.html: Added.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::draw):

Canonical link: <a href="https://commits.webkit.org/281854@main">https://commits.webkit.org/281854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc401a3c523efee116de7a3e5541224398249cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11765 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49482 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8184 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10371 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57066 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4271 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37464 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38558 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->