### PR TITLE
[LFC][IFC] Remove floats that are outside of the "rebuild" range to ensure we don't add them twice

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -226,8 +226,6 @@ http/tests/security/clipboard/drag-drop-html-cross-origin-iframe-in-same-origin.
 # rdar://problem/61793884 : making this test WK1 specific as, for WK2 its timing out.
 fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 
-webkit.org/b/247625 [ Debug ] fast/block/float/intrusive-floats-with-reverted-inline-content.html [ Skip ]
-
 [ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
 
 # Only iOS supports QuickLook

--- a/LayoutTests/fast/block/float/intrusive-floats-with-reverted-inline-content-expected.txt
+++ b/LayoutTests/fast/block/float/intrusive-floats-with-reverted-inline-content-expected.txt
@@ -1,1 +1,1 @@
-PASS if no crash in release.
+PASS if no crash.

--- a/LayoutTests/fast/block/float/intrusive-floats-with-reverted-inline-content.html
+++ b/LayoutTests/fast/block/float/intrusive-floats-with-reverted-inline-content.html
@@ -12,7 +12,7 @@ img {
 <div>
   PASS
   <img><img><img><img>
-  if no crash in release.
+  if no crash.
   <span style="padding: 500px;">
     <span style="float: left"></span>
   </span></div>

--- a/Source/WebCore/layout/floats/PlacedFloats.h
+++ b/Source/WebCore/layout/floats/PlacedFloats.h
@@ -86,6 +86,7 @@ public:
     const Item* last() const { return list().isEmpty() ? nullptr : &m_list.last(); }
 
     void append(Item);
+    bool remove(const Box&);
     void clear();
 
     bool isEmpty() const { return list().isEmpty(); }
@@ -109,6 +110,13 @@ private:
     OptionSet<PositionType> m_positionTypes;
     bool m_isLeftToRightDirection { true };
 };
+
+inline bool PlacedFloats::remove(const Box& floatBox)
+{
+    return m_list.removeFirstMatching([&floatBox](auto& placedFloatItem) {
+        return placedFloatItem.layoutBox() == &floatBox;
+    });
+}
 
 inline bool PlacedFloats::hasLeftPositioned() const
 {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1161,7 +1161,6 @@ size_t LineBuilder::rebuildLineWithInlineContent(const InlineItemRange& layoutRa
 {
     ASSERT(!m_wrapOpportunityList.isEmpty());
     size_t numberOfInlineItemsOnLine = 0;
-    // FIXME: Remove floats that are outside of this "rebuild" range to ensure we don't add them twice.
     size_t numberOfFloatsInRange = 0;
     // We might already have added floats. They shrink the available horizontal space for the line.
     // Let's just reuse what the line has at this point.
@@ -1172,7 +1171,9 @@ size_t LineBuilder::rebuildLineWithInlineContent(const InlineItemRange& layoutRa
         if (&m_partialLeadingTextItem.value() == &lastInlineItemToAdd)
             return 1;
     }
-    for (size_t index = layoutRange.startIndex() + numberOfInlineItemsOnLine; index < layoutRange.endIndex(); ++index) {
+
+    size_t index = layoutRange.startIndex() + numberOfInlineItemsOnLine;
+    for (; index < layoutRange.endIndex(); ++index) {
         auto& inlineItem = m_inlineItemList[index];
         if (inlineItem.isFloat()) {
             ++numberOfFloatsInRange;
@@ -1188,6 +1189,20 @@ size_t LineBuilder::rebuildLineWithInlineContent(const InlineItemRange& layoutRa
         if (&inlineItem == &lastInlineItemToAdd)
             break;
     }
+
+    // Remove floats that are outside of this "rebuild" range to ensure we don't add them twice.
+    auto unplaceFloatBox = [&](const Box& floatBox) -> bool {
+        m_placedFloats.removeFirstMatching([&floatBox](auto& placedFloatItem) {
+            return placedFloatItem.layoutBox() == &floatBox;
+        });
+        return layoutState().placedFloats().remove(floatBox);
+    };
+    for (; index < layoutRange.endIndex(); ++index) {
+        auto& inlineItem = m_inlineItemList[index];
+        if (inlineItem.isFloat() && unplaceFloatBox(inlineItem.layoutBox()))
+            break;
+    }
+
     return numberOfInlineItemsOnLine + numberOfFloatsInRange;
 }
 


### PR DESCRIPTION
#### 363d7e6b674dc92a23cf41e34737254b0ac81707
<pre>
[LFC][IFC] Remove floats that are outside of the &quot;rebuild&quot; range to ensure we don&apos;t add them twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=247625">https://bugs.webkit.org/show_bug.cgi?id=247625</a>

Reviewed by Alan Baradlay.

When rebuilding a line, we should remove any floats starting from
`lastInlineItemToAdd` up to `layoutRange.endIndex()` from both
`layoutState().placedFloats()` and `m_placedFloats`.

* LayoutTests/TestExpectations:
* LayoutTests/fast/block/float/intrusive-floats-with-reverted-inline-content-expected.txt:
* LayoutTests/fast/block/float/intrusive-floats-with-reverted-inline-content.html:
* Source/WebCore/layout/floats/PlacedFloats.h:
(WebCore::Layout::PlacedFloats::remove):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::rebuildLineWithInlineContent):

Canonical link: <a href="https://commits.webkit.org/282129@main">https://commits.webkit.org/282129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec73acc8ef30c041fbcb610adf98f8582d05c45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50089 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8793 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11095 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57691 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5032 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37305 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->