### PR TITLE
[Navigation] Add finished promise to NavigationTransition

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error
+
+PASS NavigationTransition finished promise is fulfilled on success
+FAIL NavigationTransition finished promise is rejected on error assert_unreached: Navigation should not succeed Reached unreachable code
+

--- a/LayoutTests/http/wpt/navigation-api/transition-promises.html
+++ b/LayoutTests/http/wpt/navigation-api/transition-promises.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Navigation API Transition Promises</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+promise_test(async t => {
+    // Wait for after the load event so that the navigation doesn't get converted
+    // into a replace navigation.
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+
+    let transition_finished = false;
+
+    navigation.onnavigate = t.step_func(e => {
+        e.intercept({ handler: async () => { }});
+    });
+
+    navigation.onnavigateerror = t.unreached_func('Navigation should not error');
+
+    navigation.onnavigatesuccess = t.step_func(e => {
+        navigation.transition.finished.then(() => {
+            transition_finished = true;
+        })
+    });
+
+    await navigation.navigate("#1");
+
+    // The navigation resolves before the transition does.
+    await new Promise(resolve => t.step_timeout(resolve, 0));
+
+    assert_true(transition_finished);
+    t.done();
+}, "NavigationTransition finished promise is fulfilled on success");
+
+promise_test(async t => {
+    let transition_finished = false;
+
+    navigation.onnavigate = t.step_func(e => {
+        e.intercept({ handler: async () => {
+            throw new Error();
+        }});
+    });
+
+    navigation.onnavigatesuccess = t.unreached_func('Navigation should not succeed');
+
+    navigation.onnavigateerror = t.step_func(e => {
+        navigation.transition.finished.then(t.unreached_func('Transition should not be fullfilled'));
+        navigation.transition.finished.catch(() => {
+            // FIXME: Test error is the same as thrown.
+            transition_finished = true;
+        })
+    });
+
+    await navigation.navigate("#1");
+
+    // The navigation resolves before the transition does.
+    await new Promise(resolve => t.step_timeout(resolve, 0));
+
+    assert_true(transition_finished);
+    t.done();
+}, "NavigationTransition finished promise is rejected on error");
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -167,7 +167,7 @@ private:
     RefPtr<NavigationAPIMethodTracker> addUpcomingTrarveseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
     void cleanupAPIMethodTracker(NavigationAPIMethodTracker*);
     void resolveFinishedPromise(NavigationAPIMethodTracker*);
-    void rejectFinishedPromise(NavigationAPIMethodTracker*, Exception&&, JSC::JSValue exceptionObject);
+    void rejectFinishedPromise(NavigationAPIMethodTracker*, const Exception&, JSC::JSValue exceptionObject);
     void abortOngoingNavigation(NavigateEvent&);
     void promoteUpcomingAPIMethodTracker(const String& destinationKey);
     void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -32,10 +32,31 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationTransition);
 
-NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry)
+NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& finished)
     : m_navigationType(type)
     , m_from(WTFMove(fromEntry))
+    , m_finished(WTFMove(finished))
 {
+}
+
+void NavigationTransition::resolvePromise()
+{
+    m_finished->resolve();
+}
+
+void NavigationTransition::rejectPromise(Exception& exception)
+{
+    m_finished->reject(exception, RejectAsHandled::Yes);
+}
+
+DOMPromise* NavigationTransition::finished()
+{
+    if (!m_finishedDOMPromise) {
+        auto& promise = *jsCast<JSC::JSPromise*>(m_finished->promise());
+        m_finishedDOMPromise = DOMPromise::create(*m_finished->globalObject(), promise);
+    }
+
+    return m_finishedDOMPromise.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -28,27 +28,30 @@
 #include "JSDOMPromise.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationNavigationType.h"
-#include "ScriptWrappable.h"
 
 namespace WebCore {
 
 class DOMPromise;
 
-class NavigationTransition final : public RefCounted<NavigationTransition>, public ScriptWrappable {
+class NavigationTransition final : public RefCounted<NavigationTransition> {
     WTF_MAKE_ISO_ALLOCATED(NavigationTransition);
 public:
-    static Ref<NavigationTransition> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry) { return adoptRef(*new NavigationTransition(type, WTFMove(fromEntry))); };
+    static Ref<NavigationTransition> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& finished) { return adoptRef(*new NavigationTransition(type, WTFMove(fromEntry), WTFMove(finished))); };
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry& from() { return m_from; };
-    DOMPromise* finished() { return m_finished.get(); };
+    DOMPromise* finished();
+
+    void resolvePromise();
+    void rejectPromise(Exception&);
 
 private:
-    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry);
+    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& finished);
 
     NavigationNavigationType m_navigationType;
     Ref<NavigationHistoryEntry> m_from;
-    RefPtr<DOMPromise> m_finished;
+    Ref<DeferredPromise> m_finished;
+    RefPtr<DOMPromise> m_finishedDOMPromise;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8467cf6fcc1de1cfa291c50575c4ec1b34387ed5
<pre>
[Navigation] Add finished promise to NavigationTransition
<a href="https://bugs.webkit.org/show_bug.cgi?id=277264">https://bugs.webkit.org/show_bug.cgi?id=277264</a>

Reviewed by Alex Christensen.

This creates a promise in NavigationTransition and resolves it per the spec:

<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm">https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm</a> (Steps 32.4, 33.4.7)

A test case for success and error were added. The error one currently
fails but will work after #31463 lands.

* LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt: Added.
* LayoutTests/http/wpt/navigation-api/transition-promises.html: Added.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationTransition.cpp:
(WebCore::NavigationTransition::NavigationTransition):
(WebCore::NavigationTransition::resolvePromise):
(WebCore::NavigationTransition::rejectPromise):
(WebCore::NavigationTransition::finished):
* Source/WebCore/page/NavigationTransition.h:

Canonical link: <a href="https://commits.webkit.org/282085@main">https://commits.webkit.org/282085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7771b16f3c1a37f385efdf425e709fb9cc040a53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49857 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8595 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67591 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5826 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10901 "Found 60 new test failures: fast/css-grid-layout/floating-empty-grids.html fast/css-grid-layout/mozilla/grid-repeat-auto-fill-fit-002.html fast/css-grid-layout/mozilla/grid-repeat-auto-fill-fit-003.html fast/css-grid-layout/mozilla/grid-repeat-auto-fill-fit-004.html fast/css-grid-layout/mozilla/grid-repeat-auto-fill-fit-005-part-1.html fast/css-grid-layout/mozilla/grid-repeat-auto-fill-fit-005-part-2.html fast/css/aspect-ratio-min-height-replaced.html fast/scrolling/mac/scrollbars/overlay-scrollbar-hovered.html http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html http/wpt/opener/parent-access-child-via-windowproxy.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57241 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57482 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4773 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37037 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->