### PR TITLE
[WebAuthn] Implement batching for checking excludeCredentials

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
@@ -7,4 +7,5 @@ PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authentic
 PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with full key store.
+PASS PublicKeyCredential's [[create]] with InvalidStateError due to excluded credentials in a mock hid authenticator using batching.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -160,7 +160,7 @@
         return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
     }, "PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.");
 
-        promise_test(function(t) {
+    promise_test(function(t) {
         const options = {
             publicKey: {
                 rp: {
@@ -182,4 +182,38 @@
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCreateMessageFullKeyStoreBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.create(options), "Operation timed out.");
     }, "PublicKeyCredential's [[create]] with full key store.");
+
+    promise_test(function(t) {
+        const config = { hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrCredentialExcludedOnlyResponseBase64] } };
+
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "example.com"
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: asciiToUint8Array("123456"),
+                    displayName: "John",
+                },
+                challenge: asciiToUint8Array("123456"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                excludeCredentials: [],
+            }
+        };
+        const numCredentials = 5;
+
+        for (let i = 0; i < numCredentials; i++) {
+            if (i == 0)
+                config.hid.payloadBase64.unshift(testAssertionMessageBase64); // Passes assertion, therefore excluded credential present
+            else
+                config.hid.payloadBase64.unshift("Lg=="); // no match
+            options.publicKey.excludeCredentials.push({ type: "public-key", id: generateID(i) });
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
+    }, "PublicKeyCredential's [[create]] with InvalidStateError due to excluded credentials in a mock hid authenticator using batching.");
+
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -18,4 +18,6 @@ PASS PublicKeyCredential's [[create]] with indirect attestation in a mock hid au
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport extension in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid extensions in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.
+PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -449,4 +449,68 @@
             checkCtapMakeCredentialResult(credential);
         });
     }, "PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.");
+
+    promise_test(t => {
+        let config = { hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } };
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 100,
+                excludeCredentials: []
+            }
+        };
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++) {
+            options.publicKey.excludeCredentials.push({ type: "public-key", id: generateID(i) });
+            config.hid.payloadBase64.unshift("Lg==");
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = { hid: { maxCredentialCountInList: 5, stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } };
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 100,
+                excludeCredentials: []
+            }
+        };
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++)
+            options.publicKey.excludeCredentials.push({ type: "public-key", id: generateID(i) });
+        for (let i = 0; i < Math.ceil(numCredentials/config.hid.maxCredentialCountInList); i++)
+            config.hid.payloadBase64.unshift("Lg==");
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2");
 </script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -279,6 +279,15 @@ function concatenateBuffers(buffer1, buffer2)
     return tmp.buffer;
 }
 
+function generateID(nonce) {
+    let idBuffer = new Uint8Array(32);
+    for (let i = 0; i < 8; i++) {
+        idBuffer[i] = nonce % 256;
+        nonce = Math.floor(nonce / 256);
+    }
+    return idBuffer;
+}
+
 // Very dirty asn1 decoder. Just works.
 function extractRawSignature(asn1signature)
 {

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -90,6 +90,18 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setRemainingDiscover
     return *this;
 }
 
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMaxCredentialCountInList(uint32_t maxCredentialCountInList)
+{
+    m_maxCredentialCountInList = maxCredentialCountInList;
+    return *this;
+}
+
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMaxCredentialIDLength(uint32_t maxCredentialIDLength)
+{
+    m_maxCredentialIdLength = maxCredentialIDLength;
+    return *this;
+}
+
 Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
 {
     using namespace cbor;
@@ -99,27 +111,31 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     CBORValue::ArrayValue versionArray;
     for (const auto& version : response.versions())
         versionArray.append(version == ProtocolVersion::kCtap ? kCtap2Version : kU2fVersion);
-    deviceInfoMap.emplace(CBORValue(1), CBORValue(WTFMove(versionArray)));
+    deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoVersionsKey), CBORValue(WTFMove(versionArray)));
 
     if (response.extensions())
-        deviceInfoMap.emplace(CBORValue(2), toArrayValue(*response.extensions()));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoExtensionsKey), toArrayValue(*response.extensions()));
 
-    deviceInfoMap.emplace(CBORValue(3), CBORValue(response.aaguid()));
-    deviceInfoMap.emplace(CBORValue(4), convertToCBOR(response.options()));
+    deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoAAGUIDKey), CBORValue(response.aaguid()));
+    deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoOptionsKey), convertToCBOR(response.options()));
 
     if (response.maxMsgSize())
-        deviceInfoMap.emplace(CBORValue(5), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxMsgSizeKey), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
 
     if (response.pinProtocol())
-        deviceInfoMap.emplace(CBORValue(6), toArrayValue(*response.pinProtocol()));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey), toArrayValue(*response.pinProtocol()));
     
     if (response.transports()) {
         auto transports = *response.transports();
-        deviceInfoMap.emplace(CBORValue(7), toArrayValue(transports.map(WebCore::toString)));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoTransportsKey), toArrayValue(transports.map(WebCore::toString)));
     }
 
     if (response.remainingDiscoverableCredentials())
-        deviceInfoMap.emplace(CBORValue(8), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoRemainingDiscoverableCredentialsKey), CBORValue(static_cast<int64_t>(*response.remainingDiscoverableCredentials())));
+    if (response.maxCredentialCountInList())
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxCredentialCountInListKey), CBORValue(static_cast<int64_t>(*response.maxCredentialCountInList())));
+    if (response.maxCredentialIDLength())
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxCredentialIdLengthKey), CBORValue(static_cast<int64_t>(*response.maxCredentialIDLength())));
 
     auto encodedBytes = CBORWriter::write(CBORValue(WTFMove(deviceInfoMap)));
     ASSERT(encodedBytes);

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
@@ -55,6 +55,8 @@ public:
     AuthenticatorGetInfoResponse& setOptions(AuthenticatorSupportedOptions&&);
     AuthenticatorGetInfoResponse& setTransports(Vector<WebCore::AuthenticatorTransport>&&);
     AuthenticatorGetInfoResponse& setRemainingDiscoverableCredentials(uint32_t);
+    AuthenticatorGetInfoResponse& setMaxCredentialCountInList(uint32_t);
+    AuthenticatorGetInfoResponse& setMaxCredentialIDLength(uint32_t);
 
     const StdSet<ProtocolVersion>& versions() const { return m_versions; }
     const Vector<uint8_t>& aaguid() const { return m_aaguid; }
@@ -64,12 +66,16 @@ public:
     const AuthenticatorSupportedOptions& options() const { return m_options; }
     const std::optional<Vector<WebCore::AuthenticatorTransport>>& transports() const { return m_transports; }
     const std::optional<uint32_t>& remainingDiscoverableCredentials() const { return m_remainingDiscoverableCredentials; }
+    const std::optional<uint32_t>& maxCredentialCountInList() const { return m_maxCredentialCountInList; }
+    const std::optional<uint32_t>& maxCredentialIDLength() const { return m_maxCredentialIdLength; }
 
 private:
     StdSet<ProtocolVersion> m_versions;
     Vector<uint8_t> m_aaguid;
     std::optional<uint32_t> m_maxMsgSize;
     std::optional<Vector<uint8_t>> m_pinProtocols;
+    std::optional<uint32_t> m_maxCredentialCountInList;
+    std::optional<uint32_t> m_maxCredentialIdLength;
     std::optional<Vector<String>> m_extensions;
     AuthenticatorSupportedOptions m_options;
     std::optional<Vector<WebCore::AuthenticatorTransport>> m_transports;

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 struct PublicKeyCredentialCreationOptions;
 struct PublicKeyCredentialRequestOptions;
+struct PublicKeyCredentialDescriptor;
 }
 
 namespace fido {
@@ -56,6 +57,8 @@ WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<ui
 // integer keys and CBOR encoded values as defined by the CTAP spec.
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorGetAssertion
 WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt);
+
+WEBCORE_EXPORT Vector<uint8_t> encodeSilentGetAssertion(const String& rpId, const Vector<uint8_t>& hash, const Vector<WebCore::PublicKeyCredentialDescriptor>& credentials, std::optional<PinParameters> = std::nullopt);
 
 // Represents CTAP requests with empty parameters, including
 // AuthenticatorGetInfo, AuthenticatorReset and AuthenticatorGetNextAssertion commands.

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -204,7 +204,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         return std::nullopt;
     const auto& responseMap = decodedMap->getMap();
 
-    auto it = responseMap.find(CBOR(1));
+    auto it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoVersionsKey));
     if (it == responseMap.end() || !it->second.isArray())
         return std::nullopt;
     StdSet<ProtocolVersion> protocolVersions;
@@ -224,13 +224,13 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
     if (protocolVersions.empty())
         return std::nullopt;
 
-    it = responseMap.find(CBOR(3));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoAAGUIDKey));
     if (it == responseMap.end() || !it->second.isByteString() || it->second.getByteString().size() != aaguidLength)
         return std::nullopt;
 
     AuthenticatorGetInfoResponse response(WTFMove(protocolVersions), Vector<uint8_t>(it->second.getByteString()));
 
-    it = responseMap.find(CBOR(2));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoExtensionsKey));
     if (it != responseMap.end()) {
         if (!it->second.isArray())
             return std::nullopt;
@@ -246,7 +246,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
     }
 
     AuthenticatorSupportedOptions options;
-    it = responseMap.find(CBOR(4));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoOptionsKey));
     if (it != responseMap.end()) {
         if (!it->second.isMap())
             return std::nullopt;
@@ -301,7 +301,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setOptions(WTFMove(options));
     }
 
-    it = responseMap.find(CBOR(5));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMaxMsgSizeKey));
     if (it != responseMap.end()) {
         if (!it->second.isUnsigned())
             return std::nullopt;
@@ -309,7 +309,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setMaxMsgSize(it->second.getUnsigned());
     }
 
-    it = responseMap.find(CBOR(6));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey));
     if (it != responseMap.end()) {
         if (!it->second.isArray())
             return std::nullopt;
@@ -324,7 +324,22 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setPinProtocols(WTFMove(supportedPinProtocols));
     }
 
-    it = responseMap.find(CBOR(9));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMaxCredentialCountInListKey));
+    if (it != responseMap.end()) {
+        if (!it->second.isUnsigned())
+            return std::nullopt;
+
+        response.setMaxCredentialCountInList(it->second.getUnsigned());
+    }
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMaxCredentialIdLengthKey));
+    if (it != responseMap.end()) {
+        if (!it->second.isUnsigned())
+            return std::nullopt;
+
+        response.setMaxCredentialIDLength(it->second.getUnsigned());
+    }
+
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoTransportsKey));
     if (it != responseMap.end()) {
         if (!it->second.isArray())
             return std::nullopt;
@@ -340,7 +355,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setTransports(WTFMove(transports));
     }
 
-    it = responseMap.find(CBOR(20));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoRemainingDiscoverableCredentialsKey));
     if (it != responseMap.end()) {
         if (!it->second.isUnsigned())
             return std::nullopt;

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -261,21 +261,44 @@ const uint8_t kCtapNfcApduIns = 0x10;
 const size_t kCtapChannelIdSize = 4;
 const uint8_t kCtapKeepAliveStatusProcessing = 1;
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#commands
-const int64_t kCtapMakeCredentialClientDataHashKey = 1;
-const int64_t kCtapMakeCredentialRpKey = 2;
-const int64_t kCtapMakeCredentialUserKey = 3;
-const int64_t kCtapMakeCredentialPubKeyCredParamsKey = 4;
-const int64_t kCtapMakeCredentialExcludeListKey = 5;
-const int64_t kCtapMakeCredentialExtensionsKey = 6;
-const int64_t kCtapMakeCredentialRequestOptionsKey = 7;
+constexpr int64_t kCtapMakeCredentialClientDataHashKey = 1;
+constexpr int64_t kCtapMakeCredentialRpKey = 2;
+constexpr int64_t kCtapMakeCredentialUserKey = 3;
+constexpr int64_t kCtapMakeCredentialPubKeyCredParamsKey = 4;
+constexpr int64_t kCtapMakeCredentialExcludeListKey = 5;
+constexpr int64_t kCtapMakeCredentialExtensionsKey = 6;
+constexpr int64_t kCtapMakeCredentialRequestOptionsKey = 7;
 
-const int64_t kCtapGetAssertionRpIdKey = 1;
-const int64_t kCtapGetAssertionClientDataHashKey = 2;
-const int64_t kCtapGetAssertionAllowListKey = 3;
-const int64_t kCtapGetAssertionExtensionsKey = 4;
-const int64_t kCtapGetAssertionRequestOptionsKey = 5;
-const int64_t kCtapGetAssertionPinUvAuthParamKey = 6;
-const int64_t kCtapGetAssertionPinUvAuthProtocolKey = 7;
+constexpr int64_t kCtapGetAssertionRpIdKey = 1;
+constexpr int64_t kCtapGetAssertionClientDataHashKey = 2;
+constexpr int64_t kCtapGetAssertionAllowListKey = 3;
+constexpr int64_t kCtapGetAssertionExtensionsKey = 4;
+constexpr int64_t kCtapGetAssertionRequestOptionsKey = 5;
+constexpr int64_t kCtapGetAssertionPinUvAuthParamKey = 6;
+constexpr int64_t kCtapGetAssertionPinUvAuthProtocolKey = 7;
+
+constexpr int64_t kCtapAuthenticatorGetInfoVersionsKey = 0x01;
+constexpr int64_t kCtapAuthenticatorGetInfoExtensionsKey = 0x02;
+constexpr int64_t kCtapAuthenticatorGetInfoAAGUIDKey = 0x03;
+constexpr int64_t kCtapAuthenticatorGetInfoOptionsKey = 0x04;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxMsgSizeKey = 0x05;
+constexpr int64_t kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey = 0x06;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxCredentialCountInListKey = 0x07;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxCredentialIdLengthKey = 0x08;
+constexpr int64_t kCtapAuthenticatorGetInfoTransportsKey = 0x09;
+constexpr int64_t kCtapAuthenticatorGetInfoAlgorithmsKey = 0x0a;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxSerializedLargeBlobArrayKey = 0x0b;
+constexpr int64_t kCtapAuthenticatorGetInfoForcePINChangeKey = 0x0c;
+constexpr int64_t kCtapAuthenticatorGetInfoMinPINLengthKey = 0x0d;
+constexpr int64_t kCtapAuthenticatorGetInfoFirmwareVersionKey = 0x0e;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxCredBlobLengthKey = 0x0f;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxRPIDsForSetMinPINLengthKey = 0x10;
+constexpr int64_t kCtapAuthenticatorGetInfoPreferredPlatformUvAttemptsKey = 0x11;
+constexpr int64_t kCtapAuthenticatorGetInfoUVModalitysKey = 0x12;
+constexpr int64_t kCtapAuthenticatorGetInfoCertificationsKey = 0x13;
+constexpr int64_t kCtapAuthenticatorGetInfoRemainingDiscoverableCredentialsKey = 0x14;
+constexpr int64_t kCtapAuthenticatorGetInfoVendorPrototypeConfigCommandsKey = 0x15;
+
 
 } // namespace fido
 

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -90,6 +90,8 @@ struct MockWebAuthenticationConfiguration {
         bool expectCancel { false };
         bool supportClientPin { false };
         bool supportInternalUV { false };
+        long maxCredentialCountInList { 1 };
+        long maxCredentialIdLength { 64 };
     };
 
     struct NfcConfiguration {

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -104,6 +104,8 @@
     boolean expectCancel = false;
     boolean supportClientPin = false;
     boolean supportInternalUV = false;
+    long maxCredentialCountInList = 1;
+    long maxCredentialIdLength = 64;
 };
 
 [

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6047,6 +6047,8 @@ header: <WebCore/ISOVTTCue.h>
     bool expectCancel;
     bool supportClientPin;
     bool supportInternalUV;
+    long maxCredentialCountInList;
+    long maxCredentialIdLength;
 };
 
 [Nested] enum class WebCore::MockWebAuthenticationConfiguration::NfcError : uint8_t {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -225,6 +225,8 @@ void MockHidConnection::feedReports()
             if (m_configuration.hid->supportInternalUV)
                 options.setUserVerificationAvailability(AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured);
             infoResponse.setOptions(WTFMove(options));
+            infoResponse.setMaxCredentialCountInList(m_configuration.hid->maxCredentialCountInList);
+            infoResponse.setMaxCredentialIDLength(m_configuration.hid->maxCredentialIdLength);
             infoData = encodeAsCBOR(infoResponse);
         }
         infoData.insert(0, static_cast<uint8_t>(CtapDeviceResponseCode::kSuccess)); // Prepend status code.

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -29,6 +29,7 @@
 
 #include "FidoAuthenticator.h"
 #include <WebCore/AuthenticatorGetInfoResponse.h>
+#include <WebCore/PublicKeyCredentialDescriptor.h>
 
 namespace fido {
 namespace pin {
@@ -57,6 +58,8 @@ private:
     void makeCredential() final;
     void continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&&);
     void getAssertion() final;
+    void continueCheckExcludedCredentialsAfterResponseRecieved(Vector<uint8_t>&& data);
+    void continueMakeCredentialAfterCheckExcludedCredentials(bool includeCurrentBatch = false);
     void continueGetAssertionAfterResponseReceived(Vector<uint8_t>&&);
     void continueGetNextAssertionAfterResponseReceived(Vector<uint8_t>&&);
 
@@ -77,7 +80,9 @@ private:
     bool m_isDowngraded { false };
     bool m_isKeyStoreFull { false };
     size_t m_remainingAssertionResponses { 0 };
+    size_t m_currentBatch { 0 };
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_assertionResponses;
+    Vector<Vector<WebCore::PublicKeyCredentialDescriptor>> m_batches;
     Vector<uint8_t> m_pinAuth;
 };
 


### PR DESCRIPTION
#### f56198757e4b0e8dbde874090cf8e4050019494f
<pre>
[WebAuthn] Implement batching for checking excludeCredentials
<a href="https://rdar.apple.com/133307666">rdar://133307666</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277695">https://bugs.webkit.org/show_bug.cgi?id=277695</a>

Reviewed by Charlie Wolfe.

This change starts to implement checking the excludeCredential list in batches as
supported by the authenticator during a makeCredential. This is accomplished by using
smaller, up=0, get requests to detect if a credential is present on the authenticator.

Then if a credential is detected, only that credential may be included with the actual
makeCredential request to get the proper error code back from the authenticator. If none
matched, we don&apos;t need to include a excludeCredentials list to the authenticator since
we already know those credentials aren&apos;t present.

This patch only implements this logic for makeCredential, getAssertion will be done in
another patch.

Added layout tests to test matching exclude list with batching, non-matching exclude list with
batching, and a security key that supports batches greater than 1.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/resources/util.js:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::AuthenticatorGetInfoResponse::setMaxCredentialCountInList):
(fido::AuthenticatorGetInfoResponse::setMaxCredentialIDLength):
(fido::encodeAsCBOR):
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h:
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp:
(fido::encodeSilentGetAssertion):
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCTAPGetInfoResponse):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::feedReports):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueCheckExcludedCredentialsAfterResponseRecieved):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/282019@main">https://commits.webkit.org/282019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bb443f83273e76873c973306ab995b904fe7b2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61769 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53503 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/30642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56658 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67476 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53450 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4698 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->