### PR TITLE
[CoreIPC] -[NSButtonCell isKindOfClass:]: message sent to deallocated instance in WebCore::ControlMac::drawCellInternal

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2449,6 +2449,7 @@ platform/graphics/controls/ApplePayButtonPart.cpp
 platform/graphics/controls/ControlFactory.cpp
 platform/graphics/controls/ControlPart.cpp
 platform/graphics/controls/ControlStyle.cpp
+platform/graphics/controls/EmptyControlFactory.cpp
 platform/graphics/controls/MeterPart.cpp
 platform/graphics/controls/ProgressBarPart.cpp
 platform/graphics/controls/SliderTrackPart.cpp

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -214,10 +214,10 @@ void GraphicsContext::drawBidiText(const FontCascade& font, const TextRun& run, 
     bidiRuns.clear();
 }
 
-void GraphicsContext::drawDisplayListItems(const Vector<DisplayList::Item>& items, const DisplayList::ResourceHeap& resourceHeap, const FloatPoint& destination)
+void GraphicsContext::drawDisplayListItems(const Vector<DisplayList::Item>& items, const DisplayList::ResourceHeap& resourceHeap, ControlFactory& controlFactory, const FloatPoint& destination)
 {
     translate(destination);
-    DisplayList::Replayer(*this, items, resourceHeap).replay();
+    DisplayList::Replayer(*this, items, resourceHeap, controlFactory).replay();
     translate(-destination);
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -321,7 +321,7 @@ public:
     virtual void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) = 0;
 
     // DisplayList
-    WEBCORE_EXPORT virtual void drawDisplayListItems(const Vector<DisplayList::Item>&, const DisplayList::ResourceHeap&, const FloatPoint& destination);
+    WEBCORE_EXPORT virtual void drawDisplayListItems(const Vector<DisplayList::Item>&, const DisplayList::ResourceHeap&, ControlFactory&, const FloatPoint& destination);
 
     // Transparency Layers
 

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.cpp
@@ -26,22 +26,22 @@
 #include "config.h"
 #include "ControlFactory.h"
 
+#include "EmptyControlFactory.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
 #if !PLATFORM(COCOA)
-std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
+RefPtr<ControlFactory> ControlFactory::create()
 {
-    RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return adoptRef(new EmptyControlFactory());
 }
 #endif
 
-ControlFactory& ControlFactory::sharedControlFactory()
+ControlFactory& ControlFactory::shared()
 {
-    static NeverDestroyed<std::unique_ptr<ControlFactory>> sharedControlFactory = createControlFactory();
-    return *sharedControlFactory.get();
+    static MainThreadNeverDestroyed<RefPtr<ControlFactory>> shared { create() };
+    return *shared.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+
 namespace WebCore {
 
 class ApplePayButtonPart;
@@ -48,13 +51,13 @@ class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
 
-class ControlFactory {
+class ControlFactory : public RefCounted<ControlFactory> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~ControlFactory() = default;
 
-    WEBCORE_EXPORT static std::unique_ptr<ControlFactory> createControlFactory();
-    static ControlFactory& sharedControlFactory();
+    WEBCORE_EXPORT static RefPtr<ControlFactory> create();
+    WEBCORE_EXPORT static ControlFactory& shared();
 
 #if ENABLE(APPLE_PAY)
     virtual std::unique_ptr<PlatformControl> createPlatformApplePayButton(ApplePayButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "ControlPart.h"
 
-#include "ControlFactory.h"
 #include "FloatRoundedRect.h"
 #include "GraphicsContext.h"
 
@@ -39,7 +38,7 @@ ControlPart::ControlPart(StyleAppearance type)
 
 ControlFactory& ControlPart::controlFactory() const
 {
-    return m_controlFactory ? *m_controlFactory : ControlFactory::sharedControlFactory();
+    return m_controlFactory ? *m_controlFactory : ControlFactory::shared();
 }
 
 PlatformControl* ControlPart::platformControl() const

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Color.h"
+#include "ControlFactory.h"
 #include "PlatformControl.h"
 #include "StyleAppearance.h"
 #include <wtf/RefCounted.h>
@@ -43,7 +44,7 @@ public:
     StyleAppearance type() const { return m_type; }
 
     WEBCORE_EXPORT ControlFactory& controlFactory() const;
-    void setControlFactory(ControlFactory* controlFactory) { m_controlFactory = controlFactory; }
+    void setControlFactory(ControlFactory& controlFactory) { m_controlFactory = &controlFactory; }
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&);
@@ -58,7 +59,7 @@ protected:
     const StyleAppearance m_type;
 
     mutable std::unique_ptr<PlatformControl> m_platformControl;
-    ControlFactory* m_controlFactory { nullptr };
+    RefPtr<ControlFactory> m_controlFactory;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/EmptyControlFactory.cpp
+++ b/Source/WebCore/platform/graphics/controls/EmptyControlFactory.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EmptyControlFactory.h"
+
+#include "NotImplemented.h"
+
+namespace WebCore {
+
+#if ENABLE(APPLE_PAY)
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformApplePayButton(ApplePayButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+#endif
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformButton(ButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+#if ENABLE(INPUT_TYPE_COLOR)
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformColorWell(ColorWellPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+#endif
+
+#if ENABLE(SERVICE_CONTROLS)
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformImageControlsButton(ImageControlsButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+#endif
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformInnerSpinButton(InnerSpinButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformMenuList(MenuListPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformMenuListButton(MenuListButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformMeter(MeterPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformProgressBar(ProgressBarPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSearchField(SearchFieldPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSearchFieldResults(SearchFieldResultsPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSliderThumb(SliderThumbPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSliderTrack(SliderTrackPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSwitchThumb(SwitchThumbPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformSwitchTrack(SwitchTrackPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformTextArea(TextAreaPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformTextField(TextFieldPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> EmptyControlFactory::createPlatformToggleButton(ToggleButtonPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/EmptyControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/EmptyControlFactory.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+
+namespace WebCore {
+
+class EmptyControlFactory : public ControlFactory {
+public:
+    using ControlFactory::ControlFactory;
+
+private:
+#if ENABLE(APPLE_PAY)
+    std::unique_ptr<PlatformControl> createPlatformApplePayButton(ApplePayButtonPart&) final;
+#endif
+    std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) final;
+#if ENABLE(INPUT_TYPE_COLOR)
+    std::unique_ptr<PlatformControl> createPlatformColorWell(ColorWellPart&) final;
+#endif
+#if ENABLE(SERVICE_CONTROLS)
+    std::unique_ptr<PlatformControl> createPlatformImageControlsButton(ImageControlsButtonPart&) final;
+#endif
+    std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&)  final;
+    std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformMenuListButton(MenuListButtonPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -147,7 +147,7 @@ inline static std::optional<RenderingResourceIdentifier> applyDrawDecomposedGlyp
     return std::nullopt;
 }
 
-ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const Item& item)
+ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resourceHeap, ControlFactory& controlFactory, const Item& item)
 {
     if (!isValid(item))
         return { StopReplayReason::InvalidItemOrExtent, std::nullopt };
@@ -156,6 +156,9 @@ ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resource
         [&](const ClipToImageBuffer& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
+            return { };
+        }, [&](const DrawControlPart& item) -> ApplyItemResult {
+            item.apply(context, controlFactory);
             return { };
         }, [&](const DrawGlyphs& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyDrawGlyphs(context, resourceHeap, item))
@@ -166,7 +169,7 @@ ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resource
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const DrawDisplayListItems& item) -> ApplyItemResult {
-            item.apply(context, resourceHeap);
+            item.apply(context, resourceHeap, controlFactory);
             return { };
         }, [&](const DrawFilteredImageBuffer& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyFilteredImageBufferItem(context, resourceHeap, item))

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -35,6 +35,7 @@ class TextStream;
 
 namespace WebCore {
 
+class ControlFactory;
 class GraphicsContext;
 
 namespace DisplayList {
@@ -220,7 +221,7 @@ enum class AsTextFlag : uint8_t {
 
 bool isValid(const Item&);
 
-ApplyItemResult applyItem(GraphicsContext&, const ResourceHeap&, const Item&);
+ApplyItemResult applyItem(GraphicsContext&, const ResourceHeap&, ControlFactory&, const Item&);
 
 bool shouldDumpItem(const Item&, OptionSet<AsTextFlag>);
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -339,9 +339,9 @@ DrawDisplayListItems::DrawDisplayListItems(Vector<Item>&& items, const FloatPoin
 {
 }
 
-void DrawDisplayListItems::apply(GraphicsContext& context, const ResourceHeap& resourceHeap) const
+void DrawDisplayListItems::apply(GraphicsContext& context, const ResourceHeap& resourceHeap, ControlFactory& controlFactory) const
 {
-    context.drawDisplayListItems(m_items, resourceHeap, m_destination);
+    context.drawDisplayListItems(m_items, resourceHeap, controlFactory, m_destination);
 }
 
 NO_RETURN_DUE_TO_ASSERT void DrawDisplayListItems::apply(GraphicsContext&) const
@@ -868,8 +868,9 @@ DrawControlPart::DrawControlPart(ControlPart& part, const FloatRoundedRect& bord
 {
 }
 
-void DrawControlPart::apply(GraphicsContext& context) const
+void DrawControlPart::apply(GraphicsContext& context, ControlFactory& controlFactory) const
 {
+    m_part->setControlFactory(controlFactory);
     context.drawControlPart(m_part, m_borderRect, m_deviceScaleFactor, m_style);
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -49,6 +49,7 @@ class TextStream;
 
 namespace WebCore {
 
+class ControlFactory;
 struct ImagePaintingOptions;
 
 namespace DisplayList {
@@ -548,7 +549,7 @@ public:
     const Vector<Item>& items() const { return m_items; }
     FloatPoint destination() const { return m_destination; }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&, const ResourceHeap&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, const ResourceHeap&, ControlFactory&) const;
     NO_RETURN_DUE_TO_ASSERT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
@@ -1467,7 +1468,7 @@ public:
     const ControlStyle& style() const { return m_style; }
     StyleAppearance type() const { return m_part->type(); }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, ControlFactory&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -236,7 +236,7 @@ void Recorder::drawGlyphsAndCacheResources(const Font& font, const GlyphBufferGl
     recordDrawGlyphs(font, glyphs, advances, numGlyphs, localAnchor, smoothingMode);
 }
 
-void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHeap& resourceHeap, const FloatPoint& destination)
+void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory&, const FloatPoint& destination)
 {
     appendStateChangeItemIfNecessary();
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -239,7 +239,7 @@ private:
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
     WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
 
-    WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, const FloatPoint& destination) final;
+    WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, ControlFactory&, const FloatPoint& destination) final;
 
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DisplayListReplayer.h"
 
+#include "ControlFactory.h"
 #include "DisplayList.h"
 #include "Logging.h"
 #include <wtf/text/TextStream.h>
@@ -34,14 +35,15 @@ namespace WebCore {
 namespace DisplayList {
 
 Replayer::Replayer(GraphicsContext& context, const DisplayList& displayList)
-    : Replayer(context, displayList.items(), displayList.resourceHeap())
+    : Replayer(context, displayList.items(), displayList.resourceHeap(), ControlFactory::shared())
 {
 }
 
-Replayer::Replayer(GraphicsContext& context, const Vector<Item>& items, const ResourceHeap& resourceHeap)
+Replayer::Replayer(GraphicsContext& context, const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory& controlFactory)
     : m_context(context)
     , m_items(items)
     , m_resourceHeap(resourceHeap)
+    , m_controlFactory(controlFactory)
 {
 }
 
@@ -61,7 +63,7 @@ ReplayResult Replayer::replay(const FloatRect& initialClip, bool trackReplayList
     for (auto& item : m_items) {
         LOG_WITH_STREAM(DisplayLists, stream << "applying " << i++ << " " << item);
 
-        auto applyResult = applyItem(m_context, m_resourceHeap, item);
+        auto applyResult = applyItem(m_context, m_resourceHeap, m_controlFactory, item);
         if (applyResult.stopReason) {
             result.reasonForStopping = *applyResult.stopReason;
             result.missingCachedResourceIdentifier = WTFMove(applyResult.resourceIdentifier);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class ControlFactory;
 class FloatRect;
 class GraphicsContext;
 
@@ -49,7 +50,7 @@ class Replayer {
     WTF_MAKE_NONCOPYABLE(Replayer);
 public:
     WEBCORE_EXPORT Replayer(GraphicsContext&, const DisplayList&);
-    WEBCORE_EXPORT Replayer(GraphicsContext&, const Vector<Item>&, const ResourceHeap&);
+    WEBCORE_EXPORT Replayer(GraphicsContext&, const Vector<Item>&, const ResourceHeap&, ControlFactory&);
     ~Replayer() = default;
 
     WEBCORE_EXPORT ReplayResult replay(const FloatRect& initialClip = { }, bool trackReplayList = false);
@@ -58,6 +59,7 @@ private:
     GraphicsContext& m_context;
     const Vector<Item>& m_items;
     const ResourceHeap& m_resourceHeap;
+    Ref<ControlFactory> m_controlFactory;
 };
 
 } // namespace DisplayList

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
@@ -32,9 +32,9 @@
 
 namespace WebCore {
 
-std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
+RefPtr<ControlFactory> ControlFactory::create()
 {
-    return makeUnique<ControlFactoryIOS>();
+    return adoptRef(new ControlFactoryIOS());
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformButton(ButtonPart&)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -41,7 +41,7 @@ class ControlFactoryMac final : public ControlFactoryCocoa {
 public:
     using ControlFactoryCocoa::ControlFactoryCocoa;
 
-    static ControlFactoryMac& sharedControlFactory();
+    static ControlFactoryMac& shared();
 
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -57,14 +57,14 @@
 
 namespace WebCore {
 
-std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
+RefPtr<ControlFactory> ControlFactory::create()
 {
-    return makeUnique<ControlFactoryMac>();
+    return adoptRef(new ControlFactoryMac());
 }
 
-ControlFactoryMac& ControlFactoryMac::sharedControlFactory()
+ControlFactoryMac& ControlFactoryMac::shared()
 {
-    return static_cast<ControlFactoryMac&>(ControlFactory::sharedControlFactory());
+    return static_cast<ControlFactoryMac&>(ControlFactory::shared());
 }
 
 NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle& style) const

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -45,7 +45,7 @@ ImageControlsButtonMac::ImageControlsButtonMac(ImageControlsButtonPart& owningPa
 
 IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
 {
-    auto& controlFactory = ControlFactoryMac::sharedControlFactory();
+    auto& controlFactory = ControlFactoryMac::shared();
     if (auto* servicesRolloverButtonCell = controlFactory.servicesRolloverButtonCell())
         return IntSize { [servicesRolloverButtonCell cellSize] };
     return { };

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "TextPainter.h"
 
+#include "ControlFactory.h"
 #include "DisplayListRecorderImpl.h"
 #include "DisplayListReplayer.h"
 #include "FilterOperations.h"
@@ -121,7 +122,7 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
         m_context.drawText(font, textRun, textOrigin, startOffset, endOffset);
     else {
         // Replaying back a whole cached glyph run to the GraphicsContext.
-        m_context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), textOrigin);
+        m_context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), ControlFactory::shared(), textOrigin);
     }
     m_glyphDisplayList = nullptr;
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -66,6 +66,13 @@ RemoteResourceCache& RemoteDisplayListRecorder::resourceCache() const
     return m_renderingBackend->remoteResourceCache();
 }
 
+ControlFactory& RemoteDisplayListRecorder::controlFactory()
+{
+    if (!m_controlFactory)
+        m_controlFactory = ControlFactory::create();
+    return *m_controlFactory;
+}
+
 RefPtr<ImageBuffer> RemoteDisplayListRecorder::imageBuffer(RenderingResourceIdentifier identifier) const
 {
     return m_renderingBackend->imageBuffer(identifier);
@@ -330,7 +337,7 @@ void RemoteDisplayListRecorder::drawDecomposedGlyphs(RenderingResourceIdentifier
 
 void RemoteDisplayListRecorder::drawDisplayListItems(Vector<WebCore::DisplayList::Item>&& items, const FloatPoint& destination)
 {
-    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap());
+    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap(), controlFactory());
 }
 
 void RemoteDisplayListRecorder::drawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -614,10 +621,7 @@ void RemoteDisplayListRecorder::clearRect(const FloatRect& rect)
 
 void RemoteDisplayListRecorder::drawControlPart(Ref<ControlPart> part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    if (!m_controlFactory)
-        m_controlFactory = ControlFactory::createControlFactory();
-    part->setControlFactory(m_controlFactory.get());
-    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style));
+    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style), controlFactory());
 }
 
 #if USE(CG)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -149,6 +149,7 @@ private:
     void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
 
     RemoteResourceCache& resourceCache() const;
+    WebCore::ControlFactory& controlFactory();
     WebCore::GraphicsContext& drawingContext() { return m_imageBuffer->context(); }
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier) const;
     std::optional<WebCore::SourceImage> sourceImage(WebCore::RenderingResourceIdentifier) const;
@@ -178,7 +179,7 @@ private:
     WebCore::RenderingResourceIdentifier m_imageBufferIdentifier;
     RefPtr<RemoteRenderingBackend> m_renderingBackend;
     Ref<RemoteSharedResourceCache> m_sharedResourceCache;
-    std::unique_ptr<WebCore::ControlFactory> m_controlFactory;
+    RefPtr<WebCore::ControlFactory> m_controlFactory;
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     std::unique_ptr<SharedVideoFrameReader> m_sharedVideoFrameReader;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -27,6 +27,7 @@
 
 #if USE(CG)
 
+#include <WebCore/ControlFactory.h>
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/DisplayList.h>
 #include <WebCore/DisplayListItems.h>
@@ -74,7 +75,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
         ResourceHeap resourceHeap;
         resourceHeap.add(imageBuffer.releaseNonNull());
 
-        Replayer replayer { context, list.items(), resourceHeap };
+        Replayer replayer { context, list.items(), resourceHeap, ControlFactory::shared() };
         auto result = replayer.replay();
         EXPECT_EQ(result.reasonForStopping, StopReplayReason::ReplayedAllItems);
         EXPECT_EQ(result.missingCachedResourceIdentifier, std::nullopt);


### PR DESCRIPTION
#### 9e6f0cd6c86a4292c888a02a7eb701bb30877609
<pre>
[CoreIPC] -[NSButtonCell isKindOfClass:]: message sent to deallocated instance in WebCore::ControlMac::drawCellInternal
<a href="https://bugs.webkit.org/show_bug.cgi?id=273788">https://bugs.webkit.org/show_bug.cgi?id=273788</a>
<a href="https://rdar.apple.com/126071623">rdar://126071623</a>

Reviewed by Said Abou-Hallawa.

`ControlFactory` is not a thread-safe object, and the shared factory should
only ever be used on the main thread. The shared factory is used by
`ControlPart` if one is not already assigned.

Currently, an attempt at ensuring thread-safety is made by avoiding use of
the shared factory on `RemoteRenderingBackend` work queues, by creating and
assigning a thread-specific `ControlFactory` to a `ControlPart` in
`RemoteDisplayListRecorder::drawControlPart`. However, this logic does not
account for the fact that the `DrawControlPart` display list item can also be
applied as a result of applying `DrawDisplayListItems`. In this scenario, the
`ControlPart` will have a null `ControlFactory`, and will simply fall back to
using the shared factory.

Fix by ensuring the creation of a `ControlFactory` in
`RemoteDisplayListRecorder::drawDisplayListItems`, and adding the necessary
plumbing to ensure `ControlPart`s drawn as a result of applying
`DrawDisplayListItems` use a thread-specific factory.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawDisplayListItems):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/controls/ControlFactory.cpp:
(WebCore::ControlFactory::create):

Remove the release assert for other platforms, as `ControlFactory` is created
when drawing display list items. However, other platforms will continue to not
actually draw `ControlPart`s, using the empty implementation.

(WebCore::ControlFactory::shared):

Use `MainThreadNeverDestroyed`, as the shared factory is not thread-safe.

(WebCore::ControlFactory::createControlFactory): Deleted.
(WebCore::ControlFactory::sharedControlFactory): Deleted.
* Source/WebCore/platform/graphics/controls/ControlFactory.h:

Make `ControlFactory` ref-counted to avoid raw pointer usage in member variables.

Rename static methods to match WebKit convention.

* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::controlFactory const):
* Source/WebCore/platform/graphics/controls/ControlPart.h:
(WebCore::ControlPart::setControlFactory):
(): Deleted.
* Source/WebCore/platform/graphics/controls/EmptyControlFactory.cpp: Added.
(WebCore::EmptyControlFactory::createPlatformApplePayButton):
(WebCore::EmptyControlFactory::createPlatformButton):
(WebCore::EmptyControlFactory::createPlatformColorWell):
(WebCore::EmptyControlFactory::createPlatformImageControlsButton):
(WebCore::EmptyControlFactory::createPlatformInnerSpinButton):
(WebCore::EmptyControlFactory::createPlatformMenuList):
(WebCore::EmptyControlFactory::createPlatformMenuListButton):
(WebCore::EmptyControlFactory::createPlatformMeter):
(WebCore::EmptyControlFactory::createPlatformProgressBar):
(WebCore::EmptyControlFactory::createPlatformSearchField):
(WebCore::EmptyControlFactory::createPlatformSearchFieldCancelButton):
(WebCore::EmptyControlFactory::createPlatformSearchFieldResults):
(WebCore::EmptyControlFactory::createPlatformSliderThumb):
(WebCore::EmptyControlFactory::createPlatformSliderTrack):
(WebCore::EmptyControlFactory::createPlatformSwitchThumb):
(WebCore::EmptyControlFactory::createPlatformSwitchTrack):
(WebCore::EmptyControlFactory::createPlatformTextArea):
(WebCore::EmptyControlFactory::createPlatformTextField):
(WebCore::EmptyControlFactory::createPlatformToggleButton):
* Source/WebCore/platform/graphics/controls/EmptyControlFactory.h: Added.
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawDisplayListItems::apply const):
(WebCore::DisplayList::DrawControlPart::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawDisplayListItems):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp:
(WebCore::DisplayList::Replayer::Replayer):
(WebCore::DisplayList::Replayer::replay):
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h:
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm:
(WebCore::ControlFactory::create):
(WebCore::ControlFactory::createControlFactory): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactory::create):
(WebCore::ControlFactoryMac::shared):
(WebCore::ControlFactory::createControlFactory): Deleted.
(WebCore::ControlFactoryMac::sharedControlFactory): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
(WebCore::ImageControlsButtonMac::servicesRolloverButtonCellSize):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextOrEmphasisMarks):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::controlFactory):
(WebKit::RemoteDisplayListRecorder::drawDisplayListItems):

This is the important part of the fix. A thread-specific `ControlFactory` must
be specified for `DrawDisplayListItems`, so that contained `DrawControlPart`
items do not use the shared factory.

(WebKit::RemoteDisplayListRecorder::drawControlPart):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):

Originally-landed-as: 272448.998@safari-7618-branch (dac0ebcb77d8). <a href="https://rdar.apple.com/132958419">rdar://132958419</a>
Canonical link: <a href="https://commits.webkit.org/282012@main">https://commits.webkit.org/282012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a93fb812c7f0ea5d9ac9f285cf8c5fb622d1b83b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49777 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8511 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5662 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10752 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57154 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57382 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4656 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9304 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36873 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->