### PR TITLE
Web Inspector: allow sourcemaps to be blackboxed

### DIFF
--- a/LayoutTests/inspector/debugger/resources/source-map.js
+++ b/LayoutTests/inspector/debugger/resources/source-map.js
@@ -1,0 +1,2 @@
+(()=>{function n(r){return"inner"+r}function t(r){let e="middle";return e+=n(r),e}globalThis.outer=function(r){let e="outer";return e+=t(r),e};})();
+//# sourceMappingURL=source-map.js.map

--- a/LayoutTests/inspector/debugger/resources/source-map.js.map
+++ b/LayoutTests/inspector/debugger/resources/source-map.js.map
@@ -1,0 +1,15 @@
+{
+    "version": 3,
+    "sources": [
+        "inner.js",
+        "middle.js",
+        "outer.js"
+    ],
+    "sourcesContent": [
+        "export function inner(x) {\n    return \"inner\" + x;\n}\n",
+        "import { inner } from \"./inner.js\"\n\nexport function middle(x) {\n    let y = \"middle\";\n    y += inner(x);\n    return y;\n}\n",
+        "import { middle } from \"./middle.js\"\n\nglobalThis.outer = function(x) {\n    let y = \"outer\";\n    y += middle(x);\n    return y;\n};\n"
+    ],
+    "mappings": "MAAO,SAASA,EAAMC,EAAG,CACrB,MAAO,QAAUA,CACrB,CCAO,SAASC,EAAOC,EAAG,CACtB,IAAIC,EAAI,SACR,OAAAA,GAAKC,EAAMF,CAAC,EACLC,CACX,CCJA,WAAW,MAAQ,SAASE,EAAG,CAC3B,IAAIC,EAAI,QACR,OAAAA,GAAKC,EAAOF,CAAC,EACNC,CACX",
+    "names": ["inner", "x", "middle", "x", "y", "inner", "x", "y", "middle"]
+}

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner-expected.txt
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner-expected.txt
@@ -1,0 +1,133 @@
+Tests Debugger.setShouldBlackboxURL.
+
+
+== Running test suite: Debugger.setShouldBlackboxURL
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.inner
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT n:3:8
+      0    import { inner } from "./inner.js"
+      1
+ ->   2    export |function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+      5        return y;
+
+PAUSE AT t:6:12
+      2    export function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+ ->   5        return |y;
+      6    }
+      7
+
+PAUSE AT t:3:1
+      0    import { middle } from "./middle.js"
+      1
+ ->   2    |globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+
+PAUSE AT <anonymous>:6:12
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+ ->   5        return |y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:7:1
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+ ->   6    |};
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.middle
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT n:2:5
+      0    export function inner(x) {
+ ->   1        |return "inner" + x;
+      2    }
+      3
+
+PAUSE AT t:3:1
+      0    import { middle } from "./middle.js"
+      1
+ ->   2    |globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+
+PAUSE AT <anonymous>:6:12
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+ ->   5        return |y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:7:1
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+ ->   6    |};
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.outer
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT n:2:5
+      0    export function inner(x) {
+ ->   1        |return "inner" + x;
+      2    }
+      3
+
+PAUSE AT n:3:8
+      0    import { inner } from "./inner.js"
+      1
+ ->   2    export |function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+      5        return y;
+
+PAUSE AT t:6:12
+      2    export function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+ ->   5        return |y;
+      6    }
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner.html
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/log-pause-location.js"></script>
+<script src="resources/source-map.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Debugger.setShouldBlackboxURL");
+
+    const sourceMappingURL = "source-map.js.map";
+
+    async function getSourceMap() {
+        for (let sourceMap of WI.SourceMap.instances) {
+            if (sourceMap.sourceMappingURL.endsWith(sourceMappingURL))
+                return sourceMap
+        }
+
+        while (true) {
+            let sourceMapAddedEvent = await WI.SourceCode.awaitEvent(WI.SourceCode.Event.SourceMapAdded);
+            let {sourceMap} = sourceMapAddedEvent.data;
+            if (sourceMap.sourceMappingURL.endsWith(sourceMappingURL))
+                return sourceMap;
+        }
+    }
+
+    async function getResources() {
+        let sourceMap = await getSourceMap();
+
+        let inner = sourceMap.resources.find((resource) => resource.url.endsWith("inner.js"));
+        let middle = sourceMap.resources.find((resource) => resource.url.endsWith("middle.js"));
+        let outer = sourceMap.resources.find((resource) => resource.url.endsWith("outer.js"));
+        InspectorTest.assert(inner && middle && outer, "All resources should exist when the WI.SourceMap is added.");
+        return {inner, middle, outer};
+    }
+
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepInto();
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.inner",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {inner} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(inner, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = inner.createSourceCodeLocation(1, 0); // first line of `inner`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(inner, false);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.middle",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {inner, middle} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(middle, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = inner.createSourceCodeLocation(1, 0); // first line of `inner`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(middle, false);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.inner.Blackbox.outer",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {inner, outer} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(outer, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = inner.createSourceCodeLocation(1, 0); // first line of `inner`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(outer, false);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests Debugger.setShouldBlackboxURL.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle-expected.txt
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle-expected.txt
@@ -1,0 +1,187 @@
+Tests Debugger.setShouldBlackboxURL.
+
+
+== Running test suite: Debugger.setShouldBlackboxURL
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.inner
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT t:4:5
+      0    import { inner } from "./inner.js"
+      1
+      2    export function middle(x) {
+ ->   3        |let y = "middle";
+      4        y += inner(x);
+      5        return y;
+      6    }
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT n:3:8
+      0    import { inner } from "./inner.js"
+      1
+ ->   2    export |function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+      5        return y;
+
+PAUSE AT t:6:12
+      2    export function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+ ->   5        return |y;
+      6    }
+      7
+
+PAUSE AT t:3:1
+      0    import { middle } from "./middle.js"
+      1
+ ->   2    |globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+
+PAUSE AT <anonymous>:6:12
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+ ->   5        return |y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:7:1
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+ ->   6    |};
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.middle
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT n:2:5
+      0    export function inner(x) {
+ ->   1        |return "inner" + x;
+      2    }
+      3
+
+PAUSE AT t:3:1
+      0    import { middle } from "./middle.js"
+      1
+ ->   2    |globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+
+PAUSE AT <anonymous>:6:12
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+ ->   5        return |y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:7:1
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+ ->   6    |};
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.outer
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT t:4:5
+      0    import { inner } from "./inner.js"
+      1
+      2    export function middle(x) {
+ ->   3        |let y = "middle";
+      4        y += inner(x);
+      5        return y;
+      6    }
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT n:2:5
+      0    export function inner(x) {
+ ->   1        |return "inner" + x;
+      2    }
+      3
+
+PAUSE AT n:3:8
+      0    import { inner } from "./inner.js"
+      1
+ ->   2    export |function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+      5        return y;
+
+PAUSE AT t:6:12
+      2    export function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+ ->   5        return |y;
+      6    }
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle.html
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/log-pause-location.js"></script>
+<script src="resources/source-map.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Debugger.setShouldBlackboxURL");
+
+    const sourceMappingURL = "source-map.js.map";
+
+    async function getSourceMap() {
+        for (let sourceMap of WI.SourceMap.instances) {
+            if (sourceMap.sourceMappingURL.endsWith(sourceMappingURL))
+                return sourceMap
+        }
+
+        while (true) {
+            let sourceMapAddedEvent = await WI.SourceCode.awaitEvent(WI.SourceCode.Event.SourceMapAdded);
+            let {sourceMap} = sourceMapAddedEvent.data;
+            if (sourceMap.sourceMappingURL.endsWith(sourceMappingURL))
+                return sourceMap;
+        }
+    }
+
+    async function getResources() {
+        let sourceMap = await getSourceMap();
+
+        let inner = sourceMap.resources.find((resource) => resource.url.endsWith("inner.js"));
+        let middle = sourceMap.resources.find((resource) => resource.url.endsWith("middle.js"));
+        let outer = sourceMap.resources.find((resource) => resource.url.endsWith("outer.js"));
+        InspectorTest.assert(inner && middle && outer, "All resources should exist when the WI.SourceMap is added.");
+        return {inner, middle, outer};
+    }
+
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepInto();
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.inner",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {inner, middle} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(inner, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = middle.createSourceCodeLocation(3, 0); // first line of `middle`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(inner, false);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.middle",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {middle} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(middle, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = middle.createSourceCodeLocation(3, 0); // first line of `middle`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(middle, false);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.middle.Blackbox.outer",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {middle, outer} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(outer, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = middle.createSourceCodeLocation(3, 0); // first line of `middle`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(outer, false);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests Debugger.setShouldBlackboxURL.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer-expected.txt
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer-expected.txt
@@ -1,0 +1,241 @@
+Tests Debugger.setShouldBlackboxURL.
+
+
+== Running test suite: Debugger.setShouldBlackboxURL
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.inner
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT <anonymous>:4:5
+      0    import { middle } from "./middle.js"
+      1
+      2    globalThis.outer = function(x) {
+ ->   3        |let y = "outer";
+      4        y += middle(x);
+      5        return y;
+      6    };
+
+PAUSE AT <anonymous>:5:5
+      1
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+ ->   4        |y += middle(x);
+      5        return y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:5:5
+      1
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+ ->   4        |y += middle(x);
+      5        return y;
+      6    };
+      7
+
+PAUSE AT t:4:5
+      0    import { inner } from "./inner.js"
+      1
+      2    export function middle(x) {
+ ->   3        |let y = "middle";
+      4        y += inner(x);
+      5        return y;
+      6    }
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT n:3:8
+      0    import { inner } from "./inner.js"
+      1
+ ->   2    export |function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+      5        return y;
+
+PAUSE AT t:6:12
+      2    export function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+ ->   5        return |y;
+      6    }
+      7
+
+PAUSE AT t:3:1
+      0    import { middle } from "./middle.js"
+      1
+ ->   2    |globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+
+PAUSE AT <anonymous>:6:12
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+ ->   5        return |y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:7:1
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+ ->   6    |};
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.middle
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT <anonymous>:4:5
+      0    import { middle } from "./middle.js"
+      1
+      2    globalThis.outer = function(x) {
+ ->   3        |let y = "outer";
+      4        y += middle(x);
+      5        return y;
+      6    };
+
+PAUSE AT <anonymous>:5:5
+      1
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+ ->   4        |y += middle(x);
+      5        return y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:5:5
+      1
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+ ->   4        |y += middle(x);
+      5        return y;
+      6    };
+      7
+
+PAUSE AT n:2:5
+      0    export function inner(x) {
+ ->   1        |return "inner" + x;
+      2    }
+      3
+
+PAUSE AT t:3:1
+      0    import { middle } from "./middle.js"
+      1
+ ->   2    |globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+
+PAUSE AT <anonymous>:6:12
+      2    globalThis.outer = function(x) {
+      3        let y = "outer";
+      4        y += middle(x);
+ ->   5        return |y;
+      6    };
+      7
+
+PAUSE AT <anonymous>:7:1
+      3        let y = "outer";
+      4        y += middle(x);
+      5        return y;
+ ->   6    |};
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+
+-- Running test case: Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.outer
+Fetching scripts...
+Blackboxing script...
+Finding pause location...
+Creating breakpoint...
+Adding breakpoint...
+Triggering pause...
+PAUSE AT t:4:5
+      0    import { inner } from "./inner.js"
+      1
+      2    export function middle(x) {
+ ->   3        |let y = "middle";
+      4        y += inner(x);
+      5        return y;
+      6    }
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT t:5:5
+      1
+      2    export function middle(x) {
+      3        let y = "middle";
+ ->   4        |y += inner(x);
+      5        return y;
+      6    }
+      7
+
+PAUSE AT n:2:5
+      0    export function inner(x) {
+ ->   1        |return "inner" + x;
+      2    }
+      3
+
+PAUSE AT n:3:8
+      0    import { inner } from "./inner.js"
+      1
+ ->   2    export |function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+      5        return y;
+
+PAUSE AT t:6:12
+      2    export function middle(x) {
+      3        let y = "middle";
+      4        y += inner(x);
+ ->   5        return |y;
+      6    }
+      7
+
+PAUSE AT Global Code:1:10
+--- Source Unavailable ---
+
+Removing breakpoint...
+Unblackboxing script...
+

--- a/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer.html
+++ b/LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/log-pause-location.js"></script>
+<script src="resources/source-map.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Debugger.setShouldBlackboxURL");
+
+    const sourceMappingURL = "source-map.js.map";
+
+    async function getSourceMap() {
+        for (let sourceMap of WI.SourceMap.instances) {
+            if (sourceMap.sourceMappingURL.endsWith(sourceMappingURL))
+                return sourceMap
+        }
+
+        while (true) {
+            let sourceMapAddedEvent = await WI.SourceCode.awaitEvent(WI.SourceCode.Event.SourceMapAdded);
+            let {sourceMap} = sourceMapAddedEvent.data;
+            if (sourceMap.sourceMappingURL.endsWith(sourceMappingURL))
+                return sourceMap;
+        }
+    }
+
+    async function getResources() {
+        let sourceMap = await getSourceMap();
+
+        let inner = sourceMap.resources.find((resource) => resource.url.endsWith("inner.js"));
+        let middle = sourceMap.resources.find((resource) => resource.url.endsWith("middle.js"));
+        let outer = sourceMap.resources.find((resource) => resource.url.endsWith("outer.js"));
+        InspectorTest.assert(inner && middle && outer, "All resources should exist when the WI.SourceMap is added.");
+        return {inner, middle, outer};
+    }
+
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        WI.debuggerManager.stepInto();
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.inner",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {inner, outer} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(inner, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = outer.createSourceCodeLocation(3, 0); // first line of `outer`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(inner, false);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.middle",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {middle, outer} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(middle, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = outer.createSourceCodeLocation(3, 0); // first line of `outer`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(middle, false);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.setShouldBlackboxURL.SourceMap.Pause.outer.Blackbox.outer",
+        async test() {
+            InspectorTest.log("Fetching scripts...");
+            let {outer} = await getResources();
+
+            InspectorTest.log("Blackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(outer, true);
+
+            InspectorTest.log("Finding pause location...");
+            let location = outer.createSourceCodeLocation(3, 0); // first line of `outer`
+
+            InspectorTest.log("Creating breakpoint...");
+            let breakpoint = new WI.JavaScriptBreakpoint(location);
+
+            InspectorTest.log("Adding breakpoint...");
+            WI.debuggerManager.addBreakpoint(breakpoint);
+
+            InspectorTest.log("Triggering pause...");
+            await Promise.all([
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+                InspectorTest.evaluateInPage(`outer(42)`),
+            ]);
+
+            InspectorTest.log("Removing breakpoint...");
+            WI.debuggerManager.removeBreakpoint(breakpoint);
+
+            InspectorTest.log("Unblackboxing script...");
+            WI.debuggerManager.setShouldBlackboxScript(outer, false);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests Debugger.setShouldBlackboxURL.</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -58,6 +58,8 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
 
+        WI.SourceCode.addEventListener(WI.SourceCode.Event.SourceMapAdded, this._handleSourceCodeSourceMapAdded, this);
+
         this._breakpointsEnabledSetting = new WI.Setting("breakpoints-enabled", true);
         this._asyncStackTraceDepthSetting = new WI.Setting("async-stack-trace-depth", 200);
 
@@ -260,6 +262,11 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
                     this._blackboxedPatternDataMap.set(new RegExp(data.url, !data.caseSensitive ? "i" : ""), data);
                     target.DebuggerAgent.setShouldBlackboxURL(data.url, shouldBlackbox, data.caseSensitive, isRegex);
                 }
+            }
+
+            for (let sourceMap of WI.SourceMap.instances) {
+                if (sourceMap.originalSourceCode.supportsScriptBlackboxing)
+                    this._updateBlackbox([target], sourceMap.originalSourceCode);
             }
         }
 
@@ -563,21 +570,16 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
     setShouldBlackboxScript(sourceCode, shouldBlackbox)
     {
-        console.assert(DebuggerManager.supportsBlackboxingScripts());
-        console.assert(sourceCode instanceof WI.SourceCode);
-        console.assert(sourceCode.contentIdentifier);
-        console.assert(!isWebKitInjectedScript(sourceCode.contentIdentifier));
-        console.assert(shouldBlackbox !== ((this.blackboxDataForSourceCode(sourceCode) || {}).type === DebuggerManager.BlackboxType.URL));
+        console.assert(sourceCode instanceof WI.SourceCode, sourceCode);
+        console.assert(sourceCode.supportsScriptBlackboxing, sourceCode);
+        console.assert(sourceCode.contentIdentifier, sourceCode);
+        console.assert(!isWebKitInjectedScript(sourceCode.contentIdentifier, sourceCode));
+        console.assert(shouldBlackbox !== (this.blackboxDataForSourceCode(sourceCode)?.type === DebuggerManager.BlackboxType.URL), sourceCode);
 
         this._blackboxedURLsSetting.value.toggleIncludes(sourceCode.contentIdentifier, shouldBlackbox);
         this._blackboxedURLsSetting.save();
 
-        const caseSensitive = true;
-        for (let target of WI.targets) {
-            // COMPATIBILITY (iOS 13): Debugger.setShouldBlackboxURL did not exist yet.
-            if (target.hasCommand("Debugger.setShouldBlackboxURL"))
-                target.DebuggerAgent.setShouldBlackboxURL(sourceCode.contentIdentifier, !!shouldBlackbox, caseSensitive);
-        }
+        this._updateBlackbox(WI.targets, sourceCode);
 
         this.dispatchEventToListeners(DebuggerManager.Event.BlackboxChanged);
     }
@@ -608,6 +610,11 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             // COMPATIBILITY (iOS 13): Debugger.setShouldBlackboxURL did not exist yet.
             if (target.hasCommand("Debugger.setShouldBlackboxURL"))
                 target.DebuggerAgent.setShouldBlackboxURL(regex.source, !!shouldBlackbox, !regex.ignoreCase, isRegex);
+        }
+
+        for (let sourceMap of WI.SourceMap.instances) {
+            if (sourceMap.originalSourceCode.supportsScriptBlackboxing)
+                this._updateBlackbox(WI.targets, sourceMap.originalSourceCode);
         }
 
         this.dispatchEventToListeners(DebuggerManager.Event.BlackboxChanged);
@@ -1416,6 +1423,31 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         }
     }
 
+    _updateBlackbox(targets, sourceCode)
+    {
+        if (sourceCode instanceof WI.SourceMapResource)
+            sourceCode = sourceCode.sourceMap.originalSourceCode;
+
+        let commandArguments = {
+            url: sourceCode.contentIdentifier,
+            caseSensitive: true,
+        };
+
+        let sourceRanges = sourceCode.sourceMaps.flatMap((sourceMap) => sourceMap.calculateBlackboxSourceRangesForProtocol());
+        console.assert(sourceCode instanceof WI.Script || !sourceRanges.length, sourceCode);
+        if (sourceRanges.length) {
+            commandArguments.shouldBlackbox = true;
+            commandArguments.sourceRanges = sourceRanges;
+        } else
+            commandArguments.shouldBlackbox = !!this.blackboxDataForSourceCode(sourceCode);
+
+        for (let target of targets) {
+            // COMPATIBILITY (iOS 13): Debugger.setShouldBlackboxURL did not exist yet.
+            if (target.hasCommand("Debugger.setShouldBlackboxURL"))
+                target.DebuggerAgent.setShouldBlackboxURL.invoke(commandArguments);
+        }
+    }
+
     _setBlackboxBreakpointEvaluations(target)
     {
         // COMPATIBILITY (macOS 12.3, iOS 15.4): Debugger.setBlackboxBreakpointEvaluations did not exist yet.
@@ -1637,6 +1669,12 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
             return;
 
         this._didResumeInternal(WI.mainTarget);
+    }
+
+    _handleSourceCodeSourceMapAdded(event)
+    {
+        if (event.target.supportsScriptBlackboxing)
+            this._updateBlackbox(WI.targets, event.target);
     }
 
     _didResumeInternal(target)

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -1534,7 +1534,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             try {
                 let payload = JSON.parse(content);
                 let baseURL = sourceMapURL.startsWith("data:") ? originalSourceCode.url : sourceMapURL;
-                let sourceMap = new WI.SourceMap(baseURL, payload, originalSourceCode);
+                let sourceMap = new WI.SourceMap(baseURL, originalSourceCode, payload);
                 this._sourceMapLoadAndParseSucceeded(sourceMapURL, sourceMap);
             } catch {
                 this._sourceMapLoadAndParseFailed(sourceMapURL);

--- a/Source/WebInspectorUI/UserInterface/Models/CallFrame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CallFrame.js
@@ -229,7 +229,7 @@ WI.CallFrame = class CallFrame
             scopeChain,
             programCode: WI.CallFrame.programCodeFromPayload(payload),
             isTailDeleted: payload.isTailDeleted,
-            blackboxed: sourceCodeLocation && !!WI.debuggerManager.blackboxDataForSourceCode(sourceCodeLocation.sourceCode),
+            blackboxed: sourceCodeLocation && !!WI.debuggerManager.blackboxDataForSourceCode(sourceCodeLocation.displaySourceCode),
         });
     }
 
@@ -273,7 +273,7 @@ WI.CallFrame = class CallFrame
             functionName: WI.CallFrame.functionNameFromPayload(payload),
             nativeCode,
             programCode: WI.CallFrame.programCodeFromPayload(payload),
-            blackboxed: sourceCodeLocation && !!WI.debuggerManager.blackboxDataForSourceCode(sourceCodeLocation.sourceCode),
+            blackboxed: sourceCodeLocation && !!WI.debuggerManager.blackboxDataForSourceCode(sourceCodeLocation.displaySourceCode),
         });
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Models/SourceCode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCode.js
@@ -161,7 +161,7 @@ WI.SourceCode = class SourceCode extends WI.Object
 
         this._sourceMaps.push(sourceMap);
 
-        this.dispatchEventToListeners(WI.SourceCode.Event.SourceMapAdded);
+        this.dispatchEventToListeners(WI.SourceCode.Event.SourceMapAdded, {sourceMap});
     }
 
     get formatterSourceMap()

--- a/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js
@@ -89,7 +89,14 @@ WI.SourceMapResource = class SourceMapResource extends WI.Resource
 
     get supportsScriptBlackboxing()
     {
-        return false;
+        if (!super.supportsScriptBlackboxing)
+            return false;
+
+        if (!this._sourceMap.originalSourceCode.supportsScriptBlackboxing)
+            return false;
+
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): Debugger.setShouldBlackboxURL.sourceRanges did not exist yet.
+        return InspectorBackend.hasCommand("Debugger.setShouldBlackboxURL", "sourceRanges");
     }
 
     requestContentFromBackend()

--- a/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
@@ -59,9 +59,11 @@ WI.appendContextMenuItemsForSourceCode = function(contextMenu, sourceCodeOrLocat
         return;
 
     let sourceCode = sourceCodeOrLocation;
+    let displaySourceCode = sourceCode;
     let location = null;
     if (sourceCodeOrLocation instanceof WI.SourceCodeLocation) {
         sourceCode = sourceCodeOrLocation.sourceCode;
+        displaySourceCode = sourceCodeOrLocation.displaySourceCode;
         location = sourceCodeOrLocation;
     }
 
@@ -129,7 +131,7 @@ WI.appendContextMenuItemsForSourceCode = function(contextMenu, sourceCodeOrLocat
 
     contextMenu.appendSeparator();
 
-    if (location && (sourceCode instanceof WI.Script || (sourceCode instanceof WI.Resource && sourceCode.type === WI.Resource.Type.Script && !sourceCode.localResourceOverride))) {
+    if (location && (displaySourceCode instanceof WI.Script || (displaySourceCode instanceof WI.Resource && displaySourceCode.type === WI.Resource.Type.Script && !displaySourceCode.localResourceOverride))) {
         let existingJavaScriptBreakpoint = WI.debuggerManager.breakpointForSourceCodeLocation(location);
         if (existingJavaScriptBreakpoint) {
             contextMenu.appendItem(WI.UIString("Delete JavaScript Breakpoint"), () => {
@@ -156,8 +158,8 @@ WI.appendContextMenuItemsForSourceCode = function(contextMenu, sourceCodeOrLocat
         }
     }
 
-    if (sourceCode.supportsScriptBlackboxing) {
-        let blackboxData = WI.debuggerManager.blackboxDataForSourceCode(sourceCode);
+    if (displaySourceCode.supportsScriptBlackboxing) {
+        let blackboxData = WI.debuggerManager.blackboxDataForSourceCode(displaySourceCode);
         if (blackboxData && blackboxData.type === WI.DebuggerManager.BlackboxType.Pattern) {
             contextMenu.appendItem(WI.UIString("Reveal Blackbox Pattern"), () => {
                 WI.showSettingsTab({
@@ -167,7 +169,7 @@ WI.appendContextMenuItemsForSourceCode = function(contextMenu, sourceCodeOrLocat
             });
         } else {
             contextMenu.appendItem(blackboxData ? WI.UIString("Unblackbox Script") : WI.UIString("Blackbox Script"), () => {
-                WI.debuggerManager.setShouldBlackboxScript(sourceCode, !blackboxData);
+                WI.debuggerManager.setShouldBlackboxScript(displaySourceCode, !blackboxData);
             });
         }
     }
@@ -204,15 +206,15 @@ WI.appendContextMenuItemsForSourceCode = function(contextMenu, sourceCodeOrLocat
         contextMenu.appendSeparator();
 
         contextMenu.appendItem(WI.UIString("Save File"), () => {
-            sourceCode.requestContent().then(() => {
+            displaySourceCode.requestContent().then(() => {
                 let saveData = {
-                    url: sourceCode.url,
-                    content: sourceCode.content,
-                    base64Encoded: sourceCode.base64Encoded,
+                    url: displaySourceCode.url,
+                    content: displaySourceCode.content,
+                    base64Encoded: displaySourceCode.base64Encoded,
                 };
 
-                if (sourceCode.urlComponents.path === "/") {
-                    let extension = WI.fileExtensionForMIMEType(sourceCode.mimeType);
+                if (displaySourceCode.urlComponents.path === "/") {
+                    let extension = WI.fileExtensionForMIMEType(displaySourceCode.mimeType);
                     if (extension)
                         saveData.suggestedName = `index.${extension}`;
                 }


### PR DESCRIPTION
#### b29b3cee5dbfd8fd6facbed5c9a87ed1bf2daffe
<pre>
Web Inspector: allow sourcemaps to be blackboxed
<a href="https://bugs.webkit.org/show_bug.cgi?id=277668">https://bugs.webkit.org/show_bug.cgi?id=277668</a>

Reviewed by Yusuke Suzuki.

As of 281634@main it&apos;s now possible to blackbox a (sub)range of a `.js` file.

This change allows developers to leverage that by automatically blackboxing only the affected range(s) if they blackbox a resource within a sourcemap.

* Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js:
(WI.SourceMapResource.prototype.get supportsScriptBlackboxing):

* Source/WebInspectorUI/UserInterface/Models/SourceMap.js:
(WI.SourceMap):
(WI.SourceMap.get instances): Added.
(WI.SourceMap.prototype.get sourceMappingURL): Added.
(WI.SourceMap.prototype.calculateBlackboxSourceRangesForProtocol): Added.
Add helper methods to get all sourcemap instances and to determine all blackbox ranges for a given sourcemap.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.async initializeTarget):
(WI.DebuggerManager.prototype.setShouldBlackboxScript):
(WI.DebuggerManager.prototype.setShouldBlackboxPattern):
(WI.DebuggerManager.prototype._updateBlackbox): Added.
(WI.DebuggerManager.prototype._handleSourceCodeSourceMapAdded): Added.
In addition to allowing `.js` files to be entirely blackboxed, also support looking at all relevant sourcemap to see if just parts are blackboxed.
Check each time a new sourcemap is added, as well as if the relevant `.js` file is unblackboxed as resources within the sourcemap may still be blackboxed.

* Source/WebInspectorUI/UserInterface/Models/CallFrame.js:
(WI.CallFrame.fromDebuggerPayload):
(WI.CallFrame.fromPayload):
* Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js:
(WI.appendContextMenuItemsForSourceCode):
Use the `displaySourceCode` so that if the developer right-clicks on a resource within a sourcemap they&apos;re able to blackbox just that instead of the entire underlying `.js` file.
Drive-by: also allow developers to set breakpoints in and save resources within a sourcemap instead of only for the entire underlying `.js` file.

* Source/WebInspectorUI/UserInterface/Models/SourceCode.js:
(WI.SourceCode.prototype.addSourceMap):
Include the sourcemap object when dispatching `WI.SourceCode.Event.SourceMapAdded` for tests.

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype._loadAndParseSourceMap.sourceMapLoaded):
Drive-by: Reorder constructor arguments for clarity.

* LayoutTests/inspector/debugger/resources/log-pause-location.js:
(isSourceAvailable): Added.
(getLineContent): Added.
(logLinesWithContext):
(logPauseLocation):
Allow for resources within a sourcemap to be printed since they are created with the content already available (instead of having to fetch it from the backend).
Additionally, prefer the display location wherever possible (instead of the actual location according to JSC).

* LayoutTests/inspector/debugger/resources/source-map.js: Added.
* LayoutTests/inspector/debugger/resources/source-map.js.map: Added.
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner.html: Added.
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-inner-expected.txt: Added.
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle.html: Added.
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-middle-expected.txt: Added.
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer.html: Added.
* LayoutTests/inspector/debugger/setShouldBlackboxURL-source-map-outer-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/282740@main">https://commits.webkit.org/282740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/143e727243e48c44542085671f603957683be175

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12770 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50147 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8833 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11161 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57524 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57742 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5094 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37379 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->