### PR TITLE
[Writing Tools] Text color becomes black-on-black when transforming into list while in dark mode in Mail

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
@@ -484,6 +484,21 @@ TEST(PasteHTML, DoesNotTransformColorsOfLightContentDuringOutdent)
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"rich.innerHTML"], @"<ul><li>hello</li><li>world</li></ul>");
 }
 
+TEST(PasteHTML, TransformColorsDependsOnUsedInlineStyle)
+{
+    auto webView = createWebViewWithCustomPasteboardDataSetting(true, true);
+    [webView forceDarkMode];
+
+    [webView synchronouslyLoadTestPageNamed:@"rich-color-filtered"];
+
+    writeHTMLToPasteboard(@"<ul style='color: black'><li style='color: white'>Coffee</li><li style='color: white'>Milk</li><li style='color: white'>Tea</li></ul>");
+
+    [webView stringByEvaluatingJavaScript:@"selectRichText()"];
+    [webView paste:nil];
+
+    EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"rich.querySelector('li').style.color"], @"rgb(0, 0, 0)");
+}
+
 #endif // ENABLE(DARK_MODE_CSS) && HAVE(OS_DARK_MODE_SUPPORT)
 
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### e11b028d2a5fa759cc49a843cc3d67603acaa048
<pre>
[Writing Tools] Text color becomes black-on-black when transforming into list while in dark mode in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=277801">https://bugs.webkit.org/show_bug.cgi?id=277801</a>
<a href="https://rdar.apple.com/129024871">rdar://129024871</a>

Reviewed by Wenson Hsieh.

In dark mode, Mail uses `-apple-color-filter: apple-invert-lightness()` to
invert colors for emails designed for light mode. In the past, this has
caused issues with pasted content, as colors could be doubly inverted,
resulting in illegible text (see 215122@main for more details).

To avoid double inversion, `fragmentNeedsColorTransformed` reports whether the
fragment inserted by `ReplaceSelectionCommand` contains content that would be
illegible after color inversion is performed. It works by traversing the
inserted node tree, checking for inline styles and the lightness of colors.
However, the current implementation is flawed, as it early returns `false`, the
moment an inline style with sufficient lightness is encountered. This is
incorrect as an inline style encountered on a parent element, may later be
overridden by a child element. Which means that the used color for the text
may never be considered in the algorithm.

This issue manifests itself in Writing Tools, when a fragment like the following
is inserted:

```
&lt;ul style=&quot;color: black&quot;&gt;
&lt;li style=&quot;color: white&quot;&gt;Item 1&lt;/li&gt;
&lt;li style=&quot;color: white&quot;&gt;Item 2&lt;/li&gt;
&lt;/ul&gt;
```

The algorithm first observes &quot;black&quot;, detects that inverted black (white) would
be legible, and bails early from the color transform. However, the actual color
of text is white, which is black when inverted, and illegible in dark mode.

Fix by reworking the algorithm to perform a depth first search, keeping track
of the used inline color, so that the algorithm considers the right colors when
determining whether to perform transformation.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::nodeTreeHasInlineStyleWithLegibleColorForInvertLightness):
(WebCore::fragmentNeedsColorTransformed):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:
(TEST(PasteHTML, TransformColorsDependsOnUsedInlineStyle)):

The test expects the list item to have &apos;color: rgb(0, 0, 0)&apos;, as that will
appear white to the user following the color filter.

Canonical link: <a href="https://commits.webkit.org/282027@main">https://commits.webkit.org/282027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be2208c4049addd489ab75e86c7a1c90c450e7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49769 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11175 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57143 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4646 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36853 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->