### PR TITLE
[Pointer Events] `pointerevent_releasepointercapture_events_to_original_target` WPT test is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture_events_to_original_target_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture_events_to_original_target_mouse-expected.txt
@@ -8,16 +8,16 @@ PASS mouse got/lost pointercapture: subsequent events to target
 PASS mouse pointerover/enter should be received before the target receives gotpointercapture even when the pointer is not over it.
 PASS mouse gotpointercapture.pointerType is correct.
 PASS mouse gotpointercapture event is a PointerEvent event
-FAIL mouse gotpointercapture.isTrusted value is true assert_equals: expected true but got false
-FAIL mouse gotpointercapture.composed value is valid assert_equals: expected true but got false
+PASS mouse gotpointercapture.isTrusted value is true
+PASS mouse gotpointercapture.composed value is valid
 PASS mouse gotpointercapture.bubbles value is valid
 PASS mouse gotpointercapture.cancelable value is valid
 PASS mouse gotpointercapture.pressure value is valid
 PASS mouse gotpointercapture properties for pointerType = mouse
 PASS mouse lostpointercapture.pointerType is correct.
 PASS mouse lostpointercapture event is a PointerEvent event
-FAIL mouse lostpointercapture.isTrusted value is true assert_equals: expected true but got false
-FAIL mouse lostpointercapture.composed value is valid assert_equals: expected true but got false
+PASS mouse lostpointercapture.isTrusted value is true
+PASS mouse lostpointercapture.composed value is valid
 PASS mouse lostpointercapture.bubbles value is valid
 PASS mouse lostpointercapture.cancelable value is valid
 PASS mouse lostpointercapture.pressure value is valid

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture_events_to_original_target_pen-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture_events_to_original_target_pen-expected.txt
@@ -8,16 +8,16 @@ PASS pen got/lost pointercapture: subsequent events to target
 PASS pen pointerover/enter should be received before the target receives gotpointercapture even when the pointer is not over it.
 FAIL pen gotpointercapture.pointerType is correct. assert_equals: expected "pen" but got "mouse"
 PASS pen gotpointercapture event is a PointerEvent event
-FAIL pen gotpointercapture.isTrusted value is true assert_equals: expected true but got false
-FAIL pen gotpointercapture.composed value is valid assert_equals: expected true but got false
+PASS pen gotpointercapture.isTrusted value is true
+PASS pen gotpointercapture.composed value is valid
 PASS pen gotpointercapture.bubbles value is valid
 PASS pen gotpointercapture.cancelable value is valid
 PASS pen gotpointercapture.pressure value is valid
 PASS pen gotpointercapture properties for pointerType = mouse
 FAIL pen lostpointercapture.pointerType is correct. assert_equals: expected "pen" but got "mouse"
 PASS pen lostpointercapture event is a PointerEvent event
-FAIL pen lostpointercapture.isTrusted value is true assert_equals: expected true but got false
-FAIL pen lostpointercapture.composed value is valid assert_equals: expected true but got false
+PASS pen lostpointercapture.isTrusted value is true
+PASS pen lostpointercapture.composed value is valid
 PASS pen lostpointercapture.bubbles value is valid
 PASS pen lostpointercapture.cancelable value is valid
 PASS pen lostpointercapture.pressure value is valid

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -53,7 +53,7 @@ Ref<DragEvent> DragEvent::create(const AtomString& type, CanBubble canBubble, Is
 }
 
 DragEvent::DragEvent(const AtomString& eventType, DragEventInit&& init)
-    : MouseEvent(EventInterfaceType::DragEvent, eventType, init)
+    : MouseEvent(EventInterfaceType::DragEvent, eventType, init, IsTrusted::No)
     , m_dataTransfer(WTFMove(init.dataTransfer))
 {
 }

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -53,7 +53,7 @@ bool isAnyClick(const Event& event)
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& type, const MouseEventInit& initializer)
 {
-    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, initializer));
+    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, initializer, IsTrusted::No));
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowProxy>&& view, const PlatformMouseEvent& event, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, int detail, Node* relatedTarget)
@@ -125,8 +125,8 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString&
     initCoordinates(clientLocation);
 }
 
-MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseEventInit& initializer)
-    : MouseRelatedEvent(eventInterface, eventType, initializer)
+MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseEventInit& initializer, IsTrusted isTrusted)
+    : MouseRelatedEvent(eventInterface, eventType, initializer, isTrusted)
     , m_button(initializer.button == enumToUnderlyingType(MouseButton::None) ? enumToUnderlyingType(MouseButton::Left) : initializer.button)
     , m_buttons(initializer.buttons)
     , m_buttonDown(initializer.button != enumToUnderlyingType(MouseButton::None))

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -104,7 +104,7 @@ protected:
         const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         SyntheticClickType, EventTarget* relatedTarget);
 
-    MouseEvent(enum EventInterfaceType, const AtomString& type, const MouseEventInit&);
+    MouseEvent(enum EventInterfaceType, const AtomString& type, const MouseEventInit&, IsTrusted);
 
     MouseEvent(enum EventInterfaceType);
 

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -69,12 +69,11 @@ MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, con
 }
 
 MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
-    : UIEventWithKeyState(eventInterface, eventType, initializer)
+    : UIEventWithKeyState(eventInterface, eventType, initializer, isTrusted)
     , m_screenLocation(IntPoint(initializer.screenX, initializer.screenY))
     , m_movementX(initializer.movementX)
     , m_movementY(initializer.movementY)
 {
-    ASSERT_UNUSED(isTrusted, isTrusted == IsTrusted::No);
     init(false, IntPoint(0, 0));
 }
 

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -86,8 +86,8 @@ PointerEvent::PointerEvent()
 {
 }
 
-PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, initializer)
+PointerEvent::PointerEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, initializer, isTrusted)
     , m_pointerId(initializer.pointerId)
     , m_width(initializer.width)
     , m_height(initializer.height)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -66,7 +66,7 @@ public:
 
     static Ref<PointerEvent> create(const AtomString& type, Init&& initializer)
     {
-        return adoptRef(*new PointerEvent(type, WTFMove(initializer)));
+        return adoptRef(*new PointerEvent(type, WTFMove(initializer), IsTrusted::No));
     }
 
     static Ref<PointerEvent> createForPointerCapture(const AtomString& type, PointerID pointerId, bool isPrimary, String pointerType)
@@ -76,7 +76,8 @@ public:
         initializer.pointerId = pointerId;
         initializer.isPrimary = isPrimary;
         initializer.pointerType = pointerType;
-        return adoptRef(*new PointerEvent(type, WTFMove(initializer)));
+        initializer.composed = true;
+        return adoptRef(*new PointerEvent(type, WTFMove(initializer), IsTrusted::Yes));
     }
 
     static Ref<PointerEvent> createForBindings()
@@ -147,7 +148,7 @@ private:
     }
 
     PointerEvent();
-    PointerEvent(const AtomString&, Init&&);
+    PointerEvent(const AtomString&, Init&&, IsTrusted);
     PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))

--- a/Source/WebCore/dom/UIEvent.h
+++ b/Source/WebCore/dom/UIEvent.h
@@ -44,9 +44,9 @@ public:
     {
         return adoptRef(*new UIEvent(EventInterfaceType::UIEvent));
     }
-    static Ref<UIEvent> create(const AtomString& type, const UIEventInit& initializer, IsTrusted = IsTrusted::No)
+    static Ref<UIEvent> create(const AtomString& type, const UIEventInit& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new UIEvent(EventInterfaceType::UIEvent, type, initializer));
+        return adoptRef(*new UIEvent(EventInterfaceType::UIEvent, type, initializer, isTrusted));
     }
     virtual ~UIEvent();
 

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -54,7 +54,7 @@ inline WheelEvent::WheelEvent()
 }
 
 inline WheelEvent::WheelEvent(const AtomString& type, const Init& initializer)
-    : MouseEvent(EventInterfaceType::WheelEvent, type, initializer)
+    : MouseEvent(EventInterfaceType::WheelEvent, type, initializer, IsTrusted::No)
     , m_wheelDelta(initializer.wheelDeltaX ? initializer.wheelDeltaX : clampTo<int>(-initializer.deltaX), initializer.wheelDeltaY ? initializer.wheelDeltaY : clampTo<int>(-initializer.deltaY))
     , m_deltaX(initializer.deltaX ? initializer.deltaX : wheelDeltaToDelta(initializer.wheelDeltaX))
     , m_deltaY(initializer.deltaY ? initializer.deltaY : wheelDeltaToDelta(initializer.wheelDeltaY))


### PR DESCRIPTION
#### 9a69e3a119fb9bf32a722703b94426d9cf991db2
<pre>
[Pointer Events] `pointerevent_releasepointercapture_events_to_original_target` WPT test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=277664">https://bugs.webkit.org/show_bug.cgi?id=277664</a>
<a href="https://rdar.apple.com/133259027">rdar://133259027</a>

Reviewed by Tim Nguyen and Abrar Rahman Protyasha.

Ensure that pointer events created for pointer capture are trusted and composed.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture_events_to_original_target_mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture_events_to_original_target_pen-expected.txt:
* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::DragEvent):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::MouseEvent):
* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::MouseRelatedEvent):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/UIEvent.h:
(WebCore::UIEvent::create):
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::WheelEvent):

Canonical link: <a href="https://commits.webkit.org/281875@main">https://commits.webkit.org/281875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a755df5a32361922040461b55250fbd8bd5efa9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49542 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8239 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30380 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10340 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10773 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10640 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66992 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57119 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4343 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38653 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->