### PR TITLE
CloneDeserializer readTerminal crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
@@ -56,12 +56,7 @@ static void deserializeJSValue(std::array<uint8_t, T> bytes)
 
 TEST(WebCore, SerializedScriptValueReadRTCCertificate)
 {
-    WTF::initialize();
-    WTF::initializeMainThread();
-    JSC::initialize();
-    WebCore::Process::identifier();
-
-    std::array<uint8_t, 149> bytes {
+    constexpr auto bytes = std::to_array<uint8_t>({
         0x0d, 0x00, 0x00, 0x00, 0x2c, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0xe7, 0x1b, 0x86, 0xc8, 0xd0, 0xdb, 0x71, 0x6a, 0xac, 0x80, 0xf4,
@@ -75,14 +70,8 @@ TEST(WebCore, SerializedScriptValueReadRTCCertificate)
         0xa8, 0x9f, 0x07, 0xd2, 0x50, 0x03, 0x5e, 0x05, 0x77, 0x4a, 0x56, 0xdd,
         0x1e, 0x68, 0xd3, 0x62, 0x8f, 0x58, 0x7e, 0x7c, 0x1e, 0xc6, 0x0f, 0xcc,
         0x01, 0x6e, 0x88, 0x4b, 0x32
-    };
-
-    Vector<uint8_t> vector { std::span<uint8_t>(bytes) };
-    const WebCore::ThreadSafeDataBuffer value = WebCore::ThreadSafeDataBuffer::create(WTFMove(vector));
-    WebCore::callOnIDBSerializationThreadAndWait([&](auto& globalObject) {
-        auto jsValue = WebCore::deserializeIDBValueToJSValue(globalObject, value);
-        UNUSED_VARIABLE(jsValue);
     });
+    deserializeJSValue(bytes);
 }
 
 TEST(WebCore, SerializedScriptValueArgListMarkedVectorAt)


### PR DESCRIPTION
#### ade4ed3c7a640be43828bdbd82dd416a51f3757a
<pre>
CloneDeserializer readTerminal crash
<a href="https://rdar.apple.com/126132442">rdar://126132442</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272530">https://bugs.webkit.org/show_bug.cgi?id=272530</a>

Reviewed by Alex Christensen.

Limiting the the depth for serializing/deserializing recursive objects like:
var array = [[[[[....................]]]]]... 2000 times

* Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp:
(TestWebKitAPI::TEST):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneBase::CloneBase):
(WebCore::CloneBase::isSafeToRecurse):
(WebCore::CloneDeserializer::readArrayBufferViewImpl):
(WebCore::CloneDeserializer::readArrayBufferView):
(WebCore::CloneDeserializer::readTerminal):

Originally-landed-as: 272448.946@safari-7618-branch (110ae765d426). <a href="https://rdar.apple.com/132956780">rdar://132956780</a>
Canonical link: <a href="https://commits.webkit.org/282242@main">https://commits.webkit.org/282242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0a3a8565757cef63e075e2272487f355873fbbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66402 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12970 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64538 "Build is in progress. Recent messages:OS: Sonoma (14.6), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50305 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11898 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68131 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6364 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11404 "13 flakes 4 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57681 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_block_downloads.tentative.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5294 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37573 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->