### PR TITLE
[Text Directionality] Fix directionality of non-HTML elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-assorted.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-assorted.window-expected.txt
@@ -1,17 +1,17 @@
 
 PASS Root element has a direction
 PASS Element outside the document tree has a direction
-FAIL Non-HTML element outside the document tree has a direction assert_true: expected true got false
+PASS Non-HTML element outside the document tree has a direction
 PASS Element without direction has parent element direction
-FAIL Non-HTML element without direction has parent element direction assert_true: expected true got false
+PASS Non-HTML element without direction has parent element direction
 PASS dir inheritance is correct after insertion and removal from document
-FAIL Non-HTML element text contents influence dir=auto assert_true: is RTL before change expected true got false
+PASS Non-HTML element text contents influence dir=auto
 PASS style element text contents do not influence dir=auto
 PASS script element text contents do not influence dir=auto
-FAIL non-html style element text contents influence dir=auto assert_true: expected true got false
-FAIL non-html script element text contents influence dir=auto assert_true: expected true got false
-FAIL non-html input element text contents influence dir=auto assert_true: expected true got false
-FAIL non-html textarea element text contents influence dir=auto assert_true: expected true got false
+PASS non-html style element text contents influence dir=auto
+PASS non-html script element text contents influence dir=auto
+PASS non-html input element text contents influence dir=auto
+PASS non-html textarea element text contents influence dir=auto
 PASS text changes apply to dir=auto on further ancestor after removing dir=auto from closer ancestor
 PASS text changes apply to dir=auto on further ancestor after removing dir=ltr from closer ancestor
 PASS directionality of bdi elements: dir=ltr with LTR contents in ltr parent

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
@@ -4,9 +4,9 @@ PASS dir=auto changes for content insertion and removal, in and out of document
 FAIL dir=auto changes for slot reassignment assert_true: #one with LTR child span expected true got false
 FAIL text changes affecting both slot and ancestor with dir=auto assert_false: slot after first text change expected false got true
 PASS dynamic changes to subtrees excluded as a result of the dir attribute
-FAIL dynamic changes inside of non-HTML elements assert_true: after dynamic change expected true got false
+PASS dynamic changes inside of non-HTML elements
 FAIL slotted non-HTML elements assert_true: initial state (slot) expected true got false
-FAIL slotted non-HTML elements after dynamically assigning dir=auto, and dir attribute ignored on non-HTML elements assert_true: initial state (element) expected true got false
+PASS slotted non-HTML elements after dynamically assigning dir=auto, and dir attribute ignored on non-HTML elements
 PASS dir=auto ancestor considers text in subtree after removing dir=ltr from it
 PASS Slotted content affects multiple dir=auto slots
 FAIL Removing slotted content resets direction on dir=auto slot assert_equals: slot initially rtl expected "rtl" but got "ltr"
@@ -17,8 +17,6 @@ FAIL dir=auto slot is updated if input stops being auto-directionality form-asso
 PASS slot provides updated directionality from host to a dir=auto container
 A א
 א
-A
-A א
 A א
 א
 اختبر

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -252,10 +252,6 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
 
 ALWAYS_INLINE bool matchesDirPseudoClass(const Element& element, const AtomString& argument)
 {
-    // FIXME: Add support for non-HTML elements.
-    if (!is<HTMLElement>(element))
-        return false;
-
     switch (element.effectiveTextDirection()) {
     case TextDirection::LTR:
         return equalIgnoringASCIICase(argument, "ltr"_s);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -818,6 +818,9 @@ public:
     bool hasCustomState(const AtomString& state) const;
     CustomStateSet& ensureCustomStateSet();
 
+    bool hasDirectionAuto() const;
+    std::optional<TextDirection> directionalityIfDirIsAuto() const;
+
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 
@@ -845,6 +848,9 @@ protected:
 
     void disconnectFromIntersectionObservers();
     static AtomString makeTargetBlankIfHasDanglingMarkup(const AtomString& target);
+
+    void updateTextDirectionalityAfterInputTypeChange();
+    void updateEffectiveDirectionalityOfDirAuto();
 
 private:
     LocalFrame* documentFrameWithNonNullView() const;
@@ -943,6 +949,17 @@ private:
 #if ASSERT_ENABLED
     WEBCORE_EXPORT bool fastAttributeLookupAllowed(const QualifiedName&) const;
 #endif
+
+    void dirAttributeChanged(const AtomString&);
+    void updateEffectiveDirectionality(std::optional<TextDirection>);
+    void adjustDirectionalityIfNeededAfterChildAttributeChanged(Element* child);
+    void adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type);
+
+    struct TextDirectionWithStrongDirectionalityNode {
+        TextDirection direction;
+        RefPtr<Node> strongDirectionalityNode;
+    };
+    TextDirectionWithStrongDirectionalityNode computeDirectionalityFromText() const;
 
     bool hasEffectiveLangState() const;
     void updateEffectiveLangState();

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -52,7 +52,6 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameLoader.h"
-#include "HTMLBDIElement.h"
 #include "HTMLBRElement.h"
 #include "HTMLButtonElement.h"
 #include "HTMLDialogElement.h"
@@ -203,40 +202,6 @@ static inline ContentEditableType contentEditableType(const AtomString& value)
 static ContentEditableType contentEditableType(const HTMLElement& element)
 {
     return contentEditableType(element.attributeWithoutSynchronization(contenteditableAttr));
-}
-
-enum class TextDirectionDirective {
-    Invalid,
-    LTR,
-    RTL,
-    Auto,
-};
-
-static inline TextDirectionDirective parseTextDirection(const AtomString& value)
-{
-    if (equalLettersIgnoringASCIICase(value, "ltr"_s))
-        return TextDirectionDirective::LTR;
-    if (equalLettersIgnoringASCIICase(value, "rtl"_s))
-        return TextDirectionDirective::RTL;
-    if (equalLettersIgnoringASCIICase(value, "auto"_s))
-        return TextDirectionDirective::Auto;
-    return TextDirectionDirective::Invalid;
-}
-
-static bool isValidDirValue(const AtomString& value)
-{
-    return parseTextDirection(value) != TextDirectionDirective::Invalid;
-}
-
-static bool elementAffectsDirectionality(const HTMLElement& element)
-{
-    return is<HTMLBDIElement>(element) || isValidDirValue(element.attributeWithoutSynchronization(dirAttr));
-}
-
-static bool elementAffectsDirectionality(const Node& node)
-{
-    auto* htmlElement = dynamicDowncast<HTMLElement>(node);
-    return htmlElement && elementAffectsDirectionality(*htmlElement);
 }
 
 void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
@@ -404,9 +369,6 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
     StyledElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     switch (name.nodeName()) {
-    case AttributeNames::dirAttr:
-        dirAttributeChanged(newValue);
-        return;
     case AttributeNames::tabindexAttr:
         if (auto optionalTabIndex = parseHTMLInteger(newValue))
             setTabIndexExplicitly(optionalTabIndex.value());
@@ -452,15 +414,6 @@ Node::InsertedIntoAncestorResult HTMLElement::insertedIntoAncestor(InsertionType
 {
     auto result = StyledElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     hideNonce();
-
-    if (RefPtr parent = parentOrShadowHostElement(); parent && UNLIKELY(parent->usesEffectiveTextDirection())) {
-        auto* input = dynamicDowncast<HTMLInputElement>(*this);
-        if (!elementAffectsDirectionality(*this) && !(input && input->isTelephoneField())) {
-            setUsesEffectiveTextDirection(true);
-            setEffectiveTextDirection(parent->effectiveTextDirection());
-        }
-    }
-
     return result;
 }
 
@@ -470,11 +423,6 @@ void HTMLElement::removedFromAncestor(RemovalType removalType, ContainerNode& ol
         hidePopoverInternal(FocusPreviousElement::No, FireEvents::No);
 
     StyledElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-
-    if (UNLIKELY(usesEffectiveTextDirection()) && !isValidDirValue(attributeWithoutSynchronization(dirAttr))) {
-        if (auto* parent = parentOrShadowHostElement(); !(parent && parent->usesEffectiveTextDirection()))
-            setUsesEffectiveTextDirection(false);
-    }
 }
 
 static Ref<DocumentFragment> textToFragment(Document& document, const String& text)
@@ -824,205 +772,6 @@ void HTMLElement::setTranslate(bool enable)
 FormAssociatedElement* HTMLElement::asFormAssociatedElement()
 {
     return nullptr;
-}
-
-static void setHasDirAutoFlagRecursively(Node* firstNode, bool flag, Node* lastNode = nullptr)
-{
-    firstNode->setSelfOrPrecedingNodesAffectDirAuto(flag);
-
-    RefPtr node = firstNode->firstChild();
-
-    while (node) {
-        if (elementAffectsDirectionality(*node)) {
-            if (node == lastNode)
-                return;
-            node = NodeTraversal::nextSkippingChildren(*node, firstNode);
-            continue;
-        }
-        node->setSelfOrPrecedingNodesAffectDirAuto(flag);
-        if (node == lastNode)
-            return;
-        node = NodeTraversal::next(*node, firstNode);
-    }
-}
-
-void HTMLElement::childrenChanged(const ChildChange& change)
-{
-    StyledElement::childrenChanged(change);
-    if (UNLIKELY(document().isDirAttributeDirty()))
-        adjustDirectionalityIfNeededAfterChildrenChanged(change.previousSiblingElement, change.type);
-}
-
-bool HTMLElement::hasDirectionAuto() const
-{
-    const AtomString& direction = attributeWithoutSynchronization(dirAttr);
-    return (hasTagName(bdiTag) && !isValidDirValue(direction)) || equalLettersIgnoringASCIICase(direction, "auto"_s);
-}
-
-std::optional<TextDirection> HTMLElement::directionalityIfDirIsAuto() const
-{
-    if (!(selfOrPrecedingNodesAffectDirAuto() && hasDirectionAuto()))
-        return std::nullopt;
-    return computeDirectionalityFromText().direction;
-}
-
-auto HTMLElement::computeDirectionalityFromText() const -> TextDirectionWithStrongDirectionalityNode
-{
-    if (RefPtr textControl = dynamicDowncast<HTMLTextFormControlElement>(const_cast<HTMLElement*>(this))) {
-        if (textControl->dirAutoUsesValue()) {
-            auto direction = textControl->value().defaultWritingDirection();
-            if (!direction)
-                return { TextDirection::LTR, nullptr };
-            return { *direction == U_LEFT_TO_RIGHT ? TextDirection::LTR : TextDirection::RTL, WTFMove(textControl) };
-        }
-    }
-
-    RefPtr node = firstChild();
-    while (node) {
-        // Skip bdi, script, style and text form controls.
-        auto* element = dynamicDowncast<Element>(*node);
-        if (node->hasTagName(bdiTag) || node->hasTagName(scriptTag) || node->hasTagName(styleTag)
-            || (element && element->isTextField())) {
-            node = NodeTraversal::nextSkippingChildren(*node, this);
-            continue;
-        }
-
-        // Skip elements with valid dir attribute
-        if (element) {
-            if (isValidDirValue(element->attributeWithoutSynchronization(dirAttr))) {
-                node = NodeTraversal::nextSkippingChildren(*element, this);
-                continue;
-            }
-        }
-
-        if (node->isTextNode()) {
-            if (auto direction = node->textContent(true).defaultWritingDirection())
-                return { *direction == U_LEFT_TO_RIGHT ? TextDirection::LTR : TextDirection::RTL, node };
-        }
-        node = NodeTraversal::next(*node, this);
-    }
-    return { TextDirection::LTR, nullptr };
-}
-
-void HTMLElement::dirAttributeChanged(const AtomString& value)
-{
-    RefPtr parent = parentOrShadowHostElement();
-    bool isValid = true;
-
-    protectedDocument()->setIsDirAttributeDirty();
-
-    auto direction = parseTextDirection(value);
-    switch (direction) {
-    case TextDirectionDirective::Invalid:
-        isValid = false;
-        if (selfOrPrecedingNodesAffectDirAuto() && (!parent || !parent->selfOrPrecedingNodesAffectDirAuto()) && !is<HTMLBDIElement>(*this))
-            setHasDirAutoFlagRecursively(this, false);
-        if (auto* input = dynamicDowncast<HTMLInputElement>(*this); parent && parent->usesEffectiveTextDirection() && !(input && input->isTelephoneField()))
-            updateEffectiveDirectionality(parent->effectiveTextDirection());
-        else
-            updateEffectiveDirectionality(std::nullopt);
-        break;
-    case TextDirectionDirective::LTR:
-        if (selfOrPrecedingNodesAffectDirAuto())
-            setHasDirAutoFlagRecursively(this, false);
-        updateEffectiveDirectionality(TextDirection::LTR);
-        break;
-    case TextDirectionDirective::RTL:
-        if (selfOrPrecedingNodesAffectDirAuto())
-            setHasDirAutoFlagRecursively(this, false);
-        updateEffectiveDirectionality(TextDirection::RTL);
-        break;
-    case TextDirectionDirective::Auto:
-        setUsesEffectiveTextDirection(true);
-        updateEffectiveDirectionalityOfDirAuto();
-        break;
-    }
-
-    if (auto* htmlParent = dynamicDowncast<HTMLElement>(parent.get()); htmlParent && htmlParent->selfOrPrecedingNodesAffectDirAuto()) {
-        if (isValid && direction != TextDirectionDirective::Auto)
-            setHasDirAutoFlagRecursively(this, false);
-        htmlParent->adjustDirectionalityIfNeededAfterChildAttributeChanged(this);
-    }
-}
-
-void HTMLElement::updateEffectiveDirectionality(std::optional<TextDirection> direction)
-{
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
-    auto effectiveDirection = direction.value_or(TextDirection::LTR);
-    setUsesEffectiveTextDirection(!!direction);
-    if (direction)
-        setEffectiveTextDirection(effectiveDirection);
-    auto updateEffectiveTextDirectionOfShadowRoot = [&](HTMLElement& element) {
-        if (RefPtr shadowRootOfElement = element.shadowRoot()) {
-            for (Ref element : childrenOfType<HTMLElement>(*shadowRootOfElement))
-                element->updateEffectiveDirectionality(direction);
-        }
-    };
-    updateEffectiveTextDirectionOfShadowRoot(*this);
-    for (auto it = descendantsOfType<HTMLElement>(*this).begin(); it;) {
-        Ref element = *it;
-        if (isValidDirValue(element->attributeWithoutSynchronization(dirAttr))) {
-            it.traverseNextSkippingChildren();
-            continue;
-        }
-        updateEffectiveTextDirectionOfShadowRoot(element);
-        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClass::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
-        element->setUsesEffectiveTextDirection(!!direction);
-        if (direction)
-            element->setEffectiveTextDirection(effectiveDirection);
-        it.traverseNext();
-    }
-}
-
-void HTMLElement::adjustDirectionalityIfNeededAfterChildAttributeChanged(Element*)
-{
-    ASSERT(selfOrPrecedingNodesAffectDirAuto());
-    for (Ref element : lineageOfType<HTMLElement>(*this)) {
-        if (elementAffectsDirectionality(element)) {
-            ASSERT(element->hasDirectionAuto());
-            element->updateEffectiveDirectionalityOfDirAuto();
-            break;
-        }
-    }
-}
-
-void HTMLElement::updateEffectiveDirectionalityOfDirAuto()
-{
-    auto result = computeDirectionalityFromText();
-    setHasDirAutoFlagRecursively(this, true, result.strongDirectionalityNode.get());
-    updateEffectiveDirectionality(result.direction);
-    if (renderer() && renderer()->style().direction() != result.direction)
-        invalidateStyleForSubtree();
-}
-
-void HTMLElement::updateTextDirectionalityAfterInputTypeChange()
-{
-    dirAttributeChanged(attributeWithoutSynchronization(dirAttr));
-}
-
-void HTMLElement::adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type changeType)
-{
-    // FIXME: This function looks suspicious.
-
-    if (!selfOrPrecedingNodesAffectDirAuto())
-        return;
-
-    RefPtr<Node> oldMarkedNode;
-    if (beforeChange)
-        oldMarkedNode = changeType == ChildChange::Type::ElementInserted ? ElementTraversal::nextSibling(*beforeChange) : beforeChange->nextSibling();
-
-    while (oldMarkedNode && elementAffectsDirectionality(*oldMarkedNode))
-        oldMarkedNode = oldMarkedNode->nextSibling();
-    if (oldMarkedNode)
-        setHasDirAutoFlagRecursively(oldMarkedNode.get(), false);
-
-    for (Ref elementToAdjust : lineageOfType<HTMLElement>(*this)) {
-        if (elementAffectsDirectionality(elementToAdjust)) {
-            ASSERT(elementToAdjust->hasDirectionAuto());
-            elementToAdjust->updateEffectiveDirectionalityOfDirAuto();
-            return;
-        }
-    }
 }
 
 void HTMLElement::addHTMLLengthToStyle(MutableStyleProperties& style, CSSPropertyID propertyID, StringView value, AllowPercentage allowPercentage, UseCSSPXAsUnitType useCSSPX, IsMultiLength isMultiLength, AllowZeroValue allowZeroValue)

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -100,10 +100,6 @@ public:
     WEBCORE_EXPORT const AtomString& dir() const;
     WEBCORE_EXPORT void setDir(const AtomString&);
 
-    bool hasDirectionAuto() const;
-
-    std::optional<TextDirection> directionalityIfDirIsAuto() const;
-
     virtual bool isTextControlInnerTextElement() const { return false; }
     virtual bool isSearchFieldResultsButtonElement() const { return false; }
 
@@ -195,10 +191,6 @@ protected:
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     unsigned parseBorderWidthAttribute(const AtomString&) const;
 
-    void childrenChanged(const ChildChange&) override;
-    void updateTextDirectionalityAfterInputTypeChange();
-    void updateEffectiveDirectionalityOfDirAuto();
-
     virtual void effectiveSpellcheckAttributeChanged(bool);
 
     using EventHandlerNameMap = HashMap<AtomString, AtomString>;
@@ -208,17 +200,6 @@ private:
     String nodeName() const final;
 
     void mapLanguageAttributeToLocale(const AtomString&, MutableStyleProperties&);
-
-    void dirAttributeChanged(const AtomString&);
-    void updateEffectiveDirectionality(std::optional<TextDirection>);
-    void adjustDirectionalityIfNeededAfterChildAttributeChanged(Element* child);
-    void adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type);
-
-    struct TextDirectionWithStrongDirectionalityNode {
-        TextDirection direction;
-        RefPtr<Node> strongDirectionalityNode;
-    };
-    TextDirectionWithStrongDirectionalityNode computeDirectionalityFromText() const;
 
     enum class AllowPercentage : bool { No, Yes };
     enum class UseCSSPXAsUnitType : bool { No, Yes };


### PR DESCRIPTION
#### e66ab86f1ac5269a25adc388f7efee404a2b07f3
<pre>
[Text Directionality] Fix directionality of non-HTML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=276871">https://bugs.webkit.org/show_bug.cgi?id=276871</a>
<a href="https://rdar.apple.com/132210868">rdar://132210868</a>

Reviewed by Ryosuke Niwa.

Move the text directionality code from HTMLElement to Element.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-assorted.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesDirPseudoClass):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeChanged):
(WebCore::parseTextDirection):
(WebCore::isValidDirValue):
(WebCore::elementAffectsDirectionality):
(WebCore::setHasDirAutoFlagRecursively):
(WebCore::Element::hasDirectionAuto const):
(WebCore::Element::directionalityIfDirIsAuto const):
(WebCore::Element::dirAttributeChanged):
(WebCore::Element::updateEffectiveDirectionality):
(WebCore::Element::adjustDirectionalityIfNeededAfterChildrenChanged):
(WebCore::Element::updateTextDirectionalityAfterInputTypeChange):
(WebCore::Element::updateEffectiveDirectionalityOfDirAuto):
(WebCore::Element::computeDirectionalityFromText const):
(WebCore::Element::adjustDirectionalityIfNeededAfterChildAttributeChanged):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::childrenChanged):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::attributeChanged):
(WebCore::HTMLElement::insertedIntoAncestor):
(WebCore::HTMLElement::removedFromAncestor):
(WebCore::parseTextDirection): Deleted.
(WebCore::isValidDirValue): Deleted.
(WebCore::elementAffectsDirectionality): Deleted.
(WebCore::setHasDirAutoFlagRecursively): Deleted.
(WebCore::HTMLElement::childrenChanged): Deleted.
(WebCore::HTMLElement::hasDirectionAuto const): Deleted.
(WebCore::HTMLElement::directionalityIfDirIsAuto const): Deleted.
(WebCore::HTMLElement::computeDirectionalityFromText const): Deleted.
(WebCore::HTMLElement::dirAttributeChanged): Deleted.
(WebCore::HTMLElement::updateEffectiveDirectionality): Deleted.
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildAttributeChanged): Deleted.
(WebCore::HTMLElement::updateEffectiveDirectionalityOfDirAuto): Deleted.
(WebCore::HTMLElement::updateTextDirectionalityAfterInputTypeChange): Deleted.
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildrenChanged): Deleted.
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/281998@main">https://commits.webkit.org/281998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d099f97b7544d45445226ae761793d6d45088b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61631 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49722 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8450 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10614 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57098 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4583 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->