### PR TITLE
[Site Isolation] Back forward navigations do not work with nested same site frames in a site isolated iframe

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -692,8 +692,11 @@ void HistoryController::setProvisionalItem(RefPtr<HistoryItem>&& item)
 void HistoryController::initializeItem(HistoryItem& item)
 {
     RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
+    if (!frame) {
+        if (!m_frame->isProvisional())
+            item.setFrameID(m_frame->frameID());
         return;
+    }
     RefPtr documentLoader = frame->loader().documentLoader();
     ASSERT(documentLoader);
 
@@ -809,9 +812,10 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
 void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
     if (!itemsAreClones(item, fromItem)) {
-        if (RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr()))
+        if (RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr())) {
             frame->checkedLoader()->loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
-        return;
+            return;
+        }
     }
 
     // Just iterate over the rest, looking for frames to navigate.

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -119,6 +119,9 @@ public:
     WEBCORE_EXPORT void setOwnerPermissionsPolicy(OwnerPermissionsPolicyData&&);
     WEBCORE_EXPORT std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const;
 
+    void setIsProvisional(bool isProvisional) { m_isProvisional = isProvisional; }
+    bool isProvisional() const { return m_isProvisional; }
+
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent, Frame* opener);
     void resetWindowProxy();
@@ -142,6 +145,7 @@ private:
     WeakHashSet<Frame> m_openedFrames;
     mutable UniqueRef<HistoryController> m_history;
     std::optional<OwnerPermissionsPolicyData> m_ownerPermisssionsPolicyOverride;
+    bool m_isProvisional { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -415,12 +415,17 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
     m_provisionalFrame = localFrame.ptr();
     localFrame->init();
 
+    remoteFrame->setIsProvisional(true);
+    localFrame->setIsProvisional(true);
+
     if (parameters.layerHostingContextIdentifier)
         setLayerHostingContextIdentifier(*parameters.layerHostingContextIdentifier);
 }
 
 void WebFrame::destroyProvisionalFrame()
 {
+    if (auto* remoteFrame = coreRemoteFrame())
+        remoteFrame->setIsProvisional(false);
     if (RefPtr frame = std::exchange(m_provisionalFrame, nullptr)) {
         if (auto* client = toWebLocalFrameLoaderClient(frame->loader().client()))
             client->takeFrameInvalidator().release();
@@ -479,6 +484,8 @@ void WebFrame::commitProvisionalFrame()
 
     if (ownerElement)
         ownerElement->scheduleInvalidateStyleAndLayerComposition();
+
+    localFrame->setIsProvisional(false);
 }
 
 void WebFrame::removeFromTree()


### PR DESCRIPTION
#### 6bb1b26c8f2ac6b17214d2b100c42a7b1a0223dd
<pre>
[Site Isolation] Back forward navigations do not work with nested same site frames in a site isolated iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=277698">https://bugs.webkit.org/show_bug.cgi?id=277698</a>
<a href="https://rdar.apple.com/133311171">rdar://133311171</a>

Reviewed by NOBODY (OOPS!).

When creating the history item tree we should include the frame id for all frames so that we do not skip
over frames that have remote parents when traversing the frame tree during a back/forward navigation.

We also need to ignore remote frames that are being transitioned to local to avoid having duplicate
history items for a single frame.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::recursiveGoToItem):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::setIsProvisional):
(WebCore::Frame::isProvisional const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
(WebKit::WebFrame::destroyProvisionalFrame):
(WebKit::WebFrame::commitProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigateNestedIframeSameOriginBackForward)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateNestedRootFramesSameOriginBackForward)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bb1b26c8f2ac6b17214d2b100c42a7b1a0223dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49736 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56562 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10939 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?vp9 (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5596 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10697 "Found 1 new test failure: fast/forms/form-submission-crash-4.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57117 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57343 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4603 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36807 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->