### PR TITLE
Make `css-text-decor/invalidation/text-decoration-thickness.html` independent of viewport size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-expected.html
@@ -8,7 +8,8 @@
             text-decoration-thickness: 3px;
         }
     </style>
+    <p>The link below should increase its underline thickness when hovered:</p>
     <div style="font-size: 28px;">
-        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+        <a href="#" id="link">Hover me</a>
     </div>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
@@ -8,7 +8,8 @@
             text-decoration-thickness: 3px;
         }
     </style>
+    <p>The link below should increase its underline thickness when hovered:</p>
     <div style="font-size: 28px;">
-        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+        <a href="#" id="link">Hover me</a>
     </div>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html
@@ -15,8 +15,9 @@
             text-decoration-thickness: 3px;
         }
     </style>
+    <p>The link below should increase its underline thickness when hovered:</p>
     <div style="font-size: 28px;">
-        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+        <a href="#" id="link">Hover me</a>
     </div>
     <script src="/resources/testdriver.js"></script>
     <script src="/resources/testdriver-actions.js"></script>


### PR DESCRIPTION
#### cff53b3fb016f9a501635f3762bc598967c07dd6
<pre>
Make `css-text-decor/invalidation/text-decoration-thickness.html` independent of viewport size
<a href="https://bugs.webkit.org/show_bug.cgi?id=277653">https://bugs.webkit.org/show_bug.cgi?id=277653</a>
<a href="https://rdar.apple.com/133249123">rdar://133249123</a>

Reviewed by Tim Nguyen.

Currently, this test can erroneously fail if the text is split into two lines and the following conditions are met;

1. The length of the second line is less than half the length of the first line
2. A click/hover happens in the center of the entire text

In this case, the click/hover does not actually end up over the text, and the test fails.

Fix by limiting the text&apos;s width so that it always wraps sufficiently, even on large viewport widths.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html:

Canonical link: <a href="https://commits.webkit.org/281861@main">https://commits.webkit.org/281861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/763950e82774d600874d836c8beb66a8ecd5c341

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30349 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10313 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10741 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5226 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53050 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13657 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4317 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->