### PR TITLE
imported/w3c/web-platform-tests/IndexedDB/idb-binary-key-detached.htm is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-binary-key-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-binary-key-detached-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Detached ArrayBuffer assert_throws_dom: function "() => { store.put('', buffer); }" did not throw
-FAIL Detached TypedArray assert_throws_dom: function "() => { store.put('', array); }" did not throw
+PASS Detached ArrayBuffer
+PASS Detached TypedArray
 

--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -47,11 +47,15 @@ Ref<IDBKey> IDBKey::createBinary(const ThreadSafeDataBuffer& buffer)
 Ref<IDBKey> IDBKey::createBinary(JSC::JSArrayBuffer& arrayBuffer)
 {
     RefPtr buffer = arrayBuffer.impl();
+    if (buffer && buffer->isDetached())
+        return createInvalid();
     return adoptRef(*new IDBKey(ThreadSafeDataBuffer::copyData(buffer->span())));
 }
 
 Ref<IDBKey> IDBKey::createBinary(JSC::JSArrayBufferView& arrayBufferView)
 {
+    if (arrayBufferView.isDetached())
+        return createInvalid();
     auto bufferView = arrayBufferView.possiblySharedImpl();
     if (!bufferView)
         return createInvalid();


### PR DESCRIPTION
#### 1e756d3dceb1c4e869f78e411b214c273010666f
<pre>
imported/w3c/web-platform-tests/IndexedDB/idb-binary-key-detached.htm is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=277669">https://bugs.webkit.org/show_bug.cgi?id=277669</a>
<a href="https://rdar.apple.com/133264961">rdar://133264961</a>

Reviewed by Ben Nham.

Detached ArrayBuffer is no longer usable and is not a valid key.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idb-binary-key-detached-expected.txt:
* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::IDBKey::createBinary):

Canonical link: <a href="https://commits.webkit.org/281911@main">https://commits.webkit.org/281911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c76f3595f7203af55e70f706e2f447b948b854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49549 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8250 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10794 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67013 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56921 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4359 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36497 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->