### PR TITLE
[WPE] WPE Platform: add support for pointer lock

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3039,6 +3039,10 @@ void webkitWebViewRequestPointerLock(WebKitWebView* webView)
 #if PLATFORM(GTK)
     webkitWebViewBaseRequestPointerLock(WEBKIT_WEB_VIEW_BASE(webView));
 #endif
+
+#if PLATFORM(WPE)
+    webView->priv->view->requestPointerLock();
+#endif
 }
 
 void webkitWebViewDenyPointerLockRequest(WebKitWebView* webView)
@@ -3051,8 +3055,12 @@ void webkitWebViewDidLosePointerLock(WebKitWebView* webView)
 #if PLATFORM(GTK)
     webkitWebViewBaseDidLosePointerLock(WEBKIT_WEB_VIEW_BASE(webView));
 #endif
-}
+
+#if PLATFORM(WPE)
+    webView->priv->view->didLosePointerLock();
 #endif
+}
+#endif // ENABLE(POINTER_LOCK)
 
 static void webkitWebViewSynthesizeCompositionKeyPress(WebKitWebView* webView, const String& text, std::optional<Vector<CompositionUnderline>>&& underlines, std::optional<EditingRange>&& selectionRange)
 {

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -96,6 +96,10 @@ public:
 #if ENABLE(WPE_PLATFORM)
     virtual WPEView* wpeView() const { return nullptr; }
 #endif
+#if ENABLE(POINTER_LOCK)
+    virtual void requestPointerLock() { };
+    virtual void didLosePointerLock() { };
+#endif
 
     virtual void setCursor(const WebCore::Cursor&) { };
     virtual void synthesizeCompositionKeyPress(const String&, std::optional<Vector<WebCore::CompositionUnderline>>&&, std::optional<WebKit::EditingRange>&&) = 0;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -576,6 +576,20 @@ void ViewPlatform::setCursor(const WebCore::Cursor& cursor)
 #endif
 }
 
+#if ENABLE(POINTER_LOCK)
+void ViewPlatform::requestPointerLock()
+{
+    if (wpe_view_lock_pointer(m_wpeView.get()))
+        setCursor(WebCore::noneCursor());
+}
+
+void ViewPlatform::didLosePointerLock()
+{
+    if (wpe_view_unlock_pointer(m_wpeView.get()))
+        setCursor(WebCore::pointerCursor());
+}
+#endif
+
 void ViewPlatform::callAfterNextPresentationUpdate(CompletionHandler<void()>&& callback)
 {
     RELEASE_ASSERT(!m_nextPresentationUpdateCallback);

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -72,6 +72,11 @@ private:
     bool activityStateChanged(WebCore::ActivityState, bool);
     void toplevelStateChanged(WPEToplevelState previousState, WPEToplevelState);
 
+#if ENABLE(POINTER_LOCK)
+    void requestPointerLock() override;
+    void didLosePointerLock() override;
+#endif
+
 #if ENABLE(TOUCH_EVENTS)
     Vector<WebKit::WebPlatformTouchPoint> touchPointsForEvent(WPEEvent*);
 #endif

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -756,6 +756,46 @@ void wpe_view_unmap(WPEView* view)
 }
 
 /**
+ * wpe_view_lock_pointer:
+ * @view: a #WPEView
+ *
+ * Disable the movements of the pointer in @view, locking it to a particular
+ * area; while the pointer is locked, mouse events are relative instead of
+ * absolute motions.
+ *
+ * Returns: %TRUE if the pointer is locked, or %FALSE otherwise
+ */
+gboolean wpe_view_lock_pointer(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    if (viewClass->lock_pointer)
+        return viewClass->lock_pointer(view);
+
+    return FALSE;
+}
+
+/**
+ * wpe_view_unlock_pointer:
+ * @view: a #WPEView
+ *
+ * Unlock the pointer in @view if it has been locked.
+ *
+ * Returns: %TRUE if the pointer is unlocked, or %FALSE otherwise
+ */
+gboolean wpe_view_unlock_pointer(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    if (viewClass->unlock_pointer)
+        return viewClass->unlock_pointer(view);
+
+    return FALSE;
+}
+
+/**
  * wpe_view_set_cursor_from_name:
  * @view: a #WPEView
  * @name: a cursor name

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -56,6 +56,8 @@ struct _WPEViewClass
                                         const WPERectangle *damage_rects,
                                         guint               n_damage_rects,
                                         GError            **error);
+    gboolean (* lock_pointer)          (WPEView            *view);
+    gboolean (* unlock_pointer)        (WPEView            *view);
     void     (* set_cursor_from_name)  (WPEView            *view,
                                         const char         *name);
     void     (* set_cursor_from_bytes) (WPEView            *view,
@@ -105,6 +107,8 @@ WPE_API void                    wpe_view_set_visible                   (WPEView 
 WPE_API gboolean                wpe_view_get_mapped                    (WPEView            *view);
 WPE_API void                    wpe_view_map                           (WPEView            *view);
 WPE_API void                    wpe_view_unmap                         (WPEView            *view);
+WPE_API gboolean                wpe_view_lock_pointer                  (WPEView            *view);
+WPE_API gboolean                wpe_view_unlock_pointer                (WPEView            *view);
 WPE_API void                    wpe_view_set_cursor_from_name          (WPEView            *view,
                                                                         const char         *name);
 WPE_API void                    wpe_view_set_cursor_from_bytes         (WPEView            *view,

--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -19,6 +19,8 @@ set(WPEPlatformWayland_SOURCES
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-shell-protocol.c
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-protocol.c
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-protocol.c
 )
 
 set(WPEPlatformWayland_INSTALLED_HEADERS
@@ -108,6 +110,32 @@ add_custom_command(
     OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
     MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml
     COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
+    DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code ${WAYLAND_PROTOCOLS_DATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-client-protocol.h
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml
+    DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code ${WAYLAND_PROTOCOLS_DATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/relative-pointer/relative-pointer-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-client-protocol.h
     VERBATIM)
 
 add_custom_command(

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -38,6 +38,8 @@
 #include "WPEWaylandSeat.h"
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
 #include "linux-explicit-synchronization-unstable-v1-client-protocol.h"
+#include "pointer-constraints-unstable-v1-client-protocol.h"
+#include "relative-pointer-unstable-v1-client-protocol.h"
 #include "text-input-unstable-v1-client-protocol.h"
 #include "text-input-unstable-v3-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
@@ -79,6 +81,8 @@ struct _WPEDisplayWaylandPrivate {
     struct zwp_text_input_v1* textInputV1;
     struct zwp_text_input_manager_v3* textInputManagerV3;
     struct zwp_text_input_v3* textInputV3;
+    struct zwp_pointer_constraints_v1* pointerConstraints;
+    struct zwp_relative_pointer_manager_v1* relativePointerManager;
     Vector<std::pair<uint32_t, uint64_t>> linuxDMABufFormats;
     std::unique_ptr<WPE::WaylandSeat> wlSeat;
     std::unique_ptr<WPE::WaylandCursor> wlCursor;
@@ -193,6 +197,8 @@ static void wpeDisplayWaylandDispose(GObject* object)
         g_clear_pointer(&priv->textInputV3, zwp_text_input_v3_destroy);
         g_clear_pointer(&priv->textInputManagerV3, zwp_text_input_manager_v3_destroy);
     }
+    g_clear_pointer(&priv->pointerConstraints, zwp_pointer_constraints_v1_destroy);
+    g_clear_pointer(&priv->relativePointerManager, zwp_relative_pointer_manager_v1_destroy);
 #if USE(LIBDRM)
     g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
 #endif
@@ -236,6 +242,10 @@ const struct wl_registry_listener registryListener = {
             priv->textInputV1 = zwp_text_input_manager_v1_create_text_input(priv->textInputManagerV1);
         } else if (!std::strcmp(interface, "zwp_text_input_manager_v3")) {
             priv->textInputManagerV3 = static_cast<struct zwp_text_input_manager_v3*>(wl_registry_bind(registry, name, &zwp_text_input_manager_v3_interface, 1));
+        } else if (!std::strcmp(interface, "zwp_pointer_constraints_v1")) {
+            priv->pointerConstraints = static_cast<struct zwp_pointer_constraints_v1*>(wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, 1));
+        } else if (!std::strcmp(interface, "zwp_relative_pointer_manager_v1")) {
+            priv->relativePointerManager = static_cast<struct zwp_relative_pointer_manager_v1*>(wl_registry_bind(registry, name, &zwp_relative_pointer_manager_v1_interface, 1));
         }
     },
     // global_remove
@@ -545,6 +555,16 @@ struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland* dis
 struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland* display)
 {
     return display->priv->textInputV3;
+}
+
+struct zwp_pointer_constraints_v1* wpeDisplayWaylandGetPointerConstraints(WPEDisplayWayland* display)
+{
+    return display->priv->pointerConstraints;
+}
+
+struct zwp_relative_pointer_manager_v1* wpeDisplayWaylandGetRelativePointerManager(WPEDisplayWayland* display)
+{
+    return display->priv->relativePointerManager;
 }
 
 struct zwp_linux_explicit_synchronization_v1* wpeDisplayWaylandGetLinuxExplicitSync(WPEDisplayWayland* display)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
@@ -38,3 +38,5 @@ struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
 struct zwp_linux_explicit_synchronization_v1* wpeDisplayWaylandGetLinuxExplicitSync(WPEDisplayWayland*);
 struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
 struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
+struct zwp_pointer_constraints_v1* wpeDisplayWaylandGetPointerConstraints(WPEDisplayWayland*);
+struct zwp_relative_pointer_manager_v1* wpeDisplayWaylandGetRelativePointerManager(WPEDisplayWayland*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -45,6 +45,8 @@ public:
 
     struct wl_seat* seat() const { return m_seat; }
     WPEKeymap* keymap() const { return m_keymap.get(); }
+    uint32_t pointerModifiers() const { return m_pointer.modifiers; }
+    std::pair<double, double> pointerCoords() const { return std::pair<double, double>(m_pointer.x, m_pointer.y); }
 
     void startListening();
 


### PR DESCRIPTION
#### 141c440e3b1ae8d55acaf1d0f92eb6d892891365
<pre>
[WPE] WPE Platform: add support for pointer lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=265648">https://bugs.webkit.org/show_bug.cgi?id=265648</a>

Reviewed by Carlos Garcia Campos.

Pointer lock requests from WebKit are sent to the platform, where we check
if pointer constraints and relative pointer protocols are available in
the Wayland implementation, then the pointer is locked and a corresponding
WPEEvent emitted.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewRequestPointerLock):
(webkitWebViewDidLosePointerLock):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
(WKWPE::View::requestPointerLock):
(WKWPE::View::didLosePointerLock):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::requestPointerLock):
(WKWPE::ViewPlatform::didLosePointerLock):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_lock_pointer):
(wpe_view_unlock_pointer):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandGetPointerConstraints):
(wpeDisplayWaylandGetRelativePointerManager):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandDispose):
(wpeViewWaylandUnlockPointer):
(wpe_view_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h:
(WPE::WaylandSeat::pointerModifiers const):
(WPE::WaylandSeat::pointerCoords const):

Canonical link: <a href="https://commits.webkit.org/282558@main">https://commits.webkit.org/282558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c763f1d929dcd4b932a932698e914c1913926dd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50762 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36018 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58278 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5770 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9597 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->