### PR TITLE
Build fix _WKWebExtensionControllerConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -30,6 +30,7 @@
 #import "_WKWebExtensionCommand.h"
 #import "_WKWebExtensionContext.h"
 #import "_WKWebExtensionController.h"
+#import "_WKWebExtensionControllerConfiguration.h"
 #import "_WKWebExtensionDataRecord.h"
 #import "_WKWebExtensionMatchPattern.h"
 #import "_WKWebExtensionMessagePort.h"
@@ -75,6 +76,10 @@ NSString * const _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns = @"
 
 #undef _WKWebExtensionController
 @implementation _WKWebExtensionController
+@end
+
+#undef _WKWebExtensionControllerConfiguration
+@implementation _WKWebExtensionControllerConfiguration
 @end
 
 NSErrorDomain const _WKWebExtensionDataRecordErrorDomain = @"WKWebExtensionDataRecordErrorDomain";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
@@ -25,4 +25,8 @@
 
 #import <WebKit/WKWebExtensionControllerConfigurationPrivate.h>
 
+WK_EXTERN
+@interface _WKWebExtensionControllerConfiguration : WKWebExtensionControllerConfiguration
+@end
+
 #define _WKWebExtensionControllerConfiguration WKWebExtensionControllerConfiguration


### PR DESCRIPTION
#### cdf0b5f2f86a0e8f9e64759d1dd6f3115ae3eb55
<pre>
Build fix _WKWebExtensionControllerConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=277674">https://bugs.webkit.org/show_bug.cgi?id=277674</a>
<a href="https://rdar.apple.com/133273439">rdar://133273439</a>

Reviewed by Timothy Hatcher.

MobileSafari fails to launch on visionOS because dyld can&apos;t find
_WKWebExtensionControllerConfiguration.  Implement
_WKWebExtensionControllerConfiguration in the same manner as 281809@main

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/281894@main">https://commits.webkit.org/281894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37822197e6fe410b40a5de3625f72f3988dd3ecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49558 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34509 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67035 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56931 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57144 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4375 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9229 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36519 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->