### PR TITLE
Accept `cursor` in `::marker`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-testing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-testing-expected.txt
@@ -1,31 +1,28 @@
 
 
-FAIL outside image ::marker's content assert_equals: event.target expected Element node <li class="image"></li> but got Element node <ol class="outside" data-x="-65">
+PASS outside image ::marker's content
+FAIL outside image ::marker assert_equals: event.target expected Element node <li class="image"></li> but got Element node <ol class="outside" data-x="-65">
   <li class="image"></l...
-FAIL outside image ::marker assert_equals: event.target expected Element node <li class="image"></li> but got Element node <html><head><meta charset="utf-8">
-<title>CSS Pseudo-Elem...
-FAIL outside string ::marker's content assert_equals: event.target expected Element node <li class="string"></li> but got Element node <ol class="outside" data-x="-65">
+PASS outside string ::marker's content
+FAIL outside string ::marker assert_equals: event.target expected Element node <li class="string"></li> but got Element node <ol class="outside" data-x="-65">
   <li class="image"></l...
-FAIL outside string ::marker assert_equals: event.target expected Element node <li class="string"></li> but got Element node <li class="image"></li>
-FAIL outside marker ::marker's content assert_equals: event.target expected Element node <li class="marker"></li> but got Element node <ol class="outside" data-x="-65">
-  <li class="image"></l...
+PASS outside marker ::marker's content
 FAIL outside marker ::marker assert_equals: event.target expected Element node <li class="marker"></li> but got Element node <ol class="outside" data-x="-65">
   <li class="image"></l...
-FAIL outside nested image ::marker's content assert_equals: event.target expected Element node <li class="nested image"></li> but got Element node <ol class="outside" data-x="-65">
+PASS outside nested image ::marker's content
+FAIL outside nested image ::marker assert_equals: event.target expected Element node <li class="nested image"></li> but got Element node <ol class="outside" data-x="-65">
   <li class="image"></l...
-FAIL outside nested image ::marker assert_equals: event.target expected Element node <li class="nested image"></li> but got Element node <li class="marker"></li>
-FAIL outside nested string ::marker's content assert_equals: event.target expected Element node <li class="nested string"></li> but got Element node <ol class="outside" data-x="-65">
+PASS outside nested string ::marker's content
+FAIL outside nested string ::marker assert_equals: event.target expected Element node <li class="nested string"></li> but got Element node <ol class="outside" data-x="-65">
   <li class="image"></l...
-FAIL outside nested string ::marker assert_equals: event.target expected Element node <li class="nested string"></li> but got Element node <li class="nested image"></li>
 PASS inside image ::marker's content
-FAIL inside image ::marker assert_equals: event.target expected Element node <li class="image"></li> but got Element node <html><head><meta charset="utf-8">
-<title>CSS Pseudo-Elem...
+PASS inside image ::marker
 PASS inside string ::marker's content
-FAIL inside string ::marker assert_equals: event.target expected Element node <li class="string"></li> but got Element node <li class="image"></li>
+PASS inside string ::marker
 PASS inside marker ::marker's content
-FAIL inside marker ::marker assert_equals: event.target expected Element node <li class="marker"></li> but got Element node <li class="string"></li>
+PASS inside marker ::marker
 PASS inside nested image ::marker's content
-FAIL inside nested image ::marker assert_equals: event.target expected Element node <li class="nested image"></li> but got Element node <li class="marker"></li>
+PASS inside nested image ::marker
 PASS inside nested string ::marker's content
-FAIL inside nested string ::marker assert_equals: event.target expected Element node <li class="nested string"></li> but got Element node <li class="nested image"></li>
+PASS inside nested string ::marker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-expected.txt
@@ -54,7 +54,7 @@ PASS Property text-emphasis-color value 'rgb(0, 255, 0)' in ::marker
 PASS Property text-emphasis-position value 'under left' in ::marker
 PASS Property text-emphasis-style value 'dot' in ::marker
 PASS Property text-shadow value 'rgb(0, 255, 0) 1px 2px 3px' in ::marker
-FAIL Property cursor value 'move' in ::marker assert_equals: expected "move" but got "auto"
+PASS Property cursor value 'move' in ::marker
 PASS Property display value 'none' in ::marker
 PASS Property position value 'absolute' in ::marker
 PASS Property float value 'right' in ::marker

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation-expected.txt
@@ -39,7 +39,7 @@ PASS Animation of text-emphasis-color in ::marker
 PASS Animation of text-emphasis-position in ::marker
 PASS Animation of text-emphasis-style in ::marker
 PASS Animation of text-shadow in ::marker
-FAIL Animation of cursor in ::marker assert_equals: expected "move" but got "auto"
+PASS Animation of cursor in ::marker
 PASS Animation of display in ::marker
 PASS Animation of position in ::marker
 PASS Animation of float in ::marker
@@ -87,7 +87,7 @@ PASS Transition of text-emphasis-color in ::marker
 PASS Transition of text-emphasis-position in ::marker
 PASS Transition of text-emphasis-style in ::marker
 PASS Transition of text-shadow in ::marker
-FAIL Transition of cursor in ::marker assert_equals: expected "move" but got "auto"
+PASS Transition of cursor in ::marker
 PASS Transition of display in ::marker
 PASS Transition of position in ::marker
 PASS Transition of float in ::marker

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -44,6 +44,7 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyColor:
     case CSSPropertyContent:
     case CSSPropertyCustom:
+    case CSSPropertyCursor:
     case CSSPropertyDirection:
     case CSSPropertyFont:
     case CSSPropertyFontFamily:


### PR DESCRIPTION
#### 1d2e717a18a2643b67b8d6a36685811344241d6f
<pre>
Accept `cursor` in `::marker`
<a href="https://bugs.webkit.org/show_bug.cgi?id=277662">https://bugs.webkit.org/show_bug.cgi?id=277662</a>
<a href="https://rdar.apple.com/problem/133256523">rdar://problem/133256523</a>

Reviewed by Tim Nguyen.

Add CSSPropertyCursor to the list of ValidMarkerStyleProperties because the CSS Working Group agreed that &quot;cursor property applies to ::marker pseudo&quot;
<a href="https://github.com/w3c/csswg-drafts/issues/6203#issuecomment-2221026768">https://github.com/w3c/csswg-drafts/issues/6203#issuecomment-2221026768</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-testing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation-expected.txt:
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidMarkerStyleProperty):

Canonical link: <a href="https://commits.webkit.org/282642@main">https://commits.webkit.org/282642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08fdceca5927b6cdd1bd6a831a3ecc1f11e0e492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14677 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9958 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32019 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13270 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55318 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14112 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6434 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->