### PR TITLE
Merge JetStreamDriver.js changes from JS2 to JS3

### DIFF
--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -42,8 +42,10 @@ if (typeof testWorstCaseCountMap === "undefined")
 if (typeof dumpJSONResults === "undefined")
     var dumpJSONResults = false;
 
+if (typeof customTestList === "undefined")
+    var customTestList = [];
+
 let shouldReport = false;
-let customTestList = [];
 if (typeof(URLSearchParams) !== "undefined") {
     const urlParameters = new URLSearchParams(window.location.search);
     shouldReport = urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true';
@@ -242,9 +244,8 @@ class Driver {
             statusElement = document.getElementById("status");
             summaryElement = document.getElementById("result-summary");
             statusElement.innerHTML = `<label>Running...</label>`;
-        } else {
+        } else if (!dumpJSONResults)
             console.log("Starting JetStream3");
-        }
 
         await updateUI();
 
@@ -278,7 +279,7 @@ class Driver {
         if (measureTotalTimeAsSubtest) {
             if (isInBrowser)
                 document.getElementById("benchmark-total-time-score").innerHTML = uiFriendlyNumber(totalTime);
-            else
+            else if (!dumpJSONResults)
                 console.log("Total time:", uiFriendlyNumber(totalTime));
             allScores.push(totalTime);
         }
@@ -307,7 +308,7 @@ class Driver {
             if (showScoreDetails)
                 displayCategoryScores();
             statusElement.innerHTML = '';
-        } else {
+        } else if (!dumpJSONResults) {
             console.log("\n");
             for (let [category, scores] of categoryScores)
                 console.log(`${category}: ${uiFriendlyNumber(geomean(scores))}`);
@@ -866,7 +867,8 @@ class Benchmark {
 
     updateUIBeforeRun() {
         if (!isInBrowser) {
-            console.log(`Running ${this.name}:`);
+            if (!dumpJSONResults)
+                console.log(`Running ${this.name}:`);
             return;
         }
 
@@ -955,6 +957,9 @@ class DefaultBenchmark extends Benchmark {
             document.getElementById(scoreID(this)).innerHTML = uiFriendlyNumber(this.score);
             return;
         }
+
+        if (dumpJSONResults)
+            return;
 
         console.log("    Startup:", uiFriendlyNumber(this.firstIteration));
         console.log("    Worst Case:", uiFriendlyNumber(this.worst4));
@@ -1050,6 +1055,9 @@ class WSLBenchmark extends Benchmark {
             document.getElementById("wsl-score-score").innerHTML = uiFriendlyNumber(this.score);
             return;
         }
+
+        if (dumpJSONResults)
+            return;
 
         console.log("    Stdlib:", uiFriendlyNumber(this.stdlib));
         console.log("    Tests:", uiFriendlyNumber(this.mainRun));
@@ -1228,6 +1236,10 @@ class WasmBenchmark extends Benchmark {
             document.getElementById(this.scoreID).innerHTML = uiFriendlyNumber(this.score);
             return;
         }
+
+        if (dumpJSONResults)
+            return;
+
         console.log("    Startup:", uiFriendlyNumber(this.startupTime));
         console.log("    Run time:", uiFriendlyNumber(this.runTime));
         if (RAMification) {


### PR DESCRIPTION
#### bb3db1a780028c0d5a9389c51436c4353a3cedf3
<pre>
Merge JetStreamDriver.js changes from JS2 to JS3
<a href="https://bugs.webkit.org/show_bug.cgi?id=277742">https://bugs.webkit.org/show_bug.cgi?id=277742</a>
<a href="https://rdar.apple.com/133394269">rdar://133394269</a>

Reviewed by Yijia Huang.

This is mostly silencing prints when dumping to JSON. But also
allowing scripts to set customTestList too.

* PerformanceTests/JetStream3/JetStreamDriver.js:
(Driver.prototype.async start):
(prototype.updateUIBeforeRun):
(DefaultBenchmark.prototype.updateUIAfterRun):
(DefaultBenchmark):
(prototype.updateUIAfterRun):
(WasmBenchmark.prototype.get runnerCode):

Canonical link: <a href="https://commits.webkit.org/281946@main">https://commits.webkit.org/281946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3804cb3daa3243d657fa389da0ca12b07e95a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14118 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12081 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12355 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53298 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34668 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10826 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10607 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/67266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53259 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4519 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9258 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36697 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37782 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->