### PR TITLE
Add a category-breakdown to compare-results

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -143,6 +143,17 @@ def detailedJetStream2Breakdown(jsonObject):
             result[test + "-" + subtest] = breakdown._results["JetStream2.0"]["tests"][test]["tests"][subtest]["metrics"]["Time"][None]["current"]
     return result
 
+def categoryJetStream2Breakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "ms"
+    for test in breakdown._results["JetStream2.0"]["tests"].keys():
+        for category in breakdown._results["JetStream2.0"]["tests"][test]["tests"]:
+            if not category in result:
+                result[category] = []
+            result[category] += breakdown._results["JetStream2.0"]["tests"][test]["tests"][category]["metrics"]["Time"][None]["current"]
+    return result
+
 def jetStream3Breakdown(jsonObject):
     breakdown = BenchmarkResults(jsonObject)
     result = {}
@@ -158,6 +169,17 @@ def detailedJetStream3Breakdown(jsonObject):
     for test in breakdown._results["JetStream3.0"]["tests"].keys():
         for subtest in breakdown._results["JetStream3.0"]["tests"][test]["tests"]:
             result[test + "-" + subtest] = breakdown._results["JetStream3.0"]["tests"][test]["tests"][subtest]["metrics"]["Time"][None]["current"]
+    return result
+
+def categoryJetStream3Breakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "ms"
+    for test in breakdown._results["JetStream3.0"]["tests"].keys():
+        for category in breakdown._results["JetStream3.0"]["tests"][test]["tests"]:
+            if not category in result:
+                result[category] = []
+            result[category] += breakdown._results["JetStream3.0"]["tests"][test]["tests"][category]["metrics"]["Time"][None]["current"]
     return result
 
 def motionMarkBreakdown(jsonObject):
@@ -635,13 +657,14 @@ def getOptions():
     parser.add_argument("--detailed-breakdown", action="store_true",
         default=False, help="Print a detailed breakdown per subtest.")
 
+    parser.add_argument("--category-breakdown", action="store_true",
+        default=False, help="Print a breakdown per category. (e.g. startup, average, worst)")
+
     return parser.parse_known_args()[0]
 
 
 def main():
     args = getOptions()
-    if args.detailed_breakdown:
-        args.breakdown = True
 
     # Flatten the list of lists of JSON files.
     a = itertools.chain.from_iterable(args.a)
@@ -662,33 +685,34 @@ def main():
         sys.exit(1)
     
     if typeA == JetStream2:
+        if args.detailed_breakdown:
+            dumpBreakdowns(detailedJetStream2Breakdown(a), detailedJetStream2Breakdown(b))
+        if args.category_breakdown:
+            dumpBreakdowns(categoryJetStream2Breakdown(a), categoryJetStream2Breakdown(b))
         if args.breakdown:
-            if args.detailed_breakdown:
-                dumpBreakdowns(detailedJetStream2Breakdown(a), detailedJetStream2Breakdown(b))
-            else:
-                dumpBreakdowns(jetStream2Breakdown(a), jetStream2Breakdown(b))
+            dumpBreakdowns(jetStream2Breakdown(a), jetStream2Breakdown(b))
 
         ttest(typeA, JetStream2Results(a), JetStream2Results(b))
 
         if args.csv:
             writeCSV(jetStream2Breakdown(a), jetStream2Breakdown(b), args.csv)
     elif typeA == JetStream3:
+        if args.detailed_breakdown:
+            dumpBreakdowns(detailedJetStream3Breakdown(a), detailedJetStream3Breakdown(b))
+        if args.category_breakdown:
+            dumpBreakdowns(categoryJetStream3Breakdown(a), categoryJetStream3Breakdown(b))
         if args.breakdown:
-            if args.detailed_breakdown:
-                dumpBreakdowns(detailedJetStream3Breakdown(a), detailedJetStream3Breakdown(b))
-            else:
-                dumpBreakdowns(jetStream3Breakdown(a), jetStream3Breakdown(b))
+            dumpBreakdowns(jetStream3Breakdown(a), jetStream3Breakdown(b))
 
         ttest(typeA, JetStream3Results(a), JetStream3Results(b))
 
         if args.csv:
             writeCSV(jetStream3Breakdown(a), jetStream3Breakdown(b), args.csv)
     elif typeA == Speedometer2:
+        if args.detailed_breakdown:
+            dumpBreakdowns(speedometer2BreakdownSyncAsync(a), speedometer2BreakdownSyncAsync(b))
         if args.breakdown:
-            if args.detailed_breakdown:
-                dumpBreakdowns(speedometer2BreakdownSyncAsync(a), speedometer2BreakdownSyncAsync(b))
-            else:
-                dumpBreakdowns(speedometer2Breakdown(a), speedometer2Breakdown(b))
+            dumpBreakdowns(speedometer2Breakdown(a), speedometer2Breakdown(b))
 
         ttest(typeA, Speedometer2Results(a), Speedometer2Results(b))
 
@@ -696,11 +720,10 @@ def main():
             writeCSV(speedometer2Breakdown(a), speedometer2Breakdown(b), args.csv)
 
     elif typeA == Speedometer3:
+        if args.detailed_breakdown:
+            dumpBreakdowns(speedometer3BreakdownSyncAsync(a), speedometer3BreakdownSyncAsync(b))
         if args.breakdown:
-            if args.detailed_breakdown:
-                dumpBreakdowns(speedometer3BreakdownSyncAsync(a), speedometer3BreakdownSyncAsync(b))
-            else:
-                dumpBreakdowns(speedometer3Breakdown(a), speedometer3Breakdown(b))
+            dumpBreakdowns(speedometer3Breakdown(a), speedometer3Breakdown(b))
 
         ttest(typeA, Speedometer3Results(a), Speedometer3Results(b))
 


### PR DESCRIPTION
#### 5c9edc56375937ca181745a48c0a7e5fa2a95b7a
<pre>
Add a category-breakdown to compare-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=277646">https://bugs.webkit.org/show_bug.cgi?id=277646</a>
<a href="https://rdar.apple.com/133235581">rdar://133235581</a>

Reviewed by Yusuke Suzuki.

This provides a breakdown per benchamrk category (e.g. Worst, Startup, Average in JetStream2).
This looks like:

-------------------------------------------------------------------------------------------------------
| subtest |     ms       |     ms       |  b / a   | pValue (significance using False Discovery Rate) |
-------------------------------------------------------------------------------------------------------
| Average |19.187656     |19.209764     |1.001152  | 0.992457                                         |
| First   |32.916071     |32.796429     |0.996365  | 0.969416                                         |
| MainRun |2385.500000   |2386.600000   |1.000461  | 0.914809                                         |
| Runtime |629.700000    |632.100000    |1.003811  | 0.984437                                         |
| Startup |8.140000      |3.000000      |0.368550  | 0.041433                                         |
| Stdlib  |1224.500000   |1221.100000   |0.997223  | 0.271944                                         |
| Worst   |22.904464     |22.745536     |0.993061  | 0.947732                                         |
-------------------------------------------------------------------------------------------------------

for JetStream2. I only added it to JetStream2/3 since those benchmarks have a lot of different categories.

I also changed the script so it will log `--detailed-breakdown` and `--breakdown` if both are passed
rather than just `--detailed-breakdown`.

* Tools/Scripts/compare-results:
(detailedJetStream2Breakdown):
(categoryJetStream2Breakdown):
(detailedJetStream3Breakdown):
(getOptions):
(main):

Canonical link: <a href="https://commits.webkit.org/281867@main">https://commits.webkit.org/281867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fcf16c317969b5cb3064259de7d7943b3c85b0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12090 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8212 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10298 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5213 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56883 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57085 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4305 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9214 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37514 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->