### PR TITLE
Wasm memories shouldn't report to the GC until they're attached to a compiled instance

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -696,11 +696,12 @@ bool Heap::unprotect(JSValue k)
     return m_protectedValues.remove(k.asCell());
 }
 
-void Heap::addReference(JSCell* cell, ArrayBuffer* buffer)
+void Heap::addReference(JSCell* cell, ArrayBuffer* buffer, bool reportDidAllocate)
 {
     if (m_arrayBuffers.addReference(cell, buffer)) {
         collectIfNecessaryOrDefer();
-        didAllocate(buffer->gcSizeEstimateInBytes());
+        if (reportDidAllocate)
+            didAllocate(buffer->gcSizeEstimateInBytes());
     }
 }
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -452,7 +452,7 @@ public:
     
     const JITStubRoutineSet& jitStubRoutines() { return *m_jitStubRoutines; }
     
-    void addReference(JSCell*, ArrayBuffer*);
+    void addReference(JSCell*, ArrayBuffer*, bool reportDidAllocate = true);
     
     bool isDeferred() const { return !!m_deferralDepth; }
 

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@ public:
 
     // This function will register the new wrapper with the vm's TypedArrayController.
     JS_EXPORT_PRIVATE static JSArrayBuffer* create(VM&, Structure*, RefPtr<ArrayBuffer>&&);
+    static JSArrayBuffer* createForWasmMemory(VM&, Structure*, RefPtr<ArrayBuffer>&&);
 
     ArrayBuffer* impl() const { return m_impl; }
     
@@ -60,7 +61,7 @@ public:
     
 private:
     JSArrayBuffer(VM&, Structure*, RefPtr<ArrayBuffer>&&);
-    void finishCreation(VM&, JSGlobalObject*);
+    void finishCreation(VM&, JSGlobalObject*, bool shouldReportAllocation = true);
 
     static size_t estimatedSize(JSCell*, VM&);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -201,6 +201,9 @@ void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObjec
         UNUSED_PARAM(startResult);
         RETURN_IF_EXCEPTION(scope, void());
     }
+
+    // We tell the memory here that it's been attached since if we told it at the actual time it got attached it would trigger a GC before wasm compilation happens.
+    memory()->didAttachToInstance(vm);
 }
 
 Identifier JSWebAssemblyInstance::createPrivateModuleKey()

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -70,6 +70,8 @@ public:
 
     static constexpr ptrdiff_t offsetOfMemory() { return OBJECT_OFFSETOF(JSWebAssemblyMemory, m_memory); }
 
+    void didAttachToInstance(VM&);
+
 private:
     JSWebAssemblyMemory(VM&, Structure*);
     void finishCreation(VM&);
@@ -78,6 +80,7 @@ private:
     Ref<Wasm::Memory> m_memory;
     WriteBarrier<JSArrayBuffer> m_bufferWrapper;
     RefPtr<ArrayBuffer> m_buffer;
+    bool m_hasBeenAttachedToInstance { false };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### f4ee0c701bcd3e83d57327cdd7ff47ced718785d
<pre>
Wasm memories shouldn&apos;t report to the GC until they&apos;re attached to a compiled instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=277711">https://bugs.webkit.org/show_bug.cgi?id=277711</a>
<a href="https://rdar.apple.com/133327754">rdar://133327754</a>

Reviewed by NOBODY (OOPS!).

Right now we inform the GC that we just allocated a huge slab of memory right when we allocate
the JSWebAssemblyMemory. This tends to cause the GC to trigger immediately since Wasm::Memories
are multiples of 64KB even though the Wasm::Memory is probably not going to be collected. Since
Wasm::Memories tend to be allocated right when a Wasm::Module gets compiled this means we&apos;re
spending time on a GC that isn&apos;t necessarily going to collect much when we could be compiling
the Wasm::Module.

This patch defers informing the GC until the JSWebAssemblyMemory&apos;s inevitable instance is
finished. Since a lot of wasm users get the JSArrayBuffer from the JSWebAssemblyMemory
this patch also adds a new constructor that prevents the JSArrayBuffer from reporting it
allocated the Wasm::Memory&apos;s backing store since JSWebAssemblyMemory will eventually do so.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::addReference):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/JSArrayBuffer.cpp:
(JSC::JSArrayBuffer::finishCreation):
(JSC::JSArrayBuffer::createForWasmMemory):
* Source/JavaScriptCore/runtime/JSArrayBuffer.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::finalizeCreation):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::buffer):
(JSC::JSWebAssemblyMemory::growSuccessCallback):
(JSC::JSWebAssemblyMemory::finishCreation):
(JSC::JSWebAssemblyMemory::didAttachToInstance):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ee0c701bcd3e83d57327cdd7ff47ced718785d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61456 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65397 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11991 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49631 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34583 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10450 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10904 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54546 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67126 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60693 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5389 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10520 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57216 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4451 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82459 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36607 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14399 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->