### PR TITLE
[Text Directionality] Setting `.value =` sometimes doesn't update dir=auto inputs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL <input dir=auto type=hidden> directionality assert_true: expected true got false
-FAIL <input dir=auto type=text> directionality assert_true: expected true got false
-FAIL <input dir=auto type=search> directionality assert_true: expected true got false
-FAIL <input dir=auto type=tel> directionality assert_true: expected true got false
-FAIL <input dir=auto type=url> directionality assert_true: expected true got false
-FAIL <input dir=auto type=email> directionality assert_true: expected true got false
-FAIL <input dir=auto type=password> directionality assert_true: expected true got false
-FAIL <input dir=auto type=submit> directionality assert_true: expected true got false
-FAIL <input dir=auto type=reset> directionality assert_true: expected true got false
-FAIL <input dir=auto type=button> directionality assert_true: expected true got false
+PASS <input dir=auto type=hidden> directionality
+PASS <input dir=auto type=text> directionality
+PASS <input dir=auto type=search> directionality
+PASS <input dir=auto type=tel> directionality
+PASS <input dir=auto type=url> directionality
+PASS <input dir=auto type=email> directionality
+PASS <input dir=auto type=password> directionality
+PASS <input dir=auto type=submit> directionality
+PASS <input dir=auto type=reset> directionality
+PASS <input dir=auto type=button> directionality
 PASS <input dir=auto type=date> directionality
 PASS <input dir=auto type=month> directionality
 PASS <input dir=auto type=week> directionality

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL <input dir=auto type=hidden> directionality assert_true: expected true got false
-FAIL <input dir=auto type=text> directionality assert_true: expected true got false
-FAIL <input dir=auto type=search> directionality assert_true: expected true got false
-FAIL <input dir=auto type=tel> directionality assert_true: expected true got false
-FAIL <input dir=auto type=url> directionality assert_true: expected true got false
-FAIL <input dir=auto type=email> directionality assert_true: expected true got false
-FAIL <input dir=auto type=password> directionality assert_true: expected true got false
-FAIL <input dir=auto type=submit> directionality assert_true: expected true got false
-FAIL <input dir=auto type=reset> directionality assert_true: expected true got false
-FAIL <input dir=auto type=button> directionality assert_true: expected true got false
+PASS <input dir=auto type=hidden> directionality
+PASS <input dir=auto type=text> directionality
+PASS <input dir=auto type=search> directionality
+PASS <input dir=auto type=tel> directionality
+PASS <input dir=auto type=url> directionality
+PASS <input dir=auto type=email> directionality
+PASS <input dir=auto type=password> directionality
+PASS <input dir=auto type=submit> directionality
+PASS <input dir=auto type=reset> directionality
+PASS <input dir=auto type=button> directionality
 FAIL <input dir=auto type=date> directionality assert_equals: expected "date" but got "text"
 FAIL <input dir=auto type=month> directionality assert_equals: expected "month" but got "text"
 FAIL <input dir=auto type=week> directionality assert_equals: expected "week" but got "text"

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL <input dir=auto type=hidden> directionality assert_true: expected true got false
-FAIL <input dir=auto type=text> directionality assert_true: expected true got false
-FAIL <input dir=auto type=search> directionality assert_true: expected true got false
-FAIL <input dir=auto type=tel> directionality assert_true: expected true got false
-FAIL <input dir=auto type=url> directionality assert_true: expected true got false
-FAIL <input dir=auto type=email> directionality assert_true: expected true got false
-FAIL <input dir=auto type=password> directionality assert_true: expected true got false
-FAIL <input dir=auto type=submit> directionality assert_true: expected true got false
-FAIL <input dir=auto type=reset> directionality assert_true: expected true got false
-FAIL <input dir=auto type=button> directionality assert_true: expected true got false
+PASS <input dir=auto type=hidden> directionality
+PASS <input dir=auto type=text> directionality
+PASS <input dir=auto type=search> directionality
+PASS <input dir=auto type=tel> directionality
+PASS <input dir=auto type=url> directionality
+PASS <input dir=auto type=email> directionality
+PASS <input dir=auto type=password> directionality
+PASS <input dir=auto type=submit> directionality
+PASS <input dir=auto type=reset> directionality
+PASS <input dir=auto type=button> directionality
 FAIL <input dir=auto type=date> directionality assert_equals: expected "date" but got "text"
 FAIL <input dir=auto type=month> directionality assert_equals: expected "month" but got "text"
 FAIL <input dir=auto type=week> directionality assert_equals: expected "week" but got "text"

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -811,6 +811,8 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
             setFormControlValueMatchesRenderer(false);
         }
         updateValidity();
+        if (selfOrPrecedingNodesAffectDirAuto())
+            updateEffectiveDirectionalityOfDirAuto();
         m_valueAttributeWasUpdatedAfterParsing = !m_parsingInProgress;
         break;
     case AttributeNames::nameAttr:


### PR DESCRIPTION
#### ef6cd5cc4e16ac3adf78d8b8481412e60d8c3266
<pre>
[Text Directionality] Setting `.value =` sometimes doesn&apos;t update dir=auto inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=276873">https://bugs.webkit.org/show_bug.cgi?id=276873</a>
<a href="https://rdar.apple.com/132214207">rdar://132214207</a>

Reviewed by Tim Nguyen.

Like what we do when the `value` property of an &lt;input&gt; element changes, we need
to update the effective directionality when its `value` atttribute changes.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-form-associated.window-expected.txt:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/281877@main">https://commits.webkit.org/281877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e21b86f48a9e4d2afdc7a34a0338414bb82cdf4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11857 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49535 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8237 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10770 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66989 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57114 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4338 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38650 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->