### PR TITLE
[GTK][WPE][Skia] Use RGBA as the pixel format for texture backed SkSurfaces

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -106,6 +106,9 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
 
         m_pixelData = WTFMove(data);
         m_imagePixelData = m_pixelData->data();
+
+        // SkSurfaces backed by textures have RGBA format.
+        m_imageSourceFormat = DataFormat::RGBA8;
     } else {
         SkPixmap pixmap;
         if (!platformImage->peekPixels(&pixmap))
@@ -113,9 +116,11 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
 
         m_skImage = WTFMove(platformImage);
         m_imagePixelData = pixmap.addr();
+
+        // Raster SkSurfaces have BGRA format.
+        m_imageSourceFormat = DataFormat::BGRA8;
     }
 
-    m_imageSourceFormat = DataFormat::BGRA8;
     m_imageSourceUnpackAlignment = srcUnpackAlignment;
     return true;
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -71,7 +71,7 @@ RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::createAcceleratedBuffer(const
 {
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     RELEASE_ASSERT(grContext);
-    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height(), SkColorSpace::MakeSRGB());
+    auto imageInfo = SkImageInfo::Make(size.width(), size.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface)


### PR DESCRIPTION
#### 50cb029965f14968a01715e5335a1381b7f2e9b6
<pre>
[GTK][WPE][Skia] Use RGBA as the pixel format for texture backed SkSurfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=277702">https://bugs.webkit.org/show_bug.cgi?id=277702</a>

Reviewed by Carlos Garcia Campos.

Currently SkSurfaces are always created using BGRA as the color format. But
when a SkSurface is backed by a texture, this texture has RGBA format because
GLES doesn&apos;t support BGRA. Due to this, skia needs perform constant format
conversions when drawing to that SkSurface, which has a big performance penalty.

This change modifies SkSurfaces backed by textures (used for tiles and accelerated
ImageBuffers) to use RGBA instead BGRA.

The format change for the tile SkSurfaces is not problematic, because the
content of those surfaces is always accessed directly from the texture during
the composition, whose format was and is still RGBA.

The ImageBuffer case is a bit more problematic because it&apos;s expected to always use
BGRA format, so we need to perform a format conversion when the internal pixels
are accessed by any mean that&apos;s not skia (because skia will perform the appropriate
format conversion). This means that we need to perform a format conversion in the
getPixelBuffer() and putPixelBuffer() methods, and also specify in the image
extractor that pixels gotten from a texture backed SkSurface are in RGBA format.

* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::createAcceleratedBuffer):

Canonical link: <a href="https://commits.webkit.org/281985@main">https://commits.webkit.org/281985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2bcbe0bf231401e7a66aee0fe426f6cd618b204

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49747 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8481 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11148 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57126 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57352 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4621 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9288 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36826 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->