### PR TITLE
[WPE] WPE Platform: enable explicit sync even when the platform doesn't support it

### DIFF
--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -336,7 +336,6 @@ struct WebPageCreationParameters {
 #if USE(GBM)
     Vector<DMABufRendererBufferFormat> preferredBufferFormats;
 #endif
-    bool useExplicitSync { false };
 #endif
 
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -260,7 +260,6 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #if USE(GBM)
     Vector<WebKit::DMABufRendererBufferFormat> preferredBufferFormats;
 #endif
-    bool useExplicitSync;
 #endif
 
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -227,6 +227,7 @@ UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp
 UIProcess/glib/DisplayVBlankMonitorTimer.cpp
+UIProcess/glib/FenceMonitor.cpp
 UIProcess/glib/ScreenManager.cpp
 UIProcess/glib/WebPageProxyGLib.cpp
 UIProcess/glib/WebProcessPoolGLib.cpp

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10621,10 +10621,6 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #endif
 #endif
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    parameters.useExplicitSync = useExplicitSync();
-#endif
-
     return parameters;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2734,7 +2734,6 @@ private:
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void bindAccessibilityTree(const String&);
     OptionSet<WebCore::PlatformEventModifier> currentStateOfModifierKeys();
-    bool useExplicitSync() const;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -151,9 +151,4 @@ void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
     webkitWebViewBaseCallAfterNextPresentationUpdate(WEBKIT_WEB_VIEW_BASE(viewWidget()), WTFMove(callback));
 }
 
-bool WebPageProxy::useExplicitSync() const
-{
-    return true;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -26,9 +26,11 @@
 #pragma once
 
 #if ENABLE(WPE_PLATFORM)
+#include "FenceMonitor.h"
 #include "MessageReceiver.h"
 #include "RendererBufferFormat.h"
 #include <WebCore/IntSize.h>
+#include <WebCore/Region.h>
 #include <wtf/HashMap.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/unix/UnixFileDescriptor.h>
@@ -70,14 +72,17 @@ private:
     void didDestroyBuffer(uint64_t id);
     void frame(uint64_t bufferID, WebCore::Region&&, WTF::UnixFileDescriptor&&);
     void frameDone();
+    void renderPendingBuffer();
     void bufferRendered();
     void bufferReleased(WPEBuffer*);
 
     WebPageProxy& m_webPage;
     GRefPtr<WPEView> m_wpeView;
+    FenceMonitor m_fenceMonitor;
     uint64_t m_surfaceID { 0 };
     GRefPtr<WPEBuffer> m_pendingBuffer;
     GRefPtr<WPEBuffer> m_committedBuffer;
+    WebCore::Region m_pendingDamageRegion;
     HashMap<uint64_t, GRefPtr<WPEBuffer>> m_buffers;
     HashMap<WPEBuffer*, uint64_t> m_bufferIDs;
 };

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -192,15 +192,6 @@ OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifier
 #endif
 }
 
-bool WebPageProxy::useExplicitSync() const
-{
-#if ENABLE(WPE_PLATFORM)
-    if (auto* view = wpeView())
-        return wpe_display_use_explicit_sync(wpe_view_get_display(view));
-#endif
-    return false;
-}
-
 void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& callback)
 {
     if (!hasRunningProcess() || !m_drawingArea) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -625,7 +625,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if USE(GBM)
     , m_preferredBufferFormats(WTFMove(parameters.preferredBufferFormats))
 #endif
-    , m_useExplicitSync(parameters.useExplicitSync)
 #endif
 #if ENABLE(APP_BOUND_DOMAINS)
     , m_limitsNavigationsToAppBoundDomains(parameters.limitsNavigationsToAppBoundDomains)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1763,7 +1763,6 @@ public:
 #if USE(GBM)
     const Vector<DMABufRendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
 #endif
-    bool useExplicitSync() const { return m_useExplicitSync; }
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
@@ -2789,7 +2788,6 @@ private:
 #if USE(GBM)
     Vector<DMABufRendererBufferFormat> m_preferredBufferFormats;
 #endif
-    bool m_useExplicitSync { false };
 #endif
 
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -66,21 +66,24 @@ std::unique_ptr<AcceleratedSurfaceDMABuf> AcceleratedSurfaceDMABuf::create(WebPa
     return std::unique_ptr<AcceleratedSurfaceDMABuf>(new AcceleratedSurfaceDMABuf(webPage, client));
 }
 
+static bool useExplicitSync()
+{
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
+    auto& extensions = display.eglExtensions();
+    return extensions.ANDROID_native_fence_sync && (display.eglCheckVersion(1, 5) || extensions.KHR_fence_sync);
+}
+
 AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf(WebPage& webPage, Client& client)
     : AcceleratedSurface(webPage, client)
     , m_id(generateID())
     , m_swapChain(m_id)
     , m_isVisible(webPage.activityState().contains(WebCore::ActivityState::IsVisible))
+    , m_useExplicitSync(useExplicitSync())
 {
 #if USE(GBM)
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
         m_swapChain.setupBufferFormat(m_webPage.preferredBufferFormats(), m_isOpaque);
 #endif
-    if (webPage.useExplicitSync()) {
-        auto& display = WebCore::PlatformDisplay::sharedDisplay();
-        auto& extensions = display.eglExtensions();
-        m_useExplicitSync = extensions.ANDROID_native_fence_sync && (display.eglCheckVersion(1, 5) || extensions.KHR_fence_sync);
-    }
 }
 
 AcceleratedSurfaceDMABuf::~AcceleratedSurfaceDMABuf()


### PR DESCRIPTION
#### 0b50ca86186d5f9bbb0ac1d7273a4ba84304607a
<pre>
[WPE] WPE Platform: enable explicit sync even when the platform doesn&apos;t support it
<a href="https://bugs.webkit.org/show_bug.cgi?id=277679">https://bugs.webkit.org/show_bug.cgi?id=277679</a>

Reviewed by Alejandro G. Castro.

We can poll the fence file descriptor like GTK port does.

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::useExplicitSync const): Deleted.
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::updateSurfaceID):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::renderPendingBuffer):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::useExplicitSync const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::useExplicitSync const): Deleted.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::useExplicitSync):
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):

Canonical link: <a href="https://commits.webkit.org/281890@main">https://commits.webkit.org/281890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68044c33e01006b2a1f5c4323ec51122830d5536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11922 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12197 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49581 "Found 1 new test failure: imported/blink/fast/images/content-url-image-with-alt-text.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8278 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34528 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67057 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56953 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57168 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4392 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36538 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37621 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->