### PR TITLE
window.open() does not work in a Web Extension popup.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -47,8 +47,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
 {
     static NSString * const apiName = @"windows.create()";
 
-    auto delegate = extensionController()->delegate();
-    if (![delegate respondsToSelector:@selector(webExtensionController:openNewWindowWithOptions:forExtensionContext:completionHandler:)]) {
+    if (!canOpenNewWindow()) {
         completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
@@ -101,7 +100,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     creationOptions.tabURLs = [urls copy];
     creationOptions.tabs = [tabs copy];
 
-    [delegate webExtensionController:extensionController()->wrapper() openNewWindowWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionWindow> newWindow, NSError *error) mutable {
+    [extensionController()->delegate() webExtensionController:extensionController()->wrapper() openNewWindowWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{public}@", privacyPreservingDescription(error));
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -40,6 +40,7 @@
 #import "WKWebExtensionControllerDelegatePrivate.h"
 #import "WKWebViewConfigurationPrivate.h"
 #import "WKWebViewInternal.h"
+#import "WKWindowFeaturesPrivate.h"
 #import "WebExtensionContext.h"
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionMenuItem.h"
@@ -120,8 +121,8 @@ using namespace WebKit;
         tabParameters.index = currentTab ? std::optional(currentTab->index() + 1) : std::nullopt;
         tabParameters.active = true;
 
-        _webExtensionAction->extensionContext()->openNewTab(tabParameters, [](RefPtr<WebExtensionTab> newTab) {
-            ASSERT(newTab);
+        _webExtensionAction->extensionContext()->openNewTab(tabParameters, [](auto newTab) {
+            // Nothing to do.
         });
 
         decisionHandler(WKNavigationActionPolicyCancel);
@@ -139,6 +140,59 @@ using namespace WebKit;
     ASSERT(isURLForThisExtension);
 
     decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+    // This can't return a web view because it must use the supplied configuration,
+    // or an exception will be thrown. Web extension URLs can't load in a web view
+    // configured for HTTP-family URLs, and vice versa, making it imposible to
+    // use the configuration for a new tab.
+
+    if (!_webExtensionAction || !_webExtensionAction->extensionContext())
+        return nil;
+
+    WebExtensionTabParameters tabParameters;
+    tabParameters.url = navigationAction.request.URL;
+
+    if (_webExtensionAction->extensionContext()->canOpenNewWindow()) {
+        WebExtensionWindowParameters windowParameters;
+        windowParameters.focused = true;
+        windowParameters.tabs = { WTFMove(tabParameters) };
+        windowParameters.type = windowFeatures._wantsPopup ? WebExtensionWindow::Type::Popup : WebExtensionWindow::Type::Normal;
+        windowParameters.state = windowFeatures._fullscreenDisplay.boolValue ? WebExtensionWindow::State::Fullscreen : WebExtensionWindow::State::Normal;
+
+        static constexpr CGFloat NaN = std::numeric_limits<CGFloat>::quiet_NaN();
+
+        CGRect frame;
+        frame.origin.x = windowFeatures.x ? windowFeatures.x.doubleValue : NaN;
+        frame.origin.y = windowFeatures.y ? windowFeatures.y.doubleValue : NaN;
+        frame.size.width = windowFeatures.width ? windowFeatures.width.doubleValue : NaN;
+        frame.size.height = windowFeatures.height ? windowFeatures.height.doubleValue : NaN;
+
+        windowParameters.frame = frame;
+
+        _webExtensionAction->extensionContext()->openNewWindow(windowParameters, [](auto newWindow) {
+            // Nothing to do.
+        });
+
+        return nil;
+    }
+
+    RefPtr currentWindow = _webExtensionAction->window();
+    RefPtr currentTab = _webExtensionAction->tab();
+    if (!currentWindow && currentTab)
+        currentWindow = currentTab->window();
+
+    tabParameters.windowIdentifier = currentWindow ? currentWindow->identifier() : WebExtensionWindowConstants::CurrentIdentifier;
+    tabParameters.index = currentTab ? std::optional(currentTab->index() + 1) : std::nullopt;
+    tabParameters.active = true;
+
+    _webExtensionAction->extensionContext()->openNewTab(tabParameters, [](auto newTab) {
+        // Nothing to do.
+    });
+
+    return nil;
 }
 
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -57,6 +57,7 @@
 #import "WKWebViewInternal.h"
 #import "WKWebpagePreferencesPrivate.h"
 #import "WKWebsiteDataStorePrivate.h"
+#import "WKWindowFeaturesPrivate.h"
 #import "WebCoreArgumentCoders.h"
 #import "WebExtensionAction.h"
 #import "WebExtensionConstants.h"
@@ -1991,6 +1992,27 @@ void WebExtensionContext::forgetTab(WebExtensionTabIdentifier identifier) const
         return;
 
     [m_tabDelegateToIdentifierMap removeObjectForKey:tab->delegate()];
+}
+
+bool WebExtensionContext::canOpenNewWindow() const
+{
+    ASSERT(isLoaded());
+
+    return [extensionController()->delegate() respondsToSelector:@selector(webExtensionController:openNewWindowWithOptions:forExtensionContext:completionHandler:)];
+}
+
+void WebExtensionContext::openNewWindow(const WebExtensionWindowParameters& parameters, CompletionHandler<void(RefPtr<WebExtensionWindow>)>&& completionHandler)
+{
+    ASSERT(isLoaded());
+
+    windowsCreate(parameters, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](Expected<std::optional<WebExtensionWindowParameters>, WebExtensionError>&& result) mutable {
+        if (!result || !result.value()) {
+            completionHandler(nullptr);
+            return;
+        }
+
+        completionHandler(getWindow(result.value()->identifier.value()));
+    });
 }
 
 void WebExtensionContext::openNewTab(const WebExtensionTabParameters& parameters, CompletionHandler<void(RefPtr<WebExtensionTab>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -386,6 +386,8 @@ public:
     RefPtr<WebExtensionTab> getCurrentTab(WebPageProxyIdentifier, IncludeExtensionViews = IncludeExtensionViews::Yes, IgnoreExtensionAccess = IgnoreExtensionAccess::No) const;
     void forgetTab(WebExtensionTabIdentifier) const;
 
+    bool canOpenNewWindow() const;
+    void openNewWindow(const WebExtensionWindowParameters&, CompletionHandler<void(RefPtr<WebExtensionWindow>)>&&);
     void openNewTab(const WebExtensionTabParameters&, CompletionHandler<void(RefPtr<WebExtensionTab>)>&&);
 
     WindowVector openWindows(IgnoreExtensionAccess = IgnoreExtensionAccess::No) const;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -39,23 +39,6 @@
 
 namespace TestWebKitAPI {
 
-static void runScriptWithUserGesture(const String& script, WKWebView *backgroundWebView)
-{
-    ASSERT(backgroundWebView);
-
-    bool callbackComplete = false;
-    RetainPtr<id> evalResult;
-    [backgroundWebView callAsyncJavaScript:script arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:[&] (id result, NSError *error) {
-        evalResult = result;
-        callbackComplete = true;
-        EXPECT_TRUE(!error);
-        if (error)
-            NSLog(@"Encountered error: %@ while evaluating script: %@", error, static_cast<NSString *>(script));
-    }];
-
-    TestWebKitAPI::Util::run(&callbackComplete);
-}
-
 TEST(WKWebExtensionAPIPermissions, Errors)
 {
     auto *manifest = @{
@@ -202,7 +185,7 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -249,7 +232,7 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -297,7 +280,7 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -347,7 +330,7 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -397,7 +380,7 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -447,7 +430,7 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -495,7 +478,7 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -691,7 +674,7 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
 
-    runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
+    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
 
     [manager run];
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -46,7 +46,10 @@
 @property (nonatomic, copy) NSArray<id <WKWebExtensionWindow>> *(^openWindows)(WKWebExtensionContext *);
 @property (nonatomic, copy) id <WKWebExtensionWindow> (^focusedWindow)(WKWebExtensionContext *);
 
+#if PLATFORM(MAC)
 @property (nonatomic, copy) void (^openNewWindow)(WKWebExtensionWindowCreationOptions *, WKWebExtensionContext *, void (^)(id<WKWebExtensionWindow>, NSError *));
+#endif
+
 @property (nonatomic, copy) void (^openNewTab)(WKWebExtensionTabCreationOptions *, WKWebExtensionContext *, void (^)(id<WKWebExtensionTab>, NSError *));
 @property (nonatomic, copy) void (^openOptionsPage)(WKWebExtensionContext *, void (^)(NSError *));
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -51,6 +51,7 @@
     return nil;
 }
 
+#if PLATFORM(MAC)
 - (void)webExtensionController:(WKWebExtensionController *)controller openNewWindowWithOptions:(WKWebExtensionWindowCreationOptions *)options forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(id<WKWebExtensionWindow> newWindow, NSError *error))completionHandler
 {
     if (_openNewWindow)
@@ -58,6 +59,7 @@
 
     completionHandler(nil, nil);
 }
+#endif
 
 - (void)webExtensionController:(WKWebExtensionController *)controller openNewTabWithOptions:(WKWebExtensionTabCreationOptions *)options forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(id<WKWebExtensionTab> newTab, NSError *error))completionHandler
 {

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -145,6 +145,8 @@ inline NSString *constructJSArrayOfStrings(NSArray *elements) { return [NSString
 
 NSData *makePNGData(CGSize, SEL colorSelector);
 
+void runScriptWithUserGesture(const String&, WKWebView *);
+
 #endif
 
 RetainPtr<TestWebExtensionManager> loadAndRunExtension(WKWebExtension *, WKWebExtensionControllerConfiguration * = nil);

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -77,8 +77,6 @@
     auto *window = [[TestWebExtensionWindow alloc] initWithExtensionController:_controller usesPrivateBrowsing:NO];
     auto *windows = [NSMutableArray arrayWithObject:window];
 
-    __weak TestWebExtensionManager *weakSelf = self;
-
     _internalDelegate.openWindows = ^NSArray<id<WKWebExtensionWindow>> *(WKWebExtensionContext *) {
         return [windows copy];
     };
@@ -86,6 +84,9 @@
     _internalDelegate.focusedWindow = ^id<WKWebExtensionWindow>(WKWebExtensionContext *) {
         return window;
     };
+
+#if PLATFORM(MAC)
+    __weak TestWebExtensionManager *weakSelf = self;
 
     _internalDelegate.openNewWindow = ^(WKWebExtensionWindowCreationOptions *options, WKWebExtensionContext *, void (^completionHandler)(id<WKWebExtensionWindow>, NSError *)) {
         auto *newWindow = [weakSelf openNewWindowUsingPrivateBrowsing:options.usePrivateBrowsing];
@@ -105,7 +106,6 @@
         if (std::isnan(desiredFrame.origin.x))
             desiredFrame.origin.x = currentFrame.origin.x;
 
-#if PLATFORM(MAC)
         CGRect screenFrame = newWindow.screenFrame;
         CGFloat screenTop = screenFrame.size.height + screenFrame.origin.y;
         if (std::isnan(desiredFrame.origin.y)) {
@@ -113,15 +113,12 @@
             CGFloat currentTop = screenTop - currentFrame.size.height - currentFrame.origin.y;
             desiredFrame.origin.y = screenTop - desiredFrame.size.height - currentTop;
         }
-#else
-        if (std::isnan(desiredFrame.origin.y))
-            desiredFrame.origin.y = currentFrame.origin.y;
-#endif
 
         newWindow.frame = desiredFrame;
 
         completionHandler(newWindow, nil);
     };
+#endif // PLATFORM(MAC)
 
     _internalDelegate.openNewTab = ^(WKWebExtensionTabCreationOptions *options, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionTab>, NSError *)) {
         auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.window) ?: window;
@@ -910,6 +907,26 @@ NSData *makePNGData(CGSize size, SEL colorSelector)
 
     return UIImagePNGRepresentation(image);
 #endif
+}
+
+void runScriptWithUserGesture(const String& script, WKWebView *webView)
+{
+    ASSERT(webView);
+
+    bool callbackComplete = false;
+    id evalResult;
+
+    [webView callAsyncJavaScript:script arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:[&](id result, NSError *error) {
+        evalResult = result;
+        callbackComplete = true;
+
+        EXPECT_NULL(error);
+
+        if (error)
+            NSLog(@"Encountered error: %@ while evaluating script: %@", error, static_cast<NSString *>(script));
+    }];
+
+    TestWebKitAPI::Util::run(&callbackComplete);
 }
 
 } // namespace Util


### PR DESCRIPTION
#### dda12ca2d8918d160f77cd179704e14d3845719a
<pre>
window.open() does not work in a Web Extension popup.
<a href="https://webkit.org/b/277728">https://webkit.org/b/277728</a>
<a href="https://rdar.apple.com/133332339">rdar://133332339</a>

Reviewed by Brian Weinstein.

Hook up `window.open()` to the web extension delegate methods to create a new window or tab
depending on if the new window delegate method is implemented or not. This dual-approach is
needed since creating windows is only supported on macOS.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]): Remove ASSERT
since a new tab is not always guaranteed.
(-[_WKWebExtensionActionWebViewDelegate webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::canOpenNewWindow const): Added.
(WebKit::WebExtensionContext::openNewWindow): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, WindowOpenOpensInNewWindow)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)): Use Util::runScriptWithUserGesture.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)): Ditto.
(TestWebKitAPI::runScriptWithUserGesture): Deleted.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h: Make new window delegate method macOS only.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm: Ditto.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]): Ditto.
(TestWebKitAPI::Util::runScriptWithUserGesture): Added.

Canonical link: <a href="https://commits.webkit.org/281995@main">https://commits.webkit.org/281995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74fddfe76d5019979cba4bdec78da019c6b6e37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49737 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64728 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5602 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10702 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57114 "22 flakes 59 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57338 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4609 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36813 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->