### PR TITLE
[JSC] Clear stringReplaceCache only when full GC runs

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2223,13 +2223,13 @@ void Heap::finalize()
     if (auto* cache = vm().megamorphicCache())
         cache->age(m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full ? CollectionScope::Full : CollectionScope::Eden);
 
-    if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full)
+    if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full) {
         vm().jsonAtomStringCache.clear();
+        vm().numericStrings.clearOnGarbageCollection();
+        vm().stringReplaceCache.clear();
+    }
     vm().keyAtomStringCache.clear();
     vm().stringSplitCache.clear();
-    vm().stringReplaceCache.clear();
-    if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full)
-        vm().numericStrings.clearOnGarbageCollection();
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();
 

--- a/Source/JavaScriptCore/runtime/StringReplaceCache.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCache.h
@@ -57,6 +57,8 @@ public:
     Entry* get(const String& subject, RegExp*);
     void set(const String& subject, RegExp*, JSImmutableButterfly*, MatchResult, const Vector<int>&);
 
+    DECLARE_VISIT_AGGREGATE;
+
     void clear()
     {
         m_entries.fill(Entry { });

--- a/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
@@ -89,4 +89,15 @@ inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImm
     }
 }
 
+template<typename Visitor>
+inline void StringReplaceCache::visitAggregateImpl(Visitor& visitor)
+{
+    for (auto& entry : m_entries) {
+        visitor.appendUnbarriered(entry.m_regExp);
+        visitor.appendUnbarriered(entry.m_result);
+    }
+}
+
+DEFINE_VISIT_AGGREGATE(StringReplaceCache);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1626,6 +1626,9 @@ void VM::visitAggregateImpl(Visitor& visitor)
     m_builtinExecutables->visitAggregate(visitor);
     m_regExpCache->visitAggregate(visitor);
 
+    if (heap.collectionScope() != CollectionScope::Full)
+        stringReplaceCache.visitAggregate(visitor);
+
     visitor.append(structureStructure);
     visitor.append(structureRareDataStructure);
     visitor.append(stringStructure);


### PR DESCRIPTION
#### 0cc7dadd7eebdc17637dcce898dc2fd18da1432a
<pre>
[JSC] Clear stringReplaceCache only when full GC runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277792">https://bugs.webkit.org/show_bug.cgi?id=277792</a>
<a href="https://rdar.apple.com/133437377">rdar://133437377</a>

Reviewed by Keith Miller.

Let&apos;s just keep these entries alive during Eden GC. We mark them in Eden GC and clear them in Full GC.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/StringReplaceCache.h:
* Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h:
(JSC::StringReplaceCache::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::visitAggregateImpl):

Canonical link: <a href="https://commits.webkit.org/281994@main">https://commits.webkit.org/281994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5313b2ddeceefbd3949e15aa684c49ecce175006

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14256 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65639 "") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12209 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12480 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/65639 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53416 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/65639 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11140 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54759 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67370 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60905 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5607 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10707 "Found 2 new test failures: imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57120 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57346 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4613 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82666 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36818 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14453 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38998 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->