### PR TITLE
WebCoreAVFResourceLoader may give more data than requested.

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -367,8 +367,7 @@ bool WebCoreAVFResourceLoader::responseReceived(const String& mimeType, int stat
         return true;
     }
 
-    if (contentRange.isValid())
-        m_responseOffset = static_cast<NSUInteger>(contentRange.firstBytePosition());
+    m_responseOffset = contentRange.isValid() ? static_cast<NSUInteger>(contentRange.firstBytePosition()) : 0;
 
     if (AVAssetResourceLoadingContentInformationRequest* contentInfo = [m_avRequest contentInformationRequest]) {
         String uti = UTIFromMIMEType(mimeType);
@@ -437,42 +436,40 @@ bool WebCoreAVFResourceLoader::newDataStoredInSharedBuffer(const FragmentedShare
     auto bytesToSkip = m_currentOffset - m_responseOffset;
     auto array = data.createNSDataArray();
     for (NSData* segment in array.get()) {
+        if (!remainingLength)
+            break;
+        NSUInteger usableBytes = segment.length;
+        NSUInteger bytesOffset = 0;
         if (bytesToSkip) {
             if (bytesToSkip > segment.length) {
                 bytesToSkip -= segment.length;
                 continue;
             }
-            auto bytesToUse = segment.length - bytesToSkip;
-            [dataRequest respondWithData:[segment subdataWithRange:NSMakeRange(static_cast<NSUInteger>(bytesToSkip), static_cast<NSUInteger>(bytesToUse))]];
+            usableBytes = segment.length - bytesToSkip;
+            bytesOffset = bytesToSkip;
             bytesToSkip = 0;
-            remainingLength -= bytesToUse;
-            m_currentOffset += bytesToUse;
-            continue;
         }
-        if (segment.length <= remainingLength) {
+        m_currentOffset += usableBytes;
+        if (!bytesOffset && usableBytes <= remainingLength)
             [dataRequest respondWithData:segment];
-            remainingLength -= segment.length;
-            m_currentOffset += segment.length;
-            continue;
+        else {
+            usableBytes = std::min(usableBytes, remainingLength);
+            [dataRequest respondWithData:[segment subdataWithRange:NSMakeRange(bytesOffset, usableBytes)]];
         }
-        [dataRequest respondWithData:[segment subdataWithRange:NSMakeRange(0, remainingLength)]];
-        m_currentOffset += remainingLength;
-        remainingLength = 0;
-        break;
+        remainingLength -= usableBytes;
     }
 
     // There was not enough data in the buffer to satisfy the data request.
     if (remainingLength)
         return false;
 
-    if (m_currentOffset >= m_requestedOffset + m_requestedLength) {
-        BEGIN_BLOCK_OBJC_EXCEPTIONS
-        [m_avRequest finishLoading];
-        END_BLOCK_OBJC_EXCEPTIONS
-        stopLoading();
-        return true;
-    }
-    return false;
+    ASSERT(m_currentOffset >= m_requestedOffset + m_requestedLength);
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    [m_avRequest finishLoading];
+    END_BLOCK_OBJC_EXCEPTIONS
+    stopLoading();
+    return true;
 }
 
 }


### PR DESCRIPTION
#### 37c2e6ab592c3248e8ef2adae350c05b583b92be
<pre>
WebCoreAVFResourceLoader may give more data than requested.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277661">https://bugs.webkit.org/show_bug.cgi?id=277661</a>
<a href="https://rdar.apple.com/133256334">rdar://133256334</a>

Reviewed by Jer Noble.

A logic error could have caused to feed the AVAssetResourceLoadingRequest more data
than requested and we would unnecessarily wait for more data to come.
We can also simplify the code a bit by removing some branches.

No observable changes, covered by existing tests.

* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::responseReceived):
(WebCore::WebCoreAVFResourceLoader::newDataStoredInSharedBuffer):

Canonical link: <a href="https://commits.webkit.org/301298@main">https://commits.webkit.org/301298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd594a3deec816b4bd6e23951614163b1aa7a05a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77413 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c44713ac-5098-4061-8181-0573b47a83fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95595 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ca671e3-189d-4e67-93dc-89fdd0cc0281) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1ebd033-3200-4170-ac9b-d184af65b038) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135055 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104075 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58012 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51570 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54925 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->