### PR TITLE
[Static Analyzer CI] Missing project subheading when there are only unexpected passes

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1659,7 +1659,7 @@ class ScanBuildSmartPointer(steps.ShellSequence, ShellMixin):
         ]
 
         if rc == SUCCESS:
-            steps_to_add += [ParseStaticAnalyzerResults(), CompareStaticAnalyzerResults(), ArchiveStaticAnalyzerResults(), UploadStaticAnalyzerResults(), ExtractStaticAnalyzerTestResults()]
+            steps_to_add += [ParseStaticAnalyzerResults(), FindUnexpectedStaticAnalyzerResults(), ArchiveStaticAnalyzerResults(), UploadStaticAnalyzerResults(), ExtractStaticAnalyzerTestResults(), DisplayUnexpectedResults()]
         self.build.addStepsAfterCurrentStep(steps_to_add)
 
         defer.returnValue(rc)
@@ -1724,10 +1724,10 @@ class ParseStaticAnalyzerResults(shell.ShellCommandNewStyle):
         return {u'step': status}
 
 
-class CompareStaticAnalyzerResults(shell.ShellCommandNewStyle):
-    name = 'compare-static-analyzer-results'
-    description = ['comparing static analyzer results']
-    descriptionDone = ['compared static analyzer results']
+class FindUnexpectedStaticAnalyzerResults(shell.ShellCommandNewStyle):
+    name = 'find-unexpected-static-analyzer-results'
+    description = ['finding unexpected static analyzer results']
+    descriptionDone = ['found unexpected static analyzer results']
     resultMsg = ''
 
     @defer.inlineCallbacks
@@ -1746,8 +1746,6 @@ class CompareStaticAnalyzerResults(shell.ShellCommandNewStyle):
 
         self.createResultMessage()
 
-        if self.getProperty('unexpected_failing_files', 0) or self.getProperty('unexpected_passing_files', 0):
-            return defer.returnValue(FAILURE)
         return defer.returnValue(rc)
 
     def createResultMessage(self):
@@ -1781,26 +1779,38 @@ class DisplayUnexpectedResults(buildstep.BuildStep, AddToLogMixin):
 
     @defer.inlineCallbacks
     def run(self):
-        result_directory = f"public_html/results/{self.getProperty('buildername')}/{self.getProperty('archive_revision')} ({self.getProperty('buildnumber')})"
-        unexpected_results_json = os.path.join(result_directory, SCAN_BUILD_OUTPUT_DIR, 'unexpected_results.json')
+        self.zipFile = f"public_html/results/{self.getProperty('buildername')}/{self.getProperty('archive_revision')} ({self.getProperty('buildnumber')}).zip"
+        self.resultDirectory = f"public_html/results/{self.getProperty('buildername')}/{self.getProperty('archive_revision')} ({self.getProperty('buildnumber')})"
+
+        unexpected_results_json = os.path.join(self.resultDirectory, SCAN_BUILD_OUTPUT_DIR, 'unexpected_results.json')
         with open(unexpected_results_json) as f:
             unexpected_results_data = json.load(f)
-        yield self.getFilesPerProject(unexpected_results_data, 'passes')
-        yield self.getFilesPerProject(unexpected_results_data, 'failures')
+        is_log = yield self.getFilesPerProject(unexpected_results_data, 'passes')
+        is_log += yield self.getFilesPerProject(unexpected_results_data, 'failures')
+        if not is_log:
+            yield self.addToLog('stdio', 'No unexpected results.\n')
+
+        self.addURL("View full static analyzer results", self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/results.html")
+        self.addURL("Download full static analyzer results", self.resultDownloadURL())
         if self.getProperty('unexpected_failing_files', 0) or self.getProperty('unexpected_passing_files', 0):
+            self.addURL("View unexpected static analyzer results", self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/unexpected-results.html")
             return defer.returnValue(FAILURE)
         return defer.returnValue(SUCCESS)
 
     @defer.inlineCallbacks
     def getFilesPerProject(self, unexpected_results_data, type):
+        is_log = 0
         for project, data in unexpected_results_data[type].items():
             log_content = ''
             for checker, files in data.items():
                 if files:
                     log_content += f'\n\n=> {checker}\n\n'
-                    log_content += '\n'.join(files)
+                    log_content += '\n'.join((sorted(files)))
+                    log_content += '\n\n'
             if log_content:
                 yield self._addToLog(f'{project}-unexpected-{type}', log_content)
+                is_log += 1
+        return defer.returnValue(is_log)
 
     def getResultSummary(self):
         if self.results != SUCCESS:
@@ -1808,6 +1818,13 @@ class DisplayUnexpectedResults(buildstep.BuildStep, AddToLogMixin):
         num_failures = self.getProperty('unexpected_failing_files', 0)
         num_passes = self.getProperty('unexpected_passing_files', 0)
         return {'step': f'Unexpected failing files: {num_failures} Unexpected passing files: {num_passes}'}
+
+    def resultDirectoryURL(self):
+        self.setProperty('result_directory', self.resultDirectory)
+        return self.resultDirectory.replace('public_html/', '/') + '/'
+
+    def resultDownloadURL(self):
+        return self.zipFile.replace('public_html/', '')
 
 
 class UpdateSmartPointerBaseline(steps.ShellSequence, ShellMixin):
@@ -1890,24 +1907,8 @@ class ExtractTestResults(master.MasterShellCommandNewStyle):
 class ExtractStaticAnalyzerTestResults(ExtractTestResults):
     name = 'extract-static-analyzer-test-results'
 
-    @defer.inlineCallbacks
-    def run(self):
-        rc = yield super().run()
-        if self.getProperty('unexpected_failing_files', 0) or self.getProperty('unexpected_passing_files', 0):
-            self.build.addStepsAfterCurrentStep([DisplayUnexpectedResults()])
-        defer.returnValue(rc)
-
-    def getLastBuildStepByName(self, name):
-        for step in reversed(self.build.executedSteps):
-            if name in step.name:
-                return step
-        return None
-
     def addCustomURLs(self):
-        step = self.getLastBuildStepByName(CompareStaticAnalyzerResults.name)
-        step.addURL("View full static analyzer results", self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/results.html")
-        step.addURL("View unexpected static analyzer results", self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/unexpected-results.html")
-        step.addURL("Download full static analyzer results", self.resultDownloadURL())
+        pass
 
 
 class PrintConfiguration(steps.ShellSequence):

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1921,7 +1921,7 @@ class TestParseStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCase)
         return self.runStep()
 
 
-class TestCompareStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCase):
+class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         return self.setUpBuildStep()
 
@@ -1929,7 +1929,7 @@ class TestCompareStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCas
         return self.tearDownBuildStep()
 
     def configureStep(self):
-        self.setupStep(CompareStaticAnalyzerResults())
+        self.setupStep(FindUnexpectedStaticAnalyzerResults())
 
     def test_success_no_issues(self):
         self.configureStep()
@@ -1945,7 +1945,7 @@ class TestCompareStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCas
         self.expectOutcome(result=SUCCESS, state_string='Found no unexpected results')
         return self.runStep()
 
-    def test_new_issues(self):
+    def test_success_new_issues(self):
         self.configureStep()
         self.setProperty('builddir', 'wkdir')
         self.setProperty('buildnumber', 1234)
@@ -1956,7 +1956,7 @@ class TestCompareStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCas
             + ExpectShell.log('stdio', stdout='Total unexpected failing files: 123\nTotal unexpected passing files: 456\nTotal unexpected issues: 789\n')
             + 0,
         )
-        self.expectOutcome(result=FAILURE, state_string='Unexpected failing files: 123 Unexpected passing files: 456 Unexpected issues: 789 (failure)')
+        self.expectOutcome(result=SUCCESS, state_string='Unexpected failing files: 123 Unexpected passing files: 456 Unexpected issues: 789')
         return self.runStep()
 
 

--- a/Tools/Scripts/generate-static-analysis-archive
+++ b/Tools/Scripts/generate-static-analysis-archive
@@ -33,6 +33,7 @@ INDEX_TEMPLATE = """
 <html>
 <head>
     <title>{title}</title>
+    <style>body {{ font-family: Helvetica, sans-serif; font-size:10pt }}</style>
 </head>
 <body>
     <div><h1>{heading}</h1></div>
@@ -42,10 +43,52 @@ INDEX_TEMPLATE = """
 </html>
 """
 PROJECT_TEMPLATE = '<li><a href="{project_file_url}">{project_name}</a> ({project_issue_count})</li>'
-CATEGORY_TEMPLATE = '<div>{category_name}<ul>{checker_links}</ul></div>'
+CATEGORY_TEMPLATE = '<div style="margin-top: 10px;">{category_name}<ul>{checker_links}</ul></div>'
 STATIC_ANALYZER = 'StaticAnalyzer'
 STATIC_ANALYZER_REGRESSIONS = 'StaticAnalyzerRegressions'
 STATIC_ANALYZER_UNEXPECTED = 'StaticAnalyzerUnexpectedRegressions'
+LINK_TEMPLATE = '<a href="{link}">{text}</a>'
+TABLE_ITEM_TEMPLATE = '<tr><td>{checker_type}</td><td>{link}</td></tr>'
+RESULTS_PAGE = """
+<html>
+<head>
+    <title>{title}</title>
+    <style>
+        body {{ font-family: Helvetica, sans-serif; font-size:10pt }}
+        table {{ font-size:10pt }}
+        table {{ border-spacing: 0px; border: 1px solid black}}
+        th, table thead {{
+        background-color:#eee; color:#666666;
+        font-weight: bold; cursor: default;
+        text-align:center;
+        font-weight: bold; font-family: Verdana;
+        white-space:nowrap;
+        }}
+        .inner {{
+            margin-left: 50px;
+        }}
+        th, td {{ padding:5px; padding-left:8px; text-align:left }}
+    </style>
+</head>
+<body>
+    <div><h1>{heading}</h1></div>
+    <div>{body}</div>
+</body>
+</html>
+"""
+UNEXPECTED_TABLE_TEMPLATE = """
+<table>
+    <thead>
+        <tr style="font-weight:bold">
+            <td>Checker</td>
+            <td>Files</td>
+        </tr>
+    </thead>
+    <tbody>
+        {table_body_contents}
+    </tbody>
+</table>
+"""
 
 
 def parse_command_line(args):
@@ -58,30 +101,46 @@ def parse_command_line(args):
     return parser.parse_args(args)
 
 
-def generate_unexpected_results_links(output_root, static_analysis_dir, project_name):
-    results_links = ''
-    for category, category_formatted in {'UnexpectedPasses': 'Unexpected Passes', 'UnexpectedFailures': 'Unexpected Failures'}.items():
-        command = 'find {} -name {}\\* -print'.format(os.path.abspath(os.path.join(static_analysis_dir, project_name)), category)
-        try:
-            result_files = subprocess.check_output(command, shell=True, text=True)
-        except subprocess.CalledProcessError as e:
-            sys.stderr.write(f'{e.output}')
-            sys.stderr.write(f'Could not find results for {project_name}\n')
-            return -1
+def generate_unexpected_table(output_root, static_analysis_dir, project_name, category):
+    category_table = ''
+    command = 'find {} -name {}\\* -print'.format(os.path.abspath(os.path.join(static_analysis_dir, project_name)), category)
+    try:
+        result_files = subprocess.check_output(command, shell=True, text=True)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f'{e.output}')
+        sys.stderr.write(f'Could not find results for {project_name}\n')
+        return -1
 
-        unexpected_results_files = result_files.splitlines()
-        checker_links = ''
-        for file_path in unexpected_results_files:
-            file_name = file_path.split('/')[-1].removeprefix(category).removesuffix('.txt')
-            relative_file_path = os.path.relpath(file_path, output_root)
-            with open(os.path.abspath(os.path.join(output_root, file_path))) as f:
-                count = len(f.read().splitlines())
-            if count:
-                checker_links += PROJECT_TEMPLATE.format(project_file_url=relative_file_path, project_name=file_name, project_issue_count=count)
-        if checker_links:
-            results_links += CATEGORY_TEMPLATE.format(category_name=category_formatted, checker_links=checker_links)
+    unexpected_results_files = result_files.splitlines()
+    table_rows = ''
+    for file_path in unexpected_results_files:
+        file_name = file_path.split('/')[-1].removeprefix(category).removesuffix('.txt')
+        relative_file_path = os.path.relpath(file_path, output_root)
+        with open(os.path.abspath(os.path.join(output_root, file_path))) as f:
+            count = len(f.read().splitlines())
+        if count:
+            table_rows += TABLE_ITEM_TEMPLATE.format(checker_type=file_name, link=LINK_TEMPLATE.format(link=relative_file_path, text=count))
+    if table_rows:
+        category_table += UNEXPECTED_TABLE_TEMPLATE.format(table_body_contents=table_rows)
 
-    return results_links
+    return category_table
+
+
+def generate_unexpected_results_page(project_dirs, id_string, output_root, static_analysis_dir):
+    body = ''
+    for category, category_formatted in {'UnexpectedFailures': 'Unexpected Failures', 'UnexpectedPasses': 'Unexpected Passes'}.items():
+        body += f'<h2>{category_formatted}</h2>'
+        body += '<div class="inner">'
+        for project_name in sorted(project_dirs):
+            static_analyzer_index_path = os.path.join(static_analysis_dir, project_name, INDEX_HTML)
+            project_count = get_project_issue_count_as_string(static_analyzer_index_path)
+            body += f'<h3>{project_name}</h3>'
+            if int(project_count) != 0 and category == 'UnexpectedFailures':
+                body += f"<b>{LINK_TEMPLATE.format(link=os.path.relpath(static_analyzer_index_path, output_root), text=f'View Issues ({project_count})')}</b></br></br>"
+            table = generate_unexpected_table(output_root, static_analysis_dir, project_name, category)
+            body += table or '<li>No unexpected results!</li>'
+        body += '</br></br></div>'
+    return RESULTS_PAGE.format(title=f'Static Analysis Results', heading=f'Unexpected Results for {id_string}', body=body)
 
 
 def generate_results_page(project_dirs, id_string, output_root, static_analysis_dir, result_type=None):
@@ -94,8 +153,6 @@ def generate_results_page(project_dirs, id_string, output_root, static_analysis_
                         project_file_url=os.path.relpath(static_analyzer_index_path, output_root),
                         project_issue_count=project_count,
                         project_name=project_name)
-        if result_type == 'unexpected':
-            project_list += generate_unexpected_results_links(output_root, static_analysis_dir, project_name)
 
     if result_type:
         heading = f'{result_type.capitalize()} results for {id_string}'
@@ -114,7 +171,10 @@ def create_results_file(options, output_root, static_analysis_dir, result_type=N
                                          os.listdir(static_analysis_dir)))
 
     if options.id_string:
-        results_page = generate_results_page(project_dirs, options.id_string, output_root, static_analysis_dir, result_type)
+        if result_type == 'unexpected':
+            results_page = generate_unexpected_results_page(project_dirs, options.id_string, output_root, static_analysis_dir)
+        else:
+            results_page = generate_results_page(project_dirs, options.id_string, output_root, static_analysis_dir, result_type)
         if result_type:
             f = open(output_root + f'/{result_type}-results.html', 'w')
         else:


### PR DESCRIPTION
#### 80c5a483f3e5534c551f534829a7339cfbae567e
<pre>
[Static Analyzer CI] Missing project subheading when there are only unexpected passes
<a href="https://rdar.apple.com/130013061">rdar://130013061</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277267">https://bugs.webkit.org/show_bug.cgi?id=277267</a>

Reviewed by NOBODY (OOPS!).

Improve clarity of results page and build.

* Tools/CISupport/build-webkit-org/steps.py:
(ScanBuildSmartPointer.run):
(FindUnexpectedStaticAnalyzerResults):
(FindUnexpectedStaticAnalyzerResults.run):
(DisplayUnexpectedResults.run):
(DisplayUnexpectedResults.getFilesPerProject):
(DisplayUnexpectedResults.resultDirectoryURL):
(DisplayUnexpectedResults):
(DisplayUnexpectedResults.resultDownloadURL):
(ExtractStaticAnalyzerTestResults):
(ExtractStaticAnalyzerTestResults.addCustomURLs):
(CompareStaticAnalyzerResults): Deleted.
(CompareStaticAnalyzerResults.run): Deleted.
(CompareStaticAnalyzerResults.createResultMessage): Deleted.
(CompareStaticAnalyzerResults.getResultSummary): Deleted.
(ExtractStaticAnalyzerTestResults.run): Deleted.
(ExtractStaticAnalyzerTestResults.getLastBuildStepByName): Deleted.

* Tools/Scripts/generate-static-analysis-archive:
(generate_unexpected_table):
(generate_unexpected_results_page):
(generate_results_page):
(create_results_file):
(generate_unexpected_results_links): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80c5a483f3e5534c551f534829a7339cfbae567e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65732 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49799 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11229 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5696 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10781 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57178 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/61431 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57410 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4685 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36907 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->