### PR TITLE
WidthCache experiment: cache with constant spacing

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -307,8 +307,7 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
             glyphOverflow = nullptr;
     }
 
-    bool hasWordSpacingOrLetterSpacing = wordSpacing() || letterSpacing();
-    float* cacheEntry = protectedFonts()->widthCache().add(run, std::numeric_limits<float>::quiet_NaN(), enableKerning() || requiresShaping(), hasWordSpacingOrLetterSpacing, glyphOverflow);
+    float* cacheEntry = protectedFonts()->widthCache().add(run, std::numeric_limits<float>::quiet_NaN(), enableKerning() || requiresShaping(), false, glyphOverflow);
     if (cacheEntry && !std::isnan(*cacheEntry))
         return *cacheEntry;
 

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -135,11 +135,9 @@ public:
 
     float* add(const TextRun& run, float entry, bool hasKerningOrLigatures, bool hasWordSpacingOrLetterSpacing, GlyphOverflow* glyphOverflow)
     {
+        UNUSED_PARAM(hasWordSpacingOrLetterSpacing);
         // The width cache is not really profitable unless we're doing expensive glyph transformations.
         if (!hasKerningOrLigatures)
-            return nullptr;
-        // Word spacing and letter spacing can change the width of a word.
-        if (hasWordSpacingOrLetterSpacing)
             return nullptr;
         // Since this is just a width cache, we don't have enough information to satisfy glyph queries.
         if (glyphOverflow)


### PR DESCRIPTION
#### 3ee57f7fea2eb9493a38542df43dfa15184fe361
<pre>
WidthCache experiment: cache with constant spacing
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::width const):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::add):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee57f7fea2eb9493a38542df43dfa15184fe361

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12380 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49684 "Found 9 new test failures: css1/text_properties/letter_spacing.html css1/text_properties/word_spacing.html fast/css/word-space-extra.html fast/css/word-spacing-between-blocks.html fast/text/atsui-spacing-features.html fast/text/text-letter-spacing.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-001.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-003.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-005.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8411 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64634 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38021 "Found 6 new test failures: css1/text_properties/letter_spacing.html css1/text_properties/word_spacing.html fast/css/word-space-extra.html fast/css/word-spacing-between-blocks.html fast/forms/datalist/datalist-option-labels.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30520 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34683 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; 4 new passes 8 flakes 4 failures; Uploaded test results; 4 new passes 7 flakes 5 failures; Compiled WebKit (warnings); layout-tests running") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10554 "Found 6 new test failures: css1/text_properties/letter_spacing.html css1/text_properties/word_spacing.html fast/css/word-space-extra.html fast/css/word-spacing-between-blocks.html fast/text/text-letter-spacing.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-005.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56490 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10853 "Found 6 new test failures: css1/text_properties/letter_spacing.html css1/text_properties/word_spacing.html fast/css/word-space-extra.html fast/css/word-spacing-between-blocks.html fast/text/text-letter-spacing.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-005.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5505 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10655 "Found 6 new test failures: css1/text_properties/letter_spacing.html css1/text_properties/word_spacing.html fast/css/word-space-extra.html fast/css/word-spacing-between-blocks.html fast/text/text-letter-spacing.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-005.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57066 "Found 9 new test failures: css1/text_properties/letter_spacing.html css1/text_properties/word_spacing.html fast/css/word-space-extra.html fast/css/word-spacing-between-blocks.html fast/text/atsui-spacing-features.html fast/text/text-letter-spacing.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-001.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-003.html imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-005.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57284 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4532 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36718 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->