### PR TITLE
[GTK][MiniBrowser] Amazon Luna landing page doesn't render

### DIFF
--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -141,8 +141,29 @@ static void removeChildIfInfoBar(GtkWidget *child, GtkContainer *tab)
 }
 #endif
 
+static void toggleAboutDataScriptMessageHandler(WebKitWebView *webView)
+{
+    WebKitUserContentManager *userContentManager = webkit_web_view_get_user_content_manager(webView);
+    if (g_str_has_prefix(webkit_web_view_get_uri(webView), BROWSER_ABOUT_SCHEME)) {
+#if GTK_CHECK_VERSION(3, 98, 0)
+        webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData", NULL);
+#else
+        webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData");
+#endif
+    } else {
+#if GTK_CHECK_VERSION(3, 98, 0)
+        webkit_user_content_manager_unregister_script_message_handler(userContentManager, "aboutData", NULL);
+#else
+        webkit_user_content_manager_unregister_script_message_handler(userContentManager, "aboutData");
+#endif
+    }
+}
+
 static void loadChanged(WebKitWebView *webView, WebKitLoadEvent loadEvent, BrowserTab *tab)
 {
+    if (loadEvent == WEBKIT_LOAD_COMMITTED)
+        toggleAboutDataScriptMessageHandler(webView);
+
     if (loadEvent != WEBKIT_LOAD_STARTED)
         return;
 

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -905,11 +905,6 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
     webkit_web_context_register_uri_scheme(webContext, BROWSER_ABOUT_SCHEME, (WebKitURISchemeRequestCallback)aboutURISchemeRequestCallback, NULL, NULL);
 
     WebKitUserContentManager *userContentManager = webkit_user_content_manager_new();
-#if GTK_CHECK_VERSION(3, 98, 0)
-    webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData", NULL);
-#else
-    webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData");
-#endif
     WebKitWebsiteDataManager *dataManager;
 #if GTK_CHECK_VERSION(3, 98, 0)
     dataManager = webkit_network_session_get_website_data_manager(networkSession);


### PR DESCRIPTION
#### d16890bc3dd257a76fbd6dc10e17bac2f95cc29b
<pre>
[GTK][MiniBrowser] Amazon Luna landing page doesn&apos;t render
<a href="https://bugs.webkit.org/show_bug.cgi?id=276585">https://bugs.webkit.org/show_bug.cgi?id=276585</a>

Reviewed by Michael Catanzaro.

Amazon Luna (luna.amazon.com) assumes that the user agent is on MacOS if
`window.webkit` is defined, leading to JS calls that only work in the
Apple Mac WebKit port.

`window.webkit` was defined in the GTK MiniBrowser because it registers
a script message handler &quot;aboutData&quot;, which makes
`window.webkit.messageHandlers.aboutData.postMessage(msg)` available to
scripts. However, this is only useful for the &quot;about:data&quot; custom page
that is defined in the MiniBrowser.

To have MiniBrowser still working like before but also supporting Amazon
Luna, only register the script message handler when loading &quot;about:*&quot; pages.

* Tools/MiniBrowser/gtk/BrowserTab.c:
(toggleAboutDataScriptMessageHandler):
(loadChanged):
* Tools/MiniBrowser/gtk/main.c:
(activate):

Canonical link: <a href="https://commits.webkit.org/281898@main">https://commits.webkit.org/281898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83cd728aacc7eabd6176f13684c397fa54c7e26c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49570 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8271 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10381 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67049 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4385 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36531 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->