### PR TITLE
[WebXR + WebGPU] add simple triangle test page

### DIFF
--- a/Websites/webkit.org/demos/webgpu/hello-triangle-xr.html
+++ b/Websites/webkit.org/demos/webgpu/hello-triangle-xr.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Hello Triangle</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Simple Triangle</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/hello-triangle-xr.js"></script>
+</body>
+</html>

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle-xr.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle-xr.js
@@ -1,0 +1,151 @@
+async function helloTriangle() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+    
+    if (navigator.xr == undefined) {
+        document.writeln("WebXR is not supported");
+        return;
+    }
+    try {
+        const xrSession = await navigator.xr.requestSession('immersive-vr');
+        const adapter = await navigator.gpu.requestAdapter({xrCompatible: true});
+        const device = await adapter.requestDevice();
+        const xrGpuBinding = new XRGPUBinding(xrSession, device);
+        const projectionLayer = xrGpuBinding.createProjectionLayer({
+          colorFormat: xrGpuBinding.getPreferredColorFormat(),
+          depthStencilFormat: 'depth24plus',
+        });
+
+        xrSession.updateRenderState({ layers: [projectionLayer] });
+        xrSession.requestAnimationFrame(onXRFrame);
+
+        /*** Vertex Buffer Setup ***/
+        
+        /* Vertex Data */
+        const vertexStride = 8 * 4;
+        const vertexDataSize = vertexStride * 3;
+        
+        /* GPUBufferDescriptor */
+        const vertexDataBufferDescriptor = {
+            size: vertexDataSize,
+            usage: GPUBufferUsage.VERTEX
+        };
+        
+        /* GPUBuffer */
+        const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+        
+        /*** Shader Setup ***/
+        const wgslSource = `
+                         struct Vertex {
+                             @builtin(position) Position: vec4<f32>,
+                             @location(0) color: vec4<f32>,
+                         }
+        
+                         @vertex fn vsmain(@builtin(vertex_index) VertexIndex: u32) -> Vertex
+                         {
+                             var pos: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+                                 vec2<f32>( 0.0,  0.5),
+                                 vec2<f32>(-0.5, -0.5),
+                                 vec2<f32>( 0.5, -0.5)
+                             );
+                             var vertex_out : Vertex;
+                             vertex_out.Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                             vertex_out.color = vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), 0.0, 1.0);
+                             return vertex_out;
+                         }
+        
+                         @fragment fn fsmain(in: Vertex) -> @location(0) vec4<f32>
+                         {
+                             return in.color;
+                         }
+        `;
+        const shaderModule = device.createShaderModule({ code: wgslSource });
+        
+        /* GPUPipelineStageDescriptors */
+        const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+        
+        const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+        
+        /* GPURenderPipelineDescriptor */
+        
+        const renderPipelineDescriptor = {
+            layout: 'auto',
+            vertex: vertexStageDescriptor,
+            fragment: fragmentStageDescriptor,
+            primitive: {topology: "triangle-list" },
+        };
+        /* GPURenderPipeline */
+        const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+        
+        /*** Swap Chain Setup ***/
+        
+        const canvas = document.querySelector("canvas");
+        canvas.width = 600;
+        canvas.height = 600;
+        
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+
+        function onXRFrame(time, xrFrame) {
+            xrSession.requestAnimationFrame(onXRFrame);
+            
+            /*** Render Pass Setup ***/
+            
+            /* Acquire Texture To Render To */
+            
+            /* GPUColor */
+            const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+            
+            /*** Rendering ***/
+            
+            /* GPUCommandEncoder */
+            const commandEncoder = device.createCommandEncoder();
+            
+            for (const view in xrViewerPose.views) {
+                const subImage = xrGpuBinding.getViewSubImage(layer, view);
+                
+                const passEncoder = commandEncoder.beginRenderPass({
+                    colorAttachments: [{
+                        attachment: subImage.colorTexture.createView(subImage.viewDescriptor),
+                        loadOp: 'clear',
+                        clearValue: [0,0,0,1],
+                    }],
+                    depthStencilAttachment: {
+                        attachment: subImage.depthStencilTexture.createView(subImage.viewDescriptor),
+                        depthLoadOp: 'clear',
+                        depthClearValue: 1.0,
+                        depthStoreOp: 'store',
+                        stencilLoadOp: 'clear',
+                        stencilClearValue: 0,
+                        stencilStoreOp: 'store',
+                    }});
+                
+                let vp = subImage.viewport;
+                passEncoder.setViewport(vp.x, vp.y, vp.width, vp.height, 0.0, 1.0);
+                passEncoder.setPipeline(renderPipeline);
+
+                const vertexBufferSlot = 0;
+                passEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+                passEncoder.draw(3, 1, 0, 0); // 3 vertices, 1 instance, 0th vertex, 0th instance.
+                passEncoder.end();
+            }
+
+            /* GPUComamndBuffer */
+            const commandBuffer = commandEncoder.finish();
+            
+            /* GPUQueue */
+            const queue = device.queue;
+            queue.submit([commandBuffer]);
+        }
+
+    } catch (error) {
+        document.writeln(error);
+    }
+}
+
+window.addEventListener("DOMContentLoaded", helloTriangle);


### PR DESCRIPTION
#### 078257c706844e65c84500b57b535a17c1e3c735
<pre>
[WebXR + WebGPU] add simple triangle test page
<a href="https://bugs.webkit.org/show_bug.cgi?id=277766">https://bugs.webkit.org/show_bug.cgi?id=277766</a>
<a href="https://rdar.apple.com/133408951">rdar://133408951</a>

Reviewed by Dan Glastonbury.

Modify hello-triangle and adopt <a href="https://github.com/immersive-web/WebXR-WebGPU-Binding/blob/main/explainer.md">https://github.com/immersive-web/WebXR-WebGPU-Binding/blob/main/explainer.md</a>
for simple WebXR + WebGPU hello triangle.

* Websites/webkit.org/demos/webgpu/hello-triangle-xr.html: Added.
* Websites/webkit.org/demos/webgpu/scripts/hello-triangle-xr.js: Added.
(async helloTriangle.try.onXRFrame):
(async helloTriangle):

Canonical link: <a href="https://commits.webkit.org/281979@main">https://commits.webkit.org/281979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b115a9f2c9027c33f8db5b5a4e35b3d989ed42f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49712 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34722 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11085 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67314 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57089 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4564 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36765 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->