### PR TITLE
[WASM] Unify error messages between typed funcrefs and GC proposals

### DIFF
--- a/JSTests/wasm/function-references/ref_types.js
+++ b/JSTests/wasm/function-references/ref_types.js
@@ -88,12 +88,12 @@ async function testRefTypeParamCheck() {
     assert.throws(
       () => instance2.exports.f(null),
       TypeError,
-      "Funcref must be an exported wasm function"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => instance2.exports.f(instance1.exports.f),
       TypeError,
-      "Argument function did not match the reference type"
+      "Argument value did not match the reference type"
     );
     instance3.exports.f(null);
   }
@@ -125,7 +125,7 @@ async function testRefGlobalCheck() {
   assert.throws(
     () => (instance1.exports.g.value = null),
     TypeError,
-    "Funcref must be an exported wasm function"
+    "Argument value did not match the reference type"
   );
 
   /*
@@ -141,12 +141,12 @@ async function testRefGlobalCheck() {
   assert.throws(
     () => (instance2.exports.g.value = null),
     TypeError,
-    "Funcref must be an exported wasm function"
+    "Argument value did not match the reference type"
   );
   assert.throws(
     () => (instance2.exports.g.value = providerInstance.exports.f),
     TypeError,
-    "Argument function did not match the reference type"
+    "Argument value did not match the reference type"
   );
 
   /*
@@ -238,7 +238,7 @@ async function testExternFuncrefNonNullCheck() {
     assert.throws(
       () => instance2.exports.f(null),
       TypeError,
-      "Funcref must be an exported wasm function"
+      "Argument value did not match the reference type"
     );
   }
 }
@@ -322,7 +322,7 @@ async function testWasmJSGlobals() {
   assert.throws(
     () => wasmGlobalFuncref.value = console.log,
     TypeError,
-    "Funcref must be an exported wasm function"
+    "Argument value did not match the reference type"
   );
 
   const wasmGlobalExtern = new WebAssembly.Global({value:'externref', mutable:true});

--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -121,7 +121,7 @@ function testArrayJS() {
       m.exports.g.value = 42;
     },
     TypeError,
-    "Argument value did not match reference type"
+    "Argument value did not match the reference type"
   )
 }
 

--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -226,7 +226,7 @@ function testI31JS() {
     assert.throws(
       () => m.exports.f(m.exports.f),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.f(null),

--- a/JSTests/wasm/gc/js-api.js
+++ b/JSTests/wasm/gc/js-api.js
@@ -104,22 +104,22 @@ function testI31() {
     assert.throws(
       () => m.exports.f(2.3),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.f(2n),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.f(2 ** 30),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.f(-(2 ** 30) - 1),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 }
@@ -232,7 +232,7 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f({}, 3),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -245,7 +245,7 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f({}),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -260,7 +260,7 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f(m.exports.g.value),
       TypeError,
-      "Funcref must be an exported wasm function"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -276,7 +276,7 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f(m.exports.g.value),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -289,7 +289,7 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f({}),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -302,7 +302,7 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f({}),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -324,12 +324,12 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.f({}),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.f(2 ** 31),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -355,22 +355,22 @@ function testCastFailure() {
     assert.throws(
       () => m.exports.g(m.exports.s0.value),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.g(m.exports.s2.value),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.h(m.exports.s0.value),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
     assert.throws(
       () => m.exports.h(m.exports.s1.value),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 }
@@ -390,7 +390,7 @@ function testGlobal() {
     assert.throws(
       () => { m.exports.g.value = { } },
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     )
   }
 
@@ -408,7 +408,7 @@ function testGlobal() {
     assert.throws(
       () => { m.exports.g.value = { } },
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     )
   }
 
@@ -426,7 +426,7 @@ function testGlobal() {
     assert.throws(
       () => { m.exports.g.value = { } },
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     )
   }
 
@@ -689,7 +689,7 @@ function testImport() {
     assert.throws(
       () => m2.exports.f(),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -707,7 +707,7 @@ function testImport() {
     assert.throws(
       () => m.exports.g(),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -772,7 +772,7 @@ function testImport() {
     assert.throws(
       () => m.exports.g(),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -790,7 +790,7 @@ function testImport() {
     assert.throws(
       () => m.exports.g(),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 
@@ -808,7 +808,7 @@ function testImport() {
     assert.throws(
       () => m.exports.g(),
       TypeError,
-      "Argument value did not match reference type"
+      "Argument value did not match the reference type"
     );
   }
 

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -159,7 +159,7 @@ function testStructJS() {
       m.exports.g.value = 42;
     },
     TypeError,
-    "Argument value did not match reference type"
+    "Argument value did not match the reference type"
   )
 }
 

--- a/JSTests/wasm/references/func_ref.js
+++ b/JSTests/wasm/references/func_ref.js
@@ -126,13 +126,13 @@ function makeFuncrefIdent() {
 
     assert.eq(instance.exports.i(null), null)
     assert.eq(instance.exports.i(myfun), myfun)
-    assert.throws(() => instance.exports.i(fun), TypeError, "Funcref must be an exported wasm function")
-    assert.throws(() => instance.exports.i(5), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => instance.exports.i(fun), TypeError, "Argument value did not match the reference type")
+    assert.throws(() => instance.exports.i(5), TypeError, "Argument value did not match the reference type")
 
-    assert.throws(() => instance.exports.get_i()(fun), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => instance.exports.get_i()(fun), TypeError, "Argument value did not match the reference type")
     assert.eq(instance.exports.get_i()(null), null)
     assert.eq(instance.exports.get_i()(myfun), myfun)
-    assert.throws(() => instance.exports.get_i()(5), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => instance.exports.get_i()(5), TypeError, "Argument value did not match the reference type")
 
     assert.eq(instance.exports.fix()(), instance.exports.fix());
     assert.eq(instance.exports.fix(), instance.exports.fix);
@@ -228,7 +228,7 @@ function makeFuncrefIdent() {
     $1.exports.set_glob(null); assert.eq($1.exports.get_glob(), null)
     $1.exports.set_glob(myfun); assert.eq($1.exports.get_glob()(), 42);
 
-    assert.throws(() => $1.exports.set_glob(fun), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => $1.exports.set_glob(fun), TypeError, "Argument value did not match the reference type")
 
     assert.eq($1.exports.glob_is_null(), 0)
     $1.exports.set_glob_null(); assert.eq($1.exports.get_glob(), null)
@@ -319,11 +319,11 @@ assert.throws(() => new WebAssembly.Module((new Builder())
     $1.exports.set_glob(null); assert.eq($1.exports.get_glob(), null); assert.throws(() => $1.exports.call_glob(42), Error, "call_indirect to a null table entry (evaluating 'func(...args)')")
     $1.exports.set_glob(ident); assert.eq($1.exports.get_glob(), ident); assert.eq($1.exports.call_glob(42), 42)
 
-    assert.throws(() => $1.exports.set_glob(fun), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => $1.exports.set_glob(fun), TypeError, "Argument value did not match the reference type")
     $1.exports.set_glob(myfun); assert.eq($1.exports.get_glob(), myfun); assert.throws(() => $1.exports.call_glob(42), Error, "call_indirect to a signature that does not match (evaluating 'func(...args)')")
 
     for (let i=0; i<1000; ++i) {
-        assert.throws(() => $1.exports.set_glob(function() {}), TypeError, "Funcref must be an exported wasm function");
+        assert.throws(() => $1.exports.set_glob(function() {}), TypeError, "Argument value did not match the reference type");
     }
 }
 
@@ -438,20 +438,20 @@ for (let importedFun of [function(i) { return i; }, makeFuncrefIdent()]) {
     for (let test of [$1.exports.test1, $1.exports.test3]) {
         assert.eq(test(myfun), myfun)
         assert.eq(test(myfun)(), 1337)
-        assert.throws(() => test(fun), TypeError, "Funcref must be an exported wasm function")
+        assert.throws(() => test(fun), TypeError, "Argument value did not match the reference type")
 
         for (let i=0; i<1000; ++i) {
-            assert.throws(() => test(fun), TypeError, "Funcref must be an exported wasm function")
+            assert.throws(() => test(fun), TypeError, "Argument value did not match the reference type")
         }
     }
 
     for (let test of [$1.exports.test2, $1.exports.test4]) {
         assert.eq(test(), $1.exports.test1)
         assert.eq(test()(myfun), myfun)
-        assert.throws(() => test()(fun), TypeError, "Funcref must be an exported wasm function")
+        assert.throws(() => test()(fun), TypeError, "Argument value did not match the reference type")
 
         for (let i=0; i<1000; ++i) {
-            assert.throws(() => test()(fun), TypeError, "Funcref must be an exported wasm function")
+            assert.throws(() => test()(fun), TypeError, "Argument value did not match the reference type")
         }
     }
 }
@@ -473,7 +473,7 @@ for (let importedFun of [function(i) { return i; }, makeFuncrefIdent()]) {
     const myfun = makeExportedFunction(1337);
     assert.eq(myfun(), 1337)
     assert.eq(42, $1.exports.test(42, myfun))
-    assert.throws(() => $1.exports.test(42, () => 5), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => $1.exports.test(42, () => 5), TypeError, "Argument value did not match the reference type")
 }
 
 {
@@ -510,7 +510,7 @@ for (let importedFun of [function(i) { return i; }, makeFuncrefIdent()]) {
     for (let i = 0; i < 100; ++i)
         foo(0);
 
-    assert.throws(() => $1.exports.test(42, () => 5), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => $1.exports.test(42, () => 5), TypeError, "Argument value did not match the reference type")
     assert.throws(() => $1.exports.test(42, myfun), RangeError, "Maximum call stack size exceeded.")
     assert.throws(() => foo(1), RangeError, "Maximum call stack size exceeded.")
 }

--- a/JSTests/wasm/references/globals.js
+++ b/JSTests/wasm/references/globals.js
@@ -36,10 +36,10 @@ async function testGlobalConstructorForFuncref() {
   {
       let global = new WebAssembly.Global({ value: "anyfunc", mutable: true }, instance.exports.foo);
       assert.eq(global.value, instance.exports.foo);
-      assert.throws(() => global.value = new Pelmen(calories), TypeError, "Funcref must be an exported wasm function");
+      assert.throws(() => global.value = new Pelmen(calories), TypeError, "Argument value did not match the reference type");
   }
 
-  assert.throws(() => new WebAssembly.Global({ value: "anyfunc", mutable: true }, new Pelmen(calories)), TypeError, "Funcref must be an exported wasm function");
+  assert.throws(() => new WebAssembly.Global({ value: "anyfunc", mutable: true }, new Pelmen(calories)), TypeError, "Argument value did not match the reference type");
 }
 
 testGlobalConstructorForExternref();

--- a/JSTests/wasm/stress/global-wrong-type.js
+++ b/JSTests/wasm/stress/global-wrong-type.js
@@ -10,4 +10,4 @@ assert.throws(() => {
     new WebAssembly.Global({
         value: 'anyfunc'
     }, {});
-}, TypeError, `Funcref must be an exported wasm function`);
+}, TypeError, `Argument value did not match the reference type`);

--- a/JSTests/wasm/stress/mutable-globals.js
+++ b/JSTests/wasm/stress/mutable-globals.js
@@ -187,12 +187,12 @@ import * as assert from '../assert.js'
                 false,
             ];
             for (let value of list) {
-                assert.throws(() => binding.value = value, TypeError, `Funcref must be an exported wasm function`);
+                assert.throws(() => binding.value = value, TypeError, `Argument value did not match the reference type`);
                 assert.eq(binding.value, null);
                 assert.eq(instance.exports.getFuncref(), null);
                 instance.exports.setFuncref(null);
                 assert.eq(instance.exports.getFuncref(), null);
-                assert.throws(() => instance.exports.setFuncref(value), TypeError, `Funcref must be an exported wasm function`);
+                assert.throws(() => instance.exports.setFuncref(value), TypeError, `Argument value did not match the reference type`);
                 assert.eq(instance.exports.getFuncref(), null);
             }
             binding.value = instance.exports.setFuncref;

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -46,7 +46,6 @@ namespace Wasm {
     macro(DivisionByZero, "Division by zero"_s) \
     macro(IntegerOverflow, "Integer overflow"_s) \
     macro(StackOverflow, "Stack overflow"_s) \
-    macro(FuncrefNotWasm, "Funcref must be an exported wasm function"_s) \
     macro(InvalidGCTypeUse, "Unsupported use of struct or array type"_s) \
     macro(OutOfBoundsArrayGet, "Out of bounds array.get"_s) \
     macro(OutOfBoundsArraySet, "Out of bounds array.set"_s) \
@@ -138,7 +137,6 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::CastFailure:
     case ExceptionType::OutOfMemory:
         return false;
-    case ExceptionType::FuncrefNotWasm:
     case ExceptionType::InvalidGCTypeUse:
     case ExceptionType::TypeErrorInvalidV128Use:
     case ExceptionType::TypeErrorV128TagAccessInJS:

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -117,7 +117,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
             WebAssemblyFunction* wasmFunction = nullptr;
             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
             if (!isWebAssemblyHostFunction(argument, wasmFunction, wasmWrapperFunction) && (!m_type.isNullable() || !argument.isNull())) {
-                throwTypeError(globalObject, throwScope, "Funcref must be an exported wasm function"_s);
+                throwTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);
                 return;
             }
 
@@ -125,7 +125,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
                 Wasm::TypeIndex paramIndex = m_type.index;
                 Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                 if (paramIndex != argIndex) {
-                    throwTypeError(globalObject, throwScope, "Argument function did not match the reference type"_s);
+                    throwTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);
                     return;
                 }
             }
@@ -135,7 +135,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
             if (!Wasm::TypeInformation::castReference(internref, m_type.isNullable(), m_type.index)) {
                 // FIXME: provide a better error message here
                 // https://bugs.webkit.org/show_bug.cgi?id=247746
-                throwTypeError(globalObject, throwScope, "Argument value did not match reference type"_s);
+                throwTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);
                 return;
             }
             m_value.m_externref.set(m_owner->vm(), m_owner, internref);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -853,7 +853,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationConvertToFuncref, EncodedJSValue, (JS
     WebAssemblyFunction* wasmFunction = nullptr;
     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
     if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
-        throwTypeError(globalObject, scope, "Funcref value is not a function"_s);
+        throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
         return { };
     }
 
@@ -865,7 +865,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationConvertToFuncref, EncodedJSValue, (JS
         Wasm::TypeIndex paramIndex = resultType.index;
         Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
         if (paramIndex != argIndex)
-            return throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
+            return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
     }
     return v;
 }
@@ -885,7 +885,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationConvertToAnyref, EncodedJSValue, (JSW
     JSValue value = JSValue::decode(v);
     value = Wasm::internalizeExternref(value);
     if (UNLIKELY(!Wasm::TypeInformation::castReference(value, resultType.isNullable(), resultType.index))) {
-        throwTypeError(globalObject, scope, "Argument value did not match reference type"_s);
+        throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
         return { };
     }
     return JSValue::encode(value);
@@ -965,14 +965,14 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyI
                     WebAssemblyFunction* wasmFunction = nullptr;
                     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
                     if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
-                        throwTypeError(globalObject, scope, "Funcref value is not a function"_s);
+                        throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         return;
                     }
                     if (Wasm::isRefWithTypeIndex(returnType) && !value.isNull()) {
                         Wasm::TypeIndex paramIndex = returnType.index;
                         Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                         if (paramIndex != argIndex) {
-                            throwTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
+                            throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                             return;
                         }
                     }
@@ -980,7 +980,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyI
                     ASSERT(Options::useWasmGC());
                     value = Wasm::internalizeExternref(value);
                     if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
-                        throwTypeError(globalObject, scope, "Argument value did not match reference type"_s);
+                        throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         return;
                     }
                 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -213,12 +213,12 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
             WebAssemblyFunction* wasmFunction = nullptr;
             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
             if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && (!type.isNullable() || !value.isNull()))
-                return throwVMTypeError(globalObject, scope, "Funcref must be an exported wasm function"_s);
+                return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
             if (isRefWithTypeIndex(type) && !value.isNull()) {
                 Wasm::TypeIndex paramIndex = type.index;
                 Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                 if (paramIndex != argIndex)
-                    return throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
+                    return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
             }
         } else {
             ASSERT(Options::useWasmGC());
@@ -226,7 +226,7 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
             if (!Wasm::TypeInformation::castReference(value, type.isNullable(), type.index)) {
                 // FIXME: provide a better error message here
                 // https://bugs.webkit.org/show_bug.cgi?id=247746
-                return throwVMTypeError(globalObject, scope, "Argument value did not match reference type"_s);
+                return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
             }
         }
         break;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -138,7 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
             if (argument.isUndefined())
                 argument = defaultValueForReferenceType(type);
             if (!isWebAssemblyHostFunction(argument) && !argument.isNull())
-                return throwVMTypeError(globalObject, throwScope, "Funcref must be an exported wasm function"_s);
+                return throwVMTypeError(globalObject, throwScope, "Argument value did not match the reference type"_s);
             initialValue = JSValue::encode(argument);
         } else if (Wasm::isExternref(type)) {
             if (argument.isUndefined())

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -282,7 +282,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                                 Wasm::TypeIndex paramIndex = global.type.index;
                                 Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                                 if (paramIndex != argIndex)
-                                    return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument function did not match the reference type"_s)));
+                                    return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             }
 
                             m_instance->setGlobal(import.kindIndex, value);
@@ -344,7 +344,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                                 Wasm::TypeIndex paramIndex = global.type.index;
                                 Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                                 if (paramIndex != argIndex)
-                                    return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument function did not match the reference type"_s)));
+                                    return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             }
 
                             m_instance->setGlobal(import.kindIndex, value);


### PR DESCRIPTION
#### 28d59bbfe713bc11306e3a9f8b6a3f40a646a444
<pre>
[WASM] Unify error messages between typed funcrefs and GC proposals
<a href="https://bugs.webkit.org/show_bug.cgi?id=277637">https://bugs.webkit.org/show_bug.cgi?id=277637</a>
<a href="https://rdar.apple.com/133225789">rdar://133225789</a>

Reviewed by Yusuke Suzuki.

Changes the error message we report when converting a JSValue to a WASM
typed function reference to be the same as the corresponding error when
WASM GC is enabled, so that our expected behavior in tests doesn&apos;t change
if WASM GC is enabled.

* JSTests/wasm/function-references/ref_types.js:
(async testRefTypeParamCheck):
(async testRefGlobalCheck):
(async testExternFuncrefNonNullCheck):
(async testWasmJSGlobals):
* JSTests/wasm/gc/arrays.js:
* JSTests/wasm/gc/i31.js:
* JSTests/wasm/gc/js-api.js:
(testI31):
(testCastFailure):
* JSTests/wasm/gc/structs.js:
* JSTests/wasm/references/func_ref.js:
(assert.throws):
(GetLocal.0.I32Const.0.TableSet.0.End.End.WebAssembly.assert.throws):
(GetLocal.0.I32Const.0.TableSet.0.End.End.WebAssembly):
(makeFuncrefIdent):
* JSTests/wasm/references/globals.js:
(async testGlobalConstructorForFuncref):
* JSTests/wasm/stress/global-wrong-type.js:
(assert.throws):
* JSTests/wasm/stress/mutable-globals.js:
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
(JSC::Wasm::Global::set):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::fromJSValue):
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/281942@main">https://commits.webkit.org/281942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4c81e1dc6e4496894bbc6860e3e58abfeb5c274

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11971 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49612 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10884 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54526 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67106 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60671 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5369 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10504 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4437 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36587 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14394 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->