### PR TITLE
Add media element watchtime diagnostic logging

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -239,6 +239,7 @@ static const Seconds ScanRepeatDelay { 1.5_s };
 static const double ScanMaximumRate = 8;
 static const double AutoplayInterferenceTimeThreshold = 10;
 static const Seconds hideMediaControlsAfterEndedDelay { 6_s };
+static const Seconds WatchtimeTimerInterval { 5_min };
 
 #if ENABLE(MEDIA_SOURCE)
 // URL protocol used to signal that the media source API is being used.
@@ -473,6 +474,72 @@ struct HTMLMediaElement::CueData {
     CueList currentlyActiveCues;
 };
 
+class PausableIntervalTimer final : public TimerBase {
+public:
+    PausableIntervalTimer(Seconds interval, Function<void()>&& function)
+        : m_interval { interval }
+        , m_function { WTFMove(function) }
+        , m_remainingInterval { interval }
+    {
+    }
+
+    void start()
+    {
+        m_startTime = MonotonicTime::now();
+        TimerBase::start(m_remainingInterval, m_interval);
+    }
+
+    void stop()
+    {
+        m_remainingInterval = m_interval;
+        TimerBase::stop();
+    }
+
+    void pause()
+    {
+        if (!isActive())
+            return;
+
+        auto partialInterval = MonotonicTime::now() - m_startTime;
+        m_remainingInterval -= partialInterval;
+        if (m_remainingInterval <= 0_s)
+            m_remainingInterval = m_interval;
+        TimerBase::stop();
+    }
+
+    Seconds secondsRemaining() const
+    {
+        if (!isActive())
+            return m_remainingInterval;
+
+        auto partialInterval = MonotonicTime::now() - m_startTime;
+        return std::max(0_s, m_remainingInterval - partialInterval);
+    }
+
+    Seconds secondsCompleted() const
+    {
+        return m_interval - secondsRemaining();
+    }
+
+private:
+    void start(Seconds, Seconds) = delete;
+    void startRepeating(Seconds) = delete;
+    void startOneShot(Seconds) = delete;
+
+    void fired() final
+    {
+        m_remainingInterval = 0_s;
+        m_function();
+        m_remainingInterval = m_interval;
+    }
+
+    Seconds m_interval;
+    Function<void()> m_function;
+
+    Seconds m_remainingInterval;
+    MonotonicTime m_startTime;
+};
+
 HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& document, bool createdByParser)
     : HTMLElement(tagName, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
     , ActiveDOMObject(document)
@@ -611,6 +678,8 @@ void HTMLMediaElement::initializeMediaSession()
 HTMLMediaElement::~HTMLMediaElement()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+
+    invalidateWatchtimeTimer();
 
     beginIgnoringTrackDisplayUpdateRequests();
 
@@ -5861,6 +5930,11 @@ void HTMLMediaElement::mediaPlayerRateChanged()
 
     ALWAYS_LOG(LOGIDENTIFIER, "rate: ", m_reportedPlaybackRate);
 
+    if (m_reportedPlaybackRate)
+        startWatchtimeTimer();
+    else
+        pauseWatchtimeTimer();
+
     if (m_playing)
         invalidateCachedTime();
 
@@ -6501,6 +6575,8 @@ void HTMLMediaElement::userCancelledLoad()
 
 void HTMLMediaElement::clearMediaPlayer()
 {
+    invalidateWatchtimeTimer();
+
 #if ENABLE(MEDIA_STREAM)
     if (!m_settingMediaStreamSrcObject)
         m_mediaStreamSrcObject = nullptr;
@@ -6565,6 +6641,8 @@ void HTMLMediaElement::clearMediaPlayer()
 void HTMLMediaElement::stopWithoutDestroyingMediaPlayer()
 {
     INFO_LOG(LOGIDENTIFIER);
+
+    invalidateWatchtimeTimer();
 
     if (m_videoFullscreenMode != VideoFullscreenModeNone)
         exitFullscreen();
@@ -7773,6 +7851,8 @@ void HTMLMediaElement::markCaptionAndSubtitleTracksAsUnconfigured(ReconfigureMod
 void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+
+    invalidateWatchtimeTimer();
 
     mediaSession().setActive(true);
 
@@ -9666,6 +9746,102 @@ void HTMLMediaElement::defaultSpatialTrackingLabelChanged(const String& defaultS
         m_player->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
 }
 #endif
+
+void HTMLMediaElement::startWatchtimeTimer()
+{
+    if (!m_watchtimeTimer) {
+        m_watchtimeTimer = makeUnique<PausableIntervalTimer>(WatchtimeTimerInterval, [weakThis = WeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->watchtimeTimerFired();
+        });
+    }
+    m_watchtimeTimer->start();
+}
+
+void HTMLMediaElement::pauseWatchtimeTimer()
+{
+    if (m_watchtimeTimer)
+        m_watchtimeTimer->pause();
+}
+
+void HTMLMediaElement::invalidateWatchtimeTimer()
+{
+    if (!m_watchtimeTimer)
+        return;
+
+    watchtimeTimerFired();
+    m_watchtimeTimer->stop();
+    m_watchtimeTimer = nullptr;
+}
+
+void HTMLMediaElement::watchtimeTimerFired()
+{
+    if (!m_watchtimeTimer)
+        return;
+
+    // Silent, autoplaying content should not produce watchtime diagnostics:
+    if (!m_hasEverHadAudio || m_muted)
+        return;
+
+    if (!m_mediaSession || m_mediaSession->hasBehaviorRestriction(MediaElementSession::RequireUserGestureForAudioRateChange))
+        return;
+
+    auto page = document().protectedPage();
+    if (!page)
+        return;
+
+    // Bucket the watchtime seconds to the nearest 10s:
+    double numberOfSeconds = m_watchtimeTimer->secondsCompleted().seconds();
+    numberOfSeconds = round(numberOfSeconds / 10) * 10;
+
+    // First log watchtime messages per-source-type:
+    if (auto sourceType = this->sourceType()) {
+        WebCore::DiagnosticLoggingClient::ValueDictionary sourceTypeDictionary;
+        sourceTypeDictionary.set(DiagnosticLoggingKeys::sourceTypeKey(), DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey(*sourceType));
+        sourceTypeDictionary.set(DiagnosticLoggingKeys::secondsKey(), numberOfSeconds);
+        page->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(DiagnosticLoggingKeys::mediaSourceTypeWatchTimeKey(), "Media Watchtime Interval By Source Type"_s, sourceTypeDictionary, ShouldSample::Yes);
+    }
+
+    // Then log watchtime messages per-video-codec-type:
+    [&] {
+        RefPtr videoTracks = this->videoTracks();
+        if (!videoTracks)
+            return;
+
+        RefPtr selectedVideoTrack = videoTracks->selectedItem();
+        if (!selectedVideoTrack)
+            return;
+
+        auto videoCodec = selectedVideoTrack->configuration().codec();
+        if (videoCodec.isEmpty())
+            return;
+
+        WebCore::DiagnosticLoggingClient::ValueDictionary videoCodecDictionary;
+        videoCodecDictionary.set(DiagnosticLoggingKeys::videoCodecKey(), videoCodec);
+        videoCodecDictionary.set(DiagnosticLoggingKeys::secondsKey(), numberOfSeconds);
+        page->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(DiagnosticLoggingKeys::mediaSourceTypeWatchTimeKey(), "Media Watchtime Interval By Video Codec"_s, videoCodecDictionary, ShouldSample::Yes);
+    }();
+
+    // Then log watchtime messages per-audio-codec-type:
+    [&] {
+        RefPtr audioTracks = this->audioTracks();
+        if (!audioTracks)
+            return;
+
+        RefPtr selectedAudioTrack = audioTracks->firstEnabled();
+        if (!selectedAudioTrack)
+            return;
+
+        auto audioCodec = selectedAudioTrack->configuration().codec();
+        if (audioCodec.isEmpty())
+            return;
+
+        WebCore::DiagnosticLoggingClient::ValueDictionary audioCodecDictionary;
+        audioCodecDictionary.set(DiagnosticLoggingKeys::audioCodecKey(), audioCodec);
+        audioCodecDictionary.set(DiagnosticLoggingKeys::secondsKey(), numberOfSeconds);
+        page->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(DiagnosticLoggingKeys::mediaSourceTypeWatchTimeKey(), "Media Watchtime Interval By Audio Codec"_s, audioCodecDictionary, ShouldSample::Yes);
+    }();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -106,6 +106,7 @@ class MediaSource;
 class MediaSourceHandle;
 class MediaSourceInterfaceProxy;
 class MediaStream;
+class PausableIntervalTimer;
 class RenderMedia;
 class ScriptController;
 class ScriptExecutionContext;
@@ -130,6 +131,16 @@ class RemotePlayback;
 
 using CueInterval = PODInterval<MediaTime, TextTrackCue*>;
 using CueList = Vector<CueInterval>;
+
+enum class HTMLMediaElementSourceType : uint8_t {
+    File,
+    HLS,
+    MediaSource,
+    ManagedMediaSource,
+    MediaStream,
+    LiveStream,
+    StoredStream,
+};
 
 using MediaProvider = std::optional < std::variant <
 #if ENABLE(MEDIA_STREAM)
@@ -670,15 +681,7 @@ public:
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRight&&);
     void updateMediaState();
 
-    enum class SourceType : uint8_t {
-        File,
-        HLS,
-        MediaSource,
-        ManagedMediaSource,
-        MediaStream,
-        LiveStream,
-        StoredStream,
-    };
+    using SourceType = HTMLMediaElementSourceType;
     std::optional<SourceType> sourceType() const;
     String localizedSourceType() const;
 
@@ -1104,6 +1107,11 @@ private:
 #endif
 
     bool shouldDisableHDR() const;
+    bool isWatchtimeTimerActive() const;
+    void startWatchtimeTimer();
+    void pauseWatchtimeTimer();
+    void invalidateWatchtimeTimer();
+    void watchtimeTimerFired();
 
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;
@@ -1408,6 +1416,8 @@ private:
 
     bool m_isChangingReadyStateWhileSuspended { false };
     Atomic<unsigned> m_remainingReadyStateChangedAttempts;
+
+    std::unique_ptr<PausableIntervalTimer> m_watchtimeTimer;
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "DiagnosticLoggingKeys.h"
 
+#include "HTMLMediaElement.h"
+
 namespace WebCore {
 
 String DiagnosticLoggingKeys::mediaLoadedKey()
@@ -753,6 +755,66 @@ String DiagnosticLoggingKeys::backgroundCPUUsageToDiagnosticLoggingKey(double cp
         return "50to70"_s;
     return "over70"_s;
 }
-    
+
+String DiagnosticLoggingKeys::mediaSourceTypeWatchTimeKey()
+{
+    return "watchtimeBySource"_s;
+}
+
+String DiagnosticLoggingKeys::mediaVideoCodecWatchTimeKey()
+{
+    return "watchtimeByVideoCodec"_s;
+}
+
+String DiagnosticLoggingKeys::mediaAudioCodecWatchTimeKey()
+{
+    return "watchtimeByAudioCodec"_s;
+}
+
+String DiagnosticLoggingKeys::secondsKey()
+{
+    return "seconds"_s;
+}
+
+String DiagnosticLoggingKeys::sourceTypeKey()
+{
+    return "sourceType"_s;
+}
+
+String DiagnosticLoggingKeys::videoCodecKey()
+{
+    return "videoCodec"_s;
+}
+
+String DiagnosticLoggingKeys::audioCodecKey()
+{
+    return "audioCodec"_s;
+}
+
+String DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey(HTMLMediaElementSourceType sourceType)
+{
+    switch (sourceType) {
+    case HTMLMediaElementSourceType::File:
+        return "file"_s;
+    case HTMLMediaElementSourceType::HLS:
+        return "hls"_s;
+    case HTMLMediaElementSourceType::MediaSource:
+        return "mediaSource"_s;
+    case HTMLMediaElementSourceType::ManagedMediaSource:
+        return "managedMediaSource"_s;
+    case HTMLMediaElementSourceType::MediaStream:
+        return "mediaStream"_s;
+    case HTMLMediaElementSourceType::LiveStream:
+        return "liveStream"_s;
+    case HTMLMediaElementSourceType::StoredStream:
+        return "storedStream"_s;
+    }
+
+    ASSERT_NOT_REACHED();
+    return nullString();
+}
+
+
+
 } // namespace WebCore
 

--- a/Source/WebCore/page/DiagnosticLoggingKeys.h
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+enum class HTMLMediaElementSourceType : uint8_t;
+
 class DiagnosticLoggingKeys {
 public:
     static String applicationCacheKey();
@@ -167,9 +169,20 @@ public:
     WEBCORE_EXPORT static String webViewKey();
     static String yesKey();
 
+    static String mediaSourceTypeWatchTimeKey();
+    static String mediaVideoCodecWatchTimeKey();
+    static String mediaAudioCodecWatchTimeKey();
+
+    static String secondsKey();
+    static String sourceTypeKey();
+    static String videoCodecKey();
+    static String audioCodecKey();
+
     WEBCORE_EXPORT static String memoryUsageToDiagnosticLoggingKey(uint64_t memoryUsage);
     WEBCORE_EXPORT static String foregroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
     WEBCORE_EXPORT static String backgroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
+
+    static String mediaElementSourceTypeDiagnosticLoggingKey(HTMLMediaElementSourceType);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 06391e123c0e3b40a30e1114af79cd61c4e2f603
<pre>
Add media element watchtime diagnostic logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=277747">https://bugs.webkit.org/show_bug.cgi?id=277747</a>
<a href="https://rdar.apple.com/133396572">rdar://133396572</a>

Reviewed by Eric Carlson.

Add diagnostic logging of watchtime for various media properties. Specifically:
- Log watchtime separated by source type (HLS, live stream, media source, etc.)
- Log watchtime separated by video and audio codecs

For each of these watchtime log events, enable random sampling, so only a small
percentage of events will actually get logged. Additionally, break up watchtime
events into 5 minute intervals, which due to sampling, only some of which will
actually be logged.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::mediaPlayerRateChanged):
(WebCore::HTMLMediaElement::clearMediaPlayer):
(WebCore::HTMLMediaElement::stopWithoutDestroyingMediaPlayer):
(WebCore::HTMLMediaElement::startWatchtimeTimer):
(WebCore::HTMLMediaElement::pauseWatchtimeTimer):
(WebCore::HTMLMediaElement::invalidateWatchtimeTimer):
(WebCore::HTMLMediaElement::watchtimeTimerFired):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/DiagnosticLoggingKeys.cpp:
(WebCore::DiagnosticLoggingKeys::mediaSourceTypeWatchTimeKey):
(WebCore::DiagnosticLoggingKeys::mediaVideoCodecWatchTimeKey):
(WebCore::DiagnosticLoggingKeys::mediaAudioCodecWatchTimeKey):
(WebCore::DiagnosticLoggingKeys::secondsKey):
(WebCore::DiagnosticLoggingKeys::sourceTypeKey):
(WebCore::DiagnosticLoggingKeys::videoCodecKey):
(WebCore::DiagnosticLoggingKeys::audioCodecKey):
(WebCore::DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey):
* Source/WebCore/page/DiagnosticLoggingKeys.h:

Canonical link: <a href="https://commits.webkit.org/282004@main">https://commits.webkit.org/282004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/945ce53485304b3951695238f68ae7259ff929f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61629 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49766 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8448 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10612 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57102 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53331 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57322 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13739 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4584 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36783 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->