### PR TITLE
imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.html is failing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6647,8 +6647,6 @@ imported/w3c/web-platform-tests/css/css-variables/wide-keyword-fallback-002.html
 
 # WPT tests that are timing out.
 imported/w3c/web-platform-tests/FileAPI/url/unicode-origin.sub.html [ Skip ]
-imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.html [ Skip ]
-imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.worker.html [ Skip ]
 imported/w3c/web-platform-tests/IndexedDB/transaction-scheduling-within-database.any.html [ Skip ]
 imported/w3c/web-platform-tests/IndexedDB/transaction-scheduling-within-database.any.worker.html [ Skip ]
 imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_RSA-OAEP.https.any.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Explicitly committed data can be read back out.
 PASS commit() on a version change transaction does not cause errors.
 PASS A committed transaction becomes inactive immediately.
@@ -10,7 +8,7 @@ PASS Calling commit on an aborted transaction throws.
 PASS Calling commit on a committed transaction throws.
 PASS Calling abort on a committed transaction throws and does not prevent persisting the data.
 PASS Calling txn.commit() when txn is inactive should throw.
-TIMEOUT Transactions with same scope should stay in program order, even if one calls commit. Test timed out
-NOTRUN Transactions that explicitly commit and have errors should abort.
-NOTRUN Transactions that handle all errors properly should behave as expected when an explicit commit is called in an onerror handler.
+PASS Transactions with same scope should stay in program order, even if one calls commit.
+PASS Transactions that explicitly commit and have errors should abort.
+PASS Transactions that handle all errors properly should behave as expected when an explicit commit is called in an onerror handler.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.js
@@ -249,7 +249,6 @@ promise_test(async testCase => {
   db.close();
 }, 'Transactions that explicitly commit and have errors should abort.');
 
-
 promise_test(async testCase => {
   const db = await createDatabase(testCase, db => {
     createBooksStore(testCase, db);

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.worker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Explicitly committed data can be read back out.
 PASS commit() on a version change transaction does not cause errors.
 PASS A committed transaction becomes inactive immediately.
@@ -10,7 +8,7 @@ PASS Calling commit on an aborted transaction throws.
 PASS Calling commit on a committed transaction throws.
 PASS Calling abort on a committed transaction throws and does not prevent persisting the data.
 PASS Calling txn.commit() when txn is inactive should throw.
-TIMEOUT Transactions with same scope should stay in program order, even if one calls commit. Test timed out
-NOTRUN Transactions that explicitly commit and have errors should abort.
-NOTRUN Transactions that handle all errors properly should behave as expected when an explicit commit is called in an onerror handler.
+PASS Transactions with same scope should stay in program order, even if one calls commit.
+PASS Transactions that explicitly commit and have errors should abort.
+PASS Transactions that handle all errors properly should behave as expected when an explicit commit is called in an onerror handler.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker_101-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker_101-last-expected.txt
@@ -1,8 +1,9 @@
 
-FAIL TypeError: TypeError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError: TypeError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError: URIError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError: URIError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS SyntaxError: SyntaxError: ghi
+PASS TypeError: TypeError
+PASS TypeError: TypeError: ghi
+PASS URIError: URIError
+PASS URIError: URIError: ghi
 PASS Array:
 PASS Array: 1,2,3
 PASS Array: foo,bar,,,,,,,,,true,false,,,,,,,,,123,456,,,,,,,,,

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any_101-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any_101-last-expected.txt
@@ -1,8 +1,9 @@
 
-FAIL TypeError: TypeError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError: TypeError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError: URIError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError: URIError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS SyntaxError: SyntaxError: ghi
+PASS TypeError: TypeError
+PASS TypeError: TypeError: ghi
+PASS URIError: URIError
+PASS URIError: URIError: ghi
 PASS Array:
 PASS Array: 1,2,3
 PASS Array: foo,bar,,,,,,,,,true,false,,,,,,,,,123,456,,,,,,,,,

--- a/LayoutTests/inspector/indexeddb/clearObjectStore.html
+++ b/LayoutTests/inspector/indexeddb/clearObjectStore.html
@@ -28,7 +28,7 @@ function test()
             IndexedDBAgent.requestDatabase(WI.networkManager.mainFrame.securityOrigin, "CompleteDatabase", (error, database) => {
                 InspectorTest.expectNoError(error);
 
-                function expectObjectStoreEntryCount(objectStore, expectedCount, message) {
+                function expectObjectStoreEntryCount(objectStore, expectedCount, message, callback) {
                     const securityOrigin = WI.networkManager.mainFrame.securityOrigin;
                     const indexName = "";
                     const skipCount = 0;
@@ -36,33 +36,44 @@ function test()
                     IndexedDBAgent.requestData(securityOrigin, database.name, objectStore.name, indexName, skipCount, pageSize, (error, entries, hasMore) => {
                         InspectorTest.expectNoError(error);
                         InspectorTest.expectThat(entries.length === expectedCount, message);
+                        callback();
                     });
                 }
 
                 let securityOrigin = WI.networkManager.mainFrame.securityOrigin;
                 let [emptyObjectStore, reviewersObjectStore, statsObjectStore] = database.objectStores;
+                let instructions = [
+                    { type: "check", objectStore: emptyObjectStore, expectedCount: 0, message: "'Empty' object store should always be empty." },
+                    { type: "check", objectStore: reviewersObjectStore, expectedCount: 4, message: "'Reviewers' object store should start with 4 entries." },
+                    { type: "check", objectStore: statsObjectStore, expectedCount: 4, message: "'Stats' object store should start with 4 entries." },
+                    { type: "clear", objectStore: reviewersObjectStore },
+                    { type: "check", objectStore: emptyObjectStore, expectedCount: 0, message: "'Empty' object store should always be empty." },
+                    { type: "check", objectStore: reviewersObjectStore, expectedCount: 0, message: "'Reviewers' object store should have been cleared." },
+                    { type: "check", objectStore: statsObjectStore, expectedCount: 4, message: "'Stats' object store remain unchanged with 4 entries." },
+                    { type: "clear", objectStore: statsObjectStore },
+                    { type: "check", objectStore: emptyObjectStore, expectedCount: 0, message: "'Empty' object store should always be empty." },
+                    { type: "check", objectStore: reviewersObjectStore, expectedCount: 0, message: "'Reviewers' object store should have been cleared." },
+                    { type: "check", objectStore: statsObjectStore, expectedCount: 0, message: "'Stats' object store should have been cleared." },
+                ];
 
-                expectObjectStoreEntryCount(emptyObjectStore, 0, "'Empty' object store should always be empty.");
-                expectObjectStoreEntryCount(reviewersObjectStore, 4, "'Reviewers' object store should start with 4 entries.");
-                expectObjectStoreEntryCount(statsObjectStore, 4, "'Stats' object store should start with 4 entries.");
+                function test() {
+                    instruction = instructions.shift();
+                    if (!instruction) {
+                        InspectorBackend.runAfterPendingDispatches(resolve);
+                        return;
+                    }
 
-                IndexedDBAgent.clearObjectStore(securityOrigin, database.name, reviewersObjectStore.name, (error) => {
-                    InspectorTest.expectNoError(error);
-                });
+                    if (instruction.type == "check")
+                        expectObjectStoreEntryCount(instruction.objectStore, instruction.expectedCount, instruction.message, test);
+                    else if (instruction.type == "clear") {
+                        IndexedDBAgent.clearObjectStore(securityOrigin, database.name, instruction.objectStore.name, (error) => {
+                            InspectorTest.expectNoError(error);
+                            test();
+                        });
+                    }
+                }
 
-                expectObjectStoreEntryCount(emptyObjectStore, 0, "'Empty' object store should always be empty.");
-                expectObjectStoreEntryCount(reviewersObjectStore, 0, "'Reviewers' object store should have been cleared.");
-                expectObjectStoreEntryCount(statsObjectStore, 4, "'Stats' object store remain unchanged with 4 entries.");
-
-                IndexedDBAgent.clearObjectStore(securityOrigin, database.name, statsObjectStore.name, (error) => {
-                    InspectorTest.expectNoError(error);
-                });
-
-                expectObjectStoreEntryCount(emptyObjectStore, 0, "'Empty' object store should always be empty.");
-                expectObjectStoreEntryCount(reviewersObjectStore, 0, "'Reviewers' object store should have been cleared.");
-                expectObjectStoreEntryCount(statsObjectStore, 0, "'Stats' object store should have been cleared.");
-
-                InspectorBackend.runAfterPendingDispatches(resolve);
+                test();
             });
         }
     });

--- a/LayoutTests/inspector/indexeddb/requestData.html
+++ b/LayoutTests/inspector/indexeddb/requestData.html
@@ -181,155 +181,165 @@ function test()
                 // Index: Name Index
                 // Keys: [3, 2, 4, 1]
                 // Values: ["Bustling Badger", "Jamming Peacock", "Monstrous Beaver", "Thirsty Hamster"];
+                let keyRanges = [
+                    // Keys >= "M"
+                    {lower: stringKeyWithString("M"), lowerOpen: false, upperOpen: true},
+                    // Keys > "M"
+                    {lower: stringKeyWithString("M"), lowerOpen: true, upperOpen: true},
+                    // Keys > "Monstrous Beaver"
+                    keyRange = {lower: stringKeyWithString("Monstrous Beaver"), lowerOpen: true, upperOpen: true},
+                    // Keys <= "M"
+                    keyRange = {upper: stringKeyWithString("M"), lowerOpen: true, upperOpen: false},
+                    // Keys <= "Monstrous Beaver"
+                    keyRange = {upper: stringKeyWithString("Monstrous Beaver"), lowerOpen: true, upperOpen: false},
+                    // Keys < "M"
+                    keyRange = {upper: stringKeyWithString("M"), lowerOpen: true, upperOpen: true},
+                    // "Monstrous Beaver" <= Key <= "Monstrous Beaver"
+                    keyRange = {lower: stringKeyWithString("Monstrous Beaver"), upper: stringKeyWithString("Monstrous Beaver"), lowerOpen: false, upperOpen: false}
 
-                // Keys >= "M"
-                let keyRange = {lower: stringKeyWithString("M"), lowerOpen: false, upperOpen: true};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- Keys >= 'M'");
-                    InspectorTest.log("-- Lower Bound: 'M' (closed)");
-                    InspectorTest.log("-- Upper Bound: -");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+                ];
+                var callbacks = [
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- Keys >= 'M'");
+                        InspectorTest.log("-- Lower Bound: 'M' (closed)");
+                        InspectorTest.log("-- Upper Bound: -");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
 
-                    let expectedPrimaryKeyOrder = [4, 1];
-                    let expectedNamesOrderedByPrimaryKey = ["Monstrous Beaver", "Thirsty Hamster"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        let expectedPrimaryKeyOrder = [4, 1];
+                        let expectedNamesOrderedByPrimaryKey = ["Monstrous Beaver", "Thirsty Hamster"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
+                    },
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- Keys > 'M'");
+                        InspectorTest.log("-- Lower Bound: 'M' (open)");
+                        InspectorTest.log("-- Upper Bound: -");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+
+                        let expectedPrimaryKeyOrder = [4, 1];
+                        let expectedNamesOrderedByPrimaryKey = ["Monstrous Beaver", "Thirsty Hamster"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
+                    },
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- Keys > 'Monstrous Beaver'");
+                        InspectorTest.log("-- Lower Bound: 'Monstrous Beaver' (open)");
+                        InspectorTest.log("-- Upper Bound: -");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 1, "Should be 1 entry.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+
+                        let expectedPrimaryKeyOrder = [1];
+                        let expectedNamesOrderedByPrimaryKey = ["Thirsty Hamster"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
+                    },
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- Keys <= 'M'");
+                        InspectorTest.log("-- Lower Bound: -");
+                        InspectorTest.log("-- Upper Bound: 'M' (closed)");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+
+                        let expectedPrimaryKeyOrder = [3, 2];
+                        let expectedNamesOrderedByPrimaryKey = ["Bustling Badger", "Jamming Peacock"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
+                    },
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- Keys <= 'Monstrous Beaver'");
+                        InspectorTest.log("-- Lower Bound: -");
+                        InspectorTest.log("-- Upper Bound: 'Monstrous Beaver' (closed)");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 3, "Should be 3 entries.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+
+                        let expectedPrimaryKeyOrder = [3, 2, 4];
+                        let expectedNamesOrderedByPrimaryKey = ["Bustling Badger", "Jamming Peacock", "Monstrous Beaver"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
+                    },
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- Keys < 'M'");
+                        InspectorTest.log("-- Lower Bound: -");
+                        InspectorTest.log("-- Upper Bound: 'M' (open)");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+
+                        let expectedPrimaryKeyOrder = [3, 2];
+                        let expectedNamesOrderedByPrimaryKey = ["Bustling Badger", "Jamming Peacock"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
+                    },
+                    (error, entries, hasMore) => {
+                        InspectorTest.log("-- 'Monstrous Beaver' <= Key <= 'Monstrous Beaver'");
+                        InspectorTest.log("-- Lower Bound: 'Monstrous Beaver' (closed)");
+                        InspectorTest.log("-- Upper Bound: 'Monstrous Beaver' (closed)");
+                        InspectorTest.expectNoError(error);
+                        InspectorTest.expectThat(entries.length === 1, "Should be 1 entry.");
+                        InspectorTest.expectThat(!hasMore, "Should not have more entries.");
+
+                        let expectedPrimaryKeyOrder = [4];
+                        let expectedNamesOrderedByPrimaryKey = ["Monstrous Beaver"];
+                        for (let i = 0; i < entries.length; ++i) {
+                            let entryPayload = entries[i];
+                            let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
+                            let value = WI.RemoteObject.fromPayload(entryPayload.value);
+                            InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
+                            InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                        }
                     }
-                });
+                ];
 
-                // Keys > "M"
-                keyRange = {lower: stringKeyWithString("M"), lowerOpen: true, upperOpen: true};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- Keys > 'M'");
-                    InspectorTest.log("-- Lower Bound: 'M' (open)");
-                    InspectorTest.log("-- Upper Bound: -");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
-
-                    let expectedPrimaryKeyOrder = [4, 1];
-                    let expectedNamesOrderedByPrimaryKey = ["Monstrous Beaver", "Thirsty Hamster"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
+                function test() {
+                    keyRange = keyRanges.shift();
+                    callback = callbacks.shift();
+                    if (!keyRange) {
+                        InspectorBackend.runAfterPendingDispatches(resolve);
+                        return;
                     }
-                });
-
-                // Keys > "Monstrous Beaver"
-                keyRange = {lower: stringKeyWithString("Monstrous Beaver"), lowerOpen: true, upperOpen: true};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- Keys > 'Monstrous Beaver'");
-                    InspectorTest.log("-- Lower Bound: 'Monstrous Beaver' (open)");
-                    InspectorTest.log("-- Upper Bound: -");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 1, "Should be 1 entry.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
-
-                    let expectedPrimaryKeyOrder = [1];
-                    let expectedNamesOrderedByPrimaryKey = ["Thirsty Hamster"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
-                    }
-                });
-
-                // Keys <= "M"
-                keyRange = {upper: stringKeyWithString("M"), lowerOpen: true, upperOpen: false};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- Keys <= 'M'");
-                    InspectorTest.log("-- Lower Bound: -");
-                    InspectorTest.log("-- Upper Bound: 'M' (closed)");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
-
-                    let expectedPrimaryKeyOrder = [3, 2];
-                    let expectedNamesOrderedByPrimaryKey = ["Bustling Badger", "Jamming Peacock"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
-                    }
-                });
-
-                // Keys <= "Monstrous Beaver"
-                keyRange = {upper: stringKeyWithString("Monstrous Beaver"), lowerOpen: true, upperOpen: false};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- Keys <= 'Monstrous Beaver'");
-                    InspectorTest.log("-- Lower Bound: -");
-                    InspectorTest.log("-- Upper Bound: 'Monstrous Beaver' (closed)");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 3, "Should be 3 entries.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
-
-                    let expectedPrimaryKeyOrder = [3, 2, 4];
-                    let expectedNamesOrderedByPrimaryKey = ["Bustling Badger", "Jamming Peacock", "Monstrous Beaver"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
-                    }
-                });
-
-                // Keys < "M"
-                keyRange = {upper: stringKeyWithString("M"), lowerOpen: true, upperOpen: true};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- Keys < 'M'");
-                    InspectorTest.log("-- Lower Bound: -");
-                    InspectorTest.log("-- Upper Bound: 'M' (open)");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 2, "Should be 2 entries.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
-
-                    let expectedPrimaryKeyOrder = [3, 2];
-                    let expectedNamesOrderedByPrimaryKey = ["Bustling Badger", "Jamming Peacock"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
-                    }
-                });
-
-                // "Monstrous Beaver" <= Key <= "Monstrous Beaver"
-                keyRange = {lower: stringKeyWithString("Monstrous Beaver"), upper: stringKeyWithString("Monstrous Beaver"), lowerOpen: false, upperOpen: false};
-                IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
-                    InspectorTest.log("-- 'Monstrous Beaver' <= Key <= 'Monstrous Beaver'");
-                    InspectorTest.log("-- Lower Bound: 'Monstrous Beaver' (closed)");
-                    InspectorTest.log("-- Upper Bound: 'Monstrous Beaver' (closed)");
-                    InspectorTest.expectNoError(error);
-                    InspectorTest.expectThat(entries.length === 1, "Should be 1 entry.");
-                    InspectorTest.expectThat(!hasMore, "Should not have more entries.");
-
-                    let expectedPrimaryKeyOrder = [4];
-                    let expectedNamesOrderedByPrimaryKey = ["Monstrous Beaver"];
-                    for (let i = 0; i < entries.length; ++i) {
-                        let entryPayload = entries[i];
-                        let primaryKey = WI.RemoteObject.fromPayload(entryPayload.primaryKey);
-                        let value = WI.RemoteObject.fromPayload(entryPayload.value);
-                        InspectorTest.expectThat(primaryKey.value === expectedPrimaryKeyOrder[i], `Primary key should be ordered by primary key: ${expectedPrimaryKeyOrder[i]}`);
-                        InspectorTest.expectThat(objectPropertyPreview(value, "name").value === expectedNamesOrderedByPrimaryKey[i], `Value should be a remote object for: '${expectedNamesOrderedByPrimaryKey[i]}'`);
-                    }
-                });
-
-                InspectorBackend.runAfterPendingDispatches(resolve);
+                    IndexedDBAgent.requestData(securityOrigin, database.name, reviewersObjectStore.name, indexName, skipCount, pageSize, keyRange, (error, entries, hasMore) => {
+                            callback(error, entries, hasMore);
+                            test();
+                    });
+                }
+                test();
             });
         }
     });

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2092,12 +2092,6 @@ svg/transforms/translation-tiny-element.svg [ ImageOnlyFailure ]
 # Timing out since its import.
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-pointerevent.html?touch [ Skip ]
 
-# webkit.org/b/243681  Newly imported tests that fail on Monterey+
-[ Debug ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.html?101-last [ Failure ]
-[ Release ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.html?101-last [ Pass Failure ]
-[ Debug ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-last [ Failure ]
-[ Release ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-last [ Pass Failure ]
-
 # These tests have been flaky on macOS since their import.
 imported/w3c/web-platform-tests/websockets/cookies/005.html?wss&wpt_flags=https [ Pass Failure ]
 imported/w3c/web-platform-tests/websockets/cookies/007.html?wss&wpt_flags=https [ Pass Failure ]

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -128,6 +128,7 @@ public:
     void setTransactionOperationID(uint64_t transactionOperationID) { m_currentTransactionOperationID = transactionOperationID; }
     bool willAbortTransactionAfterDispatchingEvent() const;
     void transactionTransitionedToFinishing();
+    bool isEventBeingDispatched() const { return !!m_eventBeingDispatched; }
 
 protected:
     IDBRequest(ScriptExecutionContext&, IDBClient::IDBConnectionProxy&, IndexedDB::RequestType);

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -484,8 +484,11 @@ void IDBTransaction::commitInternal()
 
     LOG(IndexedDBOperations, "IDB commit operation: Transaction %s", info().identifier().loggingString().utf8().data());
 
-    scheduleOperation(IDBClient::TransactionOperationImpl::create(*this, nullptr, [protectedThis = Ref { *this }] (auto& operation) {
-        protectedThis->commitOnServer(operation, protectedThis->m_handledRequestResultsCount);
+    uint64_t handledRequestResultsCount = m_handledRequestResultsCount;
+    if (m_currentlyCompletingRequest && m_currentlyCompletingRequest->isEventBeingDispatched())
+        ++handledRequestResultsCount;
+    scheduleOperation(IDBClient::TransactionOperationImpl::create(*this, nullptr, [protectedThis = Ref { *this }, handledRequestResultsCount] (auto& operation) {
+        protectedThis->commitOnServer(operation, handledRequestResultsCount);
     }));
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
@@ -89,7 +89,7 @@ public:
     virtual IDBObjectStoreInfo* infoForObjectStore(uint64_t objectStoreIdentifier) = 0;
     virtual void deleteBackingStore() = 0;
 
-    virtual bool supportsSimultaneousTransactions() = 0;
+    virtual bool supportsSimultaneousReadWriteTransactions() = 0;
     virtual bool isEphemeral() = 0;
     virtual String fullDatabasePath() const = 0;
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -80,7 +80,7 @@ private:
     IDBObjectStoreInfo* infoForObjectStore(uint64_t objectStoreIdentifier) final;
     void deleteBackingStore() final;
 
-    bool supportsSimultaneousTransactions() final { return true; }
+    bool supportsSimultaneousReadWriteTransactions() final { return true; }
     bool isEphemeral() final { return true; }
     String fullDatabasePath() const final { return nullString(); }
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -1151,7 +1151,7 @@ IDBError SQLiteIDBBackingStore::createObjectStore(const IDBResourceIdentifier& t
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to create an object store without an in-progress transaction"_s };
 
     if (transaction->mode() != IDBTransactionMode::Versionchange) {
@@ -2100,7 +2100,7 @@ IDBError SQLiteIDBBackingStore::getRecord(const IDBResourceIdentifier& transacti
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to get a record from database without an in-progress transaction"_s };
 
     auto* objectStoreInfo = infoForObjectStore(objectStoreID);
@@ -2253,7 +2253,7 @@ IDBError SQLiteIDBBackingStore::getAllObjectStoreRecords(const IDBResourceIdenti
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to get records from database without an in-progress transaction"_s };
 
     auto key = getAllRecordsData.keyRangeData.lowerKey;
@@ -2345,7 +2345,7 @@ IDBError SQLiteIDBBackingStore::getAllIndexRecords(const IDBResourceIdentifier& 
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to get all index records from database without an in-progress transaction"_s };
 
     auto cursor = transaction->maybeOpenBackingStoreCursor(getAllRecordsData.objectStoreIdentifier, getAllRecordsData.indexIdentifier, getAllRecordsData.keyRangeData);
@@ -2395,7 +2395,7 @@ IDBError SQLiteIDBBackingStore::getIndexRecord(const IDBResourceIdentifier& tran
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to get an index record from database without an in-progress transaction"_s };
 
     if (range.isExactlyOneKey())
@@ -2492,7 +2492,7 @@ IDBError SQLiteIDBBackingStore::getCount(const IDBResourceIdentifier& transactio
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to get count from database without an in-progress transaction"_s };
 
     outCount = 0;
@@ -2673,7 +2673,7 @@ IDBError SQLiteIDBBackingStore::openCursor(const IDBResourceIdentifier& transact
     ASSERT(m_sqliteDB->isOpen());
 
     auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
+    if (!transaction || !transaction->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to open a cursor in database without an in-progress transaction"_s };
 
     auto* cursor = transaction->maybeOpenCursor(info);
@@ -2705,7 +2705,7 @@ IDBError SQLiteIDBBackingStore::iterateCursor(const IDBResourceIdentifier& trans
 
     ASSERT_UNUSED(transactionIdentifier, cursor->transaction()->transactionIdentifier() == transactionIdentifier);
 
-    if (!cursor->transaction() || !cursor->transaction()->inProgress())
+    if (!cursor->transaction() || !cursor->transaction()->inProgressOrReadOnly())
         return IDBError { ExceptionCode::UnknownError, "Attempt to iterate a cursor without an in-progress transaction"_s };
 
     auto key = data.keyData;

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -83,7 +83,7 @@ public:
     IDBObjectStoreInfo* infoForObjectStore(uint64_t objectStoreIdentifier) final;
     void deleteBackingStore() final;
 
-    bool supportsSimultaneousTransactions() final { return false; }
+    bool supportsSimultaneousReadWriteTransactions() final { return false; }
     bool isEphemeral() final { return false; }
     String fullDatabasePath() const final;
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
@@ -67,7 +67,9 @@ public:
     IDBTransactionMode mode() const { return m_info.mode(); }
     IDBTransactionDurability durability() const { return m_info.durability(); }
     bool inProgress() const;
+    bool inProgressOrReadOnly() const;
 
+    SQLiteDatabase* sqliteDatabase() const;
     SQLiteTransaction* sqliteTransaction() const { return m_sqliteTransaction.get(); }
     SQLiteIDBBackingStore& backingStore() { return m_backingStore; }
 
@@ -80,10 +82,12 @@ private:
 
     void moveBlobFilesIfNecessary();
     void deleteBlobFilesIfNecessary();
+    bool isReadOnly() const { return mode() == IDBTransactionMode::Readonly; }
 
     IDBTransactionInfo m_info;
 
     SQLiteIDBBackingStore& m_backingStore;
+    CheckedPtr<SQLiteDatabase> m_sqliteDatabase;
     std::unique_ptr<SQLiteTransaction> m_sqliteTransaction;
     HashMap<IDBResourceIdentifier, std::unique_ptr<SQLiteIDBCursor>> m_cursors;
     HashSet<SQLiteIDBCursor*> m_backingStoreCursors;


### PR DESCRIPTION
#### 0aa9402244d02204000756d26981253ddb6a9578
<pre>
imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=277659">https://bugs.webkit.org/show_bug.cgi?id=277659</a>
<a href="https://rdar.apple.com/133254563">rdar://133254563</a>

Reviewed by Chris Dumez.

To fix test failure, this patch makes following changes:
1. Add support for simultaneous transactions in SQLiteIDBBackingStore, by only creating a SQLite transaction when the
mode of IDBTransaction is readwrite. With this change, the backend can support simultaneous readonly transactions per
spec. Also, update existing checks in operations that expect SQLite transaction to exists, to expect either SQLite
transaction exists or the transaction is read-only.
2. When IDBTransaction.commit() is invoked during event dispatch for a request, consider the request as handled by
incrementing handledRequestResultsCount. Otherwise, the IndexedDB backend will take the request as not handled by
client, and if the event is error, the backend would abort the transaction instead of committing it. According to spec,
if error event is handled, the transaction can commit; if error event is not handled, the transaction should abort.

This patch also updates some tests that start simultaneous read-only transactions and expect the transactions to happen
in order to start transaction in order (i.e. starting a new transaction when the previous one has finished), to make
the result deterministic.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.js:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker_101-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any_101-last-expected.txt:
* LayoutTests/inspector/indexeddb/clearObjectStore.html:
* LayoutTests/inspector/indexeddb/requestData.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
(WebCore::IDBRequest::isEventBeingDispatched const):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::commitInternal):
* Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::createObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::getRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllIndexRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::getIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getCount):
(WebCore::IDBServer::SQLiteIDBBackingStore::openCursor):
(WebCore::IDBServer::SQLiteIDBBackingStore::iterateCursor):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::createSQLiteStatement):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindStatement):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary):
(WebCore::IDBServer::SQLiteIDBCursor::internalFetchNextRecord):
(WebCore::IDBServer::SQLiteIDBCursor::iterate):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp:
(WebCore::IDBServer::SQLiteIDBTransaction::begin):
(WebCore::IDBServer::SQLiteIDBTransaction::commit):
(WebCore::IDBServer::SQLiteIDBTransaction::moveBlobFilesIfNecessary):
(WebCore::IDBServer::SQLiteIDBTransaction::deleteBlobFilesIfNecessary):
(WebCore::IDBServer::SQLiteIDBTransaction::abort):
(WebCore::IDBServer::SQLiteIDBTransaction::maybeOpenBackingStoreCursor):
(WebCore::IDBServer::SQLiteIDBTransaction::maybeOpenCursor):
(WebCore::IDBServer::SQLiteIDBTransaction::notifyCursorsOfChanges):
(WebCore::IDBServer::SQLiteIDBTransaction::inProgressOrReadOnly const):
(WebCore::IDBServer::SQLiteIDBTransaction::addBlobFile):
(WebCore::IDBServer::SQLiteIDBTransaction::addRemovedBlobFile):
(WebCore::IDBServer::SQLiteIDBTransaction::sqliteDatabase const):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h:
(WebCore::IDBServer::SQLiteIDBTransaction::isReadOnly const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::takeNextRunnableTransaction):

Canonical link: <a href="https://commits.webkit.org/281933@main">https://commits.webkit.org/281933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba7547aa7dbe6f83b731fc211b1a673a887ec22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12034 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49645 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34613 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10485 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67169 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10549 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57243 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13698 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4481 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37733 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38827 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->