### PR TITLE
REGRESSION (279847@main): Expanding threaded emails in Fastmail web UI results in missing content, repaint artifacts, broken rendering

### DIFF
--- a/LayoutTests/fast/repaint/simplified-repaint-with-overflow-expected.txt
+++ b/LayoutTests/fast/repaint/simplified-repaint-with-overflow-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 18 18 50 50)
+  (rect 18 118 50 50)
+)
+

--- a/LayoutTests/fast/repaint/simplified-repaint-with-overflow.html
+++ b/LayoutTests/fast/repaint/simplified-repaint-with-overflow.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .relative_container {
+            position: relative;
+            width: 500px;
+            height: 20px;
+            outline: 1px solid orange;
+            padding: 10px;
+        }
+
+        .absolute_container {
+            position: absolute;
+            width: 200px;
+            height: 200px;
+            outline: 1px solid blue;
+        }
+
+        .growing {
+            margin-bottom: 0px;
+        }
+
+        body.changed .growing {
+            margin-bottom: 100px;
+        }
+
+        .sibling {
+            position: relative;
+            width: 50px;
+            height: 50px;
+            background-color: green;
+        }
+    </style>
+    <script src="resources/text-based-repaint.js"></script>
+    <script>
+        function repaintTest()
+        {
+            document.body.classList.add('changed');
+        }
+        
+        window.addEventListener('load', () => {
+            runRepaintTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class=relative_container>
+        <div class=absolute_container>
+          <div class=growing></div>
+          <div class=sibling></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1057,7 +1057,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
                 return true;
             if (!renderer().didVisitDuringLastLayout())
                 return false;
-            if (auto* renderBox = this->renderBox(); renderBox && renderBox->hasRenderOverflow() && renderBox->hasTransformRelatedProperty()) {
+            if (auto* renderBox = this->renderBox(); renderBox && renderBox->hasRenderOverflow()) {
                 // Disable optimization for subtree when dealing with overflow as RenderLayer is not sized to enclose overflow.
                 // FIXME: This should check if transform related property has changed.
                 canUseSimplifiedRepaintPass = CanUseSimplifiedRepaintPass::No;


### PR DESCRIPTION
#### b72f845e52d9b27dc8a6cd67aed3215f59f56031
<pre>
REGRESSION (279847@main): Expanding threaded emails in Fastmail web UI results in missing content, repaint artifacts, broken rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=277782">https://bugs.webkit.org/show_bug.cgi?id=277782</a>
<a href="https://rdar.apple.com/133344580">rdar://133344580</a>

Reviewed by Tim Horton.

The optimization added in 279847@main caused us to skip repaints on a layer which moved, when the movement is triggered by
layout on an ancestor layer. This caused repaint bugs on Google Sheets when dragging rows, and Fastmail when collapsing
rows.

Fix by undoing the &quot;simplified repaint&quot; optimization on the descendant layers of a layer with overflow, by removing the check for
the layer also having a transform.

* LayoutTests/fast/repaint/simplified-repaint-with-overflow-expected.txt: Added.
* LayoutTests/fast/repaint/simplified-repaint-with-overflow.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):

Canonical link: <a href="https://commits.webkit.org/281993@main">https://commits.webkit.org/281993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db5a807a10572ad4728e9e2a6a879b0dc4ae3b10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49723 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8457 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10924 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67341 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57104 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57328 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4590 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36793 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37877 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->