### PR TITLE
[view-transitions] Add support for view transition types

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7553,18 +7553,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-vie
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom.html [ Pass ]
 
-# View transitions Level 2 - types.
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early-mutation.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-late-mutation.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-removed.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved-mutation.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-stay.html [ Skip ]
-
 # Depends on overflow-clip-margin (unimplemented).
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-expected.txt
@@ -1,5 +1,9 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Old view transition aborted by new view transition.
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Old view transition aborted by new view transition.
 
-FAIL ViewTransition.types is a ViewTransitionTypeSet Can't find variable: ViewTransitionTypeSet
-FAIL ViewTransitionTypeSet behaves like an ordinary Set of strings undefined is not an object (evaluating 'types.add')
-FAIL ViewTransitionTypeSet should reflect its members for a non-active transition promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'transition.types.add')"
+Harness Error (FAIL), message = Unhandled rejection: Old view transition aborted by new view transition.
+
+PASS ViewTransition.types is a ViewTransitionTypeSet
+PASS ViewTransitionTypeSet behaves like an ordinary Set of strings
+PASS ViewTransitionTypeSet should reflect its members for a non-active transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved-mutation.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-transitions-2/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="view-transition-types-reserved-ref.html">
+<meta name="fuzzy" content="maxDifference=88; totalPixels=400" />
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-transitions-2/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="view-transition-types-reserved-ref.html">
+<meta name="fuzzy" content="maxDifference=88; totalPixels=400" />
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7420,6 +7420,20 @@ ViewTransitionsEnabled:
     WebCore:
       default: true
 
+ViewTransitionsTypeEnabled:
+  type: bool
+  category: animation
+  status: testable
+  humanReadableName: "View Transitions :active-view-transition-type() support"
+  humanReadableDescription: "Support specifying active view transition types"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 VisibleDebugOverlayRegions:
   type: uint32_t
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1145,6 +1145,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ShadowRootMode.idl
     dom/SlotAssignmentMode.idl
     dom/Slotable.idl
+    dom/StartViewTransitionOptions.idl
     dom/StaticRange.idl
     dom/StringCallback.idl
     dom/SubscribeOptions.idl
@@ -1174,7 +1175,9 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/UIEvent.idl
     dom/UIEventInit.idl
     dom/ValidityStateFlags.idl
+    dom/ViewTransition+Types.idl
     dom/ViewTransition.idl
+    dom/ViewTransitionTypeSet.idl
     dom/ViewTransitionUpdateCallback.idl
     dom/VisibilityState.idl
     dom/WheelEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1459,6 +1459,7 @@ $(PROJECT_DIR)/dom/ShadowRootInit.idl
 $(PROJECT_DIR)/dom/ShadowRootMode.idl
 $(PROJECT_DIR)/dom/SlotAssignmentMode.idl
 $(PROJECT_DIR)/dom/Slotable.idl
+$(PROJECT_DIR)/dom/StartViewTransitionOptions.idl
 $(PROJECT_DIR)/dom/StaticRange.idl
 $(PROJECT_DIR)/dom/StringCallback.idl
 $(PROJECT_DIR)/dom/SubscribeOptions.idl
@@ -1491,7 +1492,9 @@ $(PROJECT_DIR)/dom/TrustedTypePolicyOptions.idl
 $(PROJECT_DIR)/dom/UIEvent.idl
 $(PROJECT_DIR)/dom/UIEventInit.idl
 $(PROJECT_DIR)/dom/ValidityStateFlags.idl
+$(PROJECT_DIR)/dom/ViewTransition+Types.idl
 $(PROJECT_DIR)/dom/ViewTransition.idl
+$(PROJECT_DIR)/dom/ViewTransitionTypeSet.idl
 $(PROJECT_DIR)/dom/ViewTransitionUpdateCallback.idl
 $(PROJECT_DIR)/dom/VisibilityState.idl
 $(PROJECT_DIR)/dom/WheelEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2877,6 +2877,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisUtterance.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisUtterance.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisVoice.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisVoice.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStartViewTransitionOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStartViewTransitionOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStaticRange.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStaticRange.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStereoPannerNode.cpp
@@ -3047,8 +3049,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimeline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimeline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimelineOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimelineOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition+Types.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition+Types.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionTypeSet.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionTypeSet.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionUpdateCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionUpdateCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisibilityState.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1152,6 +1152,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/ShadowRootMode.idl \
     $(WebCore)/dom/SlotAssignmentMode.idl \
     $(WebCore)/dom/Slotable.idl \
+    $(WebCore)/dom/StartViewTransitionOptions.idl \
     $(WebCore)/dom/StaticRange.idl \
     $(WebCore)/dom/StringCallback.idl \
     $(WebCore)/dom/Subscriber.idl \
@@ -1179,6 +1180,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/UIEventInit.idl \
     $(WebCore)/dom/ValidityStateFlags.idl \
     $(WebCore)/dom/ViewTransition.idl \
+    $(WebCore)/dom/ViewTransitionTypeSet.idl \
+    $(WebCore)/dom/ViewTransition+Types.idl \
     $(WebCore)/dom/ViewTransitionUpdateCallback.idl \
     $(WebCore)/dom/VisibilityState.idl \
     $(WebCore)/dom/WheelEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1059,6 +1059,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/SimulatedClickOptions.h
     dom/SlotAssignmentMode.h
     dom/SpaceSplitString.h
+    dom/StartViewTransitionOptions.h
     dom/StaticRange.h
     dom/StyledElement.h
     dom/TaskSource.h
@@ -1086,6 +1087,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/UserTypingGestureIndicator.h
     dom/ValidityStateFlags.h
     dom/ViewTransition.h
+    dom/ViewTransitionTypeSet.h
     dom/VisibilityAdjustment.h
     dom/ViewTransitionUpdateCallback.h
     dom/ViewportArguments.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1280,6 +1280,7 @@ dom/UserActionElementSet.cpp
 dom/UserGestureIndicator.cpp
 dom/UserTypingGestureIndicator.cpp
 dom/ViewTransition.cpp
+dom/ViewTransitionTypeSet.cpp
 dom/ViewportArguments.cpp
 dom/VisitedLinkState.cpp
 dom/WheelEvent.cpp
@@ -4442,6 +4443,7 @@ JSSpeechSynthesisUtterance.cpp
 JSSpeechSynthesisVoice.cpp
 JSStereoPannerNode.cpp
 JSStereoPannerOptions.cpp
+JSStartViewTransitionOptions.cpp
 JSStaticRange.cpp
 JSStorage.cpp
 JSStorageManager.cpp
@@ -4561,6 +4563,7 @@ JSVideoTransferCharacteristics.cpp
 JSViewTimeline.cpp
 JSViewTimelineOptions.cpp
 JSViewTransition.cpp
+JSViewTransitionTypeSet.cpp
 JSViewTransitionUpdateCallback.cpp
 JSVisibilityState.cpp
 JSVisualViewport.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -462,6 +462,7 @@ namespace WebCore {
     macro(VideoFrame) \
     macro(ViewTimeline) \
     macro(ViewTransition) \
+    macro(ViewTransitionTypeSet) \
     macro(VisualViewport) \
     macro(WGSLLanguageFeatures) \
     macro(WakeLock) \

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -75,6 +75,10 @@
         "active-view-transition": {
             "settings-flag": "viewTransitionsEnabled"
         },
+        "active-view-transition-type": {
+            "argument": "required",
+            "settings-flag": "viewTransitionsTypeEnabled"
+        },
         "any-link": {
             "aliases": [
                 "-webkit-any-link"

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -511,6 +511,12 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 serializeIdentifier(cs->argument(), builder);
                 builder.append(')');
                 break;
+            case PseudoClass::ActiveViewTransitionType: {
+                builder.append('(');
+                // FIXME do things here
+                builder.append(')');
+                break;
+            }
             default:
                 ASSERT(!pseudoClassMayHaveArgument(cs->pseudoClass()), "Missing serialization for pseudo-class argument");
                 break;

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1164,6 +1164,12 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
         case CSSSelector::PseudoClass::ActiveViewTransition:
             return matchesActiveViewTransitionPseudoClass(element);
+
+        case CSSSelector::PseudoClass::ActiveViewTransitionType: {
+            ASSERT(selector.argumentList() && !selector.argumentList()->isEmpty());
+            return matchesActiveViewTransitionTypePseudoClass(element, *selector.argumentList());
+        }
+
         }
         return false;
     }

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -40,6 +40,7 @@
 #include "SelectorChecker.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "ViewTransition.h"
 #include <wtf/Compiler.h>
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -588,6 +589,32 @@ ALWAYS_INLINE bool matchesActiveViewTransitionPseudoClass(const Element& element
     if (&element != element.document().documentElement())
         return false;
     return !!element.document().activeViewTransition();
+}
+
+ALWAYS_INLINE bool matchesActiveViewTransitionTypePseudoClass(const Element& element, const FixedVector<PossiblyQuotedIdentifier>& typesInSelector)
+{
+    // check if element is the root element
+    if (&element != element.document().documentElement())
+        return false;
+
+    if (const auto* viewTransition = element.document().activeViewTransition()) {
+        const auto& activeTypes = viewTransition->types();
+
+        for (const auto& type : typesInSelector) {
+            ASSERT(!type.wasQuoted);
+
+            // https://github.com/w3c/csswg-drafts/issues/9534#issuecomment-1802364085
+            // RESOLVED: type can accept any idents, except 'none' or '-ua-' prefixes
+            const auto& ident = type.identifier;
+            if (ident.convertToASCIILowercase() == "none"_s || ident.convertToASCIILowercase().startsWith("-ua-"_s))
+                continue;
+
+            if (activeTypes.has(ident))
+                return true;
+        }
+    }
+
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -108,6 +108,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , imageControlsEnabled { document.settings().imageControlsEnabled() }
 #endif
     , lightDarkEnabled { document.settings().cssLightDarkEnabled() }
+    , viewTransitionsTypeEnabled { document.settings().viewTransitionsTypeEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -141,7 +142,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.imageControlsEnabled                      << 21
 #endif
         | context.lightDarkEnabled                          << 22
-        | (uint32_t)context.mode                            << 23; // This is multiple bits, so keep it last.
+        | context.viewTransitionsTypeEnabled                << 23
+        | (uint32_t)context.mode                            << 24; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -100,6 +100,7 @@ struct CSSParserContext {
     bool imageControlsEnabled : 1 { false };
 #endif
     bool lightDarkEnabled : 1 { false };
+    bool viewTransitionsTypeEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -44,6 +44,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
     , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
+    , viewTransitionsTypeEnabled(viewTransitionsEnabled && context.viewTransitionsTypeEnabled)
 {
 }
 
@@ -59,6 +60,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
     , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
+    , viewTransitionsTypeEnabled(viewTransitionsEnabled && document.settings().viewTransitionsTypeEnabled())
 {
 }
 
@@ -75,7 +77,8 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
 #endif
         context.popoverAttributeEnabled,
         context.thumbAndTrackPseudoElementsEnabled,
-        context.viewTransitionsEnabled
+        context.viewTransitionsEnabled,
+        context.viewTransitionsTypeEnabled
     );
 }
 

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -46,6 +46,7 @@ struct CSSSelectorParserContext {
     bool popoverAttributeEnabled { false };
     bool thumbAndTrackPseudoElementsEnabled { false };
     bool viewTransitionsEnabled { false };
+    bool viewTransitionsTypeEnabled { false };
 
     bool isHashTableDeletedValue { false };
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Yusuke Suzuki <utatane.tea@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1225,6 +1225,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::WebKitDrag:
     case CSSSelector::PseudoClass::Has:
     case CSSSelector::PseudoClass::State:
+    case CSSSelector::PseudoClass::ActiveViewTransitionType:
         return FunctionType::CannotCompile;
 
     // Optimized pseudo selectors.

--- a/Source/WebCore/dom/Document+ViewTransition.idl
+++ b/Source/WebCore/dom/Document+ViewTransition.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,5 +24,5 @@
  */
 
 partial interface Document {
-    [EnabledBySetting=ViewTransitionsEnabled] ViewTransition startViewTransition(optional ViewTransitionUpdateCallback? updateCallback = null);
+    [EnabledBySetting=ViewTransitionsEnabled] ViewTransition startViewTransition(optional (ViewTransitionUpdateCallback or StartViewTransitionOptions) callbackOptions = {});
 };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -172,6 +172,7 @@ class ImageBitmapRenderingContext;
 class IntPoint;
 class IntersectionObserver;
 class JSNode;
+class JSViewTransitionUpdateCallback;
 class LayoutPoint;
 class LayoutRect;
 class LazyLoadImageObserver;
@@ -277,6 +278,7 @@ struct IntersectionObserverData;
 struct OwnerPermissionsPolicyData;
 struct QuerySelectorAllResults;
 struct SecurityPolicyViolationEventInit;
+struct StartViewTransitionOptions;
 
 #if ENABLE(TOUCH_EVENTS)
 struct EventTrackingRegions;
@@ -403,6 +405,8 @@ using RenderingContext = std::variant<
     RefPtr<ImageBitmapRenderingContext>,
     RefPtr<CanvasRenderingContext2D>
 >;
+
+using StartViewTransitionCallbackOptions = std::optional<std::variant<WTF::RefPtr<JSViewTransitionUpdateCallback>, StartViewTransitionOptions>>;
 
 class DocumentParserYieldToken {
     WTF_MAKE_FAST_ALLOCATED;
@@ -1699,7 +1703,7 @@ public:
     void unobserveForContainIntrinsicSize(Element&);
     void resetObservationSizeForContainIntrinsicSize(Element&);
 
-    RefPtr<ViewTransition> startViewTransition(RefPtr<ViewTransitionUpdateCallback>&& = nullptr);
+    ExceptionOr<RefPtr<ViewTransition>> startViewTransition(StartViewTransitionCallbackOptions&&);
     ViewTransition* activeViewTransition() const;
     bool activeViewTransitionCapturedDocumentElement() const;
     void setActiveViewTransition(RefPtr<ViewTransition>&&);

--- a/Source/WebCore/dom/StartViewTransitionOptions.h
+++ b/Source/WebCore/dom/StartViewTransitionOptions.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ViewTransitionUpdateCallback.h"
+
+namespace WebCore {
+
+struct StartViewTransitionOptions {
+    RefPtr<ViewTransitionUpdateCallback> update;
+    std::optional<Vector<AtomString>> types;
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/dom/StartViewTransitionOptions.idl
+++ b/Source/WebCore/dom/StartViewTransitionOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary StartViewTransitionOptions {
+    ViewTransitionUpdateCallback? update = null;
+    [EnabledBySetting=ViewTransitionsTypeEnabled] sequence<[AtomString] DOMString>? types = null;
+};

--- a/Source/WebCore/dom/ViewTransition+Types.idl
+++ b/Source/WebCore/dom/ViewTransition+Types.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+partial interface ViewTransition {
+    [EnabledBySetting=ViewTransitionsTypeEnabled] attribute ViewTransitionTypeSet types;
+};

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -63,20 +63,21 @@ static std::pair<Ref<DOMPromise>, Ref<DeferredPromise>> createPromiseAndWrapper(
     return { WTFMove(domPromise), deferredPromise.releaseNonNull() };
 }
 
-ViewTransition::ViewTransition(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
+ViewTransition::ViewTransition(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback, Vector<AtomString>&& initialActiveTypes)
     : ActiveDOMObject(document)
     , m_updateCallback(WTFMove(updateCallback))
     , m_ready(createPromiseAndWrapper(document))
     , m_updateCallbackDone(createPromiseAndWrapper(document))
     , m_finished(createPromiseAndWrapper(document))
+    , m_types(ViewTransitionTypeSet::create(document, WTFMove(initialActiveTypes)))
 {
 }
 
 ViewTransition::~ViewTransition() = default;
 
-Ref<ViewTransition> ViewTransition::create(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
+Ref<ViewTransition> ViewTransition::create(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback, Vector<AtomString>&& initialActiveTypes)
 {
-    Ref viewTransition = adoptRef(*new ViewTransition(document, WTFMove(updateCallback)));
+    Ref viewTransition = adoptRef(*new ViewTransition(document, WTFMove(updateCallback), WTFMove(initialActiveTypes)));
     viewTransition->suspendIfNeeded();
     return viewTransition;
 }

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -33,6 +33,7 @@
 #include "JSValueInWrappedObject.h"
 #include "MutableStyleProperties.h"
 #include "Styleable.h"
+#include "ViewTransitionTypeSet.h"
 #include "ViewTransitionUpdateCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -134,7 +135,7 @@ private:
 
 class ViewTransition : public RefCounted<ViewTransition>, public CanMakeWeakPtr<ViewTransition>, public ActiveDOMObject {
 public:
-    static Ref<ViewTransition> create(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
+    static Ref<ViewTransition> create(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     ~ViewTransition();
 
     // ActiveDOMObject.
@@ -159,10 +160,13 @@ public:
 
     bool documentElementIsCaptured() const;
 
+    const ViewTransitionTypeSet& types() const { return m_types; }
+    void setTypes(Ref<ViewTransitionTypeSet>&& newTypes) { m_types = newTypes; }
+
     RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject&);
 
 private:
-    ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
+    ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
 
     Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&);
 
@@ -195,6 +199,8 @@ private:
     PromiseAndWrapper m_updateCallbackDone;
     PromiseAndWrapper m_finished;
     EventLoopTimerHandle m_updateCallbackTimeout;
+
+    Ref<ViewTransitionTypeSet> m_types;
 };
 
 }

--- a/Source/WebCore/dom/ViewTransitionTypeSet.cpp
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ViewTransitionTypeSet.h"
+
+#include "Document.h"
+#include "PseudoClassChangeInvalidation.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ViewTransitionTypeSet);
+
+ViewTransitionTypeSet::ViewTransitionTypeSet(Document& document, Vector<AtomString>&& initialActiveTypes)
+    : m_typeSet()
+    , m_document(document)
+{
+    for (auto initialActiveType : initialActiveTypes)
+        m_typeSet.add(initialActiveType);
+}
+
+void ViewTransitionTypeSet::initializeSetLike(DOMSetAdapter& setAdapter) const
+{
+    for (auto activeType : m_typeSet)
+        setAdapter.add<IDLDOMString>(activeType);
+}
+
+void ViewTransitionTypeSet::clearFromSetLike()
+{
+    WTFLogAlways("ViewTransitionTypeSet: clearing");
+
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (m_document.documentElement()) {
+        styleInvalidation.emplace(
+            *m_document.documentElement(),
+            CSSSelector::PseudoClass::ActiveViewTransitionType,
+            Style::PseudoClassChangeInvalidation::AnyValue
+        );
+    }
+
+    m_typeSet.clear();
+}
+
+void ViewTransitionTypeSet::addToSetLike(const AtomString& type)
+{
+    WTFLogAlways("ViewTransitionTypeSet: adding '%s'", type.string().ascii().data());
+
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (m_document.documentElement()) {
+        styleInvalidation.emplace(
+            *m_document.documentElement(),
+            CSSSelector::PseudoClass::ActiveViewTransitionType,
+            Style::PseudoClassChangeInvalidation::AnyValue
+        );
+    }
+
+    m_typeSet.add(type);
+}
+
+bool ViewTransitionTypeSet::removeFromSetLike(const AtomString& type)
+{
+    WTFLogAlways("ViewTransitionTypeSet: deleting '%s'", type.string().ascii().data());
+
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (m_document.documentElement()) {
+        styleInvalidation.emplace(
+            *m_document.documentElement(),
+            CSSSelector::PseudoClass::ActiveViewTransitionType,
+            Style::PseudoClassChangeInvalidation::AnyValue
+        );
+    }
+
+    return m_typeSet.remove(type);
+}
+
+bool ViewTransitionTypeSet::has(const AtomString& type) const
+{
+    bool result = m_typeSet.contains(type);
+
+    WTFLogAlways("ViewTransitionTypeSet: has '%s'? %s", type.string().ascii().data(), result ? "true" : "false");
+
+    return result;
+}
+
+}

--- a/Source/WebCore/dom/ViewTransitionTypeSet.h
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Element.h"
+#include "JSDOMSetLike.h"
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/ListHashSet.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class ViewTransitionTypeSet : public RefCounted<ViewTransitionTypeSet> {
+    WTF_MAKE_ISO_ALLOCATED(ViewTransitionTypeSet);
+
+public:
+    static Ref<ViewTransitionTypeSet> create(Document& document, Vector<AtomString>&& initialActiveTypes)
+    {
+        return adoptRef(*new ViewTransitionTypeSet(document, WTFMove(initialActiveTypes)));
+    }
+
+    void initializeSetLike(DOMSetAdapter&) const;
+
+    void clearFromSetLike();
+    void addToSetLike(const AtomString&);
+    bool removeFromSetLike(const AtomString&);
+
+    bool has(const AtomString&) const;
+
+private:
+    ViewTransitionTypeSet(Document&, Vector<AtomString>&&);
+
+    ListHashSet<AtomString> m_typeSet;
+    Document& m_document;
+};
+
+}

--- a/Source/WebCore/dom/ViewTransitionTypeSet.idl
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=ViewTransitionsTypeEnabled,
+    Exposed=Window
+]
+interface ViewTransitionTypeSet {
+    setlike<[AtomString] DOMString>;
+};


### PR DESCRIPTION
#### f8283e6053dba10aa72e8f301d4d6c3b6cc2c432
<pre>
[view-transitions] Add support for view transition types
<a href="https://rdar.apple.com/132051697">rdar://132051697</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=276801">https://bugs.webkit.org/show_bug.cgi?id=276801</a>

Reviewed by NOBODY (OOPS!).

FIXME fill in description and modifications in each file.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved-mutation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesActiveViewTransitionTypePseudoClass):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::consumeCustomIdent):
(WebCore::consumeCommaSeparatedCustomIdentsList):
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/Document+ViewTransition.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setActiveViewTransition):
(WebCore::Document::startViewTransition):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/StartViewTransitionOptions.h: Added.
* Source/WebCore/dom/StartViewTransitionOptions.idl: Added.
* Source/WebCore/dom/ViewTransition+Types.idl: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::ViewTransition):
(WebCore::ViewTransition::create):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::types const):
(WebCore::ViewTransition::setTypes):
* Source/WebCore/dom/ViewTransitionTypeSet.cpp: Added.
(WebCore::ViewTransitionTypeSet::ViewTransitionTypeSet):
(WebCore::ViewTransitionTypeSet::initializeSetLike const):
(WebCore::ViewTransitionTypeSet::clearFromSetLike):
(WebCore::ViewTransitionTypeSet::addToSetLike):
(WebCore::ViewTransitionTypeSet::removeFromSetLike):
(WebCore::ViewTransitionTypeSet::has const):
* Source/WebCore/dom/ViewTransitionTypeSet.h: Added.
(WebCore::ViewTransitionTypeSet::create):
* Source/WebCore/dom/ViewTransitionTypeSet.idl: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8283e6053dba10aa72e8f301d4d6c3b6cc2c432

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14085 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65455 "Hash f8283e60 for PR 31821 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12324 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/65455 "Hash f8283e60 for PR 31821 does not build (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53269 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/65455 "Hash f8283e60 for PR 31821 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34627 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches.html imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10498 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10963 "Hash f8283e60 for PR 31821 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54604 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56435 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10797 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches.html imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67184 "Hash f8283e60 for PR 31821 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60752 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5447 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10562 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches.html imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html workers/worker-to-worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/67184 "Hash f8283e60 for PR 31821 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5472 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53234 "Exiting early after 10 failures. 53 tests run. 2 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/67184 "Hash f8283e60 for PR 31821 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4494 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36665 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14418 "Found 1466 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->