### PR TITLE
Adds interface to send ECN bits for WebRTC from 'Network Process' to 'Web Process'.

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -104,7 +104,7 @@ void LibWebRTCSocketClient::signalReadPacket(rtc::AsyncPacketSocket* socket, con
 {
     ASSERT_UNUSED(socket, m_socket.get() == socket);
     std::span data(byteCast<uint8_t>(value), length);
-    m_connection->send(Messages::LibWebRTCNetwork::SignalReadPacket(m_identifier, data, RTCNetwork::IPAddress(address.ipaddr()), address.port(), packetTime), 0);
+    m_connection->send(Messages::LibWebRTCNetwork::SignalReadPacket(m_identifier, data, RTCNetwork::IPAddress(address.ipaddr()), address.port(), packetTime, RTC::Network::EcnMarking::kNotEct), 0);
 }
 
 void LibWebRTCSocketClient::signalSentPacket(rtc::AsyncPacketSocket* socket, const rtc::SentPacket& sentPacket)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -145,7 +145,7 @@ NetworkRTCTCPSocketCocoa::NetworkRTCTCPSocketCocoa(LibWebRTCSocketIdentifier ide
 
     processIncomingData(m_nwConnection.get(), [identifier = m_identifier, connection = m_connection.copyRef(), ip = remoteAddress.ipaddr(), port = remoteAddress.port(), isSTUN = m_isSTUN](Vector<uint8_t>&& buffer) mutable {
         return WebRTC::extractMessages(WTFMove(buffer), isSTUN ? WebRTC::MessageType::STUN : WebRTC::MessageType::Data, [&](auto data) {
-            connection->send(Messages::LibWebRTCNetwork::SignalReadPacket { identifier, data, RTCNetwork::IPAddress(ip), port, rtc::TimeMicros() }, 0);
+            connection->send(Messages::LibWebRTCNetwork::SignalReadPacket { identifier, data, RTCNetwork::IPAddress(ip), port, rtc::TimeMicros(), RTC::Network::EcnMarking::kNotEct }, 0);
         });
     });
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -129,6 +129,31 @@ void NetworkRTCUDPSocketCocoa::sendTo(std::span<const uint8_t> data, const rtc::
     m_connections->sendTo(data, address, options);
 }
 
+static RTC::Network::EcnMarking getECN(nw_content_context_t nwContext)
+{
+    auto protocol = adoptNS(nw_protocol_copy_ip_definition());
+    auto metadata = adoptNS(nw_content_context_copy_protocol_metadata(nwContext, protocol.get()));
+
+    if (metadata && nw_protocol_metadata_is_ip(metadata.get())) {
+        auto ecnFlag = nw_ip_metadata_get_ecn_flag(metadata.get());
+        switch (ecnFlag) {
+        case nw_ip_ecn_flag_non_ect:
+            return RTC::Network::EcnMarking::kNotEct;
+        case nw_ip_ecn_flag_ect_0:
+            return RTC::Network::EcnMarking::kEct0;
+        case nw_ip_ecn_flag_ect_1:
+            return RTC::Network::EcnMarking::kEct1;
+        case nw_ip_ecn_flag_ce:
+            return RTC::Network::EcnMarking::kCe;
+        default:
+            return RTC::Network::EcnMarking::kNotEct;
+        }
+    }
+
+    RELEASE_LOG_IF(!metadata, WebRTC, "Could not retreive the metadata from UDPSocket Context, so use default ECN value");
+    return RTC::Network::EcnMarking::kNotEct;
+}
+
 static rtc::SocketAddress socketAddressFromIncomingConnection(nw_connection_t connection)
 {
     auto endpoint = adoptNS(nw_connection_copy_endpoint(connection));
@@ -300,13 +325,13 @@ void NetworkRTCUDPSocketCocoaConnections::setOption(int option, int value)
         nw_connection_reset_traffic_class(nwConnection.first.get(), *m_trafficClass);
 }
 
-static inline void processUDPData(RetainPtr<nw_connection_t>&& nwConnection, Ref<NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker> connectionStateTracker, int errorCode, Function<void(std::span<const uint8_t>)>&& processData)
+static inline void processUDPData(RetainPtr<nw_connection_t>&& nwConnection, Ref<NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker> connectionStateTracker, int errorCode, Function<void(std::span<const uint8_t>, RTC::Network::EcnMarking)>&& processData)
 {
     auto nwConnectionReference = nwConnection.get();
     nw_connection_receive(nwConnectionReference, 1, std::numeric_limits<uint32_t>::max(), makeBlockPtr([nwConnection = WTFMove(nwConnection), processData = WTFMove(processData), errorCode, connectionStateTracker = WTFMove(connectionStateTracker)](dispatch_data_t content, nw_content_context_t context, bool, nw_error_t error) mutable {
         if (content) {
             dispatch_data_apply(content, makeBlockPtr([&](dispatch_data_t, size_t, const void* data, size_t size) {
-                processData({ static_cast<const uint8_t*>(data), size });
+                processData({ static_cast<const uint8_t*>(data), size }, getECN(context));
                 return true;
             }).get());
         }
@@ -360,8 +385,8 @@ void NetworkRTCUDPSocketCocoaConnections::setupNWConnection(nw_connection_t nwCo
             connectionStateTracker->markAsStopped();
     }).get());
 
-    processUDPData(nwConnection, Ref  { connectionStateTracker }, 0, [identifier = m_identifier, connection = m_connection.copyRef(), ip = remoteAddress.ipaddr(), port = remoteAddress.port()](std::span<const uint8_t> message) mutable {
-        connection->send(Messages::LibWebRTCNetwork::SignalReadPacket { identifier, message, RTCNetwork::IPAddress(ip), port, rtc::TimeMicros() }, 0);
+    processUDPData(nwConnection, Ref  { connectionStateTracker }, 0, [identifier = m_identifier, connection = m_connection.copyRef(), ip = remoteAddress.ipaddr(), port = remoteAddress.port()](std::span<const uint8_t> message, RTC::Network::EcnMarking ecn) mutable {
+        connection->send(Messages::LibWebRTCNetwork::SignalReadPacket { identifier, message, RTCNetwork::IPAddress(ip), port, rtc::TimeMicros(), ecn }, 0);
     });
 
     nw_connection_start(nwConnection);

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1113,6 +1113,7 @@ def headers_for_type(type):
         'WebKit::PaymentSetupFeatures': ['"ApplePayPaymentSetupFeaturesWebKit.h"'],
         'WebKit::ImageBufferSetPrepareBufferForDisplayInputData': ['"PrepareBackingStoreBuffersData.h"'],
         'WebKit::ImageBufferSetPrepareBufferForDisplayOutputData': ['"PrepareBackingStoreBuffersData.h"'],
+        'WebKit::RTC::Network::EcnMarking': ['"RTCNetwork.h"'],
         'WebKit::RTC::Network::IPAddress': ['"RTCNetwork.h"'],
         'WebKit::RTC::Network::SocketAddress': ['"RTCNetwork.h"'],
         'WebKit::RemoteVideoFrameReadReference': ['"RemoteVideoFrameIdentifier.h"'],

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -43,6 +43,14 @@ namespace WebKit {
 
 namespace RTC::Network {
 
+// This enums corresponds to rtc::EcnMarking.
+enum class EcnMarking : int {
+    kNotEct = 0, // Not ECN-Capable Transport
+    kEct1 = 1, // ECN-Capable Transport
+    kEct0 = 2, // Not used by L4s (or webrtc.)
+    kCe = 3, // Congestion experienced
+};
+
 struct IPAddress {
     struct UnspecifiedFamily { };
 

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -22,6 +22,14 @@
 
 #if USE(LIBWEBRTC)
 
+header: "RTCNetwork.h"
+enum class WebKit::RTC::Network::EcnMarking : int {
+    kNotEct,
+    kEct1,
+    kEct0,
+    kCe
+}
+
 [CustomHeader] struct WebKit::RTC::Network::IPAddress {
     std::variant<WebKit::RTC::Network::IPAddress::UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
 };

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -71,7 +71,7 @@ private:
 #if USE(LIBWEBRTC)
     void setSocketFactoryConnection();
 
-    void signalReadPacket(WebCore::LibWebRTCSocketIdentifier, std::span<const uint8_t>, const RTCNetwork::IPAddress&, uint16_t port, int64_t);
+    void signalReadPacket(WebCore::LibWebRTCSocketIdentifier, std::span<const uint8_t>, const RTCNetwork::IPAddress&, uint16_t port, int64_t, RTC::Network::EcnMarking);
     void signalSentPacket(WebCore::LibWebRTCSocketIdentifier, int64_t, int64_t);
     void signalAddressReady(WebCore::LibWebRTCSocketIdentifier, const RTCNetwork::SocketAddress&);
     void signalConnect(WebCore::LibWebRTCSocketIdentifier);

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
@@ -23,7 +23,7 @@
 #if USE(LIBWEBRTC)
 
 messages -> LibWebRTCNetwork NotRefCounted {
-    SignalReadPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, std::span<const uint8_t> data, WebKit::RTC::Network::IPAddress address, uint16_t port, int64_t timestamp)
+    SignalReadPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, std::span<const uint8_t> data, WebKit::RTC::Network::IPAddress address, uint16_t port, int64_t timestamp, WebKit::RTC::Network::EcnMarking ecn)
     SignalSentPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, int64_t rtcPacketID, int64_t timestamp)
     SignalAddressReady(WebCore::LibWebRTCSocketIdentifier socketIdentifier, WebKit::RTC::Network::SocketAddress address)
     SignalConnect(WebCore::LibWebRTCSocketIdentifier socketIdentifier)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -77,7 +77,7 @@ void LibWebRTCSocket::signalAddressReady(const rtc::SocketAddress& address)
     SignalAddressReady(this, m_localAddress);
 }
 
-void LibWebRTCSocket::signalReadPacket(std::span<const uint8_t> data, rtc::SocketAddress&& address, int64_t timestamp)
+void LibWebRTCSocket::signalReadPacket(std::span<const uint8_t> data, rtc::SocketAddress&& address, int64_t timestamp, rtc::EcnMarking ecn)
 {
     if (m_isSuspended)
         return;
@@ -86,7 +86,7 @@ void LibWebRTCSocket::signalReadPacket(std::span<const uint8_t> data, rtc::Socke
     absl::optional<webrtc::Timestamp> packetTimestamp;
     if (timestamp)
         packetTimestamp = webrtc::Timestamp::Micros(timestamp);
-    NotifyPacketReceived({ { data.data(), data.size() }, m_remoteAddress, packetTimestamp });
+    NotifyPacketReceived({ { data.data(), data.size() }, m_remoteAddress, packetTimestamp, ecn });
 }
 
 void LibWebRTCSocket::signalSentPacket(int64_t rtcPacketID, int64_t sendTimeMs)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -80,7 +80,7 @@ private:
     bool willSend(size_t);
 
     friend class LibWebRTCNetwork;
-    void signalReadPacket(std::span<const uint8_t>, rtc::SocketAddress&&, int64_t);
+    void signalReadPacket(std::span<const uint8_t>, rtc::SocketAddress&&, int64_t, rtc::EcnMarking);
     void signalSentPacket(int64_t, int64_t);
     void signalAddressReady(const rtc::SocketAddress&);
     void signalConnect();


### PR DESCRIPTION
#### e243885913ef60bed4b13c7efce0abf0a17f2541
<pre>
Adds interface to send ECN bits for WebRTC from &apos;Network Process&apos; to &apos;Web Process&apos;.

<a href="https://bugs.webkit.org/show_bug.cgi?id=271191">https://bugs.webkit.org/show_bug.cgi?id=271191</a>

Reviewed by Youenn Fablet.

ECN means Explicit Congestion Notification.
See RFC9330 for details.

* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:
(WebKit::LibWebRTCSocketClient::signalReadPacket):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::NetworkRTCTCPSocketCocoa::NetworkRTCTCPSocketCocoa):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::getECN):
(WebKit::processUDPData):
(WebKit::NetworkRTCUDPSocketCocoaConnections::setupNWConnection):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/RTCNetwork.h:
* Source/WebKit/Shared/RTCNetwork.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::convertToWebRTCEcnMarking):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::signalReadPacket):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:

Canonical link: <a href="https://commits.webkit.org/282674@main">https://commits.webkit.org/282674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4599874a5587858a2e0ab0dbd79990cbb7faa68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14455 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51450 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10000 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32066 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/63359 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36702 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13328 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69565 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58772 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55372 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14136 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6483 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39846 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->