### PR TITLE
Make LengthSize and LengthPoint consistent

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -1017,8 +1017,8 @@ private:
     {
         auto fromLengthPoint = value(from);
         auto toLengthPoint = value(to);
-        return lengthsRequireBlendingForAccumulativeIteration(fromLengthPoint.x(), toLengthPoint.x())
-            || lengthsRequireBlendingForAccumulativeIteration(fromLengthPoint.y(), toLengthPoint.y());
+        return lengthsRequireBlendingForAccumulativeIteration(fromLengthPoint.x, toLengthPoint.x)
+            || lengthsRequireBlendingForAccumulativeIteration(fromLengthPoint.y, toLengthPoint.y);
     }
 
     void blend(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const CSSPropertyBlendingContext& context) const final
@@ -1048,7 +1048,7 @@ private:
         auto valueFrom = value(from);
         auto valueTo = value(to);
 
-        return !valueFrom.x().isAuto() && !valueTo.x().isAuto() && !valueFrom.x().isNormal() && !valueTo.x().isNormal();
+        return !valueFrom.x.isAuto() && !valueTo.x.isAuto() && !valueFrom.x.isNormal() && !valueTo.x.isNormal();
     }
 };
 

--- a/Source/WebCore/css/BasicShapeConversion.cpp
+++ b/Source/WebCore/css/BasicShapeConversion.cpp
@@ -92,7 +92,7 @@ Ref<CSSValue> valueForBasicShape(const RenderStyle& style, const BasicShape& bas
         return CSSValuePair::create(createValue(size.width), createValue(size.height));
     };
     auto createCoordinatePair = [&](const LengthPoint& point) {
-        return CSSValuePair::createNoncoalescing(createValue(point.x()), createValue(point.y()));
+        return CSSValuePair::createNoncoalescing(createValue(point.x), createValue(point.y));
     };
     auto createReflectedSumValue = [&](const Length& a, const Length& b) {
         auto reflected = convertTo100PercentMinusLengthSum(a, b);

--- a/Source/WebCore/css/BasicShapesShapeSegmentConversion.cpp
+++ b/Source/WebCore/css/BasicShapesShapeSegmentConversion.cpp
@@ -43,8 +43,8 @@ static auto lengthToCSSValue(const Length& value, const RenderStyle& style)
 static auto lengthPointToCSSValue(const LengthPoint& value, const RenderStyle& style)
 {
     return CSSValuePair::createNoncoalescing(
-        CSSPrimitiveValue::create(value.x(), style),
-        CSSPrimitiveValue::create(value.y(), style));
+        CSSPrimitiveValue::create(value.x, style),
+        CSSPrimitiveValue::create(value.y, style));
 }
 
 static auto lengthSizeToCSSValue(const LengthSize& value, const RenderStyle& style)

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1930,18 +1930,18 @@ static Element* styleElementForNode(Node* node)
 
 static Ref<CSSValue> valueForPosition(const RenderStyle& style, const LengthPoint& position)
 {
-    return CSSValueList::createSpaceSeparated(ComputedStyleExtractor::zoomAdjustedPixelValueForLength(position.x(), style),
-        ComputedStyleExtractor::zoomAdjustedPixelValueForLength(position.y(), style));
+    return CSSValueList::createSpaceSeparated(ComputedStyleExtractor::zoomAdjustedPixelValueForLength(position.x, style),
+        ComputedStyleExtractor::zoomAdjustedPixelValueForLength(position.y, style));
 }
 
 static bool isAuto(const LengthPoint& position)
 {
-    return position.x().isAuto() && position.y().isAuto();
+    return position.x.isAuto() && position.y.isAuto();
 }
 
 static bool isNormal(const LengthPoint& position)
 {
-    return position.x().isNormal();
+    return position.x.isNormal();
 }
 
 static Ref<CSSValue> valueForPositionOrAuto(const RenderStyle& style, const LengthPoint& position)
@@ -2010,7 +2010,7 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
     case PathOperation::Type::Ray: {
         auto& ray = uncheckedDowncast<RayPathOperation>(*operation);
         auto angle = CSSPrimitiveValue::create(ray.angle(), CSSUnitType::CSS_DEG);
-        RefPtr<CSSValuePair> position = ray.position().x().isAuto() ? nullptr : RefPtr { CSSValuePair::createNoncoalescing(Ref { ComputedStyleExtractor::zoomAdjustedPixelValueForLength(ray.position().x(), style) }, Ref { ComputedStyleExtractor::zoomAdjustedPixelValueForLength(ray.position().y(), style) }) };
+        RefPtr<CSSValuePair> position = ray.position().x.isAuto() ? nullptr : RefPtr { CSSValuePair::createNoncoalescing(Ref { ComputedStyleExtractor::zoomAdjustedPixelValueForLength(ray.position().x, style) }, Ref { ComputedStyleExtractor::zoomAdjustedPixelValueForLength(ray.position().y, style) }) };
         return CSSRayValue::create(WTFMove(angle), valueIDForRaySize(ray.size()), ray.isContaining(), WTFMove(position), ray.referenceBox());
     }
     }

--- a/Source/WebCore/platform/LengthFunctions.cpp
+++ b/Source/WebCore/platform/LengthFunctions.cpp
@@ -126,7 +126,7 @@ LayoutSize sizeForLengthSize(const LengthSize& length, const LayoutSize& maximum
 
 LayoutPoint pointForLengthPoint(const LengthPoint& lengthPoint, const LayoutSize& maximumValue)
 {
-    return { valueForLength(lengthPoint.x(), maximumValue.width()), valueForLength(lengthPoint.y(), maximumValue.height()) };
+    return { valueForLength(lengthPoint.x, maximumValue.width()), valueForLength(lengthPoint.y, maximumValue.height()) };
 }
 
 FloatSize floatSizeForLengthSize(const LengthSize& lengthSize, const FloatSize& boxSize)
@@ -136,7 +136,7 @@ FloatSize floatSizeForLengthSize(const LengthSize& lengthSize, const FloatSize& 
 
 FloatPoint floatPointForLengthPoint(const LengthPoint& lengthPoint, const FloatSize& boxSize)
 {
-    return { floatValueForLength(lengthPoint.x(), boxSize.width()), floatValueForLength(lengthPoint.y(), boxSize.height()) };
+    return { floatValueForLength(lengthPoint.x, boxSize.width()), floatValueForLength(lengthPoint.y, boxSize.height()) };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/LengthPoint.cpp
+++ b/Source/WebCore/platform/LengthPoint.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 TextStream& operator<<(TextStream& ts, const LengthPoint& size)
 {
-    return ts << size.x() << " " << size.y();
+    return ts << size.x << " " << size.y;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/LengthPoint.h
+++ b/Source/WebCore/platform/LengthPoint.h
@@ -32,36 +32,25 @@ namespace WebCore {
 struct BlendingContext;
 
 struct LengthPoint {
-public:
-    LengthPoint()
-    {
-    }
-    
+    LengthPoint() = default;
+
     LengthPoint(Length x, Length y)
-        : m_x(WTFMove(x))
-        , m_y(WTFMove(y))
+        : x(x)
+        , y(y)
     {
     }
 
+    // FIXME: it would be nice to pack the two Lengths together better somehow (to avoid padding between them).
+    Length x;
+    Length y;
     friend bool operator==(const LengthPoint&, const LengthPoint&) = default;
 
-    void setX(Length x) { m_x = WTFMove(x); }
-    const Length& x() const { return m_x; }
-
-    void setY(Length y) { m_y = WTFMove(y); }
-    const Length& y() const { return m_y; }
-
-    bool isZero() const { return m_x.isZero() && m_y.isZero(); }
-
-private:
-    // FIXME: it would be nice to pack the two Lengths together better somehow (to avoid padding between them).
-    Length m_x;
-    Length m_y;
+    bool isZero() const { return x.isZero() && y.isZero(); }
 };
 
 inline LengthPoint blend(const LengthPoint& from, const LengthPoint& to, const BlendingContext& context)
 {
-    return LengthPoint(blend(from.x(), to.x(), context), blend(from.y(), to.y(), context));
+    return LengthPoint(blend(from.x, to.x, context), blend(from.y, to.y, context));
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const LengthPoint&);

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -93,11 +93,11 @@ AcceleratedEffectValues AcceleratedEffectValues::clone() const
 
 static LengthPoint nonCalculatedLengthPoint(LengthPoint lengthPoint, const IntSize& borderBoxSize)
 {
-    if (!lengthPoint.x().isCalculated() && !lengthPoint.y().isCalculated())
+    if (!lengthPoint.x.isCalculated() && !lengthPoint.y.isCalculated())
         return lengthPoint;
     return {
-        { floatValueForLength(lengthPoint.x(), borderBoxSize.width()), LengthType::Fixed },
-        { floatValueForLength(lengthPoint.y(), borderBoxSize.height()), LengthType::Fixed }
+        { floatValueForLength(lengthPoint.x, borderBoxSize.width()), LengthType::Fixed },
+        { floatValueForLength(lengthPoint.y, borderBoxSize.height()), LengthType::Fixed }
     };
 }
 
@@ -128,7 +128,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
     offsetDistance = style.offsetDistance();
     if (offsetDistance.isCalculated() && offsetPath) {
         auto anchor = borderBoxRect.location() + floatPointForLengthPoint(transformOrigin, borderBoxSize);
-        if (!offsetAnchor.x().isAuto())
+        if (!offsetAnchor.x.isAuto())
             anchor = floatPointForLengthPoint(offsetAnchor, borderBoxRect.size()) + borderBoxRect.location();
 
         auto path = offsetPath->getPath(TransformOperationData(FloatRect(borderBoxRect)));

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -74,10 +74,10 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 
     auto startingPositionForOffsetPosition = [&](const LengthPoint& offsetPosition, const FloatRect& referenceRect, RenderBlock& container) -> FloatPoint {
         // If offset-position is normal, the element does not have an offset starting position.
-        if (offsetPosition.x().isNormal())
+        if (offsetPosition.x.isNormal())
             return normalPositionForOffsetPath(pathOperation, referenceRect);
         // If offset-position is auto, use top / left corner of the box.
-        if (offsetPosition.x().isAuto())
+        if (offsetPosition.x.isAuto())
             return offsetFromContainer(renderer, container, referenceRect);
         return floatPointForLengthPoint(offsetPosition, referenceRect.size());
     };
@@ -96,7 +96,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 
     if (auto* rayPathOperation = dynamicDowncast<RayPathOperation>(pathOperation)) {
         auto startingPosition = rayPathOperation->position();
-        data.usedStartingPosition = startingPosition.x().isAuto() ? startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container) : floatPointForLengthPoint(startingPosition, data.containingBlockBoundingRect.rect().size());
+        data.usedStartingPosition = startingPosition.x.isAuto() ? startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container) : floatPointForLengthPoint(startingPosition, data.containingBlockBoundingRect.rect().size());
     }
 
     return data;
@@ -125,7 +125,7 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
 {
     auto boundingBox = transformData.boundingBox;
     auto anchor = transformOrigin;
-    if (!offsetAnchor.x().isAuto())
+    if (!offsetAnchor.x.isAuto())
         anchor = floatPointForLengthPoint(offsetAnchor, boundingBox.size()) + boundingBox.location();
 
     // Shift element to the point on path specified by offset-path and offset-distance.

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -513,8 +513,8 @@ LayoutRect RenderReplaced::replacedContentRect(const LayoutSize& intrinsicSize) 
 
     LengthPoint objectPosition = style().objectPosition();
 
-    LayoutUnit xOffset = minimumValueForLength(objectPosition.x(), contentRect.width() - finalRect.width());
-    LayoutUnit yOffset = minimumValueForLength(objectPosition.y(), contentRect.height() - finalRect.height());
+    LayoutUnit xOffset = minimumValueForLength(objectPosition.x, contentRect.width() - finalRect.width());
+    LayoutUnit yOffset = minimumValueForLength(objectPosition.y, contentRect.height() - finalRect.height());
 
     finalRect.move(xOffset, yOffset);
 

--- a/Source/WebCore/rendering/style/ShadowData.cpp
+++ b/Source/WebCore/rendering/style/ShadowData.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ShadowData);
 
 ShadowData::ShadowData(const ShadowData& o)
-    : m_location(o.m_location.x(), o.m_location.y())
+    : m_location(o.m_location.x, o.m_location.y)
     , m_spread(o.m_spread)
     , m_radius(o.m_radius)
     , m_color(o.m_color)

--- a/Source/WebCore/rendering/style/ShadowData.h
+++ b/Source/WebCore/rendering/style/ShadowData.h
@@ -44,7 +44,7 @@ public:
     ShadowData() = default;
 
     ShadowData(const LengthPoint& location, Length radius, Length spread, ShadowStyle style, bool isWebkitBoxShadow, const StyleColor& color)
-        : m_location(location.x(), location.y())
+        : m_location(location.x, location.y)
         , m_spread(spread)
         , m_radius(radius)
         , m_color(color)
@@ -62,8 +62,8 @@ public:
 
     bool operator==(const ShadowData& o) const;
     
-    const Length& x() const { return m_location.x(); }
-    const Length& y() const { return m_location.y(); }
+    const Length& x() const { return m_location.x; }
+    const Length& y() const { return m_location.y; }
     const LengthPoint& location() const { return m_location; }
     const Length& radius() const { return m_radius; }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3155,8 +3155,8 @@ header: <WebCore/PathOperation.h>
 
 header: <WebCore/LengthPoint.h>
 struct WebCore::LengthPoint {
-    WebCore::Length x();
-    WebCore::Length y();
+    WebCore::Length x;
+    WebCore::Length y;
 }
 
 [RefCounted, CustomHeader] class WebCore::RayPathOperation {


### PR DESCRIPTION
#### 42049e8173df70e36fdcffcf2369f8de82b5b7c1
<pre>
Make LengthSize and LengthPoint consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=277521">https://bugs.webkit.org/show_bug.cgi?id=277521</a>
<a href="https://rdar.apple.com/133228272">rdar://133228272</a>

Reviewed by Tim Nguyen.

This fix  gets rid of using public/private control in LengthPoint, which was already a struct. It makes all members of LengthPoint public and removes their getter and setter members.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/css/BasicShapeConversion.cpp:
(WebCore::valueForBasicShape):
* Source/WebCore/css/BasicShapesShapeSegmentConversion.cpp:
(WebCore::lengthPointToCSSValue):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForPosition):
(WebCore::isAuto):
(WebCore::isNormal):
(WebCore::valueForPathOperation):
* Source/WebCore/platform/LengthFunctions.cpp:
(WebCore::pointForLengthPoint):
(WebCore::floatPointForLengthPoint):
* Source/WebCore/platform/LengthPoint.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/LengthPoint.h:
(WebCore::LengthPoint::LengthPoint):
(WebCore::LengthPoint::isZero const):
(WebCore::blend):
(WebCore::LengthPoint::setX): Deleted.
(WebCore::LengthPoint::x const): Deleted.
(WebCore::LengthPoint::setY): Deleted.
(WebCore::LengthPoint::y const): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::nonCalculatedLengthPoint):
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::motionPathDataForRenderer):
(WebCore::MotionPath::applyMotionPathTransform):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/style/ShadowData.cpp:
(WebCore::ShadowData::ShadowData):
* Source/WebCore/rendering/style/ShadowData.h:
(WebCore::ShadowData::ShadowData):
(WebCore::ShadowData::x const):
(WebCore::ShadowData::y const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/284009@main">https://commits.webkit.org/284009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b49aeb33a117a5f6d8ca88bbda50b928e3d2269

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19187 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73801 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61856 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3370 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43234 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->