### PR TITLE
Rename Style::Builder::applyDeferredProperties

### DIFF
--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -929,7 +929,7 @@ class StyleProperties:
         if not a_is_high_priority and b_is_high_priority:
             return 1
 
-        # Sort logical longhands to the back, before shorthands.
+        # Sort longhands in a logical property group to the back, before shorthands.
         a_is_in_logical_property_group = a.codegen_properties.logical_property_group
         b_is_in_logical_property_group = b.codegen_properties.logical_property_group
         if a_is_in_logical_property_group and not b_is_in_logical_property_group:

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -124,7 +124,7 @@ private:
     // The CSSPropertyID enum is sorted like this:
     // 1. CSSPropertyInvalid and CSSPropertyCustom.
     // 2. Normal longhand properties (high priority ones followed by low priority ones).
-    // 3. Logical longhand properties.
+    // 3. Longhand properties in a logical property group.
     // 4. Shorthand properties.
     //
     // 'm_properties' is used for both normal and logical longhands, so it has size 'lastLogicalGroupProperty + 1'.

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -123,15 +123,16 @@ void Builder::applyNonHighPriorityProperties()
     ASSERT(!m_state.fontDirty());
 
     applyProperties(firstLowPriorityProperty, lastLowPriorityProperty);
-    applyDeferredProperties();
+    applyLogicalGroupProperties();
     // Any referenced custom properties are already resolved. This will resolve the remaining ones.
     applyCustomProperties();
 
     ASSERT(!m_state.fontDirty());
 }
 
-void Builder::applyDeferredProperties()
+void Builder::applyLogicalGroupProperties()
 {
+    // Properties in a logical property group are applied in author specified order which is maintained separately for them.
     for (auto id : m_cascade.logicalGroupPropertyIDs())
         applyCascadeProperty(m_cascade.logicalGroupProperty(id));
 }

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -56,7 +56,7 @@ public:
 
 private:
     void applyProperties(int firstProperty, int lastProperty);
-    void applyDeferredProperties();
+    void applyLogicalGroupProperties();
     void applyCustomProperties();
     void applyCustomPropertyImpl(const AtomString&, const PropertyCascade::Property&);
 


### PR DESCRIPTION
#### 83d0b7bdba51349acf5e0ef1fa7a4e8b2fd2257b
<pre>
Rename Style::Builder::applyDeferredProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=277676">https://bugs.webkit.org/show_bug.cgi?id=277676</a>
<a href="https://rdar.apple.com/133275653">rdar://133275653</a>

Reviewed by Oriol Brufau and Sam Weinig.

Deferred properties are now just logical group properties.

* Source/WebCore/css/process-css-properties.py:
(StyleProperties._sort_by_descending_priority_and_name):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyNonHighPriorityProperties):
(WebCore::Style::Builder::applyLogicalGroupProperties):
(WebCore::Style::Builder::applyDeferredProperties): Deleted.
* Source/WebCore/style/StyleBuilder.h:

Canonical link: <a href="https://commits.webkit.org/281935@main">https://commits.webkit.org/281935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3e41c49cdc96b35885925821cd31f49f2a3d7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49563 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8265 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67044 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10451 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56940 "Found 2 new test failures: imported/w3c/web-platform-tests/service-workers/service-worker/navigation-headers.https.html webgl/2.0.0/conformance/canvas/rapid-resizing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57155 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4380 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36527 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->