### PR TITLE
Check whether overflowLayer is composited in appendOverflowLayerNodeID

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-into-view-on-composited-scrollable-overflow-layer-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-into-view-on-composited-scrollable-overflow-layer-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash or assert.
+
+

--- a/LayoutTests/fast/scrolling/scroll-into-view-on-composited-scrollable-overflow-layer-crash.html
+++ b/LayoutTests/fast/scrolling/scroll-into-view-on-composited-scrollable-overflow-layer-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<style>
+  #scroller {
+      width: 200px;
+      height: 200px;
+      overflow: scroll;
+  }
+  #container {
+      perspective: 1px;
+      margin-left: 150vw;
+  }
+  table {
+      overflow-y: auto;
+  }
+  caption {
+      writing-mode: vertical-lr;
+      opacity: .9;
+  }
+  #fixed {
+      position: fixed;
+  }
+  #rect {
+      width: 500px;
+      height: 200px;
+  }
+</style>
+<p>PASS if no crash or assert.</p>
+<div id="scroller">
+  <div id="container">
+    <table id="table">
+      <caption>
+        <span id="fixed"></span>
+        <div id="rect"></div>
+      </caption>
+    </table>
+  </div>
+</div>
+<script>
+  if (window.testRunner)
+      testRunner.dumpAsText();
+  table.scrollIntoView();
+</script>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4056,11 +4056,13 @@ static void collectStationaryLayerRelatedOverflowNodes(const RenderLayer& layer,
 
     auto appendOverflowLayerNodeID = [&scrollingNodes] (const RenderLayer& overflowLayer) {
         ASSERT(overflowLayer.isComposited());
-        auto scrollingNodeID = overflowLayer.backing()->scrollingNodeIDForRole(ScrollCoordinationRole::Scrolling);
-        if (scrollingNodeID)
-            scrollingNodes.append(scrollingNodeID);
-        else
-            LOG(Scrolling, "Layer %p doesn't have scrolling node ID yet", &overflowLayer);
+        if (overflowLayer.isComposited()) {
+            if (auto scrollingNodeID = overflowLayer.backing()->scrollingNodeIDForRole(ScrollCoordinationRole::Scrolling)) {
+                scrollingNodes.append(scrollingNodeID);
+                return;
+            }
+        }
+        LOG(Scrolling, "Layer %p isn't composited or doesn't have scrolling node ID yet", &overflowLayer);
     };
 
     // Collect all the composited scrollers which affect the position of this layer relative to its compositing ancestor (which might be inside the scroller or the scroller itself).


### PR DESCRIPTION
#### aad1e95e11d2afc44bd5711895f099e7694c7e41
<pre>
Check whether overflowLayer is composited in appendOverflowLayerNodeID
<a href="https://bugs.webkit.org/show_bug.cgi?id=272972">https://bugs.webkit.org/show_bug.cgi?id=272972</a>
<a href="https://rdar.apple.com/126745401">rdar://126745401</a>

Reviewed by Simon Fraser.

The call to appendOverflowLayerNodeID is conditioned on
hasCompositedScrollableOverflow() but as explained in r243908 that does
not guarantee that the layer is composited. Add a null-check in addition
to the debug ASSERT(overflowLayer.isComposited()), making this
consistent with updateScrollingNodeForScrollingProxyRole and
setupScrollProxyRelatedOverflowScrollingNode.

A non-regression test is added. In MiniBrowser, it is crashing without
the null-check, and it is still failing related debug ASSERTIONs. So far
it has always run normally in WebKitTestRunner though.

* LayoutTests/fast/scrolling/scroll-into-view-on-composited-scrollable-overflow-layer-crash-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-into-view-on-composited-scrollable-overflow-layer-crash.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::collectStationaryLayerRelatedOverflowNodes): Add a null-check and tweak log error.

Originally-landed-as: 277198.4@webkit-2024.4-embargoed (9a7d6e22efa6). <a href="https://rdar.apple.com/132955154">rdar://132955154</a>
Canonical link: <a href="https://commits.webkit.org/281901@main">https://commits.webkit.org/281901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6775f0425a34564de0db37394ae73434f2cca44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11818 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49511 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8214 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10303 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10731 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66950 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10402 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56886 "Found 1 new test failure: imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/update-the-rendering.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57088 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4307 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36434 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->