### PR TITLE
[WPE][Skia] Enable MSAA when available

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -145,6 +145,7 @@ public:
 #if USE(SKIA)
     GLContext* skiaGLContext();
     GrDirectContext* skiaGrContext();
+    unsigned msaaSampleCount();
 #endif
 
 #if USE(ATSPI)

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -27,7 +27,9 @@
 #include "PlatformDisplay.h"
 
 #if USE(SKIA)
+#include "FontRenderOptions.h"
 #include "GLContext.h"
+#include <skia/core/SkColorSpace.h>
 #include <skia/gpu/GrBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
@@ -36,6 +38,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
@@ -49,6 +52,21 @@ IGNORE_CLANG_WARNINGS_END
 #endif
 
 namespace WebCore {
+
+#if PLATFORM(WPE)
+#if CPU(X86) || CPU(X86_64)
+// On x86 ot x86_64 we need at least 8 samples for the antialiasing result to be similar
+// to non MSAA.
+static const unsigned s_defaultSampleCount = 8;
+#else
+// On embedded, we sacrifice a bit of antialiasing quality to save memory and improve
+// performance.
+static const unsigned s_defaultSampleCount = 4;
+#endif
+#else
+// Disable MSAA by default.
+static const unsigned s_defaultSampleCount = 0;
+#endif
 
 #if !(PLATFORM(PLAYSTATION) && USE(COORDINATED_GRAPHICS))
 static sk_sp<const GrGLInterface> skiaGLInterface()
@@ -65,6 +83,32 @@ static sk_sp<const GrGLInterface> skiaGLInterface()
 }
 
 static thread_local RefPtr<SkiaGLContext> s_skiaGLContext;
+
+unsigned initializeMSAASampleCount(GrDirectContext* grContext)
+{
+    static std::once_flag onceFlag;
+    static int sampleCount = s_defaultSampleCount;
+
+    std::call_once(onceFlag, [grContext] {
+        // Let the user override the default sample count if they want to.
+        String envString = String::fromLatin1(getenv("WEBKIT_MSAA_SAMPLE_COUNT"));
+        if (!envString.isEmpty())
+            sampleCount = parseInteger<unsigned>(envString).value_or(0);
+
+        // Skia checks internally whether MSAA is supported, but also disables it for several platforms where it
+        // knows there are bugs. The only way to know whether our sample count will work is trying to create a
+        // surface with that value and check whether it works.
+        auto imageInfo = SkImageInfo::Make(512, 512, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+        auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, sampleCount, kTopLeft_GrSurfaceOrigin, &properties);
+
+        // If the creation of the surface failed, disable MSAA.
+        if (!surface)
+            sampleCount = 0;
+    });
+
+    return sampleCount;
+}
 
 class SkiaGLContext : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SkiaGLContext> {
 public:
@@ -102,6 +146,11 @@ public:
         return m_skiaGrContext.get();
     }
 
+    unsigned sampleCount()
+    {
+        return m_sampleCount;
+    }
+
 private:
     explicit SkiaGLContext(PlatformDisplay& display)
         : m_runLoop(&RunLoop::current())
@@ -115,6 +164,8 @@ private:
             m_skiaGLContext = WTFMove(glContext);
             m_skiaGrContext = WTFMove(grContext);
         }
+
+        m_sampleCount = initializeMSAASampleCount(m_skiaGrContext.get());
     }
 
     void invalidateOnCurrentThread()
@@ -128,6 +179,7 @@ private:
     std::unique_ptr<GLContext> m_skiaGLContext WTF_GUARDED_BY_LOCK(m_lock);
     sk_sp<GrDirectContext> m_skiaGrContext WTF_GUARDED_BY_LOCK(m_lock);
     mutable Lock m_lock;
+    unsigned m_sampleCount { 0 };
 };
 #endif
 
@@ -150,6 +202,11 @@ GrDirectContext* PlatformDisplay::skiaGrContext()
 {
     RELEASE_ASSERT(s_skiaGLContext);
     return s_skiaGLContext->skiaGrContext();
+}
+
+unsigned PlatformDisplay::msaaSampleCount()
+{
+    return s_skiaGLContext->sampleCount();
 }
 
 void PlatformDisplay::invalidateSkiaGLContexts()

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -73,7 +73,7 @@ RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::createAcceleratedBuffer(const
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::Make(size.width(), size.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
-    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
+    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, PlatformDisplay::sharedDisplay().msaaSampleCount(), kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface)
         return nullptr;
     return Nicosia::AcceleratedBuffer::create(WTFMove(surface), supportsAlpha ? Nicosia::Buffer::SupportsAlpha : Nicosia::Buffer::NoFlags);


### PR DESCRIPTION
#### 1bd3d2f0f7e6380b6d9e2e6003dfb2636b51b266
<pre>
[WPE][Skia] Enable MSAA when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=277800">https://bugs.webkit.org/show_bug.cgi?id=277800</a>

Reviewed by Carlos Garcia Campos.

Enable MSAA on WPE whenever possible. On x86 or x86_64, use eight samples
to get an antialiasing result similar to non MSAA. On embedded devices, use
four samples instead, as this is a nice compromise between quality and
resource usage. On GTK keep it disabled by default. The user can overwrite
this default value through the WEBKIT_MSAA_SAMPLE_COUNT env var.

Even if MSAA is reported as available by GLES, Skia has a lot of internal checks
that may disable it, so the best way to check whether we can use it with Skia is
trying to create a texture backed SkSurface with a sample count of four and
check whether it works.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
(WebCore::flushSurfaceIfNeeded):
(WebCore::ImageBufferSkiaAcceleratedBackend::copyNativeImage):
(WebCore::ImageBufferSkiaAcceleratedBackend::createNativeImageReference):
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::initializeMSAASampleCount):
(WebCore::SkiaGLContext::sampleCount):
(WebCore::SkiaGLContext::SkiaGLContext):
(WebCore::PlatformDisplay::msaaSampleCount):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::createAcceleratedBuffer):

Canonical link: <a href="https://commits.webkit.org/282223@main">https://commits.webkit.org/282223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f949da483fbcafe7f97996a8873f94111de36936

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66328 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12893 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50253 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8904 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57626 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57836 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5228 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37503 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->