### PR TITLE
Notification permission lookup should be handled by webpushd when built-in notifications are enabled

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -410,6 +410,15 @@ bool NetworkConnectionToWebProcess::didReceiveSyncMessage(IPC::Connection& conne
         return false;
     }
 
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    if (decoder.messageReceiverName() == Messages::NotificationManagerMessageHandler::messageReceiverName()) {
+        MESSAGE_CHECK_WITH_RETURN_VALUE(m_networkProcess->builtInNotificationsEnabled(), false);
+        if (auto* networkSession = this->networkSession())
+            return networkSession->notificationManager().didReceiveSyncMessage(connection, decoder, reply);
+        return false;
+    }
+#endif
+
 #if ENABLE(APPLE_PAY_REMOTE_UI)
     if (decoder.messageReceiverName() == Messages::WebPaymentCoordinatorProxy::messageReceiverName())
         return paymentCoordinator().didReceiveSyncMessage(connection, decoder, reply);

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -236,5 +236,23 @@ void NetworkNotificationManager::getAppBadgeForTesting(CompletionHandler<void(st
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAppBadgeForTesting(), WTFMove(completionHandler));
 }
 
+static void getPushPermissionStateImpl(WebPushD::Connection* connection, WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
+{
+    if (!connection)
+        return completionHandler(WebCore::PushPermissionState::Denied);
+
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WTFMove(origin)), WTFMove(completionHandler));
+}
+
+void NetworkNotificationManager::getPermissionState(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
+{
+    getPushPermissionStateImpl(m_connection.get(), WTFMove(origin), WTFMove(completionHandler));
+}
+
+void NetworkNotificationManager::getPermissionStateSync(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
+{
+    getPushPermissionStateImpl(m_connection.get(), WTFMove(origin), WTFMove(completionHandler));
+}
+
 } // namespace WebKit
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -80,6 +80,8 @@ private:
     void pageWasNotifiedOfNotificationPermission() final { }
     void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) final;
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) final;
+    void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
+    void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
 
     NetworkSession& m_networkSession;
     std::unique_ptr<WebPushD::Connection> m_connection;

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -31,6 +31,7 @@
 #include <wtf/UUID.h>
 
 namespace WebCore {
+enum class PushPermissionState : uint8_t;
 class NotificationResources;
 class SecurityOriginData;
 struct NotificationData;
@@ -49,9 +50,12 @@ public:
     virtual void pageWasNotifiedOfNotificationPermission() = 0;
     virtual void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) = 0;
     virtual void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) = 0;
+    virtual void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) = 0;
+    virtual void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) = 0;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -28,4 +28,6 @@ messages -> NotificationManagerMessageHandler NotRefCounted {
     PageWasNotifiedOfNotificationPermission()
     RequestPermission(WebCore::SecurityOriginData origin) -> (bool granted)
     SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
+    GetPermissionState(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState permission)
+    GetPermissionStateSync(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState permission) Synchronous
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1192,7 +1192,7 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
     if (frame && frame._handle && frame._handle->_frameHandle->frameID())
         frameID = frame._handle->_frameHandle->frameID();
 
-    auto removeTransientActivation = WebKit::shouldEvaluateJavaScriptWithoutTransientActivation() ? WebCore::RemoveTransientActivation::Yes : WebCore::RemoveTransientActivation::No;
+    auto removeTransientActivation = !_dontResetTransientActivationAfterRunJavaScript && WebKit::shouldEvaluateJavaScriptWithoutTransientActivation() ? WebCore::RemoveTransientActivation::Yes : WebCore::RemoveTransientActivation::No;
     _page->runJavaScriptInFrameInScriptWorld({ javaScriptString, JSC::SourceTaintedOrigin::Untainted, sourceURL, !!asAsyncFunction, WTFMove(argumentsMap), !!forceUserGesture, removeTransientActivation }, frameID, *world->_contentWorld.get(), [handler] (auto&& result) {
         if (!handler)
             return;
@@ -4781,6 +4781,16 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
     _page->simulateClickOverFirstMatchingTextInViewportWithUserInteraction(targetText, [completionHandler = makeBlockPtr(completionHandler)](bool success) {
         completionHandler(static_cast<BOOL>(success));
     });
+}
+
+- (BOOL)_dontResetTransientActivationAfterRunJavaScript
+{
+    return _dontResetTransientActivationAfterRunJavaScript;
+}
+
+- (void)_setDontResetTransientActivationAfterRunJavaScript:(BOOL)value
+{
+    _dontResetTransientActivationAfterRunJavaScript = value;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -374,6 +374,7 @@ struct PerWebProcessState {
 #endif
 
     BOOL _didAccessBackForwardList;
+    BOOL _dontResetTransientActivationAfterRunJavaScript;
 
 #if ENABLE(PAGE_LOAD_OBSERVER)
     RetainPtr<NSString> _pendingPageLoadObserverHost;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -573,6 +573,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 - (void)_simulateClickOverFirstMatchingTextInViewportWithUserInteraction:(NSString *)targetText completionHandler:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+@property (nonatomic, setter=_setDontResetTransientActivationAfterRunJavaScript:) BOOL _dontResetTransientActivationAfterRunJavaScript WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -88,4 +88,14 @@ void ServiceWorkerNotificationHandler::requestPermission(WebCore::SecurityOrigin
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void ServiceWorkerNotificationHandler::getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void ServiceWorkerNotificationHandler::getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -46,6 +46,8 @@ public:
     void pageWasNotifiedOfNotificationPermission() final { }
     void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) final;
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) final { }
+    void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
+    void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
 
     bool handlesNotification(WTF::UUID value) const { return m_notificationToSessionMap.contains(value); }
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -101,4 +101,14 @@ void WebNotificationManagerMessageHandler::requestPermission(WebCore::SecurityOr
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void WebNotificationManagerMessageHandler::getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void WebNotificationManagerMessageHandler::getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -43,6 +43,8 @@ private:
     void pageWasNotifiedOfNotificationPermission() final;
     void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) final;
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t>) final { }
+    void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
+    void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
 
     WebPageProxy& m_webPageProxy;
 };

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -44,6 +44,7 @@
 #include <WebCore/Notification.h>
 #include <WebCore/NotificationData.h>
 #include <WebCore/Page.h>
+#include <WebCore/PushPermissionState.h>
 #include <WebCore/SWContextManager.h>
 #include <WebCore/ScriptExecutionContext.h>
 #include <WebCore/SecurityOrigin.h>
@@ -144,6 +145,28 @@ void WebNotificationManager::didRemoveNotificationDecisions(const Vector<String>
 
 NotificationClient::Permission WebNotificationManager::policyForOrigin(const String& originString, WebPage* page) const
 {
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
+        Ref connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        auto origin = SecurityOriginData::fromURL(URL { originString });
+        auto result = connection->sendSync(Messages::NotificationManagerMessageHandler::GetPermissionStateSync(WTFMove(origin)), WebProcess::singleton().sessionID().toUInt64());
+        if (!result.succeeded())
+            RELEASE_LOG_ERROR(Notifications, "Could not look up notification permission for origin %" SENSITIVE_LOG_STRING": %u", originString.utf8().data(), static_cast<unsigned>(result.error()));
+
+        auto [pushPermission] = result.takeReplyOr(PushPermissionState::Denied);
+        switch (pushPermission) {
+        case PushPermissionState::Denied:
+            return NotificationPermission::Denied;
+        case PushPermissionState::Granted:
+            return NotificationPermission::Granted;
+        case PushPermissionState::Prompt:
+            return NotificationPermission::Default;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+#endif
+
 #if ENABLE(NOTIFICATIONS)
     if (originString.isEmpty())
         return NotificationClient::Permission::Default;

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -121,7 +121,6 @@ private:
     void showNotification(const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
     void cancelNotification(const WTF::UUID& notificationID);
-    void enableMockUserNotificationCenterForTesting(CompletionHandler<void()>&&);
     void setAppBadge(WebCore::SecurityOriginData&&, std::optional<uint64_t>);
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
 

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -41,7 +41,6 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     DidShowNotificationForTesting(URL scopeURL) -> ()
     ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
-    EnableMockUserNotificationCenterForTesting() -> ()
     CancelNotification(WTF::UUID notificationID)
     RequestPushPermission(WebCore::SecurityOriginData origin) -> (bool granted)
     SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -318,16 +318,6 @@ String PushClientConnection::associatedWebClipTitle() const
 }
 #endif // PLATFORM(IOS)
 
-void PushClientConnection::enableMockUserNotificationCenterForTesting(CompletionHandler<void()>&& completionHandler)
-{
-#if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().enableMockUserNotificationCenterForTesting(*this);
-    completionHandler();
-#else
-    completionHandler();
-#endif
-}
-
 } // namespace WebPushD
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -99,8 +99,6 @@ public:
 
     void getPushPermissionState(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(WebCore::PushPermissionState)>&&);
     void requestPushPermission(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&&);
-
-    void enableMockUserNotificationCenterForTesting(PushClientConnection&);
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 
     void setAppBadge(PushClientConnection&, WebCore::SecurityOriginData&&, std::optional<uint64_t>);

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -87,6 +87,11 @@ WebPushDaemon::WebPushDaemon()
 void WebPushDaemon::startMockPushService()
 {
     m_usingMockPushService = true;
+
+#if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
+    m_userNotificationCenterClass = [_WKMockUserNotificationCenter class];
+#endif
+
     auto messageHandler = [this](const PushSubscriptionSetIdentifier& identifier, WebKit::WebPushMessage&& message) {
         handleIncomingPush(identifier, WTFMove(message));
     };
@@ -632,12 +637,6 @@ static NSString *platformNotificationSourceForDisplay(PushClientConnection& conn
     // FIXME: Calculate appropriate value on macOS
     return nil;
 #endif
-}
-
-void WebPushDaemon::enableMockUserNotificationCenterForTesting(PushClientConnection& connection)
-{
-    RELEASE_ASSERT(connection.hostAppCodeSigningIdentifier() == "com.apple.WebKit.TestWebKitAPI"_s);
-    m_userNotificationCenterClass = [_WKMockUserNotificationCenter class];
 }
 
 void WebPushDaemon::showNotification(PushClientConnection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources> resources, CompletionHandler<void()>&& completionHandler)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -466,6 +466,55 @@ async function unsubscribe()
     }
 }
 
+async function getNotificationPermissionFromServiceWorker()
+{
+    const channel = new MessageChannel();
+    const promise = new Promise((resolve) => {
+        channel.port1.onmessage = (event) => resolve(event.data);
+    });
+    globalRegistration.active.postMessage({ message: "notificationPermission", port: channel.port2 }, [channel.port2]);
+    return await promise;
+}
+
+async function getPushPermissionState()
+{
+    try {
+        return await globalRegistration.pushManager.permissionState();
+    } catch (error) {
+        return "Error: " + error;
+    }
+}
+
+async function getPushPermissionStateFromServiceWorker()
+{
+    const channel = new MessageChannel();
+    const promise = new Promise((resolve) => {
+        channel.port1.onmessage = (event) => resolve(event.data);
+    });
+    globalRegistration.active.postMessage({ message: "getPushPermissionState", port: channel.port2 }, [channel.port2]);
+    return await promise;
+}
+
+async function queryPermission(name)
+{
+    try {
+        let status = await navigator.permissions.query({ name });
+        return status.state;
+    } catch (error) {
+        return "Error: " + error;
+    }
+}
+
+async function queryPermissionFromServiceWorker(name)
+{
+    const channel = new MessageChannel();
+    const promise = new Promise((resolve) => {
+        channel.port1.onmessage = (event) => resolve(event.data);
+    });
+    globalRegistration.active.postMessage({ message: "queryPermission", arguments: [name], port: channel.port2 }, [channel.port2]);
+    return await promise;
+}
+
 async function getPushSubscription()
 {
     try {
@@ -519,11 +568,24 @@ function notificationToString(n)
 }
 
 self.addEventListener("message", (event) => {
-    let { message, port } = event.data;
+    let { message, arguments, port } = event.data;
     var closeAllNotifications = message === "closeAllNotifications";
     if (message === "setup") {
         globalPort = port;
         port.postMessage("Ready");
+    } else if (message === "notificationPermission") {
+        port.postMessage(Notification.permission);
+    } else if (message === "getPushPermissionState") {
+        registration.pushManager.permissionState().then(port.postMessage.bind(port), (error) => {
+            port.postMessage("getPushPermissionState failed: " + error);
+        });
+    } else if (message === "queryPermission") {
+        let [name] = arguments;
+        navigator.permissions.query({ name }).then((status) => {
+            port.postMessage(status.state);
+        }, (error) => {
+            port.postMessage("queryPermission failed: " + error);
+        });
     } else if (message === "disableShowNotifications") {
         showNotifications = false;
         port.postMessage(true);
@@ -703,6 +765,8 @@ public:
 
         m_webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
+        [m_webView _setDontResetTransientActivationAfterRunJavaScript:YES];
+
         [m_webView setUIDelegate:m_delegate.get()];
 
         auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -722,6 +786,13 @@ public:
 
     RetainPtr<WKWebsiteDataStore> dataStore() { return m_dataStore; }
 
+    id requestNotificationPermission()
+    {
+        NSError *error = nil;
+        id obj = [m_webView objectByCallingAsyncFunction:@"return await Notification.requestPermission()" withArguments:@{ } error:&error];
+        return error ?: obj;
+    }
+
     id subscribe(String key = validServerKey)
     {
         NSError *error = nil;
@@ -734,6 +805,46 @@ public:
     {
         NSError *error = nil;
         id obj = [m_webView objectByCallingAsyncFunction:@"return await unsubscribe()" withArguments:@{ } error:&error];
+        return error ?: obj;
+    }
+
+    id getNotificationPermission()
+    {
+        return [m_webView stringByEvaluatingJavaScript:@"Notification.permission"];
+    }
+
+    id getNotificationPermissionFromServiceWorker()
+    {
+        NSError *error = nil;
+        id obj = [m_webView objectByCallingAsyncFunction:@"return await getNotificationPermissionFromServiceWorker()" withArguments:@{ } error:&error];
+        return error ?: obj;
+    }
+
+    id getPushPermissionState()
+    {
+        NSError *error = nil;
+        id obj = [m_webView objectByCallingAsyncFunction:@"return await getPushPermissionState()" withArguments:@{ } error:&error];
+        return error ?: obj;
+    }
+
+    id getPushPermissionStateFromServiceWorker()
+    {
+        NSError *error = nil;
+        id obj = [m_webView objectByCallingAsyncFunction:@"return await getPushPermissionStateFromServiceWorker()" withArguments:@{ } error:&error];
+        return error ?: obj;
+    }
+
+    id queryPermission(NSString *name)
+    {
+        NSError *error = nil;
+        id obj = [m_webView objectByCallingAsyncFunction:@"return await queryPermission(name)" withArguments:@{ @"name": name } error:&error];
+        return error ?: obj;
+    }
+
+    id queryPermissionFromServiceWorker(NSString *name)
+    {
+        NSError *error = nil;
+        id obj = [m_webView objectByCallingAsyncFunction:@"return await queryPermissionFromServiceWorker(name)" withArguments:@{ @"name": name } error:&error];
         return error ?: obj;
     }
 
@@ -1606,12 +1717,6 @@ TEST_F(WebPushDBuiltInTest, ShowAndGetNotifications)
     message.disposition = WebKit::WebPushD::PushMessageDisposition::Legacy;
     message.payload = @"hello";
 
-    __block bool done = false;
-    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::EnableMockUserNotificationCenterForTesting(), ^() {
-        done = true;
-    });
-    TestWebKitAPI::Util::run(&done);
-
     // No badge had been set, so confirm its `nil`
     EXPECT_FALSE(view->getAppBadge());
 
@@ -1645,7 +1750,58 @@ TEST_F(WebPushDBuiltInTest, ShowAndGetNotifications)
 
     // The push message handler should set the app badge to 42
     EXPECT_TRUE([view->getAppBadge() isEqual:@42]);
+}
 
+TEST_F(WebPushDBuiltInTest, TestPermissionsAfterNotificatonRequestPermission)
+{
+    auto& view = webViews().last();
+
+    EXPECT_TRUE([view->getNotificationPermission() isEqual:@"default"]);
+    EXPECT_TRUE([view->getNotificationPermissionFromServiceWorker() isEqualToString:@"default"]);
+    EXPECT_TRUE([view->getPushPermissionState() isEqual:@"prompt"]);
+    EXPECT_TRUE([view->getPushPermissionStateFromServiceWorker() isEqualToString:@"prompt"]);
+    EXPECT_TRUE([view->queryPermission(@"push") isEqual:@"prompt"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"push") isEqual:@"prompt"]);
+    EXPECT_TRUE([view->queryPermission(@"notifications") isEqual:@"prompt"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"notifications") isEqual:@"prompt"]);
+
+    EXPECT_TRUE([view->requestNotificationPermission() isEqual:@"granted"]);
+
+    EXPECT_TRUE([view->getNotificationPermission() isEqual:@"granted"]);
+    EXPECT_TRUE([view->getNotificationPermissionFromServiceWorker() isEqualToString:@"granted"]);
+    EXPECT_TRUE([view->getPushPermissionState() isEqual:@"granted"]);
+    EXPECT_TRUE([view->getPushPermissionStateFromServiceWorker() isEqualToString:@"granted"]);
+    EXPECT_TRUE([view->queryPermission(@"push") isEqual:@"granted"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"push") isEqual:@"granted"]);
+    EXPECT_TRUE([view->queryPermission(@"notifications") isEqual:@"granted"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"notifications") isEqual:@"granted"]);
+}
+
+TEST_F(WebPushDBuiltInTest, TestPermissionsAfterSubscribe)
+{
+    auto& view = webViews().last();
+
+    EXPECT_FALSE(view->hasPushSubscription());
+    EXPECT_TRUE([view->getNotificationPermission() isEqual:@"default"]);
+    EXPECT_TRUE([view->getNotificationPermissionFromServiceWorker() isEqualToString:@"default"]);
+    EXPECT_TRUE([view->getPushPermissionState() isEqual:@"prompt"]);
+    EXPECT_TRUE([view->getPushPermissionStateFromServiceWorker() isEqualToString:@"prompt"]);
+    EXPECT_TRUE([view->queryPermission(@"push") isEqual:@"prompt"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"push") isEqual:@"prompt"]);
+    EXPECT_TRUE([view->queryPermission(@"notifications") isEqual:@"prompt"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"notifications") isEqual:@"prompt"]);
+
+    view->subscribe();
+
+    EXPECT_TRUE(view->hasPushSubscription());
+    EXPECT_TRUE([view->getNotificationPermission() isEqual:@"granted"]);
+    EXPECT_TRUE([view->getNotificationPermissionFromServiceWorker() isEqualToString:@"granted"]);
+    EXPECT_TRUE([view->getPushPermissionState() isEqual:@"granted"]);
+    EXPECT_TRUE([view->getPushPermissionStateFromServiceWorker() isEqualToString:@"granted"]);
+    EXPECT_TRUE([view->queryPermission(@"push") isEqual:@"granted"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"push") isEqual:@"granted"]);
+    EXPECT_TRUE([view->queryPermission(@"notifications") isEqual:@"granted"]);
+    EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"notifications") isEqual:@"granted"]);
 }
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 


### PR DESCRIPTION
#### 566b4eccdb82b90363aa42d4c2a7b77cc7916e7c
<pre>
Notification permission lookup should be handled by webpushd when built-in notifications are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=277656">https://bugs.webkit.org/show_bug.cgi?id=277656</a>
<a href="https://rdar.apple.com/131367219">rdar://131367219</a>

Reviewed by Sihui Liu.

When built-in notifications mode is enabled, we should ask webpushd for notification permissions
instead of calling back to the embedder. This extends to:

1. Notification.permission (via WebNotificationManager::policyForOrigin)
2. PushManager.permissionState (via WebNotificationManager::policyForOrigin)
3. Permissions.query (via WebPermissionController::query)

Right now, both (1) and (2) send a sync IPC to NetworkProcess. In theory, we can do (2) without a
sync IPC, but I&apos;ll look in to optimizing that in a future PR.

I added an integration test to make sure that all of these APIs work in both the document and
service worker context.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveSyncMessage):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::getPushPermissionStateImpl):
(WebKit::NetworkNotificationManager::getPermissionState):
(WebKit::NetworkNotificationManager::getPermissionStateSync):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
(-[WKWebView _forceStickyTransientActivation]):
(-[WKWebView _setForceStickyTransientActivation:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::getPermissionState):
(WebKit::ServiceWorkerNotificationHandler::getPermissionStateSync):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::getPermissionState):
(WebKit::WebNotificationManagerMessageHandler::getPermissionStateSync):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::policyForOrigin const):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::enableMockUserNotificationCenterForTesting): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::startMockPushService):
(WebPushD::WebPushDaemon::enableMockUserNotificationCenterForTesting): Deleted.
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter getNotificationSettingsWithCompletionHandler:]):
(-[_WKMockUserNotificationCenter requestAuthorizationWithOptions:completionHandler:]):
(notificationPermissions): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/281903@main">https://commits.webkit.org/281903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c455a396e56c146120a4e65b940ff1512814fb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61299 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49528 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8233 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66980 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13683 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4331 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36464 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->