### PR TITLE
Temporarily avoid using _Float16 on PlayStation

### DIFF
--- a/Source/WTF/wtf/Float16.h
+++ b/Source/WTF/wtf/Float16.h
@@ -55,7 +55,7 @@ namespace WTF {
  */
 constexpr float convertFloat16ToFloat32(uint16_t h)
 {
-#if CPU(ARM64) || CPU(X86_64)
+#if CPU(ARM64) || (CPU(X86_64) && !PLATFORM(PLAYSTATION))
     return static_cast<float>(std::bit_cast<_Float16>(h));
 #else
     /*
@@ -176,7 +176,7 @@ constexpr double convertFloat16ToFloat64(uint16_t h)
  */
 constexpr uint16_t convertFloat32ToFloat16(float f)
 {
-#if CPU(ARM64) || CPU(X86_64)
+#if CPU(ARM64) || (CPU(X86_64) && !PLATFORM(PLAYSTATION))
     return std::bit_cast<uint16_t>(static_cast<_Float16>(f));
 #else
     const float scale_to_inf = 0x1.0p+112f; // 0x77800000
@@ -204,7 +204,7 @@ constexpr uint16_t convertFloat32ToFloat16(float f)
 // Adopted from V8's DoubleToFloat16, which adopted from https://gist.github.com/rygorous/2156668.
 constexpr uint16_t convertFloat64ToFloat16(double value)
 {
-#if CPU(ARM64) || CPU(X86_64)
+#if CPU(ARM64) || (CPU(X86_64) && !PLATFORM(PLAYSTATION))
     return std::bit_cast<uint16_t>(static_cast<_Float16>(value));
 #else
     // uint64_t constants prefixed with kFP64 are bit patterns of doubles.
@@ -284,7 +284,7 @@ constexpr uint16_t convertFloat64ToFloat16(double value)
 #endif
 }
 
-#if CPU(ARM64) || CPU(X86_64)
+#if CPU(ARM64) || (CPU(X86_64) && !PLATFORM(PLAYSTATION))
 class Float16 {
 public:
     constexpr Float16() = default;


### PR DESCRIPTION
#### ffba70c72dfc6f0e57de55b37e25b5601274079d
<pre>
Temporarily avoid using _Float16 on PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=277725">https://bugs.webkit.org/show_bug.cgi?id=277725</a>

Unreviewed PlayStation build fix.
We&apos;re having trouble with __truncdfhf2 on our platform and it will take a bit of time to resolve.

* Source/WTF/wtf/Float16.h:

Canonical link: <a href="https://commits.webkit.org/281928@main">https://commits.webkit.org/281928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57d6ae4771481171514d0cd925359dbddf443c50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14069 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12308 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64567 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/37953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/10484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/10946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/54588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/10783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67168 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60736 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5431 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5456 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/53220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/4480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82501 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9248 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/14411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->