### PR TITLE
Fill in sidebarAction / sidePanel WebProcess <=> UIProcess messaging stubs.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h
@@ -30,8 +30,8 @@
 namespace WebKit {
 
 struct WebExtensionSidebarParameters {
-    bool enabled { false };
-    String panelPath;
+    bool enabled { true };
+    String panelPath { emptyString() };
     std::optional<WebExtensionTabIdentifier> tabIdentifier;
 };
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -32,55 +32,336 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
+#import "WebExtensionSidebar.h"
+
 namespace WebKit {
+
+template<typename T>
+static Expected<T, WebExtensionError> toExpected(std::optional<T>&& optional, NSString * const errorMessage = @"value not found")
+{
+    if (optional)
+        return WTFMove(optional.value());
+    return toWebExtensionError(nil, nil, errorMessage);
+}
+
+static Expected<Ref<WebExtensionSidebar>, WebExtensionError> getSidebarWithIdentifiers(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, WebExtensionContext& context)
+{
+    if (windowIdentifier && tabIdentifier)
+        return toWebExtensionError(nil, nil, @"cannot specify both windowId and tabId");
+
+    if (windowIdentifier) {
+        RefPtr window = context.getWindow(*windowIdentifier);
+        if (!window)
+            return toWebExtensionError(nil, nil, @"window not found");
+        return context.getSidebar(*window).value_or(context.defaultSidebar());
+    }
+
+    if (tabIdentifier) {
+        RefPtr tab = context.getTab(*tabIdentifier);
+        if (!tab)
+            return toWebExtensionError(nil, nil, @"tab not found");
+        return context.getSidebar(*tab)
+            .or_else([&] { return context.getSidebar(*(tab->window())); })
+            .value_or(context.defaultSidebar());
+    }
+
+    return Ref { context.defaultSidebar() };
+}
+
+static Expected<Ref<WebExtensionSidebar>, WebExtensionError> getOrCreateSidebarWithIdentifiers(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, WebExtensionContext& context)
+{
+    if (windowIdentifier && tabIdentifier)
+        return toWebExtensionError(nil, nil, @"cannot specify both windowId and tabId");
+
+    if (windowIdentifier) {
+        RefPtr window = context.getWindow(*windowIdentifier);
+        if (!window)
+            return toWebExtensionError(nil, nil, @"window not found");
+        return toExpected(context.getOrCreateSidebar(*window), @"could not create sidebar");
+    }
+
+    if (tabIdentifier) {
+        RefPtr tab = context.getTab(*tabIdentifier);
+        if (!tab)
+            return toWebExtensionError(nil, nil, @"tab not found");
+        return toExpected(context.getOrCreateSidebar(*tab), @"could not create sidebar");
+    }
+
+    return Ref { context.defaultSidebar() };
+}
+
+using UserTriggered = WebExtensionContext::UserTriggered;
+void WebExtensionContext::openSidebarForTab(WebExtensionTab& tab, const UserTriggered userTriggered)
+{
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
+
+    if (userTriggered == UserTriggered::Yes)
+        userGesturePerformed(tab);
+
+    auto maybeSidebar = getOrCreateSidebar(tab);
+    if (!maybeSidebar)
+        return;
+
+    auto& sidebar = maybeSidebar.value().get();
+    if (sidebar.opensSidebar())
+        sidebar.openSidebarWhenReady();
+
+    fireActionClickedEventIfNeeded(&tab);
+}
+
+void WebExtensionContext::closeSidebarForTab(WebExtensionTab& tab, const UserTriggered userTriggered)
+{
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
+
+    if (userTriggered == UserTriggered::Yes)
+        userGesturePerformed(tab);
+
+    auto maybeSidebar = getOrCreateSidebar(tab);
+    if (!maybeSidebar)
+        return;
+
+    auto& sidebar = maybeSidebar.value().get();
+    if (sidebar.canProgrammaticallyCloseSidebar())
+        sidebar.closeSidebarWhenReady();
+}
 
 void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    // the error below is a placeholder to fill sidebar, since we cannot instantiate it empty
+    Expected<Ref<WebExtensionSidebar>, WebExtensionError> sidebar = toWebExtensionError(nil, nil, @"Placeholder error");
+    RefPtr<WebExtensionTab> tab;
 
+    if (!tabIdentifier && !windowIdentifier) {
+        // In the case where we have neither identifier, we must be servicing sidebarAction rather than sidepanel
+        // since sidePanel requires one of the identifiers to be set in calls to open.
+        // The firefox API specifies that open() will just toggle the sidebar in the active window.
+        if (auto window = frontmostWindow()) {
+            auto maybeSidebar = getOrCreateSidebar(*window);
+            if (!maybeSidebar) {
+                completionHandler(toWebExtensionError(nil, nil, @"could not create sidebar"));
+                return;
+            }
+
+            sidebar = WTFMove(maybeSidebar.value());
+            tab = window->activeTab();
+        } else {
+            completionHandler(toWebExtensionError(nil, nil, @"no windows are open"));
+            return;
+        }
+    } else {
+        // chrome's sidePanel allows both windowIdentifier and tabIdentifier to be specified for sidePanel.open(), so we will discard windowIdentifier if they are both set
+        // since firefox's sidebarAction takes no arguments to sidebarAction.open(), this does not break behavior for that API
+        auto correctedWindowIdentifier = tabIdentifier ? std::nullopt : windowIdentifier;
+
+        auto maybeSidebar = getOrCreateSidebarWithIdentifiers(correctedWindowIdentifier, tabIdentifier, *this);
+        if (!maybeSidebar) {
+            completionHandler(toWebExtensionError(nil, nil, @"could not create sidebar"));
+            return;
+        }
+
+        sidebar = WTFMove(maybeSidebar.value());
+
+        if (auto window = sidebar.value()->window())
+            tab = window->get().activeTab();
+        else if (auto maybeTab = sidebar.value()->tab())
+            tab = RefPtr { maybeTab.value().ptr() };
+        else if (auto window = frontmostWindow())
+            tab = window->activeTab();
+        else {
+            completionHandler(toWebExtensionError(nil, nil, @"no windows are open"));
+            return;
+        }
+    }
+
+    if (!tab) {
+        completionHandler(toWebExtensionError(nil, nil, @"could not determine active tab"));
+        return;
+    }
+
+    if (!sidebar) {
+        completionHandler(makeUnexpected(sidebar.error()));
+        return;
+    }
+
+    if (!sidebar.value()->canProgrammaticallyOpenSidebar()) {
+        completionHandler(toWebExtensionError(nil, nil, @"it is not implemented"));
+        return;
+    }
+
+    if (sidebar.value()->opensSidebar())
+        openSidebarForTab(*tab, UserTriggered::No);
+
+    completionHandler({ });
 }
 
 void WebExtensionContext::sidebarClose(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    // This method services a firefox-only API which will just close the sidebar in the active window
+    auto window = frontmostWindow();
+    if (!window) {
+        completionHandler(toWebExtensionError(nil, nil, @"no windows are open"));
+        return;
+    }
 
+    auto tab = window->activeTab();
+    if (!tab) {
+        completionHandler(toWebExtensionError(nil, nil, @"unable to determine the active tab"));
+        return;
+    }
+
+    auto maybeSidebar = getOrCreateSidebar(*window);
+    if (!maybeSidebar) {
+        completionHandler(toWebExtensionError(nil, nil, @"the sidebar could not be created"));
+        return;
+    }
+
+    auto& sidebar = maybeSidebar.value();
+    if (!sidebar->canProgrammaticallyCloseSidebar()) {
+        completionHandler(toWebExtensionError(nil, nil, @"it is not implemented"));
+        return;
+    }
+
+    closeSidebarForTab(*tab, UserTriggered::No);
+
+    completionHandler({ });
 }
 
-void WebExtensionContext::sidebarIsOpen(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, CompletionHandler<void(Expected<bool, WebExtensionError>&&)>&& tabIdentifier)
+void WebExtensionContext::sidebarIsOpen(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, CompletionHandler<void(Expected<bool, WebExtensionError>&&)>&& completionHandler)
 {
+    // This method services a Firefox-only API which will check if a sidebar is open in the specified window, or the active window if no window is specified
+    RefPtr<WebExtensionWindow> window;
+    if (windowIdentifier)
+        window = getWindow(*windowIdentifier);
+    else
+        window = frontmostWindow();
 
+    // if no windows are open, then no sidebars are open
+    if (!window) {
+        completionHandler(false);
+        return;
+    }
+
+    bool isOpen = false;
+    if (auto currentTab = window->activeTab()) {
+        if (auto currentTabSidebar = getSidebar(*currentTab))
+            isOpen |= currentTabSidebar.value()->isOpen();
+    }
+
+    if (auto currentWindowSidebar = getSidebar(*window))
+        isOpen |= currentWindowSidebar.value()->isOpen();
+
+    completionHandler(isOpen);
 }
 
 void WebExtensionContext::sidebarToggle(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    // this method services a Firefox-only API which toggles the sidebar in the currently active window
+    auto window = frontmostWindow();
+    if (!window) {
+        completionHandler(toWebExtensionError(nil, nil, @"no windows are open"));
+        return;
+    }
 
+    auto tab = window->activeTab();
+    if (!tab) {
+        completionHandler(toWebExtensionError(nil, nil, @"unable to determine the active tab"));
+        return;
+    }
+
+    auto maybeSidebar = getOrCreateSidebar(*window);
+    if (!maybeSidebar) {
+        completionHandler(toWebExtensionError(nil, nil, @"could not create sidebar"));
+        return;
+    }
+
+    auto& sidebar = maybeSidebar.value();
+    if (sidebar->isOpen()) {
+        if (!sidebar->canProgrammaticallyCloseSidebar()) {
+            completionHandler(toWebExtensionError(nil, nil, @"it is not implemented"));
+            return;
+        }
+
+        closeSidebarForTab(*tab, UserTriggered::No);
+    } else {
+        if (!sidebar->canProgrammaticallyOpenSidebar()) {
+            completionHandler(toWebExtensionError(nil, nil, @"it is not implemented"));
+            return;
+        }
+
+        openSidebarForTab(*tab, UserTriggered::No);
+    }
+
+    completionHandler({ });
 }
 
 void WebExtensionContext::sidebarSetIcon(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& iconJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-
+    // FIXME: <https://webkit.org/b/276833> implement icon-related methods
 }
 
 void WebExtensionContext::sidebarGetTitle(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
+    auto sidebar = getSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
+    if (!sidebar) {
+        completionHandler(makeUnexpected(sidebar.error()));
+        return;
+    }
 
+    completionHandler(sidebar.value()->title());
 }
 
 void WebExtensionContext::sidebarSetTitle(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, const std::optional<String>& title, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    auto sidebar = getOrCreateSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
+    if (!sidebar) {
+        completionHandler(makeUnexpected(sidebar.error()));
+        return;
+    }
 
+    completionHandler({ });
 }
 
 void WebExtensionContext::sidebarGetOptions(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<WebExtensionSidebarParameters, WebExtensionError>&&)>&& completionHandler)
 {
+    auto maybeSidebar = getOrCreateSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
+    if (!maybeSidebar) {
+        completionHandler(makeUnexpected(maybeSidebar.error()));
+        return;
+    }
 
+    auto& sidebar = maybeSidebar.value().get();
+    completionHandler(WebExtensionSidebarParameters {
+        .enabled       = sidebar.isEnabled(),
+        .panelPath     = sidebar.sidebarPath(),
+        .tabIdentifier = sidebar.tab().transform([](auto tab) { return tab.get().identifier(); }),
+    });
 }
 
 void WebExtensionContext::sidebarSetOptions(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, const std::optional<String>& panelSourcePath, const std::optional<bool> enabled, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    auto maybeSidebar = getOrCreateSidebarWithIdentifiers(windowIdentifier, tabIdentifier, *this);
+    if (!maybeSidebar) {
+        completionHandler(makeUnexpected(maybeSidebar.error()));
+        return;
+    }
 
+    auto& sidebar = maybeSidebar.value().get();
+    sidebar.setSidebarPath(panelSourcePath);
+    // according to the sidePanel docs, `enabled` is optional with default value `true`
+    // we only need to be concerned with chrome's semantics here since sidebarAction does not have any concept of enablement
+    // see: https://developer.chrome.com/docs/extensions/reference/api/sidePanel#type-PanelOptions
+    sidebar.setEnabled(enabled.value_or(true));
+    completionHandler({ });
 }
 
 bool WebExtensionContext::isSidebarMessageAllowed()
 {
+    if (auto *controller = extensionController())
+        return controller->isFeatureEnabled(@"WebExtensionSidebarEnabled");
     return false;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -37,6 +37,9 @@
 #import "ContextMenuContextData.h"
 #import "Logging.h"
 #import "SandboxUtilities.h"
+#import "WKFeature.h"
+#import "WKPreferences.h"
+#import "WKPreferencesPrivate.h"
 #import "WKWebViewConfigurationPrivate.h"
 #import "WKWebsiteDataStoreInternal.h"
 #import "WebExtensionContext.h"
@@ -49,6 +52,7 @@
 #import "WebExtensionEventListenerType.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
+#import "_WKFeatureInternal.h"
 #import "_WKWebExtensionStorageSQLiteStore.h"
 #import <WebCore/ContentRuleListResults.h>
 #import <wtf/BlockPtr.h>
@@ -505,6 +509,19 @@ void WebExtensionController::cookiesDidChange(API::HTTPCookieStore& cookieStore)
 
     for (Ref context : m_extensionContexts)
         context->cookiesDidChange(cookieStore);
+}
+
+bool WebExtensionController::isFeatureEnabled(const String& featureName) const
+{
+    WKPreferences *preferences = configuration().webViewConfiguration().preferences;
+
+    NSString *cocoaFeatureName = static_cast<NSString *>(featureName);
+    for (_WKFeature *feature in WKPreferences._features) {
+        if ([feature.key isEqualToString:cocoaFeatureName])
+            return [preferences _isEnabledForFeature:feature];
+    }
+
+    return false;
 }
 
 RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const WebExtension& extension) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -263,6 +263,7 @@ public:
         Background,
         Inspector,
         Popup,
+        Sidebar,
         Tab,
     };
 
@@ -446,6 +447,8 @@ public:
     std::optional<Ref<WebExtensionSidebar>> getSidebar(WebExtensionTab const&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionWindow&);
     std::optional<Ref<WebExtensionSidebar>> getOrCreateSidebar(WebExtensionTab&);
+    void openSidebarForTab(WebExtensionTab&, UserTriggered = UserTriggered::No);
+    void closeSidebarForTab(WebExtensionTab&, UserTriggered = UserTriggered::No);
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     const CommandsVector& commands();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -155,6 +155,8 @@ public:
     template<typename T, typename RawValue>
     void sendToAllProcesses(const T& message, const ObjectIdentifierGenericBase<RawValue>& destinationID);
 
+    bool isFeatureEnabled(const String& featureName) const;
+
 #if PLATFORM(MAC)
     void addItemsToContextMenu(WebPageProxy&, const ContextMenuContextData&, NSMenu *);
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -32,52 +32,228 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
+#import "MessageSenderInlines.h"
+#import "WebExtensionContextMessages.h"
+#import "WebExtensionSidebarParameters.h"
+#import "WebExtensionTabIdentifier.h"
+#import "WebExtensionWindowIdentifier.h"
+#import "WebProcess.h"
+
 namespace WebKit {
+
+static NSString * const tabIdKey = @"tabId";
+static NSString * const windowIdKey = @"windowId";
+static NSString * const panelKey = @"panel";
+static NSString * const titleKey = @"title";
+
+static ParseResult parseSidebarActionDetails(NSDictionary *details)
+{
+    id maybeTabId = [details objectForKey:tabIdKey];
+    id maybeWindowId = [details objectForKey:windowIdKey];
+
+    if (maybeTabId && maybeWindowId)
+        return toErrorString(nil, @"details", @"it cannot specify both 'tabId' and 'windowId'");
+
+    if (maybeTabId && ![maybeTabId isKindOfClass:NSNumber.class])
+        return toErrorString(nil, @"details", @"'tabId' must be a number");
+
+    if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class])
+        return toErrorString(nil, @"details", @"'windowId' must be a number");
+
+    if (maybeTabId) {
+        auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
+        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nil, @"details", @"'tabId' is invalid"));
+    }
+
+    if (maybeWindowId) {
+        auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
+        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nil, @"details", @"'windowId' is invalid"));
+    }
+
+    return std::monostate();
+}
+
+static std::variant<std::monostate, String, SidebarError> parseDetailsStringFromKey(NSDictionary *dict, NSString *key, bool required = false)
+{
+    id maybeValue = [dict objectForKey:key];
+    if (!maybeValue && required)
+        return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+
+    if ([maybeValue isKindOfClass:NSNull.class]) {
+        if (required)
+            return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+        return std::monostate();
+    }
+
+    if (![maybeValue isKindOfClass:NSString.class]) {
+        if (required)
+            return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' must be of type 'string'", key]) };
+        return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]) };
+    }
+
+    return SidebarError { (NSString *)maybeValue };
+}
+
+template<typename VariantType>
+static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>> getIdentifiers(VariantType& variant)
+{
+    static_assert(isVariantMember<WebExtensionWindowIdentifier, VariantType>::value);
+    static_assert(isVariantMember<WebExtensionTabIdentifier, VariantType>::value);
+
+    return std::make_tuple(WTFMove(toOptional<WebExtensionWindowIdentifier>(variant)), WTFMove(toOptional<WebExtensionTabIdentifier>(variant)));
+}
 
 void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callback , NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarOpen(std::nullopt, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarClose(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::toggle(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarToggle(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::isOpen(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    // we don't use parseSidebarActionDetails here because we only need windowId for isOpen
+    id maybeWindowId = details[windowIdKey];
+    if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class]) {
+        *outExceptionString = toErrorString(nil, @"details", @"'windowId' must be a number");
+        return;
+    }
+
+    std::optional<WebExtensionWindowIdentifier> windowId = maybeWindowId ? toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue) : std::nullopt;
+    if (!isValid(windowId)) {
+        *outExceptionString = toErrorString(nil, @"details", @"'windowId' is invalid");
+        return;
+    }
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarIsOpen(windowId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<bool, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call(@(result.value()));
+    }, extensionContext().identifier());
 }
 
 
 void WebExtensionAPISidebarAction::getPanel(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    auto result = parseSidebarActionDetails(details);
+    if ((*outExceptionString = indicatesError(result).get()))
+        return;
+
+    const auto [windowId, tabId] = getIdentifiers(result);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetOptions(windowId, tabId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionSidebarParameters, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call(result.value().panelPath);
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::setPanel(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    auto panelResult = parseDetailsStringFromKey(details, panelKey);
+    if ((*outExceptionString = indicatesError(panelResult).get()))
+        return;
+
+    const auto panelPath = toOptional<String>(panelResult);
+
+    auto result = parseSidebarActionDetails(details);
+    if ((*outExceptionString = indicatesError(result).get()))
+        return;
+
+    const auto [windowId, tabId] = getIdentifiers(result);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(windowId, tabId, std::nullopt, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::getTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    auto result = parseSidebarActionDetails(details);
+    if ((*outExceptionString = indicatesError(result).get()))
+        return;
+
+    const auto [windowId, tabId] = getIdentifiers(result);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetTitle(windowId, tabId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call(result.value());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::setTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    auto titleResult = parseDetailsStringFromKey(details, titleKey);
+    if ((*outExceptionString = indicatesError(titleResult).get()))
+        return;
+
+    const auto title = toOptional<String>(titleResult);
+
+    auto result = parseSidebarActionDetails(details);
+    if ((*outExceptionString = indicatesError(result).get()))
+        return;
+
+    const auto [windowId, tabId] = getIdentifiers(result);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetTitle(windowId, tabId, title), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPISidebarAction::setIcon(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    // FIXME: <https://webkit.org/b/276833> Implement icon-related functionality
+    static NSString * const apiName = @"sidebarAction.setIcon()";
+    callback->reportError([NSString stringWithFormat:@"'%@' is unimplemented", apiName]);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### b2e851ada7eee7b13ffde9f5d2d6189461732869
<pre>
Fill in sidebarAction / sidePanel WebProcess &lt;=&gt; UIProcess messaging stubs.
<a href="https://webkit.org/b/277688">https://webkit.org/b/277688</a>
<a href="https://rdar.apple.com/133073249">rdar://133073249</a>

Reviewed by Timothy Hatcher.

This PR fills in most of the message senders and receivers which pertain
to sidePanel / sidebarAction. Additionally, it adds several helper
utilities to aid in parameter parsing for sidePanel / sidebarAction.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::toExpected): Utility function to convert an optional&lt;T&gt;
to an Expected&lt;T, WebExtensionError&gt;
(WebKit::getSidebarWithIdentifiers): Utility function to validate window
/ tab identifiers then return the sidebar object associated with said
identifiers
(WebKit::getOrCreateSidebarWithIdentifiers): Utility function to
validate window / tab identifiers and create a sidebar object
associated with said identifiers if necessary
(WebKit::WebExtensionContext::openSidebarForTab): Utility function to
open a sidebar object
(WebKit::WebExtensionContext::closeSidebarForTab): Utility function to
close a sidebar object
(WebKit::WebExtensionContext::sidebarOpen): Fill in message receiver for
sidebarOpen
(WebKit::WebExtensionContext::sidebarClose): Fill in message receiver for
sidebarClose
(WebKit::WebExtensionContext::sidebarIsOpen): Fill in message receiver for
sidebarIsOpen
(WebKit::WebExtensionContext::sidebarToggle): Fill in message receiver for
sidebarToggle
(WebKit::WebExtensionContext::sidebarSetIcon): Update stub with FIXME
(WebKit::WebExtensionContext::sidebarGetTitle): Fill in message receiver for
sidebarGetTitle
(WebKit::WebExtensionContext::sidebarSetTitle): Fill in message receiver for
sidebarSetTitle
(WebKit::WebExtensionContext::sidebarGetOptions): Fill in message receiver for
sidebarGetOptions
(WebKit::WebExtensionContext::sidebarSetOptions): Fill in message receiver for
sidebarSetOptions
(WebKit::WebExtensionContext::isSidebarMessageAllowed): Gate sidebar
messages behind sidebar feature flag
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::parseTabIdentifier): Utility function to parse and validate the
tab identifier received through a sidePanel details object
(WebKit::parseWindowIdentifier): Utility function to parse and validate
the window identifier received through a sidePanel details object
(WebKit::serializeSidebarParameters): Utility function to serialize a
WebExtensionSidebarParameters struct to an NSDictionary
(WebKit::deserializeSidebarParameters): Utility function to deserialize
a WebExtensionSidebarParameters struct from an NSDictionary
(WebKit::WebExtensionAPISidePanel::getOptions): Fill in message sender
for getOptions
(WebKit::WebExtensionAPISidePanel::setOptions): Fill in message sender
for setOptions
(WebKit::WebExtensionAPISidePanel::getPanelBehavior): Update stub with
FIXME
(WebKit::WebExtensionAPISidePanel::setPanelBehavior): Update stub with
FIXME
(WebKit::WebExtensionAPISidePanel::open): Fill in message sender for
open
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseSidebarActionDetails): Utility function to parse the
`details` object passed to many sidebarAction method calls
(WebKit::parseDetailsStringFromKey): Utility function to validate the
string value of some key in a dictionary, optionally allowing it to be
NSNull
(WebKit::getIdentifiers): Utility function to retrieve whatever window
or tab identifiers are set in a variant, returning them as
std::optionals
(WebKit::WebExtensionAPISidebarAction::open): Fill in message sender for
open
(WebKit::WebExtensionAPISidebarAction::close): Fill in message sender
for close
(WebKit::WebExtensionAPISidebarAction::toggle): Fill in message sender
for toggle
(WebKit::WebExtensionAPISidebarAction::isOpen): Fill in message sender
for isOpen
(WebKit::WebExtensionAPISidebarAction::getPanel): Fill in message sender
for getPanel
(WebKit::WebExtensionAPISidebarAction::setPanel): Fill in message sender
for setPanel
(WebKit::WebExtensionAPISidebarAction::getTitle): Fill in message sender
for getTitle
(WebKit::WebExtensionAPISidebarAction::setTitle): Fill in message sender
for setTitle
(WebKit::WebExtensionAPISidebarAction::setIcon): Fill in message sender
for setIcon
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h:
(WebKit::toOptional): Utility function to attempt to access
one particular field from a variant and return it in an std::optional,
returning std::nullopt if the variant does not contain the requested
field
(WebKit::indicatesError): Utility function to determine whether a
variant indicates that an error occurred, and return the error if it
does
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::isFeatureEnabled const): Helper
function to check if a particular feature is enabled using its name.

Canonical link: <a href="https://commits.webkit.org/282026@main">https://commits.webkit.org/282026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d9d248d82376ef58fb6dcb3b45e98a0010ebc89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14397 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12621 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53530 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34871 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11064 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5748 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/67513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53478 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4716 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->