### PR TITLE
[JSC] Fold super call with explicitly specified `Object` constructor

### DIFF
--- a/JSTests/microbenchmarks/construct-object.js
+++ b/JSTests/microbenchmarks/construct-object.js
@@ -1,0 +1,18 @@
+class A extends Object {
+}
+
+class B extends A {
+    constructor() {
+        super();
+    }
+}
+
+function test()
+{
+    return new B();
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    test();
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -50,6 +50,7 @@
 #include "JSWebAssemblyInstance.h"
 #include "MathCommon.h"
 #include "NumberConstructor.h"
+#include "ObjectConstructor.h"
 #include "PutByStatus.h"
 #include "RegExpObject.h"
 #include "RegExpPrototype.h"
@@ -4992,10 +4993,45 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case Flush:
     case PhantomLocal:
         break;
+
+    case Construct: {
+        Edge calleeNode = m_graph.child(node, 0);
+        Edge newTargetNode = m_graph.child(node, 1);
+        JSValue calleeValue = forNode(calleeNode).m_value;
+        JSValue newTargetValue = forNode(newTargetNode).m_value;
+        if (calleeValue && newTargetValue) {
+            auto* callee = jsDynamicCast<JSObject*>(calleeValue);
+            auto* newTarget = jsDynamicCast<JSFunction*>(newTargetValue);
+            if (callee && newTarget) {
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                if (callee->globalObject() == globalObject) {
+                    if (callee->classInfo() == ObjectConstructor::info() && node->numChildren() == 2) {
+                        if (FunctionRareData* rareData = newTarget->rareData()) {
+                            if (rareData->allocationProfileWatchpointSet().isStillValid() && globalObject->structureCacheClearedWatchpointSet().isStillValid()) {
+                                Structure* structure = rareData->internalFunctionAllocationStructure();
+                                if (structure && structure->classInfoForCells() == JSFinalObject::info() && structure->hasMonoProto()) {
+                                    m_graph.freeze(rareData);
+                                    m_graph.watchpoints().addLazily(rareData->allocationProfileWatchpointSet());
+                                    m_graph.freeze(globalObject);
+                                    m_graph.watchpoints().addLazily(globalObject->structureCacheClearedWatchpointSet());
+                                    m_state.setShouldTryConstantFolding(true);
+                                    didFoldClobberWorld();
+                                    setForNode(node, structure);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        clobberWorld();
+        makeHeapTopForNode(node);
+        break;
+    }
             
     case Call:
     case TailCallInlinedCaller:
-    case Construct:
     case CallVarargs:
     case CallForwardVarargs:
     case TailCallVarargsInlinedCaller:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1280,6 +1280,39 @@ private:
                 break;
             }
 
+            case Construct: {
+                Edge calleeNode = m_graph.child(node, 0);
+                Edge newTargetNode = m_graph.child(node, 1);
+                JSValue calleeValue = m_state.forNode(calleeNode).m_value;
+                JSValue newTargetValue = m_state.forNode(newTargetNode).m_value;
+                if (calleeValue && newTargetValue) {
+                    auto* callee = jsDynamicCast<JSObject*>(calleeValue);
+                    auto* newTarget = jsDynamicCast<JSFunction*>(newTargetValue);
+                    if (callee && newTarget) {
+                        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                        if (callee->globalObject() == globalObject) {
+                            if (callee->classInfo() == ObjectConstructor::info() && node->numChildren() == 2) {
+                                if (FunctionRareData* rareData = newTarget->rareData()) {
+                                    if (rareData->allocationProfileWatchpointSet().isStillValid() && globalObject->structureCacheClearedWatchpointSet().isStillValid()) {
+                                        Structure* structure = rareData->internalFunctionAllocationStructure();
+                                        if (structure && structure->classInfoForCells() == JSFinalObject::info() && structure->hasMonoProto()) {
+                                            m_graph.freeze(rareData);
+                                            m_graph.watchpoints().addLazily(rareData->allocationProfileWatchpointSet());
+                                            m_graph.freeze(globalObject);
+                                            m_graph.watchpoints().addLazily(globalObject->structureCacheClearedWatchpointSet());
+                                            node->convertToNewObject(m_graph.registerStructure(structure));
+                                            changed = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+
             case PhantomNewObject:
             case PhantomNewFunction:
             case PhantomNewGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -840,7 +840,7 @@ public:
 
     void convertToNewObject(RegisteredStructure structure)
     {
-        ASSERT(m_op == CallObjectConstructor || m_op == CreateThis || m_op == ObjectCreate);
+        ASSERT(m_op == CallObjectConstructor || m_op == CreateThis || m_op == ObjectCreate || m_op == Construct);
         setOpAndDefaultFlags(NewObject);
         children.reset();
         m_opInfo = structure;


### PR DESCRIPTION
#### 06b27b91cf2cb5e6e4fc78f5410c065d75de1633
<pre>
[JSC] Fold super call with explicitly specified `Object` constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=277787">https://bugs.webkit.org/show_bug.cgi?id=277787</a>
<a href="https://rdar.apple.com/133426751">rdar://133426751</a>

Reviewed by Keith Miller.

We do slow path when we explicitly specifying `Object` for the super class. We found these patterns in some cases, so we would like to optimize it.
In DFG AI, we attempt to figure out that

1. super class is `Object`
2. new.target is something constant JSFunction

Then we do folding into NewObject by using internalFunctionAllocationProfile.

                                 ToT                     Patched

    construct-object       10.3615+-0.0283     ^      2.9730+-0.0200        ^ definitely 3.4852x faster

* JSTests/microbenchmarks/construct-object.js: Added.
(A):
(B):
(test):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToNewObject):

Canonical link: <a href="https://commits.webkit.org/281981@main">https://commits.webkit.org/281981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3fc020aa7b6a526a067b7ba14674a87d3cd9f49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12466 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11126 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54745 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67355 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60891 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5593 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4600 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82652 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9285 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14450 "Found 1465 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37888 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38984 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->