### PR TITLE
Read host app info from extension process directly in webpushd

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -44,7 +44,7 @@ void Connection::newConnectionWasInitialized() const
     if (networkSession().sessionID().isEphemeral())
         return;
 
-    sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(m_configuration));
+    sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(m_configuration));
 }
 
 static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)

--- a/Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h
@@ -41,6 +41,8 @@ extern const NSTimeInterval RBSProcessTimeLimitationNone;
 
 #else
 
+#import <mach/message.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RBSAttribute : NSObject
@@ -105,6 +107,8 @@ extern const NSTimeInterval RBSProcessTimeLimitationNone;
 @property (nonatomic, readonly, assign) pid_t pid;
 @property (nonatomic, readonly, strong) RBSProcessState *currentState;
 @property (nonatomic, readonly, strong) RBSProcessLimitations *activeLimitations;
+@property (nonatomic, readonly, strong, nullable) RBSProcessHandle *hostProcess;
+@property (nonatomic, readonly, assign) audit_token_t auditToken;
 @end
 
 @interface RBSProcessStateUpdate : NSObject

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
@@ -186,6 +186,10 @@
 (allow file-read*
     (home-subpath "/Library/WebClips"))
 
+;; Support for looking up host apps from extensions.
+(allow mach-lookup
+    (global-name "com.apple.runningboard"))
+
 ;; Daemon prefs.
 (allow user-preference-read user-preference-write
     (preference-domain "com.apple.webkit.webpushd"))

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -32,8 +32,7 @@
 namespace WebKit::WebPushD {
 
 struct WebPushDaemonConnectionConfiguration {
-    bool useMockBundlesForTesting { false };
-    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    Vector<uint8_t> hostAppAuditTokenData;
     String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -23,8 +23,7 @@
 webkit_platform_headers: "ArgumentCoders.h" "WebPushDaemonConnectionConfiguration.h"
 
 [CustomHeader, WebKitPlatform] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
-    bool useMockBundlesForTesting;
-    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    Vector<uint8_t> hostAppAuditTokenData;
     String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -106,7 +106,6 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));
-@property (nonatomic) BOOL webPushDaemonUsesMockBundlesForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -802,16 +802,6 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
     _configuration->setAllLoadsBlockedByDeviceManagementRestrictionsForTesting(blocked);
 }
 
-- (BOOL)webPushDaemonUsesMockBundlesForTesting
-{
-    return _configuration->webPushDaemonUsesMockBundlesForTesting();
-}
-
-- (void)setWebPushDaemonUsesMockBundlesForTesting:(BOOL)usesMockBundles
-{
-    _configuration->setWebPushDaemonUsesMockBundlesForTesting(usesMockBundles);
-}
-
 - (BOOL)resourceLoadStatisticsDebugModeEnabled
 {
     return _configuration->resourceLoadStatisticsDebugModeEnabled();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -142,7 +142,6 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_httpsProxy = this->m_httpsProxy;
     copy->m_deviceManagementRestrictionsEnabled = this->m_deviceManagementRestrictionsEnabled;
     copy->m_allLoadsBlockedByDeviceManagementRestrictionsForTesting = this->m_allLoadsBlockedByDeviceManagementRestrictionsForTesting;
-    copy->m_webPushDaemonUsesMockBundlesForTesting = this->m_webPushDaemonUsesMockBundlesForTesting;
     copy->m_boundInterfaceIdentifier = this->m_boundInterfaceIdentifier;
     copy->m_allowsCellularAccess = this->m_allowsCellularAccess;
     copy->m_legacyTLSEnabled = this->m_legacyTLSEnabled;
@@ -176,7 +175,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 
 WebPushD::WebPushDaemonConnectionConfiguration WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration() const
 {
-    return { m_webPushDaemonUsesMockBundlesForTesting, { }, { }, m_webPushPartitionString, m_identifier };
+    return { { }, { }, m_webPushPartitionString, m_identifier };
 }
 
 WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Directories::isolatedCopy() const &

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -209,8 +209,6 @@ public:
     bool allLoadsBlockedByDeviceManagementRestrictionsForTesting() const { return m_allLoadsBlockedByDeviceManagementRestrictionsForTesting; }
     void setAllLoadsBlockedByDeviceManagementRestrictionsForTesting(bool blocked) { m_allLoadsBlockedByDeviceManagementRestrictionsForTesting = blocked; }
 
-    bool webPushDaemonUsesMockBundlesForTesting() const { return m_webPushDaemonUsesMockBundlesForTesting; }
-    void setWebPushDaemonUsesMockBundlesForTesting(bool usesMockBundles) { m_webPushDaemonUsesMockBundlesForTesting = usesMockBundles; }
     WebPushD::WebPushDaemonConnectionConfiguration webPushDaemonConnectionConfiguration() const;
 
     const String& dataConnectionServiceType() const { return m_dataConnectionServiceType; }
@@ -309,7 +307,6 @@ private:
     URL m_httpsProxy;
     bool m_deviceManagementRestrictionsEnabled { false };
     bool m_allLoadsBlockedByDeviceManagementRestrictionsForTesting { false };
-    bool m_webPushDaemonUsesMockBundlesForTesting { false };
     bool m_allowsCellularAccess { true };
     bool m_legacyTLSEnabled { true };
     bool m_fastServerTrustEvaluationEnabled { false };

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -72,20 +72,14 @@ using PushClientConnectionIdentifier = AtomicObjectIdentifier<PushClientConnecti
 class PushClientConnection : public RefCounted<PushClientConnection>, public Identified<PushClientConnectionIdentifier>, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<PushClientConnection> create(xpc_connection_t);
+    static RefPtr<PushClientConnection> create(xpc_connection_t, IPC::Decoder&);
 
-    bool hasHostAppAuditToken() const { return !!m_hostAppAuditToken; }
-
-    WebCore::PushSubscriptionSetIdentifier subscriptionSetIdentifier();
-    const String& hostAppCodeSigningIdentifier();
-
-    bool hostAppHasPushEntitlement();
-    bool hostAppHasPushInjectEntitlement();
+    WebCore::PushSubscriptionSetIdentifier subscriptionSetIdentifier() const;
+    const String& hostAppCodeSigningIdentifier() const { return m_hostAppCodeSigningIdentifier; }
+    bool hostAppHasPushInjectEntitlement() const { return m_hostAppHasPushInjectEntitlement; };
 
     const String& pushPartitionString() const { return m_pushPartitionString; }
     std::optional<WTF::UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
-
-    bool useMockBundlesForTesting() const { return m_useMockBundlesForTesting; }
 
     void connectionClosed();
 
@@ -96,7 +90,7 @@ public:
 #endif
 
 private:
-    PushClientConnection(xpc_connection_t);
+    PushClientConnection(xpc_connection_t, String&& hostAppCodeSigningIdentifier, bool hostAppHasPushInjectEntitlement, String&& pushPartitionString, std::optional<WTF::UUID>&& dataStoreIdentifier);
 
     // PushClientConnectionMessages
     void setPushAndNotificationsEnabledForOrigin(const String& originString, bool, CompletionHandler<void()>&& replySender);
@@ -111,7 +105,7 @@ private:
     void removeAllPushSubscriptions(CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
     void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
-    void updateConnectionConfiguration(WebPushDaemonConnectionConfiguration&&);
+    void initializeConnection(WebPushDaemonConnectionConfiguration&&);
     void getPushPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&);
     void requestPushPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
@@ -123,25 +117,15 @@ private:
     void setAppBadge(WebCore::SecurityOriginData&&, std::optional<uint64_t>);
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
 
-    String bundleIdentifierFromAuditToken(audit_token_t);
-    bool hostHasEntitlement(ASCIILiteral);
-
     OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    String m_hostAppCodeSigningIdentifier;
+    bool m_hostAppHasPushInjectEntitlement { false };
+    String m_pushPartitionString;
+    Markable<WTF::UUID> m_dataStoreIdentifier;
 
 #if PLATFORM(IOS)
     mutable RetainPtr<UIWebClip> m_associatedWebClip;
 #endif
-
-    std::optional<audit_token_t> m_hostAppAuditToken;
-    std::optional<String> m_hostAppCodeSigningIdentifier;
-    std::optional<bool> m_hostAppHasPushEntitlement;
-
-    String m_bundleIdentifierOverride;
-    String m_pushPartitionString;
-    Markable<WTF::UUID> m_dataStoreIdentifier;
-
-    bool m_debugModeEnabled { false };
-    bool m_useMockBundlesForTesting { false };
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -26,7 +26,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     SetPushAndNotificationsEnabledForOrigin(String originString, bool enabled) -> ()
     GetPendingPushMessage() -> (std::optional<WebKit::WebPushMessage> message)
     GetPendingPushMessages() -> (Vector<WebKit::WebPushMessage> messages)
-    UpdateConnectionConfiguration(WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration)
+    InitializeConnection(WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration)
     InjectPushMessageForTesting(WebKit::WebPushD::PushMessageForTesting message) -> (String error)
     InjectEncryptedPushMessageForTesting(String encryptedMessage) -> (bool injected)
     SubscribeToPushService(URL scopeURL, Vector<uint8_t> vapidPublicKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -121,6 +121,7 @@ private:
     void didShowNotification(const WebCore::PushSubscriptionSetIdentifier&, const String& scope);
 
     PushClientConnection* toPushClientConnection(xpc_connection_t);
+    HashSet<xpc_connection_t> m_pendingConnectionSet;
     HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;
 
     std::unique_ptr<PushService> m_pushService;

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -46,6 +46,14 @@
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/MakeString.h>
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPushDaemonMainAdditions.mm>)
+#import <WebKitAdditions/WebPushDaemonMainAdditions.mm>
+#endif
+
+#if !defined(WEB_PUSH_DAEMON_MAIN_ADDITIONS)
+#define WEB_PUSH_DAEMON_MAIN_ADDITIONS
+#endif
+
 using WebKit::Daemon::EncodedMessage;
 using WebPushD::WebPushDaemon;
 
@@ -110,8 +118,9 @@ int WebPushDaemonMain(int argc, char** argv)
 {
     @autoreleasepool {
         WTF::initializeMainThread();
-        
+
         auto transaction = adoptOSObject(os_transaction_create("com.apple.webkit.webpushd.push-service-main"));
+        auto peerEntitlementName = entitlementName;
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
         _CFPrefsSetDirectModeEnabled(YES);
@@ -153,7 +162,9 @@ int WebPushDaemonMain(int argc, char** argv)
             }
         }
 
-        WebKit::startListeningForMachServiceConnections(machServiceName, entitlementName, connectionAdded, connectionRemoved, connectionEventHandler);
+        WEB_PUSH_DAEMON_MAIN_ADDITIONS;
+
+        WebKit::startListeningForMachServiceConnections(machServiceName, peerEntitlementName, connectionAdded, connectionRemoved, connectionEventHandler);
 
         if (useMockPushService)
             ::WebPushD::WebPushDaemon::singleton().startMockPushService();

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -134,7 +134,6 @@ void Connection::sendAuditToken()
     }
 
     WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration;
-    configuration.useMockBundlesForTesting = true;
     configuration.bundleIdentifierOverride = m_bundleIdentifier;
     configuration.pushPartitionString = m_pushPartition;
 
@@ -143,7 +142,7 @@ void Connection::sendAuditToken()
     memcpy(tokenVector.data(), &token, sizeof(token));
     configuration.hostAppAuditTokenData = WTFMove(tokenVector);
 
-    sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(WTFMove(configuration)));
+    sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTFMove(configuration)));
 }
 
 static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -318,7 +318,7 @@ RetainPtr<xpc_connection_t> createAndConfigureConnectionToService(const char* se
 
     if (!configuration)
         configuration = defaultWebPushDaemonConfiguration();
-    sender.sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(configuration.value()));
+    sender.sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(configuration.value()));
 
     return WTFMove(connection);
 }
@@ -341,7 +341,7 @@ TEST(WebPushD, BasicCommunication)
 
     // Send a basic message and make sure its reply handler ran.
     auto sender = WebPushXPCConnectionMessageSender { connection.get() };
-    sender.sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(defaultWebPushDaemonConfiguration()));
+    sender.sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(defaultWebPushDaemonConfiguration()));
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushTopicsForTesting(), ^(Vector<String>, Vector<String>) {
         done = true;
     });
@@ -716,7 +716,6 @@ public:
             (NSString *)kCFStreamPropertyHTTPSProxyPort: @(m_server->port())
         }];
         dataStoreConfiguration.get().webPushMachServiceName = @"org.webkit.webpushtestdaemon.service";
-        dataStoreConfiguration.get().webPushDaemonUsesMockBundlesForTesting = YES;
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
         dataStoreConfiguration.get().isDeclarativeWebPushEnabled = YES;
@@ -2280,7 +2279,6 @@ TEST(WebPushD, DeclarativeParsing)
 
     auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().webPushMachServiceName = @"org.webkit.webpushtestdaemon.service";
-    dataStoreConfiguration.get().webPushDaemonUsesMockBundlesForTesting = YES;
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     clearWebsiteDataStore(dataStore.get());
 
@@ -2335,7 +2333,6 @@ TEST(WebPushD, DeclarativeWebPushHandling)
 
     auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().webPushMachServiceName = @"org.webkit.webpushtestdaemon.service";
-    dataStoreConfiguration.get().webPushDaemonUsesMockBundlesForTesting = YES;
     dataStoreConfiguration.get().isDeclarativeWebPushEnabled = YES;
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     clearWebsiteDataStore(dataStore.get());


### PR DESCRIPTION
#### c9c593aab62e8afdbbc714677a087029754184ed
<pre>
Read host app info from extension process directly in webpushd
<a href="https://bugs.webkit.org/show_bug.cgi?id=277755">https://bugs.webkit.org/show_bug.cgi?id=277755</a>
<a href="https://rdar.apple.com/131367853">rdar://131367853</a>

Reviewed by Brady Eidson.

Currently webpushd depends on the remote process (which is NetworkProcess) to provide the audit
token of the host app as part of a connection setup IPC message. When ExtensionKit is enabled,
instead of having to trust the remote process for that info, we can just read the audit token of the
host app directly from within webpushd.

The main refactoring here is making it so that `PushClientConnection` represents a connection to a
valid peer (i.e. one associated with a host app with the appropriate entitlements and with a
non-empty code signing identifier). As part of this, I renamed the UpdateConnectionConfiguration
message to InitializeConnection, and enforce that it is the first message sent on the
connection. Previously, `PushClientConnection` could be in an invalid state while awaiting the
UpdateConnectionConfiguration message, and we also had code that dealt with
UpdateConnectionConfiguration being sent multiple times. I deleted all of that code since you now
can&apos;t have a connection that is in an invalid state.

I also deleted the webPushDaemonUsesMockBundlesForTesting member variable since it was unused.

* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::newConnectionWasInitialized const):
* Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
(): Deleted.
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration webPushDaemonUsesMockBundlesForTesting]): Deleted.
(-[_WKWebsiteDataStoreConfiguration setWebPushDaemonUsesMockBundlesForTesting:]): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
(WebKit::WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::webPushDaemonUsesMockBundlesForTesting const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::setWebPushDaemonUsesMockBundlesForTesting): Deleted.
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::PushClientConnection::hostAppCodeSigningIdentifier const):
(WebPushD::PushClientConnection::hostAppHasPushInjectEntitlement const):
(WebPushD::PushClientConnection::hasHostAppAuditToken const): Deleted.
(WebPushD::PushClientConnection::useMockBundlesForTesting const): Deleted.
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::hostAppHasEntitlement):
(WebPushD::bundleIdentifierFromAuditToken):
(WebPushD::PushClientConnection::create):
(WebPushD::PushClientConnection::PushClientConnection):
(WebPushD::PushClientConnection::initializeConnection):
(WebPushD::PushClientConnection::getPushTopicsForTesting):
(WebPushD::PushClientConnection::subscriptionSetIdentifier const):
(WebPushD::PushClientConnection::connectionClosed):
(WebPushD::PushClientConnection::updateConnectionConfiguration): Deleted.
(WebPushD::PushClientConnection::setHostAppAuditTokenData): Deleted.
(WebPushD::PushClientConnection::subscriptionSetIdentifier): Deleted.
(WebPushD::PushClientConnection::hostAppCodeSigningIdentifier): Deleted.
(WebPushD::PushClientConnection::bundleIdentifierFromAuditToken): Deleted.
(WebPushD::PushClientConnection::hostAppHasPushEntitlement): Deleted.
(WebPushD::PushClientConnection::hostAppHasPushInjectEntitlement): Deleted.
(WebPushD::PushClientConnection::hostHasEntitlement): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::connectionAdded):
(WebPushD::WebPushDaemon::connectionRemoved):
(WebPushD::WebPushDaemon::getPendingPushMessage):
(WebPushD::WebPushDaemon::getPendingPushMessages):
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::sendAuditToken):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::createAndConfigureConnectionToService):
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):
(TestWebKitAPI::(WebPushD, DeclarativeParsing)):
(TestWebKitAPI::(WebPushD, DeclarativeWebPushHandling)):

Canonical link: <a href="https://commits.webkit.org/282035@main">https://commits.webkit.org/282035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ef46a31fdaf51dad224fa55ccb0f81ceda296a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65827 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38262 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/30672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56715 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53515 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4745 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->