### PR TITLE
Optimize BBQ for runs of jump targets in `br.table`

### DIFF
--- a/Source/JavaScriptCore/jit/BinarySwitch.h
+++ b/Source/JavaScriptCore/jit/BinarySwitch.h
@@ -62,7 +62,9 @@ class BinarySwitch {
 public:
     enum Type {
         Int32,
-        IntPtr
+        IntPtr,
+        Int32CheckRuns,
+        IntPtrCheckRuns,
     };
     
     BinarySwitch(GPRReg value, std::span<const int64_t> cases, Type);
@@ -77,6 +79,7 @@ public:
     
 private:
     void build(unsigned start, bool hardStart, unsigned end);
+    void buildCheckRuns(unsigned start, unsigned end);
     
     struct Case {
         Case() { }
@@ -99,6 +102,8 @@ private:
     };
     
     enum BranchKind {
+        NegativeToFallThrough,
+        NotLessThanToFallThrough,
         NotEqualToFallThrough,
         NotEqualToPush,
         LessThanToPush,
@@ -109,9 +114,10 @@ private:
     struct BranchCode {
         BranchCode() { }
         
-        BranchCode(BranchKind kind, unsigned index = UINT_MAX)
+        BranchCode(BranchKind kind, unsigned index = UINT_MAX, unsigned value = UINT_MAX)
             : kind(kind)
             , index(index)
+            , value(value)
         {
         }
 
@@ -119,6 +125,7 @@ private:
         
         BranchKind kind;
         unsigned index;
+        unsigned value;
     };
 
     WeakRandom m_weakRandom;
@@ -130,6 +137,7 @@ private:
     GPRReg m_value;
     unsigned m_index { 0 };
     unsigned m_caseIndex { UINT_MAX };
+    unsigned m_totalCases;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### d39f470ccbc0f2d146764be5e7a3f223cab49f30
<pre>
Optimize BBQ for runs of jump targets in `br.table`
<a href="https://bugs.webkit.org/show_bug.cgi?id=277686">https://bugs.webkit.org/show_bug.cgi?id=277686</a>
<a href="https://rdar.apple.com/133300128">rdar://133300128</a>

Reviewed by NOBODY (OOPS!).

Previously, BBQ generated an entire binary search for every possible case in a `br.table`,
even if we had long consecutive runs that could avoid many comparisons. This patch
optimizes `br.table` generation to reduce the tree depth when it is possible.

* Source/JavaScriptCore/jit/BinarySwitch.cpp:
(JSC::BinarySwitch::BinarySwitch):
(JSC::BinarySwitch::advance):
(JSC::BinarySwitch::buildCheckRuns):
(JSC::BinarySwitch::BranchCode::dump const):
* Source/JavaScriptCore/jit/BinarySwitch.h:
(JSC::BinarySwitch::BranchCode::BranchCode):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSwitch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d39f470ccbc0f2d146764be5e7a3f223cab49f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61447 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11984 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49620 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10897 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54539 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67119 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60686 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5382 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10512 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4441 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36600 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->