### PR TITLE
[CoreIPC] -[NSButtonCell isKindOfClass:]: message sent to deallocated instance in WebCore::ControlMac::drawCellInternal

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -214,10 +214,10 @@ void GraphicsContext::drawBidiText(const FontCascade& font, const TextRun& run, 
     bidiRuns.clear();
 }
 
-void GraphicsContext::drawDisplayListItems(const Vector<DisplayList::Item>& items, const DisplayList::ResourceHeap& resourceHeap, const FloatPoint& destination)
+void GraphicsContext::drawDisplayListItems(const Vector<DisplayList::Item>& items, const DisplayList::ResourceHeap& resourceHeap, ControlFactory& controlFactory, const FloatPoint& destination)
 {
     translate(destination);
-    DisplayList::Replayer(*this, items, resourceHeap).replay();
+    DisplayList::Replayer(*this, items, resourceHeap, controlFactory).replay();
     translate(-destination);
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -321,7 +321,7 @@ public:
     virtual void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) = 0;
 
     // DisplayList
-    WEBCORE_EXPORT virtual void drawDisplayListItems(const Vector<DisplayList::Item>&, const DisplayList::ResourceHeap&, const FloatPoint& destination);
+    WEBCORE_EXPORT virtual void drawDisplayListItems(const Vector<DisplayList::Item>&, const DisplayList::ResourceHeap&, ControlFactory&, const FloatPoint& destination);
 
     // Transparency Layers
 

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.cpp
@@ -31,17 +31,17 @@
 namespace WebCore {
 
 #if !PLATFORM(COCOA)
-std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
+RefPtr<ControlFactory> ControlFactory::create()
 {
     RELEASE_ASSERT_NOT_REACHED();
     return nullptr;
 }
 #endif
 
-ControlFactory& ControlFactory::sharedControlFactory()
+ControlFactory& ControlFactory::shared()
 {
-    static NeverDestroyed<std::unique_ptr<ControlFactory>> sharedControlFactory = createControlFactory();
-    return *sharedControlFactory.get();
+    static MainThreadNeverDestroyed<RefPtr<ControlFactory>> shared { create() };
+    return *shared.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+
 namespace WebCore {
 
 class ApplePayButtonPart;
@@ -48,13 +51,13 @@ class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
 
-class ControlFactory {
+class ControlFactory : public RefCounted<ControlFactory> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~ControlFactory() = default;
 
-    WEBCORE_EXPORT static std::unique_ptr<ControlFactory> createControlFactory();
-    static ControlFactory& sharedControlFactory();
+    WEBCORE_EXPORT static RefPtr<ControlFactory> create();
+    WEBCORE_EXPORT static ControlFactory& shared();
 
 #if ENABLE(APPLE_PAY)
     virtual std::unique_ptr<PlatformControl> createPlatformApplePayButton(ApplePayButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "ControlPart.h"
 
-#include "ControlFactory.h"
 #include "FloatRoundedRect.h"
 #include "GraphicsContext.h"
 
@@ -39,7 +38,7 @@ ControlPart::ControlPart(StyleAppearance type)
 
 ControlFactory& ControlPart::controlFactory() const
 {
-    return m_controlFactory ? *m_controlFactory : ControlFactory::sharedControlFactory();
+    return m_controlFactory ? *m_controlFactory : ControlFactory::shared();
 }
 
 PlatformControl* ControlPart::platformControl() const

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Color.h"
+#include "ControlFactory.h"
 #include "PlatformControl.h"
 #include "StyleAppearance.h"
 #include <wtf/RefCounted.h>
@@ -43,7 +44,7 @@ public:
     StyleAppearance type() const { return m_type; }
 
     WEBCORE_EXPORT ControlFactory& controlFactory() const;
-    void setControlFactory(ControlFactory* controlFactory) { m_controlFactory = controlFactory; }
+    void setControlFactory(ControlFactory& controlFactory) { m_controlFactory = &controlFactory; }
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&);
@@ -58,7 +59,7 @@ protected:
     const StyleAppearance m_type;
 
     mutable std::unique_ptr<PlatformControl> m_platformControl;
-    ControlFactory* m_controlFactory { nullptr };
+    RefPtr<ControlFactory> m_controlFactory;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -147,7 +147,7 @@ inline static std::optional<RenderingResourceIdentifier> applyDrawDecomposedGlyp
     return std::nullopt;
 }
 
-ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const Item& item)
+ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resourceHeap, ControlFactory& controlFactory, const Item& item)
 {
     if (!isValid(item))
         return { StopReplayReason::InvalidItemOrExtent, std::nullopt };
@@ -156,6 +156,9 @@ ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resource
         [&](const ClipToImageBuffer& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
+            return { };
+        }, [&](const DrawControlPart& item) -> ApplyItemResult {
+            item.apply(context, controlFactory);
             return { };
         }, [&](const DrawGlyphs& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyDrawGlyphs(context, resourceHeap, item))
@@ -166,7 +169,7 @@ ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resource
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const DrawDisplayListItems& item) -> ApplyItemResult {
-            item.apply(context, resourceHeap);
+            item.apply(context, resourceHeap, controlFactory);
             return { };
         }, [&](const DrawFilteredImageBuffer& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyFilteredImageBufferItem(context, resourceHeap, item))

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -35,6 +35,7 @@ class TextStream;
 
 namespace WebCore {
 
+class ControlFactory;
 class GraphicsContext;
 
 namespace DisplayList {
@@ -220,7 +221,7 @@ enum class AsTextFlag : uint8_t {
 
 bool isValid(const Item&);
 
-ApplyItemResult applyItem(GraphicsContext&, const ResourceHeap&, const Item&);
+ApplyItemResult applyItem(GraphicsContext&, const ResourceHeap&, ControlFactory&, const Item&);
 
 bool shouldDumpItem(const Item&, OptionSet<AsTextFlag>);
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -339,9 +339,9 @@ DrawDisplayListItems::DrawDisplayListItems(Vector<Item>&& items, const FloatPoin
 {
 }
 
-void DrawDisplayListItems::apply(GraphicsContext& context, const ResourceHeap& resourceHeap) const
+void DrawDisplayListItems::apply(GraphicsContext& context, const ResourceHeap& resourceHeap, ControlFactory& controlFactory) const
 {
-    context.drawDisplayListItems(m_items, resourceHeap, m_destination);
+    context.drawDisplayListItems(m_items, resourceHeap, controlFactory, m_destination);
 }
 
 NO_RETURN_DUE_TO_ASSERT void DrawDisplayListItems::apply(GraphicsContext&) const
@@ -868,8 +868,9 @@ DrawControlPart::DrawControlPart(ControlPart& part, const FloatRoundedRect& bord
 {
 }
 
-void DrawControlPart::apply(GraphicsContext& context) const
+void DrawControlPart::apply(GraphicsContext& context, ControlFactory& controlFactory) const
 {
+    m_part->setControlFactory(controlFactory);
     context.drawControlPart(m_part, m_borderRect, m_deviceScaleFactor, m_style);
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -49,6 +49,7 @@ class TextStream;
 
 namespace WebCore {
 
+class ControlFactory;
 struct ImagePaintingOptions;
 
 namespace DisplayList {
@@ -548,7 +549,7 @@ public:
     const Vector<Item>& items() const { return m_items; }
     FloatPoint destination() const { return m_destination; }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&, const ResourceHeap&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, const ResourceHeap&, ControlFactory&) const;
     NO_RETURN_DUE_TO_ASSERT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
@@ -1467,7 +1468,7 @@ public:
     const ControlStyle& style() const { return m_style; }
     StyleAppearance type() const { return m_part->type(); }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, ControlFactory&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -236,7 +236,7 @@ void Recorder::drawGlyphsAndCacheResources(const Font& font, const GlyphBufferGl
     recordDrawGlyphs(font, glyphs, advances, numGlyphs, localAnchor, smoothingMode);
 }
 
-void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHeap& resourceHeap, const FloatPoint& destination)
+void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory&, const FloatPoint& destination)
 {
     appendStateChangeItemIfNecessary();
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -239,7 +239,7 @@ private:
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
     WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
 
-    WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, const FloatPoint& destination) final;
+    WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, ControlFactory&, const FloatPoint& destination) final;
 
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DisplayListReplayer.h"
 
+#include "ControlFactory.h"
 #include "DisplayList.h"
 #include "Logging.h"
 #include <wtf/text/TextStream.h>
@@ -34,14 +35,15 @@ namespace WebCore {
 namespace DisplayList {
 
 Replayer::Replayer(GraphicsContext& context, const DisplayList& displayList)
-    : Replayer(context, displayList.items(), displayList.resourceHeap())
+    : Replayer(context, displayList.items(), displayList.resourceHeap(), ControlFactory::shared())
 {
 }
 
-Replayer::Replayer(GraphicsContext& context, const Vector<Item>& items, const ResourceHeap& resourceHeap)
+Replayer::Replayer(GraphicsContext& context, const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory& controlFactory)
     : m_context(context)
     , m_items(items)
     , m_resourceHeap(resourceHeap)
+    , m_controlFactory(controlFactory)
 {
 }
 
@@ -61,7 +63,7 @@ ReplayResult Replayer::replay(const FloatRect& initialClip, bool trackReplayList
     for (auto& item : m_items) {
         LOG_WITH_STREAM(DisplayLists, stream << "applying " << i++ << " " << item);
 
-        auto applyResult = applyItem(m_context, m_resourceHeap, item);
+        auto applyResult = applyItem(m_context, m_resourceHeap, m_controlFactory, item);
         if (applyResult.stopReason) {
             result.reasonForStopping = *applyResult.stopReason;
             result.missingCachedResourceIdentifier = WTFMove(applyResult.resourceIdentifier);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class ControlFactory;
 class FloatRect;
 class GraphicsContext;
 
@@ -49,7 +50,7 @@ class Replayer {
     WTF_MAKE_NONCOPYABLE(Replayer);
 public:
     WEBCORE_EXPORT Replayer(GraphicsContext&, const DisplayList&);
-    WEBCORE_EXPORT Replayer(GraphicsContext&, const Vector<Item>&, const ResourceHeap&);
+    WEBCORE_EXPORT Replayer(GraphicsContext&, const Vector<Item>&, const ResourceHeap&, ControlFactory&);
     ~Replayer() = default;
 
     WEBCORE_EXPORT ReplayResult replay(const FloatRect& initialClip = { }, bool trackReplayList = false);
@@ -58,6 +59,7 @@ private:
     GraphicsContext& m_context;
     const Vector<Item>& m_items;
     const ResourceHeap& m_resourceHeap;
+    Ref<ControlFactory> m_controlFactory;
 };
 
 } // namespace DisplayList

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
@@ -32,9 +32,9 @@
 
 namespace WebCore {
 
-std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
+RefPtr<ControlFactory> ControlFactory::create()
 {
-    return makeUnique<ControlFactoryIOS>();
+    return adoptRef(new ControlFactoryIOS());
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformButton(ButtonPart&)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -41,7 +41,7 @@ class ControlFactoryMac final : public ControlFactoryCocoa {
 public:
     using ControlFactoryCocoa::ControlFactoryCocoa;
 
-    static ControlFactoryMac& sharedControlFactory();
+    static ControlFactoryMac& shared();
 
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -57,14 +57,14 @@
 
 namespace WebCore {
 
-std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
+RefPtr<ControlFactory> ControlFactory::create()
 {
-    return makeUnique<ControlFactoryMac>();
+    return adoptRef(new ControlFactoryMac());
 }
 
-ControlFactoryMac& ControlFactoryMac::sharedControlFactory()
+ControlFactoryMac& ControlFactoryMac::shared()
 {
-    return static_cast<ControlFactoryMac&>(ControlFactory::sharedControlFactory());
+    return static_cast<ControlFactoryMac&>(ControlFactory::shared());
 }
 
 NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle& style) const

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -45,7 +45,7 @@ ImageControlsButtonMac::ImageControlsButtonMac(ImageControlsButtonPart& owningPa
 
 IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
 {
-    auto& controlFactory = ControlFactoryMac::sharedControlFactory();
+    auto& controlFactory = ControlFactoryMac::shared();
     if (auto* servicesRolloverButtonCell = controlFactory.servicesRolloverButtonCell())
         return IntSize { [servicesRolloverButtonCell cellSize] };
     return { };

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "TextPainter.h"
 
+#include "ControlFactory.h"
 #include "DisplayListRecorderImpl.h"
 #include "DisplayListReplayer.h"
 #include "FilterOperations.h"
@@ -121,7 +122,7 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
         m_context.drawText(font, textRun, textOrigin, startOffset, endOffset);
     else {
         // Replaying back a whole cached glyph run to the GraphicsContext.
-        m_context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), textOrigin);
+        m_context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), ControlFactory::shared(), textOrigin);
     }
     m_glyphDisplayList = nullptr;
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -66,6 +66,13 @@ RemoteResourceCache& RemoteDisplayListRecorder::resourceCache() const
     return m_renderingBackend->remoteResourceCache();
 }
 
+ControlFactory& RemoteDisplayListRecorder::controlFactory()
+{
+    if (!m_controlFactory)
+        m_controlFactory = ControlFactory::create();
+    return *m_controlFactory;
+}
+
 RefPtr<ImageBuffer> RemoteDisplayListRecorder::imageBuffer(RenderingResourceIdentifier identifier) const
 {
     return m_renderingBackend->imageBuffer(identifier);
@@ -330,7 +337,7 @@ void RemoteDisplayListRecorder::drawDecomposedGlyphs(RenderingResourceIdentifier
 
 void RemoteDisplayListRecorder::drawDisplayListItems(Vector<WebCore::DisplayList::Item>&& items, const FloatPoint& destination)
 {
-    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap());
+    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap(), controlFactory());
 }
 
 void RemoteDisplayListRecorder::drawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -614,10 +621,7 @@ void RemoteDisplayListRecorder::clearRect(const FloatRect& rect)
 
 void RemoteDisplayListRecorder::drawControlPart(Ref<ControlPart> part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    if (!m_controlFactory)
-        m_controlFactory = ControlFactory::createControlFactory();
-    part->setControlFactory(m_controlFactory.get());
-    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style));
+    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style), controlFactory());
 }
 
 #if USE(CG)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -149,6 +149,7 @@ private:
     void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
 
     RemoteResourceCache& resourceCache() const;
+    WebCore::ControlFactory& controlFactory();
     WebCore::GraphicsContext& drawingContext() { return m_imageBuffer->context(); }
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier) const;
     std::optional<WebCore::SourceImage> sourceImage(WebCore::RenderingResourceIdentifier) const;
@@ -178,7 +179,7 @@ private:
     WebCore::RenderingResourceIdentifier m_imageBufferIdentifier;
     RefPtr<RemoteRenderingBackend> m_renderingBackend;
     Ref<RemoteSharedResourceCache> m_sharedResourceCache;
-    std::unique_ptr<WebCore::ControlFactory> m_controlFactory;
+    RefPtr<WebCore::ControlFactory> m_controlFactory;
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     std::unique_ptr<SharedVideoFrameReader> m_sharedVideoFrameReader;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -27,6 +27,7 @@
 
 #if USE(CG)
 
+#include <WebCore/ControlFactory.h>
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/DisplayList.h>
 #include <WebCore/DisplayListItems.h>
@@ -74,7 +75,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
         ResourceHeap resourceHeap;
         resourceHeap.add(imageBuffer.releaseNonNull());
 
-        Replayer replayer { context, list.items(), resourceHeap };
+        Replayer replayer { context, list.items(), resourceHeap, ControlFactory::shared() };
         auto result = replayer.replay();
         EXPECT_EQ(result.reasonForStopping, StopReplayReason::ReplayedAllItems);
         EXPECT_EQ(result.missingCachedResourceIdentifier, std::nullopt);


### PR DESCRIPTION
#### 6fef989d57caa136d7e4e7b3912b9ac69bae707a
<pre>
[CoreIPC] -[NSButtonCell isKindOfClass:]: message sent to deallocated instance in WebCore::ControlMac::drawCellInternal
<a href="https://bugs.webkit.org/show_bug.cgi?id=273788">https://bugs.webkit.org/show_bug.cgi?id=273788</a>
<a href="https://rdar.apple.com/126071623">rdar://126071623</a>

Reviewed by Said Abou-Hallawa.

`ControlFactory` is not a thread-safe object, and the shared factory should
only ever be used on the main thread. The shared factory is used by
`ControlPart` if one is not already assigned.

Currently, an attempt at ensuring thread-safety is made by avoiding use of
the shared factory on `RemoteRenderingBackend` work queues, by creating and
assigning a thread-specific `ControlFactory` to a `ControlPart` in
`RemoteDisplayListRecorder::drawControlPart`. However, this logic does not
account for the fact that the `DrawControlPart` display list item can also be
applied as a result of applying `DrawDisplayListItems`. In this scenario, the
`ControlPart` will have a null `ControlFactory`, and will simply fall back to
using the shared factory.

Fix by ensuring the creation of a `ControlFactory` in
`RemoteDisplayListRecorder::drawDisplayListItems`, and adding the necessary
plumbing to ensure `ControlPart`s drawn as a result of applying
`DrawDisplayListItems` use a thread-specific factory.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawDisplayListItems):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/controls/ControlFactory.cpp:
(WebCore::ControlFactory::create):
(WebCore::ControlFactory::shared):

Use `MainThreadNeverDestroyed`, as the shared factory is not thread-safe.

(WebCore::ControlFactory::createControlFactory): Deleted.
(WebCore::ControlFactory::sharedControlFactory): Deleted.
* Source/WebCore/platform/graphics/controls/ControlFactory.h:

Make `ControlFactory` ref-counted to avoid raw pointer usage in member variables.

Rename static methods to match WebKit convention.

* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::controlFactory const):
* Source/WebCore/platform/graphics/controls/ControlPart.h:
(WebCore::ControlPart::setControlFactory):
(): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawDisplayListItems::apply const):
(WebCore::DisplayList::DrawControlPart::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawDisplayListItems):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp:
(WebCore::DisplayList::Replayer::Replayer):
(WebCore::DisplayList::Replayer::replay):
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h:
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm:
(WebCore::ControlFactory::create):
(WebCore::ControlFactory::createControlFactory): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactory::create):
(WebCore::ControlFactoryMac::shared):
(WebCore::ControlFactory::createControlFactory): Deleted.
(WebCore::ControlFactoryMac::sharedControlFactory): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
(WebCore::ImageControlsButtonMac::servicesRolloverButtonCellSize):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextOrEmphasisMarks):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::controlFactory):
(WebKit::RemoteDisplayListRecorder::drawDisplayListItems):

This is the important part of the fix. A thread-specific `ControlFactory` must
be specified for `DrawDisplayListItems`, so that contained `DrawControlPart`
items do not use the shared factory.

(WebKit::RemoteDisplayListRecorder::drawControlPart):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):

Originally-landed-as: 272448.998@safari-7618-branch (dac0ebcb77d8). rdar://132958419
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fef989d57caa136d7e4e7b3912b9ac69bae707a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12047 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49489 "Failure limit exceed. At least found 415 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/add-children-pseudo-element.html accessibility/adjacent-continuations-cause-assertion-failure.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8191 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/CSSKeyframesRule-parameters.html animations/added-while-suspended.html animations/additive-transform-animations.html animations/animation-border-overflow.html animations/animation-callback-timestamp.html animations/animation-controller-drt-api.html animations/animation-direction-normal.html animations/animation-direction-reverse-fill-mode-hardware.html animations/animation-direction-reverse-fill-mode.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53047 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30319 "Found 27 new API test failures: /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /TestWebKit:WebKit.RestoreSessionStateContainingFormData, /TestWebKit:WebKit.PageLoadTwiceAndReload, /TestWebKit:WebKit.PageLoadState, /TestWebKit:WebKit.FocusedFrameAfterCrash, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, /WPE/TestWebKitWebView:/webkit/WebKitWebView/page-visibility ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10375 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56860 "Failure limit exceed. At least found 438 new test failures: accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-reparent.html accessibility/active-descendant-changes-result-in-focus-changes.html accessibility/alt-tag-on-image-with-nonimage-role.html accessibility/anchor-linked-anonymous-block-crash.html accessibility/anonymous-render-block-in-continuation-causes-crash.html accessibility/appearance-none-meter-and-progress-elements.html accessibility/aria-activedescendant-crash.html accessibility/aria-busy.html accessibility/aria-cellspans-with-native-cellspans.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53010 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57058 "Found 49 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/scroll-to, /TestWebKit:WebKit.PageLoadTwiceAndReload, /TestWebKit:WebKit.ParentFrame, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4279 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36388 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37471 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->