### PR TITLE
heap-use-after-free | WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope; WebCore::WorkerOrWorkletThread::workerOrWorkletThread; WTF::Thread::entryPoint)

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -87,8 +87,10 @@ void AudioDestinationNode::renderQuantum(AudioBus* destinationBus, size_t number
     context().handlePreRenderTasks(outputPosition);
 
     RefPtr<AudioWorkletGlobalScope> workletGlobalScope;
-    if (RefPtr audioWorkletProxy = context().audioWorklet().proxy())
-        workletGlobalScope = audioWorkletProxy->workletThread().globalScope();
+    if (RefPtr audioWorkletProxy = context().audioWorklet().proxy()) {
+        if (Ref workletThread = audioWorkletProxy->workletThread(); workletThread->thread() == &Thread::current())
+            workletGlobalScope = workletThread->globalScope();
+    }
     if (workletGlobalScope)
         workletGlobalScope->handlePreRenderTasks();
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -192,10 +192,9 @@ AudioWorkletThread& AudioWorkletGlobalScope::thread() const
 void AudioWorkletGlobalScope::handlePreRenderTasks()
 {
     // This makes sure that we only drain the MicroTask queue after each render quantum.
-    // It is only safe to grab the lock if we are on the context thread. We might get called on
-    // another thread if audio rendering started before the audio worklet got started.
-    if (isContextThread())
-        m_delayMicrotaskDrainingDuringRendering = script()->vm().drainMicrotaskDelayScope();
+    // It is only safe to grab the lock if we are on the context thread.
+    RELEASE_ASSERT(isContextThread());
+    m_delayMicrotaskDrainingDuringRendering = script()->vm().drainMicrotaskDelayScope();
 }
 
 void AudioWorkletGlobalScope::handlePostRenderTasks(size_t currentFrame)

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -195,6 +195,7 @@ SocketProvider* WorkerThread::socketProvider()
 
 WorkerGlobalScope* WorkerThread::globalScope()
 {
+    ASSERT(!thread() || thread() == &Thread::current());
     return downcast<WorkerGlobalScope>(WorkerOrWorkletThread::globalScope());
 }
 


### PR DESCRIPTION
#### f80743cbb13c7ae9bcb75cc9c4e326f83e3b5c4c
<pre>
heap-use-after-free | WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope; WebCore::WorkerOrWorkletThread::workerOrWorkletThread; WTF::Thread::entryPoint)
<a href="https://rdar.apple.com/131127484">rdar://131127484</a>

Reviewed by Ryosuke Niwa.

AudioWorkletGlobalScope is RefCounted so it is unsafe to ref/unref it from various threads.
Before this patch, AudioDestinationNode::renderQuantum may either be called from the audio worklet thread (expected) or the audio rendering thread at init time (unexpected).
This is done to call AudioWorkletGlobalScope::handlePreRenderTasks, which is a no-op if called in another thread than the worklet thread.

To fix the issue, if we are not in the context thread, we do not ref AudioWorkletGlobalScope in AudioDestinationNode::renderQuantum.
AudioWorkletGlobalScope::handlePreRenderTasks will then no longer be called in another thread than the worklet thread.
We update AudioWorkletGlobalScope::handlePreRenderTasks accordingly.

* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::renderQuantum):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::handlePreRenderTasks):
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::globalScope):

Originally-landed-as: f98cf4e20b37. <a href="https://rdar.apple.com/132955637">rdar://132955637</a>
Canonical link: <a href="https://commits.webkit.org/281918@main">https://commits.webkit.org/281918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566abc21624fd82bf7fe8c7db22d7149206a096b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49497 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30328 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5193 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10386 "Found 1 new test failure: media/video-playsinline.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57071 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4295 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36411 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->