### PR TITLE
Improve device pixel accuracy for Touch Events

### DIFF
--- a/LayoutTests/fast/events/touch/resources/frame-touchevent-forwarder.html
+++ b/LayoutTests/fast/events/touch/resources/frame-touchevent-forwarder.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+html {
+  border: 1px solid blue;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+}
+</style>
+<script>
+    document.addEventListener('touchstart', function(e) {
+        parent.onTouchStart(e);
+    });
+</script>
+Iframe

--- a/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll-expected.txt
+++ b/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll-expected.txt
@@ -5,10 +5,10 @@ PASS event.touches[0].pageX is 100
 PASS event.touches[0].pageY is 100
 
 Just zoomed
-PASS event.touches[0].clientX is 83
-PASS event.touches[0].clientY is 83
-PASS event.touches[0].pageX is 83
-PASS event.touches[0].pageY is 83
+PASS event.touches[0].clientX is within 0.00001 of 83.33333
+PASS event.touches[0].clientY is within 0.00001 of 83.33333
+PASS event.touches[0].pageX is within 0.00001 of 83.33333
+PASS event.touches[0].pageY is within 0.00001 of 83.33333
 
 Just scrolled
 PASS event.touches[0].clientX is 100
@@ -17,10 +17,10 @@ PASS event.touches[0].pageX is 150
 PASS event.touches[0].pageY is 150
 
 Zoomed and scrolled
-PASS event.touches[0].clientX is 84
-PASS event.touches[0].clientY is 84
-PASS event.touches[0].pageX is 133
-PASS event.touches[0].pageY is 133
+PASS event.touches[0].clientX is within 0.00001 of 83.33333
+PASS event.touches[0].clientY is within 0.00001 of 83.33333
+PASS event.touches[0].pageX is within 0.00001 of 133.33333
+PASS event.touches[0].pageY is within 0.00001 of 133.33333
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html
+++ b/LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html
@@ -67,10 +67,10 @@
     {
         event = e;
         debug("\nJust zoomed");
-        shouldBe("event.touches[0].clientX", "83");
-        shouldBe("event.touches[0].clientY", "83");
-        shouldBe("event.touches[0].pageX", "83");
-        shouldBe("event.touches[0].pageY", "83");
+        shouldBeCloseTo("event.touches[0].clientX", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].clientY", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageX", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageY", 83.33333, floatPrecision);
     }
     window.addEventListener("touchstart", justZoomed, false);
     zoomPageIn();
@@ -99,10 +99,10 @@
     {
         event = e;
         debug("\nZoomed and scrolled");
-        shouldBe("event.touches[0].clientX", "84");
-        shouldBe("event.touches[0].clientY", "84");
-        shouldBe("event.touches[0].pageX", "133");
-        shouldBe("event.touches[0].pageY", "133");
+        shouldBeCloseTo("event.touches[0].clientX", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].clientY", 83.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageX", 133.33333, floatPrecision);
+        shouldBeCloseTo("event.touches[0].pageY", 133.33333, floatPrecision);
     }
     window.addEventListener("touchstart", zoomedAndScrolled, false);
     zoomPageIn();

--- a/LayoutTests/fast/events/touch/touch-fractional-coordinates-expected.txt
+++ b/LayoutTests/fast/events/touch/touch-fractional-coordinates-expected.txt
@@ -1,0 +1,55 @@
+Tests non-integer TouchEvent co-ordinates and radii
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Testing simple fractional touch
+PASS eventCount is 1
+PASS lastEvent.type is "touchstart"
+PASS lastEvent.changedTouches[0].screenX is within 0.00001 of 30.33
+PASS lastEvent.changedTouches[0].screenY is within 0.00001 of 4.5
+PASS lastEvent.changedTouches[0].clientX is within 0.00001 of 30.33
+PASS lastEvent.changedTouches[0].clientY is within 0.00001 of 4.5
+PASS lastEvent.changedTouches[0].pageX is within 0.00001 of 33.33
+PASS lastEvent.changedTouches[0].pageY is within 0.00001 of 14.5
+PASS lastEvent.changedTouches[0].radiusX is within 0.00001 of 5.2
+PASS lastEvent.changedTouches[0].radiusY is within 0.00001 of 6.3
+
+
+Testing fractional touch inside simple iframe
+PASS eventCount is 1
+PASS lastEvent.type is "touchstart"
+PASS lastEvent.changedTouches[0].screenX is within 0.00001 of 11.5
+PASS lastEvent.changedTouches[0].screenY is within 0.00001 of 92.2
+PASS lastEvent.changedTouches[0].clientX is within 0.00001 of 4.5
+PASS lastEvent.changedTouches[0].clientY is within 0.00001 of 2.2
+PASS lastEvent.changedTouches[0].pageX is within 0.00001 of 4.5
+PASS lastEvent.changedTouches[0].pageY is within 0.00001 of 2.2
+
+
+Testing fractional touch inside rotated iframe
+PASS eventCount is 1
+PASS lastEvent.type is "touchstart"
+PASS lastEvent.changedTouches[0].screenX is within 0.00001 of 115.5
+PASS lastEvent.changedTouches[0].screenY is within 0.00001 of 92.2
+PASS lastEvent.changedTouches[0].clientX is within 0.00001 of 95.5
+PASS lastEvent.changedTouches[0].clientY is within 0.00001 of 97.8
+PASS lastEvent.changedTouches[0].pageX is within 0.00001 of 95.5
+PASS lastEvent.changedTouches[0].pageY is within 0.00001 of 97.8
+
+
+Testing fractional touch inside scaled iframe
+PASS eventCount is 1
+PASS lastEvent.type is "touchstart"
+PASS lastEvent.changedTouches[0].screenX is within 0.00001 of 244.5
+PASS lastEvent.changedTouches[0].screenY is within 0.00001 of 97.2
+PASS lastEvent.changedTouches[0].clientX is within 0.00001 of 2.25
+PASS lastEvent.changedTouches[0].clientY is within 0.00001 of 1.1
+PASS lastEvent.changedTouches[0].pageX is within 0.00001 of 2.25
+PASS lastEvent.changedTouches[0].pageY is within 0.00001 of 1.1
+
+

--- a/LayoutTests/fast/events/touch/touch-fractional-coordinates.html
+++ b/LayoutTests/fast/events/touch/touch-fractional-coordinates.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<script src='../../../resources/js-test.js'></script>
+<style>
+#spacer {
+  height: 1000px;
+  width: 1000px;
+}
+iframe {
+  width: 100px;
+  height: 100px;
+  border: 0;
+}
+#rotatedFrame {
+  transform: rotate(180deg);
+}
+#scaledFrame {
+  transform: scale(2);
+  width: 50px;
+  height: 50px;
+  margin-left: 50px;
+  margin-bottom: 20px;
+}
+#container {
+  /* Want this at a stable place across platforms so the output co-ords are stable */
+  position: absolute;
+  top: 100px;
+  left: 10px;
+}
+#console {
+  margin-top: 200px;
+}
+</style>
+<p id='description'></p>
+<div id='container'>
+  <iframe id=simpleFrame src='resources/frame-touchevent-forwarder.html'></iframe>
+  <iframe id=rotatedFrame src='resources/frame-touchevent-forwarder.html'></iframe>
+  <iframe id=scaledFrame src='resources/frame-touchevent-forwarder.html'></iframe>
+</div>
+<div id='console'></div>
+<div id='spacer'></div>
+<script>
+    description('Tests non-integer TouchEvent co-ordinates and radii');
+
+    var scrollX = 3;
+    var scrollY = 10;
+    scrollTo(scrollX, scrollY);
+
+    eventCount = 0;
+    function onTouchStart(e) {
+        eventCount++;
+        lastEvent = e;
+    }
+    function expectEvent(eventName) {
+        shouldBeEqualToNumber('eventCount', 1);
+        var origEventCount = eventCount;
+        eventCount = 0;
+        if (origEventCount > 0) {
+            shouldBeEqualToString('lastEvent.type', eventName);
+            return true;
+        }
+        return false;
+    }
+
+    document.addEventListener('touchstart', onTouchStart);
+    var floatPrecision = 0.00001;
+
+    function runTest() {
+        if (!eventSender) {
+            debug('This test requires eventSender.');
+            return;
+        }
+
+        debug('Testing simple fractional touch');
+        eventSender.addTouchPoint(30.33, 4.5, 5.2, 6.3);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', 30.33, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 30.33, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 30.33 + scrollX, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 4.5 + scrollY, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].radiusX', 5.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].radiusY', 6.3, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+
+        debug('Testing fractional touch inside simple iframe');
+        frameRect = document.getElementById('simpleFrame').getBoundingClientRect();
+        eventSender.addTouchPoint(frameRect.left + 4.5, frameRect.top + 2.2);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', frameRect.left + 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', frameRect.top + 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 2.2, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+
+        debug('Testing fractional touch inside rotated iframe');
+        frameRect = document.getElementById('rotatedFrame').getBoundingClientRect();
+        eventSender.addTouchPoint(frameRect.left + 4.5, frameRect.top + 2.2);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', frameRect.left + 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', frameRect.top + 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 100 - 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 100 - 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 100 - 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 100 - 2.2, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+
+        debug('Testing fractional touch inside scaled iframe');
+        frameRect = document.getElementById('scaledFrame').getBoundingClientRect();
+        eventSender.addTouchPoint(frameRect.left + 4.5, frameRect.top + 2.2);
+        eventSender.touchStart();
+        if (expectEvent('touchstart')) {
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenX', frameRect.left + 4.5, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].screenY', frameRect.top + 2.2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientX', 4.5 / 2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].clientY', 2.2 / 2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageX', 4.5 / 2, floatPrecision);
+            shouldBeCloseTo('lastEvent.changedTouches[0].pageY', 2.2 / 2, floatPrecision);
+        }
+        eventSender.releaseTouchPoint(0);
+        eventSender.touchEnd();
+        debug('');
+    }
+
+    addEventListener('load', runTest);
+</script>

--- a/Source/WebCore/dom/Document+Touch.idl
+++ b/Source/WebCore/dom/Document+Touch.idl
@@ -25,8 +25,8 @@
     // FIXME: This has been dropped from the standard now that Touch has a constructor.
     [NewObject] Touch createTouch(optional WindowProxy? window = null, optional EventTarget? target = null,
         optional long identifier = 0,
-        optional long pageX = 0, optional long pageY = 0, optional long screenX = 0, optional long screenY = 0,
-        optional long webkitRadiusX = 0, optional long webkitRadiusY = 0,
+        optional double pageX = 0, optional double pageY = 0, optional double screenX = 0, optional double screenY = 0,
+        optional double webkitRadiusX = 0, optional double webkitRadiusY = 0,
         optional unrestricted float webkitRotationAngle = NaN, optional unrestricted float webkitForce = NaN);
     [NewObject] TouchList createTouchList(Touch... touches);
 };

--- a/Source/WebCore/dom/DocumentTouch.h
+++ b/Source/WebCore/dom/DocumentTouch.h
@@ -43,7 +43,7 @@ class WindowProxy;
 
 class DocumentTouch {
 public:
-    static Ref<Touch> createTouch(Document&, RefPtr<WindowProxy>&&, EventTarget*, int identifier, int pageX, int pageY, int screenX, int screenY, int radiusX, int radiusY, float rotationAngle, float force);
+    static Ref<Touch> createTouch(Document&, RefPtr<WindowProxy>&&, EventTarget*, int identifier, double pageX, double pageY, double screenX, double screenY, double radiusX, double radiusY, float rotationAngle, float force);
     static Ref<TouchList> createTouchList(Document&, FixedVector<std::reference_wrapper<Touch>>&&);
 };
 

--- a/Source/WebCore/dom/Touch.cpp
+++ b/Source/WebCore/dom/Touch.cpp
@@ -29,68 +29,52 @@
 
 #include "Touch.h"
 
+#include "FloatPoint.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 
 namespace WebCore {
 
-static int contentsX(LocalFrame* frame)
+static FloatPoint contentsOffset(LocalFrame* frame)
 {
     if (!frame)
-        return 0;
+        return FloatPoint();
     auto* frameView = frame->view();
     if (!frameView)
-        return 0;
-    return frameView->scrollX() / frame->pageZoomFactor() / frame->frameScaleFactor();
+        return FloatPoint();
+    float scale = 1.0f / frame->pageZoomFactor();
+    return FloatPoint(frameView->scrollPosition()).scaledBy(scale);
 }
 
-static int contentsY(LocalFrame* frame)
+static LayoutPoint scaledLocation(LocalFrame* frame, const FloatPoint& pagePos)
 {
     if (!frame)
-        return 0;
-    auto* frameView = frame->view();
-    if (!frameView)
-        return 0;
-    return frameView->scrollY() / frame->pageZoomFactor() / frame->frameScaleFactor();
-}
-
-static LayoutPoint scaledLocation(LocalFrame* frame, int pageX, int pageY)
-{
-    if (!frame)
-        return { pageX, pageY };
+        return LayoutPoint(pagePos);
     float scaleFactor = frame->pageZoomFactor() * frame->frameScaleFactor();
-    return { pageX * scaleFactor, pageY * scaleFactor };
+    return LayoutPoint(pagePos.scaledBy(scaleFactor));
 }
 
-Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force)
+Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, const FloatPoint& screenPos, const FloatPoint& pagePos, const FloatSize& radius, float rotationAngle, float force)
     : m_target(target)
     , m_identifier(identifier)
-    , m_clientX(pageX - contentsX(frame))
-    , m_clientY(pageY - contentsY(frame))
-    , m_screenX(screenX)
-    , m_screenY(screenY)
-    , m_pageX(pageX)
-    , m_pageY(pageY)
-    , m_radiusX(radiusX)
-    , m_radiusY(radiusY)
+    , m_clientPos(pagePos - contentsOffset(frame))
+    , m_screenPos(screenPos)
+    , m_pagePos(pagePos)
+    , m_radius(radius)
     , m_rotationAngle(rotationAngle)
     , m_force(force)
-    , m_absoluteLocation(scaledLocation(frame, pageX, pageY))
+    , m_absoluteLocation(scaledLocation(frame, pagePos))
 {
 }
 
-Touch::Touch(EventTarget* target, int identifier, int clientX, int clientY, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation)
+Touch::Touch(EventTarget* target, int identifier, const FloatPoint& clientPos, const FloatPoint& screenPos, const FloatPoint& pagePos, const FloatSize& radius, float rotationAngle, float force, LayoutPoint absoluteLocation)
     : m_target(target)
     , m_identifier(identifier)
-    , m_clientX(clientX)
-    , m_clientY(clientY)
-    , m_screenX(screenX)
-    , m_screenY(screenY)
-    , m_pageX(pageX)
-    , m_pageY(pageY)
-    , m_radiusX(radiusX)
-    , m_radiusY(radiusY)
+    , m_clientPos(clientPos)
+    , m_screenPos(screenPos)
+    , m_pagePos(pagePos)
+    , m_radius(radius)
     , m_rotationAngle(rotationAngle)
     , m_force(force)
     , m_absoluteLocation(absoluteLocation)
@@ -99,7 +83,7 @@ Touch::Touch(EventTarget* target, int identifier, int clientX, int clientY, int 
 
 Ref<Touch> Touch::cloneWithNewTarget(EventTarget* eventTarget) const
 {
-    return adoptRef(*new Touch(eventTarget, m_identifier, m_clientX, m_clientY, m_screenX, m_screenY, m_pageX, m_pageY, m_radiusX, m_radiusY, m_rotationAngle, m_force, m_absoluteLocation));
+    return adoptRef(*new Touch(eventTarget, m_identifier, m_clientPos, m_screenPos, m_pagePos, m_radius, m_rotationAngle, m_force, m_absoluteLocation));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Touch.h
+++ b/Source/WebCore/dom/Touch.h
@@ -30,6 +30,8 @@
 #elif ENABLE(TOUCH_EVENTS)
 
 #include "EventTarget.h"
+#include "FloatPoint.h"
+#include "FloatSize.h"
 #include "LayoutPoint.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -41,23 +43,23 @@ class LocalFrame;
 class Touch : public RefCounted<Touch> {
 public:
     static Ref<Touch> create(LocalFrame* frame, EventTarget* target,
-            int identifier, int screenX, int screenY, int pageX, int pageY,
-            int radiusX, int radiusY, float rotationAngle, float force)
+        int identifier, const FloatPoint& screenPos, const FloatPoint& pagePos,
+        const FloatSize& radius, float rotationAngle, float force)
     {
-        return adoptRef(*new Touch(frame, target, identifier, screenX, 
-                screenY, pageX, pageY, radiusX, radiusY, rotationAngle, force));
+        return adoptRef(
+            *new Touch(frame, target, identifier, screenPos, pagePos, radius, rotationAngle, force));
     }
 
     EventTarget* target() const { return m_target.get(); }
     int identifier() const { return m_identifier; }
-    int clientX() const { return m_clientX; }
-    int clientY() const { return m_clientY; }
-    int screenX() const { return m_screenX; }
-    int screenY() const { return m_screenY; }
-    int pageX() const { return m_pageX; }
-    int pageY() const { return m_pageY; }
-    int webkitRadiusX() const { return m_radiusX; }
-    int webkitRadiusY() const { return m_radiusY; }
+    double clientX() const { return m_clientPos.x(); }
+    double clientY() const { return m_clientPos.y(); }
+    double screenX() const { return m_screenPos.x(); }
+    double screenY() const { return m_screenPos.y(); }
+    double pageX() const { return m_pagePos.x(); }
+    double pageY() const { return m_pagePos.y(); }
+    double webkitRadiusX() const { return m_radius.width(); }
+    double webkitRadiusY() const { return m_radius.height(); }
     float webkitRotationAngle() const { return m_rotationAngle; }
     float webkitForce() const { return m_force; }
     const LayoutPoint& absoluteLocation() const { return m_absoluteLocation; }
@@ -65,23 +67,23 @@ public:
 
 private:
     Touch(LocalFrame*, EventTarget*, int identifier,
-            int screenX, int screenY, int pageX, int pageY,
-            int radiusX, int radiusY, float rotationAngle, float force);
+        const FloatPoint& screenPos, const FloatPoint& pagePos,
+            const FloatSize& radius, float rotationAngle, float force);
 
-    Touch(EventTarget*, int identifier, int clientX, int clientY,
-        int screenX, int screenY, int pageX, int pageY,
-        int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation);
+    Touch(EventTarget*, int identifier, const FloatPoint& clientPos,
+        const FloatPoint& screenPos, const FloatPoint& pagePos,
+        const FloatSize& radius, float rotationAngle, float force, LayoutPoint absoluteLocation);
 
     RefPtr<EventTarget> m_target;
     int m_identifier;
-    int m_clientX;
-    int m_clientY;
-    int m_screenX;
-    int m_screenY;
-    int m_pageX;
-    int m_pageY;
-    int m_radiusX;
-    int m_radiusY;
+    // Position relative to the viewport in CSS px.
+    FloatPoint m_clientPos;
+    // Position relative to the screen in DIPs.
+    FloatPoint m_screenPos;
+    // Position relative to the page in CSS px.
+    FloatPoint m_pagePos;
+    // Radius in CSS px.
+    FloatSize m_radius;
     float m_rotationAngle;
     float m_force;
     LayoutPoint m_absoluteLocation;

--- a/Source/WebCore/dom/Touch.idl
+++ b/Source/WebCore/dom/Touch.idl
@@ -29,16 +29,16 @@
     Conditional=TOUCH_EVENTS,
     Exposed=Window
 ] interface Touch {
-    readonly attribute long                clientX;
-    readonly attribute long                clientY;
-    readonly attribute long                screenX;
-    readonly attribute long                screenY;
-    readonly attribute long                pageX;
-    readonly attribute long                pageY;
+    readonly attribute double              clientX;
+    readonly attribute double              clientY;
+    readonly attribute double              screenX;
+    readonly attribute double              screenY;
+    readonly attribute double              pageX;
+    readonly attribute double              pageY;
     readonly attribute EventTarget         target;
     readonly attribute long                identifier;
-    readonly attribute long                webkitRadiusX;
-    readonly attribute long               webkitRadiusY;
+    readonly attribute double              webkitRadiusX;
+    readonly attribute double              webkitRadiusY;
     readonly attribute unrestricted float webkitRotationAngle;
     readonly attribute unrestricted float webkitForce;
 };

--- a/Source/WebCore/dom/wpe/PointerEventWPE.cpp
+++ b/Source/WebCore/dom/wpe/PointerEventWPE.cpp
@@ -72,10 +72,10 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 }
 
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, roundedIntPoint(event.touchPoints().at(index).pos()), roundedIntPoint(event.touchPoints().at(index).pos()), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchPoints().at(index).id())
-    , m_width(2 * event.touchPoints().at(index).radiusX())
-    , m_height(2 * event.touchPoints().at(index).radiusY())
+    , m_width(2 * event.touchPoints().at(index).radius().width())
+    , m_height(2 * event.touchPoints().at(index).radius().height())
     , m_pressure(event.touchPoints().at(index).force())
     , m_pointerType(touchPointerEventType())
     , m_isPrimary(isPrimary)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -288,8 +288,7 @@ public:
         m_id = idDefaultValue; // There is only one active TouchPoint.
         m_screenPos = event.globalPosition();
         m_pos = event.position();
-        m_radiusY = radiusYDefaultValue;
-        m_radiusX = radiusXDefaultValue;
+        m_radius = WebCore::FloatSize(radiusYDefaultValue, radiusXDefaultValue);
         m_rotationAngle = rotationAngleDefaultValue;
         m_force = forceDefaultValue;
 
@@ -4957,7 +4956,7 @@ HandleUserInputEventResult EventHandler::handleTouchEvent(const PlatformTouchEve
     for (unsigned index = 0; index < points.size(); index++) {
         auto& point = points[index];
         PlatformTouchPoint::State pointState = point.state();
-        LayoutPoint pagePoint = documentPointForWindowPoint(frame, point.pos());
+        LayoutPoint pagePoint = LayoutPoint(frame->view()->windowToContents(point.pos()));
 
         OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::TouchEvent };
         // The HitTestRequest types used for mouse events map quite adequately
@@ -5001,8 +5000,8 @@ HandleUserInputEventResult EventHandler::handleTouchEvent(const PlatformTouchEve
                 m_originatingTouchPointTargetKey = touchPointTargetKey;
             } else if (m_originatingTouchPointDocument && m_originatingTouchPointDocument->frame()) {
                 Ref frame = *m_originatingTouchPointDocument->frame();
-                LayoutPoint pagePointInOriginatingDocument = documentPointForWindowPoint(frame, point.pos());
-                result = hitTestResultInFrame(frame.ptr(), pagePointInOriginatingDocument, hitType);
+                LayoutPoint framePoint = roundedIntPoint(frame->view()->windowToContents(point.pos()));
+                result = hitTestResultInFrame(frame.ptr(), framePoint, hitType);
                 if (!result.innerNode())
                     continue;
             } else
@@ -5078,19 +5077,16 @@ HandleUserInputEventResult EventHandler::handleTouchEvent(const PlatformTouchEve
             *pointerTarget, event, index, !index, *document->windowProxy(), { 0, 0 });
 #endif
 
-        if (frame.ptr() != targetFrame) {
-            // pagePoint should always be relative to the target elements containing frame.
-            pagePoint = documentPointForWindowPoint(*targetFrame, point.pos());
-        }
+        // pagePoint should always be relative to the target elements containing frame.
+        pagePoint = LayoutPoint(targetFrame->view()->windowToContents(point.pos()));
 
         float scaleFactor = targetFrame->pageZoomFactor() * targetFrame->frameScaleFactor();
 
-        int adjustedPageX = lroundf(pagePoint.x() / scaleFactor);
-        int adjustedPageY = lroundf(pagePoint.y() / scaleFactor);
+        FloatPoint adjustedPagePoint = FloatPoint(pagePoint.x() / scaleFactor, pagePoint.y() / scaleFactor);
+        FloatSize adjustedRadius = point.radius().scaledBy(scaleFactor);
 
         auto touch = Touch::create(targetFrame.get(), touchTarget.get(), point.id(),
-            point.screenPos().x(), point.screenPos().y(), adjustedPageX, adjustedPageY,
-            point.radiusX(), point.radiusY(), point.rotationAngle(), point.force());
+            point.screenPos(), adjustedPagePoint, adjustedRadius, point.rotationAngle(), point.force());
 
         // Ensure this target's touch list exists, even if it ends up empty, so it can always be passed to TouchEvent::Create below.
         TargetTouchesMap::iterator targetTouchesIterator = touchesByTarget.find(touchTarget.get());

--- a/Source/WebCore/platform/PlatformTouchPoint.h
+++ b/Source/WebCore/platform/PlatformTouchPoint.h
@@ -20,7 +20,7 @@
 #ifndef PlatformTouchPoint_h
 #define PlatformTouchPoint_h
 
-#include "IntPoint.h"
+#include "FloatPoint.h"
 
 #if ENABLE(TOUCH_EVENTS)
 
@@ -42,8 +42,6 @@ public:
     // This is necessary for us to be able to build synthetic events.
     PlatformTouchPoint()
         : m_id(0)
-        , m_radiusY(0)
-        , m_radiusX(0)
         , m_rotationAngle(0)
         , m_force(0)
     {
@@ -52,7 +50,7 @@ public:
 #if PLATFORM(WPE)
     // FIXME: since WPE currently does not send touch stationary events, we need to be able to
     // create a PlatformTouchPoint of type TouchCancelled artificially
-    PlatformTouchPoint(unsigned id, State state, IntPoint screenPos, IntPoint pos)
+    PlatformTouchPoint(unsigned id, State state, FloatPoint screenPos, FloatPoint pos)
         : m_id(id)
         , m_state(state)
         , m_screenPos(screenPos)
@@ -63,20 +61,18 @@ public:
 
     unsigned id() const { return m_id; }
     State state() const { return m_state; }
-    IntPoint screenPos() const { return m_screenPos; }
-    IntPoint pos() const { return m_pos; }
-    int radiusX() const { return m_radiusX; }
-    int radiusY() const { return m_radiusY; }
+    FloatPoint screenPos() const { return m_screenPos; }
+    FloatPoint pos() const { return m_pos; }
+    FloatSize radius() const { return m_radius; }
     float rotationAngle() const { return m_rotationAngle; }
     float force() const { return m_force; }
 
 protected:
     unsigned m_id;
     State m_state;
-    IntPoint m_screenPos;
-    IntPoint m_pos;
-    int m_radiusY;
-    int m_radiusX;
+    FloatPoint m_screenPos;
+    FloatPoint m_pos;
+    FloatSize m_radius;
     float m_rotationAngle;
     float m_force;
 };

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -920,7 +920,7 @@ FloatPoint ScrollView::viewToContents(const FloatPoint& point) const
     if (delegatesScrollingToNativeView())
         return point;
 
-    return viewToContents(IntPoint(point));
+    return point + toFloatSize(documentScrollPositionRelativeToViewOrigin());
 }
 
 FloatPoint ScrollView::contentsToView(const FloatPoint& point) const
@@ -1062,6 +1062,14 @@ IntRect ScrollView::contentsToRootView(const IntRect& contentsRect) const
 
 IntPoint ScrollView::windowToContents(const IntPoint& windowPoint) const
 {
+    return viewToContents(convertFromContainingWindow(windowPoint));
+}
+
+FloatPoint ScrollView::windowToContents(const FloatPoint& windowPoint) const
+{
+    if (delegatesScrolling())
+        return convertFromContainingWindow(windowPoint);
+
     return viewToContents(convertFromContainingWindow(windowPoint));
 }
 

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -343,6 +343,7 @@ public:
     // the entire widget hierarchy. It is up to the platform to decide what the precise definition
     // of containing window is. (For example on Mac it is the containing NSWindow.)
     WEBCORE_EXPORT IntPoint windowToContents(const IntPoint&) const;
+    WEBCORE_EXPORT FloatPoint windowToContents(const FloatPoint&) const;
     WEBCORE_EXPORT IntPoint contentsToWindow(const IntPoint&) const;
     WEBCORE_EXPORT IntRect windowToContents(const IntRect&) const;
     WEBCORE_EXPORT IntRect contentsToWindow(const IntRect&) const;

--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -164,6 +164,20 @@ IntRect Widget::convertFromContainingWindow(const IntRect& windowRect) const
     return convertFromContainingWindowToRoot(this, windowRect);
 }
 
+FloatPoint Widget::convertFromContainingWindow(const FloatPoint& windowPoint) const
+{
+    IntPoint flooredPoint = flooredIntPoint(windowPoint);
+    FloatPoint parentPoint = this->convertFromContainingWindow(flooredPoint);
+    FloatSize windowFraction = windowPoint - flooredPoint;
+    if (!windowFraction.isEmpty()) {
+        const int kFactor = 1000;
+        IntPoint parentLineEnd = this->convertFromContainingWindow(flooredPoint + roundedIntSize(windowFraction.scaledBy(kFactor)));
+        FloatSize parentFraction = (parentLineEnd - parentPoint).scaledBy(1.0f / kFactor);
+        parentPoint.move(parentFraction);
+    }
+    return parentPoint;
+}
+
 IntRect Widget::convertToContainingWindow(const IntRect& localRect) const
 {
     if (const ScrollView* parentScrollView = parent()) {

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -163,6 +163,7 @@ public:
     // when converting window rects.
     WEBCORE_EXPORT IntRect convertToContainingWindow(const IntRect&) const;
     IntRect convertFromContainingWindow(const IntRect&) const;
+    FloatPoint convertFromContainingWindow(const FloatPoint&) const;
 
     WEBCORE_EXPORT IntPoint convertToContainingWindow(const IntPoint&) const;
     IntPoint convertFromContainingWindow(const IntPoint&) const;

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -172,6 +172,11 @@ public:
         return { m_y, m_x };
     }
 
+    FloatPoint scaledBy(float scale) const
+    {
+        return FloatPoint(m_x * scale, m_y * scale);
+    }
+
 #if USE(CG)
     WEBCORE_EXPORT FloatPoint(const CGPoint&);
     WEBCORE_EXPORT operator CGPoint() const;

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -143,6 +143,16 @@ public:
         return FloatSize(m_height, m_width);
     }
 
+    FloatSize scaledBy(float scale) const
+    {
+        return scaledBy(scale, scale);
+    }
+
+    FloatSize scaledBy(float scaleX, float scaleY) const
+    {
+        return FloatSize(m_width * scaleX, m_height * scaleY);
+    }
+
 #if USE(CG)
     WEBCORE_EXPORT explicit FloatSize(const CGSize&); // don't do this implicitly since it's lossy
     WEBCORE_EXPORT operator CGSize() const;

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -323,8 +323,7 @@ public:
 
         m_screenPos = webTouchPoint.screenPosition();
         m_pos = webTouchPoint.position();
-        m_radiusX = webTouchPoint.radius().width();
-        m_radiusY = webTouchPoint.radius().height();
+        m_radius = webTouchPoint.radius();
         m_force = webTouchPoint.force();
         m_rotationAngle = webTouchPoint.rotationAngle();
     }

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -52,7 +52,7 @@ public:
     };
 
     WebPlatformTouchPoint() = default;
-    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint location, State phase)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::FloatPoint location, State phase)
         : m_identifier(identifier)
         , m_location(location)
         , m_phase(phase)
@@ -75,7 +75,7 @@ public:
 #endif
 
     unsigned identifier() const { return m_identifier; }
-    WebCore::IntPoint location() const { return m_location; }
+    WebCore::FloatPoint location() const { return m_location; }
     State phase() const { return m_phase; }
     State state() const { return phase(); }
 
@@ -99,7 +99,7 @@ public:
 
 private:
     unsigned m_identifier { 0 };
-    WebCore::IntPoint m_location;
+    WebCore::FloatPoint m_location;
     State m_phase { State::Released };
 #if ENABLE(IOS_TOUCH_EVENTS)
     double m_radiusX { 0 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4058,7 +4058,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
         auto update = [this, location](TrackingType& trackingType, EventTrackingRegions::EventType eventType) {
             if (trackingType == TrackingType::Synchronous)
                 return;
-            auto trackingTypeForLocation = m_scrollingCoordinatorProxy->eventTrackingTypeForPoint(eventType, location);
+            auto trackingTypeForLocation = m_scrollingCoordinatorProxy->eventTrackingTypeForPoint(eventType, roundedIntPoint(location));
             trackingType = mergeTrackingTypes(trackingType, trackingTypeForLocation);
         };
         auto& tracking = internals().touchEventTracking;


### PR DESCRIPTION
#### 628bfae1ad5915f3ef863e76dc0ef5082925e13f
<pre>
Improve device pixel accuracy for Touch Events
<a href="https://bugs.webkit.org/show_bug.cgi?id=133180">https://bugs.webkit.org/show_bug.cgi?id=133180</a>

Reviewed by NOBODY (OOPS!).

Previously TouchEvents had their co-ordinates truncated to integers.
By supporting sup-pixel precision we get smoother dragging and line
drawing at slow speeds on high-dpi devices or when zoomed.

This is a cherry-pick from Blink:
- <a href="https://codereview.chromium.org/298133003">https://codereview.chromium.org/298133003</a>

* LayoutTests/fast/events/touch/resources/frame-touchevent-forwarder.html: Added.
* LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll-expected.txt:
* LayoutTests/fast/events/touch/touch-coords-in-zoom-and-scroll.html:
* LayoutTests/fast/events/touch/touch-fractional-coordinates-expected.txt: Added.
* LayoutTests/fast/events/touch/touch-fractional-coordinates.html: Added.
* Source/WebCore/dom/Document+Touch.idl:
* Source/WebCore/dom/DocumentTouch.cpp:
(WebCore::DocumentTouch::createTouch):
* Source/WebCore/dom/DocumentTouch.h:
* Source/WebCore/dom/Touch.cpp:
(WebCore::contentsOffset):
(WebCore::scaledLocation):
(WebCore::Touch::Touch):
(WebCore::Touch::cloneWithNewTarget const):
(WebCore::contentsX): Deleted.
(WebCore::contentsY): Deleted.
* Source/WebCore/dom/Touch.h:
(WebCore::Touch::create):
(WebCore::Touch::clientX const):
(WebCore::Touch::clientY const):
(WebCore::Touch::screenX const):
(WebCore::Touch::screenY const):
(WebCore::Touch::pageX const):
(WebCore::Touch::pageY const):
(WebCore::Touch::webkitRadiusX const):
(WebCore::Touch::webkitRadiusY const):
* Source/WebCore/dom/Touch.idl:
* Source/WebCore/dom/wpe/PointerEventWPE.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::SyntheticTouchPoint::SyntheticTouchPoint):
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/platform/PlatformTouchPoint.h:
(WebCore::PlatformTouchPoint::PlatformTouchPoint):
(WebCore::PlatformTouchPoint::screenPos const):
(WebCore::PlatformTouchPoint::pos const):
(WebCore::PlatformTouchPoint::radius const):
(WebCore::PlatformTouchPoint::radiusX const): Deleted.
(WebCore::PlatformTouchPoint::radiusY const): Deleted.
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::viewToContents const):
(WebCore::ScrollView::windowToContents const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::convertFromContainingWindow const):
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::FloatPoint::scaledBy const):
* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::FloatSize::scaledBy const):
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchPoint::WebKit2PlatformTouchPoint):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebPlatformTouchPoint::WebPlatformTouchPoint):
(WebKit::WebPlatformTouchPoint::location const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateTouchEventTracking):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/628bfae1ad5915f3ef863e76dc0ef5082925e13f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69270 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15852 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16134 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52416 "Found 2 new test failures: fast/events/touch/touch-coords-in-zoom-and-scroll.html fast/events/touch/touch-fractional-coordinates.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37903 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13845 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9198 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13663 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-addsourcebuffer-mode.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59741 "Found 1 new test failure: fast/events/touch/touch-fractional-coordinates.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56535 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60015 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/basic-hierarchy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1272 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40425 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->