### PR TITLE
[view-transitions] Implement DOM API necessary to support :active-view-transition-type()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7551,7 +7551,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-m
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-late-mutation.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-matches.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-removed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-reserved-mutation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View transitions: types from rule are reflected in pagereveal and pageswap promise_test: Unhandled rejection with value: object "TypeError: Spread syntax requires ...iterable not be null or undefined"
+FAIL View transitions: types from rule are reflected in pagereveal and pageswap assert_array_equals: lengths differ, expected array ["check"] length 1, got [] length 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-expected.txt
@@ -1,5 +1,9 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Old view transition aborted by new view transition.
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Old view transition aborted by new view transition.
 
-FAIL ViewTransition.types is a ViewTransitionTypeSet Can't find variable: ViewTransitionTypeSet
-FAIL ViewTransitionTypeSet behaves like an ordinary Set of strings undefined is not an object (evaluating 'types.add')
-FAIL ViewTransitionTypeSet should reflect its members for a non-active transition promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'transition.types.add')"
+Harness Error (FAIL), message = Unhandled rejection: Old view transition aborted by new view transition.
+
+PASS ViewTransition.types is a ViewTransitionTypeSet
+PASS ViewTransitionTypeSet behaves like an ordinary Set of strings
+PASS ViewTransitionTypeSet should reflect its members for a non-active transition
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7496,6 +7496,20 @@ ViewGestureDebuggingEnabled:
     WebKit:
       default: false
 
+ViewTransitionTypesEnabled:
+  type: bool
+  category: animation
+  status: testable
+  humanReadableName: "View Transition Types"
+  humanReadableDescription: "Support specifying types for view transitions"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ViewTransitionsEnabled:
   type: bool
   category: animation

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1148,6 +1148,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ShadowRootMode.idl
     dom/SlotAssignmentMode.idl
     dom/Slotable.idl
+    dom/StartViewTransitionOptions.idl
     dom/StaticRange.idl
     dom/StringCallback.idl
     dom/SubscribeOptions.idl
@@ -1177,7 +1178,9 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/UIEvent.idl
     dom/UIEventInit.idl
     dom/ValidityStateFlags.idl
+    dom/ViewTransition+Types.idl
     dom/ViewTransition.idl
+    dom/ViewTransitionTypeSet.idl
     dom/ViewTransitionUpdateCallback.idl
     dom/VisibilityState.idl
     dom/WheelEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1482,6 +1482,7 @@ $(PROJECT_DIR)/dom/ShadowRootInit.idl
 $(PROJECT_DIR)/dom/ShadowRootMode.idl
 $(PROJECT_DIR)/dom/SlotAssignmentMode.idl
 $(PROJECT_DIR)/dom/Slotable.idl
+$(PROJECT_DIR)/dom/StartViewTransitionOptions.idl
 $(PROJECT_DIR)/dom/StaticRange.idl
 $(PROJECT_DIR)/dom/StringCallback.idl
 $(PROJECT_DIR)/dom/SubscribeOptions.idl
@@ -1514,7 +1515,9 @@ $(PROJECT_DIR)/dom/TrustedTypePolicyOptions.idl
 $(PROJECT_DIR)/dom/UIEvent.idl
 $(PROJECT_DIR)/dom/UIEventInit.idl
 $(PROJECT_DIR)/dom/ValidityStateFlags.idl
+$(PROJECT_DIR)/dom/ViewTransition+Types.idl
 $(PROJECT_DIR)/dom/ViewTransition.idl
+$(PROJECT_DIR)/dom/ViewTransitionTypeSet.idl
 $(PROJECT_DIR)/dom/ViewTransitionUpdateCallback.idl
 $(PROJECT_DIR)/dom/VisibilityState.idl
 $(PROJECT_DIR)/dom/WheelEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2883,6 +2883,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisUtterance.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisUtterance.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisVoice.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSpeechSynthesisVoice.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStartViewTransitionOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStartViewTransitionOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStaticRange.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStaticRange.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStereoPannerNode.cpp
@@ -3053,8 +3055,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimeline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimeline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimelineOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimelineOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition+Types.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition+Types.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransition.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionTypeSet.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionTypeSet.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionUpdateCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionUpdateCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisibilityState.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1175,6 +1175,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/ShadowRootMode.idl \
     $(WebCore)/dom/SlotAssignmentMode.idl \
     $(WebCore)/dom/Slotable.idl \
+    $(WebCore)/dom/StartViewTransitionOptions.idl \
     $(WebCore)/dom/StaticRange.idl \
     $(WebCore)/dom/StringCallback.idl \
     $(WebCore)/dom/Subscriber.idl \
@@ -1202,6 +1203,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/UIEventInit.idl \
     $(WebCore)/dom/ValidityStateFlags.idl \
     $(WebCore)/dom/ViewTransition.idl \
+    $(WebCore)/dom/ViewTransitionTypeSet.idl \
+    $(WebCore)/dom/ViewTransition+Types.idl \
     $(WebCore)/dom/ViewTransitionUpdateCallback.idl \
     $(WebCore)/dom/VisibilityState.idl \
     $(WebCore)/dom/WheelEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1063,6 +1063,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/SimulatedClickOptions.h
     dom/SlotAssignmentMode.h
     dom/SpaceSplitString.h
+    dom/StartViewTransitionOptions.h
     dom/StaticRange.h
     dom/StyledElement.h
     dom/TaskSource.h
@@ -1090,6 +1091,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/UserTypingGestureIndicator.h
     dom/ValidityStateFlags.h
     dom/ViewTransition.h
+    dom/ViewTransitionTypeSet.h
     dom/VisibilityAdjustment.h
     dom/ViewTransitionUpdateCallback.h
     dom/ViewportArguments.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1287,6 +1287,7 @@ dom/UserActionElementSet.cpp
 dom/UserGestureIndicator.cpp
 dom/UserTypingGestureIndicator.cpp
 dom/ViewTransition.cpp
+dom/ViewTransitionTypeSet.cpp
 dom/ViewportArguments.cpp
 dom/VisitedLinkState.cpp
 dom/WheelEvent.cpp
@@ -4453,6 +4454,7 @@ JSSpeechSynthesisUtterance.cpp
 JSSpeechSynthesisVoice.cpp
 JSStereoPannerNode.cpp
 JSStereoPannerOptions.cpp
+JSStartViewTransitionOptions.cpp
 JSStaticRange.cpp
 JSStorage.cpp
 JSStorageManager.cpp
@@ -4572,6 +4574,7 @@ JSVideoTransferCharacteristics.cpp
 JSViewTimeline.cpp
 JSViewTimelineOptions.cpp
 JSViewTransition.cpp
+JSViewTransitionTypeSet.cpp
 JSViewTransitionUpdateCallback.cpp
 JSVisibilityState.cpp
 JSVisualViewport.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -462,6 +462,7 @@ namespace WebCore {
     macro(VideoFrame) \
     macro(ViewTimeline) \
     macro(ViewTransition) \
+    macro(ViewTransitionTypeSet) \
     macro(VisualViewport) \
     macro(WGSLLanguageFeatures) \
     macro(WakeLock) \

--- a/Source/WebCore/dom/Document+ViewTransition.idl
+++ b/Source/WebCore/dom/Document+ViewTransition.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,5 +24,5 @@
  */
 
 partial interface Document {
-    [EnabledBySetting=ViewTransitionsEnabled] ViewTransition startViewTransition(optional ViewTransitionUpdateCallback? updateCallback = null);
+    [EnabledBySetting=ViewTransitionsEnabled] ViewTransition startViewTransition(optional (ViewTransitionUpdateCallback or StartViewTransitionOptions) callbackOptions = {});
 };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -172,6 +172,7 @@ class ImageBitmapRenderingContext;
 class IntPoint;
 class IntersectionObserver;
 class JSNode;
+class JSViewTransitionUpdateCallback;
 class LayoutPoint;
 class LayoutRect;
 class LazyLoadImageObserver;
@@ -277,6 +278,7 @@ struct IntersectionObserverData;
 struct OwnerPermissionsPolicyData;
 struct QuerySelectorAllResults;
 struct SecurityPolicyViolationEventInit;
+struct StartViewTransitionOptions;
 struct ViewTransitionParams;
 
 #if ENABLE(TOUCH_EVENTS)
@@ -399,6 +401,8 @@ using RenderingContext = std::variant<
     RefPtr<ImageBitmapRenderingContext>,
     RefPtr<CanvasRenderingContext2D>
 >;
+
+using StartViewTransitionCallbackOptions = std::optional<std::variant<RefPtr<JSViewTransitionUpdateCallback>, StartViewTransitionOptions>>;
 
 class DocumentParserYieldToken {
     WTF_MAKE_FAST_ALLOCATED;
@@ -1699,7 +1703,7 @@ public:
     void unobserveForContainIntrinsicSize(Element&);
     void resetObservationSizeForContainIntrinsicSize(Element&);
 
-    RefPtr<ViewTransition> startViewTransition(RefPtr<ViewTransitionUpdateCallback>&& = nullptr);
+    RefPtr<ViewTransition> startViewTransition(StartViewTransitionCallbackOptions&&);
     ViewTransition* activeViewTransition() const;
     bool activeViewTransitionCapturedDocumentElement() const;
     void setActiveViewTransition(RefPtr<ViewTransition>&&);

--- a/Source/WebCore/dom/StartViewTransitionOptions.h
+++ b/Source/WebCore/dom/StartViewTransitionOptions.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ViewTransitionUpdateCallback.h"
+
+namespace WebCore {
+
+struct StartViewTransitionOptions {
+    RefPtr<ViewTransitionUpdateCallback> update;
+    std::optional<Vector<AtomString>> types;
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/dom/StartViewTransitionOptions.idl
+++ b/Source/WebCore/dom/StartViewTransitionOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary StartViewTransitionOptions {
+    ViewTransitionUpdateCallback? update = null;
+    [EnabledBySetting=ViewTransitionTypesEnabled] sequence<[AtomString] DOMString>? types = null;
+};

--- a/Source/WebCore/dom/ViewTransition+Types.idl
+++ b/Source/WebCore/dom/ViewTransition+Types.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+partial interface ViewTransition {
+    [EnabledBySetting=ViewTransitionTypesEnabled] attribute ViewTransitionTypeSet types;
+};

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -63,13 +63,14 @@ static std::pair<Ref<DOMPromise>, Ref<DeferredPromise>> createPromiseAndWrapper(
     return { WTFMove(domPromise), deferredPromise.releaseNonNull() };
 }
 
-ViewTransition::ViewTransition(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
+ViewTransition::ViewTransition(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback, Vector<AtomString>&& initialActiveTypes)
     : ActiveDOMObject(document)
     , m_updateCallback(WTFMove(updateCallback))
     , m_shouldCallUpdateCallback(true)
     , m_ready(createPromiseAndWrapper(document))
     , m_updateCallbackDone(createPromiseAndWrapper(document))
     , m_finished(createPromiseAndWrapper(document))
+    , m_types(ViewTransitionTypeSet::create(document, WTFMove(initialActiveTypes)))
 {
 }
 
@@ -78,15 +79,16 @@ ViewTransition::ViewTransition(Document& document)
     , m_ready(createPromiseAndWrapper(document))
     , m_updateCallbackDone(createPromiseAndWrapper(document))
     , m_finished(createPromiseAndWrapper(document))
+    , m_types(ViewTransitionTypeSet::create(document, { }))
 {
 }
 
 
 ViewTransition::~ViewTransition() = default;
 
-Ref<ViewTransition> ViewTransition::createSamePage(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
+Ref<ViewTransition> ViewTransition::createSamePage(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback, Vector<AtomString>&& initialActiveTypes)
 {
-    Ref viewTransition = adoptRef(*new ViewTransition(document, WTFMove(updateCallback)));
+    Ref viewTransition = adoptRef(*new ViewTransition(document, WTFMove(updateCallback), WTFMove(initialActiveTypes)));
     viewTransition->suspendIfNeeded();
     return viewTransition;
 }

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -33,6 +33,7 @@
 #include "JSValueInWrappedObject.h"
 #include "MutableStyleProperties.h"
 #include "Styleable.h"
+#include "ViewTransitionTypeSet.h"
 #include "ViewTransitionUpdateCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -149,7 +150,7 @@ public:
 
 class ViewTransition : public RefCounted<ViewTransition>, public CanMakeWeakPtr<ViewTransition>, public ActiveDOMObject {
 public:
-    static Ref<ViewTransition> createSamePage(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
+    static Ref<ViewTransition> createSamePage(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     static Ref<ViewTransition> createInbound(Document&, std::unique_ptr<ViewTransitionParams>);
     static Ref<ViewTransition> createOutbound(Document&);
     ~ViewTransition();
@@ -180,10 +181,13 @@ public:
 
     bool documentElementIsCaptured() const;
 
+    const ViewTransitionTypeSet& types() const { return m_types; }
+    void setTypes(Ref<ViewTransitionTypeSet>&& newTypes) { m_types = newTypes; }
+
     RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject&);
 
 private:
-    ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
+    ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     ViewTransition(Document&);
 
     Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&);
@@ -218,6 +222,8 @@ private:
     PromiseAndWrapper m_updateCallbackDone;
     PromiseAndWrapper m_finished;
     EventLoopTimerHandle m_updateCallbackTimeout;
+
+    Ref<ViewTransitionTypeSet> m_types;
 };
 
 }

--- a/Source/WebCore/dom/ViewTransitionTypeSet.cpp
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ViewTransitionTypeSet.h"
+
+#include "Document.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ViewTransitionTypeSet);
+
+ViewTransitionTypeSet::ViewTransitionTypeSet(Document& document, Vector<AtomString>&& initialActiveTypes)
+    : m_typeSet()
+    , m_document(document)
+{
+    for (auto initialActiveType : initialActiveTypes)
+        m_typeSet.add(initialActiveType);
+}
+
+void ViewTransitionTypeSet::initializeSetLike(DOMSetAdapter& setAdapter) const
+{
+    for (auto activeType : m_typeSet)
+        setAdapter.add<IDLDOMString>(activeType);
+}
+
+void ViewTransitionTypeSet::clearFromSetLike()
+{
+    m_typeSet.clear();
+}
+
+void ViewTransitionTypeSet::addToSetLike(const AtomString& type)
+{
+    m_typeSet.add(type);
+}
+
+bool ViewTransitionTypeSet::removeFromSetLike(const AtomString& type)
+{
+    return m_typeSet.remove(type);
+}
+
+bool ViewTransitionTypeSet::has(const AtomString& type) const
+{
+    return m_typeSet.contains(type);
+}
+
+}

--- a/Source/WebCore/dom/ViewTransitionTypeSet.h
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Element.h"
+#include "JSDOMSetLike.h"
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/ListHashSet.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class ViewTransitionTypeSet : public RefCounted<ViewTransitionTypeSet> {
+    WTF_MAKE_ISO_ALLOCATED(ViewTransitionTypeSet);
+
+public:
+    static Ref<ViewTransitionTypeSet> create(Document& document, Vector<AtomString>&& initialActiveTypes)
+    {
+        return adoptRef(*new ViewTransitionTypeSet(document, WTFMove(initialActiveTypes)));
+    }
+
+    void initializeSetLike(DOMSetAdapter&) const;
+
+    void clearFromSetLike();
+    void addToSetLike(const AtomString&);
+    bool removeFromSetLike(const AtomString&);
+
+    bool has(const AtomString&) const;
+
+private:
+    ViewTransitionTypeSet(Document&, Vector<AtomString>&&);
+
+    ListHashSet<AtomString> m_typeSet;
+    Document& m_document;
+};
+
+}

--- a/Source/WebCore/dom/ViewTransitionTypeSet.idl
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=ViewTransitionTypesEnabled,
+    Exposed=Window
+]
+interface ViewTransitionTypeSet {
+    setlike<[AtomString] DOMString>;
+};


### PR DESCRIPTION
#### c6cadba6b01325cd2e8a3b35d8f0ef440ea97429
<pre>
[view-transitions] Implement DOM API necessary to support :active-view-transition-type()
<a href="https://bugs.webkit.org/show_bug.cgi?id=277777">https://bugs.webkit.org/show_bug.cgi?id=277777</a>
<a href="https://rdar.apple.com/133419258">rdar://133419258</a>

Reviewed by Tim Nguyen.

This commit sets up the necessary infrastructure on the JavaScript DOM
API side to support :active-view-transition-type(). This includes:
* Adding a new setting called ViewTransitionsTypeEnabled
* Extending Document.startViewTransition to additionally accept
  StartViewTransitionOptions
* Implementing the ViewTransitionTypeSet object
* Extending ViewTransition to include a `types` member of type
  ViewTransitionTypeSet.

* LayoutTests/TestExpectations: Removed one passing test.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt:
Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-expected.txt:
Rebaselined now that the test is passing.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Added new setting ViewTransitionsTypeEnabled
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/Document+ViewTransition.idl: Extended Document.startViewTransition
to additionally accept StartViewTransitionOptions.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::startViewTransition): Extended to accept StartViewTransitionOptions
and pass the types within the options to ViewTransition.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/StartViewTransitionOptions.h: Added.
* Source/WebCore/dom/StartViewTransitionOptions.idl: Added.
* Source/WebCore/dom/ViewTransition+Types.idl: Added new member `types` of type
ViewTransitionTypeSet.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::ViewTransition): Additionally accept a vector of types and pass it
to ViewTransitionTypeSet.
(WebCore::ViewTransition::createSamePage):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::types const):
(WebCore::ViewTransition::setTypes):
* Source/WebCore/dom/ViewTransitionTypeSet.cpp: Added.
(WebCore::ViewTransitionTypeSet::ViewTransitionTypeSet):
(WebCore::ViewTransitionTypeSet::initializeSetLike const):
(WebCore::ViewTransitionTypeSet::clearFromSetLike):
(WebCore::ViewTransitionTypeSet::addToSetLike):
(WebCore::ViewTransitionTypeSet::removeFromSetLike):
(WebCore::ViewTransitionTypeSet::has const):
* Source/WebCore/dom/ViewTransitionTypeSet.h: Added.
(WebCore::ViewTransitionTypeSet::create):
* Source/WebCore/dom/ViewTransitionTypeSet.idl: Added.

Canonical link: <a href="https://commits.webkit.org/282088@main">https://commits.webkit.org/282088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78095386d6d36d15c241feee50cf953d5430495c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49935 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11489 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55108 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67721 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61255 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57559 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4875 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37167 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14548 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->