### PR TITLE
REGRESSION(281744@main): [GTK] Flickering when switching tabs

### DIFF
--- a/Source/WebKit/UIProcess/glib/FenceMonitor.h
+++ b/Source/WebKit/UIProcess/glib/FenceMonitor.h
@@ -40,11 +40,13 @@ public:
     ~FenceMonitor();
 
     void addFileDescriptor(WTF::UnixFileDescriptor&&);
+    bool hasFileDescriptor() const { return !!m_fd; }
 
 private:
     void ensureSource();
 
     Function<void()> m_callback;
+    WTF::UnixFileDescriptor m_fd;
     GRefPtr<GSource> m_source;
 };
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -623,7 +623,7 @@ void AcceleratedBackingStoreDMABuf::update(const LayerTreeContext& context)
 
 bool AcceleratedBackingStoreDMABuf::prepareForRendering()
 {
-    if (m_pendingBuffer) {
+    if (m_pendingBuffer && !m_fenceMonitor.hasFileDescriptor()) {
         if (m_pendingBuffer->type() == Buffer::Type::EglImage) {
             ensureGLContext();
             gdk_gl_context_make_current(m_gdkGLContext.get());


### PR DESCRIPTION
#### 139b28de2305ed20adb028cbab3e9b0ddb4dca4d
<pre>
REGRESSION(281744@main): [GTK] Flickering when switching tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277675">https://bugs.webkit.org/show_bug.cgi?id=277675</a>

Reviewed by Alejandro G. Castro.

This seems to be caused by a memory corruption or something like that.
For some reason we can&apos;t add a UnixFileDescriptor to the FenceSource
struct that is allocated by GLib. So, move the UnixFileDescriptor to the
FenceMonitor class, keeping FenceSource struct simple. Also make sure we
don&apos;t commit the pending buffer if gtk schedules a redraw while are
still waiting for the fence.

* Source/WebKit/UIProcess/glib/FenceMonitor.cpp:
(WebKit::FenceMonitor::ensureSource):
(WebKit::FenceMonitor::addFileDescriptor):
(WebKit::FenceSource::~FenceSource): Deleted.
* Source/WebKit/UIProcess/glib/FenceMonitor.h:
(WebKit::FenceMonitor::hasFileDescriptor const):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::prepareForRendering):

Canonical link: <a href="https://commits.webkit.org/281885@main">https://commits.webkit.org/281885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03419cd837d44f161ff09aeb5fcfec1afa3c135

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49560 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8266 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34515 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10821 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67041 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10447 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53110 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57152 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4378 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9224 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->