### PR TITLE
webpushd should check that associated web clip has push permissions before subscribing on iOS

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h
@@ -63,6 +63,7 @@
 
 @interface UNUserNotificationCenter ()
 - (instancetype)initWithBundleIdentifier:(NSString *)bundleIdentifier;
+- (UNNotificationSettings *)notificationSettings;
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
@@ -36,6 +36,7 @@
 - (void)getNotificationSettingsWithCompletionHandler:(void(^)(UNNotificationSettings *settings))completionHandler;
 - (void)requestAuthorizationWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError *))completionHandler;
 - (NSNumber *)getAppBadgeForTesting;
+- (UNNotificationSettings *)notificationSettings;
 @end
 
 #endif

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -134,6 +134,13 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
     });
 }
 
+- (UNNotificationSettings *)notificationSettings
+{
+    RetainPtr settings = [UNMutableNotificationSettings emptySettings];
+    [settings setAuthorizationStatus:_hasPermission ? UNAuthorizationStatusAuthorized : UNAuthorizationStatusNotDetermined];
+    return settings.get();
+}
+
 @end
 
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)


### PR DESCRIPTION
#### 425e8378047cab03196f8f46e17871511342d2db
<pre>
webpushd should check that associated web clip has push permissions before subscribing on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=277704">https://bugs.webkit.org/show_bug.cgi?id=277704</a>
<a href="https://rdar.apple.com/131362578">rdar://131362578</a>

Reviewed by Chris Dumez.

We are moving permission management to webpushd on iOS. As part of this, we should also check that
the associated web clip has the appropriate permission before allowing them to create a Web Push
subscription. The embedder already does this check, but the daemon should verify this.

* Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformShouldPlaySound):
(WebPushD::platformDefaultActionBundleIdentifier):
(WebPushD::platformNotificationCenterBundleIdentifier):
(WebPushD::platformNotificationSourceForDisplay):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::getPushPermissionState):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.h:
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter notificationSettings]):

Canonical link: <a href="https://commits.webkit.org/281958@main">https://commits.webkit.org/281958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932148352f6086591997b4999f210c81e14c2d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11987 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49621 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30464 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34577 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56994 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4445 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36603 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->