### PR TITLE
Digital Credentials: implement base OpenID4VP IDL structure

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -377,6 +377,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/identity/IdentityCredentialProtocol.idl
     Modules/identity/IdentityRequestProvider.idl
     Modules/identity/Navigator+Identity.idl
+    Modules/identity/OpenID4VPRequest.idl
 
     Modules/indexeddb/IDBCursor.idl
     Modules/indexeddb/IDBCursorDirection.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -509,6 +509,7 @@ $(PROJECT_DIR)/Modules/identity/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/identity/IdentityCredentialProtocol.idl
 $(PROJECT_DIR)/Modules/identity/IdentityRequestProvider.idl
 $(PROJECT_DIR)/Modules/identity/Navigator+Identity.idl
+$(PROJECT_DIR)/Modules/identity/OpenID4VPRequest.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursor.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorDirection.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorWithValue.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2087,6 +2087,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOffscreenCanvas.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOffscreenCanvas.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOffscreenCanvasRenderingContext2D.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOffscreenCanvasRenderingContext2D.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOpenID4VPRequest.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOpenID4VPRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOptionalEffectTiming.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOptionalEffectTiming.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOpusEncoderConfig.cpp
@@ -2243,10 +2245,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionErrorCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionErrorCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionOptions.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredicateCallback.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredicateCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredefinedColorSpace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredefinedColorSpace.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredicateCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredicateCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSProcessingInstruction.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSProcessingInstruction.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSProgressEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -376,8 +376,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/highlight/Highlight.idl \
     $(WebCore)/Modules/identity/DigitalCredential.idl \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \
-    $(WebCore)/Modules/identity/IdentityRequestProvider.idl \
+    $(WebCore)/Modules/identity/OpenID4VPRequest.idl \
     $(WebCore)/Modules/identity/IdentityCredentialProtocol.idl \
+    $(WebCore)/Modules/identity/IdentityRequestProvider.idl \
     $(WebCore)/Modules/identity/Navigator+Identity.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -397,6 +397,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/CredentialRequestCoordinatorClient.h
     Modules/identity/DigitalCredentialRequestOptions.h
     Modules/identity/IdentityCredentialsContainer.h
+    Modules/identity/IdentityRequestProvider.h
+    Modules/identity/OpenID4VPRequest.h
 
     Modules/indexeddb/IDBActiveDOMObject.h
     Modules/indexeddb/IDBDatabaseIdentifier.h

--- a/Source/WebCore/Modules/identity/IdentityRequestProvider.h
+++ b/Source/WebCore/Modules/identity/IdentityRequestProvider.h
@@ -26,14 +26,13 @@
 #pragma once
 
 #include "IdentityCredentialProtocol.h"
-#include <JavaScriptCore/JSObject.h>
-#include <JavaScriptCore/Strong.h>
+#include "OpenID4VPRequest.h"
 
 namespace WebCore {
 
 struct IdentityRequestProvider {
     IdentityCredentialProtocol protocol;
-    JSC::Strong<JSC::JSObject> request;
+    OpenID4VPRequest request;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/IdentityRequestProvider.idl
+++ b/Source/WebCore/Modules/identity/IdentityRequestProvider.idl
@@ -25,5 +25,5 @@
 
 dictionary IdentityRequestProvider {
     required IdentityCredentialProtocol protocol;
-    required object request;
+    required OpenID4VPRequest request;
 };

--- a/Source/WebCore/Modules/identity/OpenID4VPRequest.h
+++ b/Source/WebCore/Modules/identity/OpenID4VPRequest.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct OpenID4VPRequest { };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/OpenID4VPRequest.idl
+++ b/Source/WebCore/Modules/identity/OpenID4VPRequest.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+// Based on https://openid.github.io/OpenID4VP/openid-4-verifiable-presentations-wg-draft.html#name-openid4vp-profile-for-the-w
+dictionary OpenID4VPRequest {
+    // Members coming soon
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4073,6 +4073,7 @@ JSOfflineAudioContext.cpp
 JSOfflineAudioContextOptions.cpp
 JSOffscreenCanvas.cpp
 JSOffscreenCanvasRenderingContext2D.cpp
+JSOpenID4VPRequest.cpp
 JSOptionalEffectTiming.cpp
 JSOpusEncoderConfig.cpp
 JSOscillatorNode.cpp


### PR DESCRIPTION
#### 46a449a46e3ee95220bcfd35ede0dff2634eade8
<pre>
Digital Credentials: implement base OpenID4VP IDL structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=277670">https://bugs.webkit.org/show_bug.cgi?id=277670</a>
<a href="https://rdar.apple.com/problem/133265654">rdar://problem/133265654</a>

Reviewed by Chris Dumez and Abrar Rahman Protyasha.

Adds basic OpenID4VPRequest IDL structure to use by Digital Credentials API.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/identity/IdentityRequestProvider.h:
* Source/WebCore/Modules/identity/IdentityRequestProvider.idl:
* Source/WebCore/Modules/identity/OpenID4VPRequest.h: Copied from Source/WebCore/Modules/identity/IdentityRequestProvider.idl.
* Source/WebCore/Modules/identity/OpenID4VPRequest.idl: Copied from Source/WebCore/Modules/identity/IdentityRequestProvider.idl.
* Source/WebCore/Sources.txt:

Canonical link: <a href="https://commits.webkit.org/282036@main">https://commits.webkit.org/282036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d3b9307e7827ba933e0288265b0cf0e1600ac7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49826 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10776 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5763 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10818 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57206 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4727 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39154 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->