### PR TITLE
[InteractionRegions] Extend the SVG color luminance check

### DIFF
--- a/LayoutTests/interaction-region/svg-luminance-expected.txt
+++ b/LayoutTests/interaction-region/svg-luminance-expected.txt
@@ -39,7 +39,13 @@
         (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath),
         (guard (243.50,129) width=80 height=83),
         (interaction (243.53,138.07) width=42.67 height=32)
-        (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath)])
+        (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath),
+        (interaction (391,160) width=18 height=21)
+        (cornerRadius 8.00),
+        (guard (507.50,160) width=18 height=21),
+        (guard (501.50,153.50) width=31.50 height=31.50),
+        (interaction (511.50,163.50) width=11.50 height=11.50)
+        (clipPath move to (0,11.50), add line to (11.50,0))])
       )
     )
   )

--- a/LayoutTests/interaction-region/svg-luminance.html
+++ b/LayoutTests/interaction-region/svg-luminance.html
@@ -103,6 +103,16 @@
             </svg>
         </button>
     </section>
+    <section>
+        <button>
+            <svg width="18" height="18" viewBox="0 0 18 18"><polyline fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" points="3.5 15, 15 3.5"></polyline><polyline fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" points="3.5 3.5, 15 15"></polyline></svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg width="18" height="18" viewBox="0 0 18 18" style="color: red;"><polyline fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" points="3.5 15, 15 3.5"></polyline><polyline fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" points="3.5 3.5, 15 15"></polyline></svg>
+        </button>
+    </section>
 </div>
 <pre id="results"></pre>
 <script>


### PR DESCRIPTION
#### 6e10fc2af54142db16d02f54e8040f5e2d59bdd9
<pre>
[InteractionRegions] Extend the SVG color luminance check
<a href="https://bugs.webkit.org/show_bug.cgi?id=277685">https://bugs.webkit.org/show_bug.cgi?id=277685</a>
&lt;<a href="https://rdar.apple.com/132908848">rdar://132908848</a>&gt;

Reviewed by Simon Fraser.

In 279859@main, we started detecting &quot;small shapes with extreme
luminance&quot; that would be challenging to highlight. This check needs to
account for SVGs using only a stroke.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::colorIsChallengingToHighlight):
Extract the luminance check.

(WebCore::usesFillColorWithExtremeLuminance): Deleted.
(WebCore::interactionRegionForRenderedRegion):
(WebCore::styleIsChallengingToHighlight):
Rename the function.
When the fill paint type is none, check the stroke color instead of the
fill color.

* LayoutTests/interaction-region/svg-luminance-expected.txt:
* LayoutTests/interaction-region/svg-luminance.html:
Add stroke based tests.

Canonical link: <a href="https://commits.webkit.org/282097@main">https://commits.webkit.org/282097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14f1be0e6f2cd2e7ceb291f60fdc70ac233ed7c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49588 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8286 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10401 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10850 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57176 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4404 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36553 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->