### PR TITLE
imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context-expected.txt
@@ -1,5 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
 
-TIMEOUT readyState accessor is valid after execution context is destroyed Test timed out
+PASS readyState accessor is valid after execution context is destroyed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context.html
@@ -10,6 +10,7 @@
 function load_iframe() {
     return new Promise(resolve => {
         const iframe = document.createElement('iframe');
+        iframe.id = "iframeid";
         iframe.onload = () => { resolve(iframe); };
         document.documentElement.appendChild(iframe);
     });
@@ -21,11 +22,8 @@ promise_test(async t => {
     const openRequest = iframe.contentWindow.indexedDB.open(dbname);
     assert_equals(openRequest.readyState, 'pending');
     iframe.remove();
-    await new Promise(resolve => {
-      openRequest.onerror = resolve;
-      openRequest.onsuccess = resolve;
-    });
-    assert_equals(openRequest.readyState, 'done');
+    await load_iframe();
+    assert_equals(typeof openRequest.readyState, 'string');
 }, 'readyState accessor is valid after execution context is destroyed');
 
 </script>


### PR DESCRIPTION
#### a9b6234df734e51e893d710d8e41d26f609e8dd8
<pre>
imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=277753">https://bugs.webkit.org/show_bug.cgi?id=277753</a>
<a href="https://rdar.apple.com/133400072">rdar://133400072</a>

Reviewed by NOBODY (OOPS!).

The test expects event to be dispatched to IDBRequest after its execution context is stopped (iframe is removed), and
this is not standard behavior. Browsers can choose to not dispatch events when script execution context stops, as in
Chrome and Safari nowadays. Update the test to wait on a new iframe with the same id to be loaded, instead of waiting on
event to be dispatched on IDBRequest. Also, since the goal of the test is to verify the accessor is valid after
execution context is destroyed (no exception is thrown), update the check to validate the type of the result, instead of
value of the result.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/ready-state-destroyed-execution-context.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b6234df734e51e893d710d8e41d26f609e8dd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14159 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12117 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12390 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8422 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53329 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10561 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11048 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67275 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57292 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4539 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36728 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37813 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->