### PR TITLE
[JSC] Fix B3CanonicalizePrePostIncrements with control and alias analysis

### DIFF
--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -120,9 +120,9 @@ void generateToAir(Procedure& procedure)
     legalizeMemoryOffsets(procedure);
     moveConstants(procedure);
     legalizeMemoryOffsets(procedure);
+    eliminateDeadCode(procedure);
     if (Options::useB3CanonicalizePrePostIncrements() && procedure.optLevel() >= 2)
         canonicalizePrePostIncrements(procedure);
-    eliminateDeadCode(procedure);
 
     // FIXME: We should run pureCSE here to clean up some platform specific changes from the previous phases.
     // https://bugs.webkit.org/show_bug.cgi?id=164873

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -2931,10 +2931,10 @@ private:
                 }
             }
 
-            // Pre-Index Canonical Form:
+            // PreIndex Canonical Form:
             //     address = Add(base, offset)    --->   Move %base %address
             //     memory = Load(base, offset)           MoveWithIncrement (%address, prefix(offset)) %memory
-            // Post-Index Canonical Form:
+            // PostIndex Canonical Form:
             //     address = Add(base, offset)    --->   Move %base %address
             //     memory = Load(base, 0)                MoveWithIncrement (%address, postfix(offset)) %memory
             auto tryAppendIncrementAddress = [&] () -> bool {
@@ -3860,10 +3860,10 @@ private:
         }
 
         case Store: {
-            // Pre-Index Canonical Form:
+            // PreIndex Canonical Form:
             //     address = Add(base, Offset)              --->    Move %base %address
             //     memory = Store(value, base, Offset)              MoveWithIncrement %value (%address, prefix(offset))
-            // Post-Index Canonical Form:
+            // PostIndex Canonical Form:
             //     address = Add(base, Offset)              --->    Move %base %address
             //     memory = Store(value, base, 0)                   MoveWithIncrement %value (%address, postfix(offset))
             auto tryAppendIncrementAddress = [&] () -> bool {

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -3047,10 +3047,10 @@ private:
                 }
             }
 
-            // Pre-Index Canonical Form:
+            // PreIndex Canonical Form:
             //     address = Add(base, offset)    --->   Move %base %address
             //     memory = Load(base, offset)           MoveWithIncrement (%address, prefix(offset)) %memory
-            // Post-Index Canonical Form:
+            // PostIndex Canonical Form:
             //     address = Add(base, offset)    --->   Move %base %address
             //     memory = Load(base, 0)                MoveWithIncrement (%address, postfix(offset)) %memory
             auto tryAppendIncrementAddress = [&] () -> bool {
@@ -4015,10 +4015,10 @@ private:
         }
 
         case Store: {
-            // Pre-Index Canonical Form:
+            // PreIndex Canonical Form:
             //     address = Add(base, Offset)              --->    Move %base %address
             //     memory = Store(value, base, Offset)              MoveWithIncrement %value (%address, prefix(offset))
-            // Post-Index Canonical Form:
+            // PostIndex Canonical Form:
             //     address = Add(base, Offset)              --->    Move %base %address
             //     memory = Store(value, base, 0)                   MoveWithIncrement %value (%address, postfix(offset))
             auto tryAppendIncrementAddress = [&] () -> bool {

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1213,6 +1213,7 @@ void testLoadPreIndex32();
 void testLoadPreIndex64();
 void testLoadPostIndex32();
 void testLoadPostIndex64();
+void testLoadPreIndex32WithStore();
 
 void testStorePreIndex32();
 void testStorePreIndex64();

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -145,14 +145,14 @@ void testLoadPreIndex32()
     if (isARM64())
         checkUsesInstruction(*code, "#4]!");
 
-    auto test = [&] () -> int32_t {
+    auto expected = [&] () -> int32_t {
         int32_t r = 0;
         while (r < 10)
             r += *++ptr;
         return r;
     };
 
-    CHECK_EQ(invoke<int32_t>(*code, bitwise_cast<intptr_t>(ptr)), test());
+    CHECK_EQ(invoke<int32_t>(*code, bitwise_cast<intptr_t>(ptr)), expected());
 }
 
 void testLoadPreIndex64()
@@ -218,14 +218,14 @@ void testLoadPreIndex64()
     if (isARM64())
         checkUsesInstruction(*code, "#8]!");
 
-    auto test = [&] () -> int64_t {
+    auto expected = [&] () -> int64_t {
         int64_t r = 0;
         while (r < 10)
             r += *++ptr;
         return r;
     };
 
-    CHECK_EQ(invoke<int64_t>(*code, bitwise_cast<intptr_t>(ptr)), test());
+    CHECK_EQ(invoke<int64_t>(*code, bitwise_cast<intptr_t>(ptr)), expected());
 }
 
 void testLoadPostIndex32()
@@ -291,14 +291,14 @@ void testLoadPostIndex32()
     if (isARM64())
         checkUsesInstruction(*code, "], #4");
 
-    auto test = [&] () -> int32_t {
+    auto expected = [&] () -> int32_t {
         int32_t r = 0;
         while (r < 10)
             r += *ptr++;
         return r;
     };
 
-    CHECK_EQ(invoke<int32_t>(*code, bitwise_cast<intptr_t>(ptr)), test());
+    CHECK_EQ(invoke<int32_t>(*code, bitwise_cast<intptr_t>(ptr)), expected());
 }
 
 void testLoadPostIndex64()
@@ -364,14 +364,91 @@ void testLoadPostIndex64()
     if (isARM64())
         checkUsesInstruction(*code, "], #8");
 
-    auto test = [&] () -> int64_t {
+    auto expected = [&] () -> int64_t {
         int64_t r = 0;
         while (r < 10)
             r += *ptr++;
         return r;
     };
 
-    CHECK_EQ(invoke<int64_t>(*code, bitwise_cast<intptr_t>(ptr)), test());
+    CHECK_EQ(invoke<int64_t>(*code, bitwise_cast<intptr_t>(ptr)), expected());
+}
+
+void testLoadPreIndex32WithStore()
+{
+    if (Options::defaultB3OptLevel() < 2)
+        return;
+
+    int32_t nums[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    int32_t* ptr = nums;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* loopTest = proc.addBlock();
+    BasicBlock* loopBody = proc.addBlock();
+    BasicBlock* done = proc.addBlock();
+
+    Variable* r = proc.addVariable(Int32);
+    Variable* p = proc.addVariable(Int64);
+
+    // ---------------------- Root_Block
+    // r1 = 0
+    // Upsilon(r1, ^r2)
+    // p1 = addr
+    // Upsilon(p1, ^p2)
+    Value* r1 = root->appendIntConstant(proc, Origin(), Int32, 0);
+    root->appendNew<VariableValue>(proc, B3::Set, Origin(), r, r1);
+    Value* p1 = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    root->appendNew<VariableValue>(proc, B3::Set, Origin(), p, p1);
+    root->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(loopTest));
+
+    // ---------------------- Loop_Test_Block
+    // loop:
+    // p2 = Phi()
+    // r2 = Phi()
+    // if r2 >= 10 goto done
+    Value* r2 = loopTest->appendNew<VariableValue>(proc, B3::Get, Origin(), r);
+    Value* p2 = loopTest->appendNew<VariableValue>(proc, B3::Get, Origin(), p);
+    Value* cond = loopTest->appendNew<Value>(proc, AboveEqual, Origin(), r2, loopTest->appendNew<Const32Value>(proc, Origin(), 10));
+    loopTest->appendNewControlValue(proc, Branch, Origin(), cond, FrequentedBlock(done), FrequentedBlock(loopBody));
+
+    // ---------------------- Loop_Body_Block
+    // p3 = p2 + 1
+    // Upsilon(p3, ^p2)
+    // p3' = p3
+    // store(5, p3')
+    // r3 = r2 + load(p3)
+    // Upsilon(r3, ^r2)
+    // goto loop
+    Value* p3 = loopBody->appendNew<Value>(proc, Add, Origin(), p2, loopBody->appendNew<Const64Value>(proc, Origin(), 4));
+    loopBody->appendNew<VariableValue>(proc, B3::Set, Origin(), p, p3);
+    Value* p3Prime = loopBody->appendNew<Value>(proc, Opaque, Origin(), p3);
+    loopBody->appendNew<MemoryValue>(proc, Store, Origin(), loopBody->appendNew<Const32Value>(proc, Origin(), 5), p3Prime);
+    Value* r3 = loopBody->appendNew<Value>(proc, Add, Origin(), r2, loopBody->appendNew<MemoryValue>(proc, Load, Int32, Origin(), p3));
+    loopBody->appendNew<VariableValue>(proc, B3::Set, Origin(), r, r3);
+    loopBody->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(loopTest));
+
+    // ---------------------- Done_Block
+    // done:
+    // return r2
+    done->appendNewControlValue(proc, Return, Origin(), r2);
+
+    proc.resetReachability();
+    validate(proc);
+    fixSSA(proc);
+
+    auto code = compileProc(proc);
+
+    auto expected = [&] () -> int32_t {
+        int32_t r = 0;
+        while (r < 10) {
+            *++ptr = 5;
+            r += *ptr;
+        }
+        return r;
+    };
+
+    CHECK_EQ(invoke<int32_t>(*code, bitwise_cast<intptr_t>(ptr)), expected());
 }
 
 void testStorePreIndex32()
@@ -421,6 +498,8 @@ void testStorePreIndex64()
     root->appendNewControlValue(proc, Return, Origin(), preIncrement);
 
     auto code = compileProc(proc);
+    if (isARM64())
+        checkUsesInstruction(*code, "#8]!");
     intptr_t res = invoke<intptr_t>(*code, bitwise_cast<intptr_t>(ptr), 4);
     ptr = bitwise_cast<int64_t*>(res);
     CHECK_EQ(nums[2], *ptr);
@@ -4159,6 +4238,7 @@ void addShrTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
         RUN(testLoadPreIndex64());
         RUN(testLoadPostIndex32());
         RUN(testLoadPostIndex64());
+        RUN(testLoadPreIndex32WithStore());
 
         RUN(testStorePreIndex32());
         RUN(testStorePreIndex64());


### PR DESCRIPTION
#### f29853f4b11b60c3257328ebc1ebe2b4bd7d2f9d
<pre>
[JSC] Fix B3CanonicalizePrePostIncrements with control and alias analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=277807">https://bugs.webkit.org/show_bug.cgi?id=277807</a>
<a href="https://rdar.apple.com/133468869">rdar://133468869</a>

Reviewed by Yusuke Suzuki.

In B3ReduceStrength, the Load and Store nodes have reductions:

              Turn This                                     Into This
--------------------------------------------------------------------------------------------
address = Add(base, offset1)              |  address = Add(base, offset1)
memory  = Load(address, offset2)          |  memory  = Load(base, offset1 + offset2)
--------------------------------------------------------------------------------------------
address = Add(base, offset1)              |  address = Add(base, offset1)
memory  = Store(value, address, offset2)  |  memory  = Store(value, base, offset1 + offset2)

In B3LowerToAir, we have the peephole optimizations for PrePostIndex forms:

        Turn Canonical Form                            Into PrePostIndex Form
-------------------------------------------------------------------------------------------------
address = Add(base, offset)               |  Move %base %address
memory  = Load(base, offset)              |  MoveWithIncrement (%address, prefix(offset)) %memory
-------------------------------------------------------------------------------------------------
address = Add(base, offset)               |  Move %base %address
memory  = Load(base, 0)                   |  MoveWithIncrement (%address, postfix(offset)) %memory
-------------------------------------------------------------------------------------------------
address = Add(base, Offset)               |  Move %base %address
memory  = Store(value, base, Offset)      |  MoveWithIncrement %value (%address, prefix(offset))
-------------------------------------------------------------------------------------------------
address = Add(base, Offset)               |  Move %base %address
memory  = Store(value, base, 0)           |  MoveWithIncrement %value (%address, postfix(offset))

The previous implementation of B3CanonicalizePrePostIncrements, converting PrePostIndex candidate
to canonical form, is wrong. This is because we cannot move the Load node directly to just after
the Add node without alias analysis to detect the violations of reference update. For example:

            Turn This                              Into This
---------------------------------------------------------------------------
    address = Add(base, offset)      |    address = Add(base, offset)
    ...                              |    newMemory = Load(base, offset)
    ...                              |    ...
    Store(value, address)            |    Store(value, address)
    memory = Load(base, offset)      |    memory = Identity(newMemory)

That conversion is semantically incorrect since the Store node can update the value in the address.
To fix this issue, this patch transforms all possible PrePostIndex candidates to these canonical
forms with control and alias analysis:

                                  Turn Candidate                       Into Canonical Form
--------------------------------------------------------------------------------------------------
                      |  address = Add(base, offset)         |  address = Nop
                      |  ...                                 |  ...
 PreIndex Load/Store  |  ...                                 |  newAddress = Add(base, offset)
      Pattern         |  memory = MemoryValue(base, offset)  |  memory = MemoryValue(base, offset)
                      |  ...                                 |  ...
                      |  use = B3Opcode(address, ...)        |  use = B3Opcode(newAddress, ...)
--------------------------------------------------------------------------------------------------
                      |  ...                                 |  newOffset = Constant
                      |  ...                                 |  newAddress = Add(base, newOffset)
 PostIndex Load/Store |  memory = MemoryValue(base, 0)       |  memory = MemoryValue(base, 0)
       Pattern        |  ...                                 |  ...
                      |  address = Add(base, offset)         |  address = Identity(newAddress)

PreIndex Load/Store Transform
When is it OK to move the address to the newAddress that is just right before the memory?
1. The basic blocks of the address and the memory must be control equivalent.
2. The basic block of the memory dominate all uses of the address.

PostIndex Load/Store Transform
When is it OK to move the address to the newAddress that is just right before the memory?
1. The basic blocks of the memory and the address must be control equivalent.

With those conditions satisfied, the code motion should be safe without changing the program&apos;s behavior.
Since this phase does not provide significant benefits on benchmarks, we will leave it disabled. However,
this patch does resolve the previous issue in B3CanonicalizePrePostIncrements.

* Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp:
(JSC::B3::canonicalizePrePostIncrements):
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testLoadPreIndex32):
(testLoadPreIndex64):
(testLoadPostIndex32):
(testLoadPostIndex64):
(testLoadPreIndex32WithStore):
(testStorePreIndex64):
(addShrTests):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/282052@main">https://commits.webkit.org/282052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ae8b929e62d1b1b6c80e73ffbbbdb8dd4a98acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12398 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49845 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8583 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11329 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54948 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61095 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57467 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4752 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82858 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37007 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14507 "Found 1466 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38091 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->