### PR TITLE
Improve SyntaxError message when unexpected token follows variable declaration

### DIFF
--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -827,7 +827,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseVariableDecla
     bool scratchBool;
     TreeExpression variableDecls = parseVariableDeclarationList(context, scratch, scratch1, scratch2, scratch3, scratch3, scratch3, VarDeclarationContext, declarationType, exportType, scratchBool);
     propagateError();
-    failIfFalse(autoSemiColon(), "Expected ';' after variable declaration");
+    failIfFalse(autoSemiColon(), "Expected ';', ',' or '=' after variable declaration");
     
     return context.createDeclarationStatement(location, variableDecls, start, end);
 }


### PR DESCRIPTION
#### df8db1bae7058945351a52fe8345434e176c918e
<pre>
Improve SyntaxError message when unexpected token follows variable declaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=277805">https://bugs.webkit.org/show_bug.cgi?id=277805</a>
<a href="https://rdar.apple.com/133466386">rdar://133466386</a>

Reviewed by NOBODY (OOPS!).

While testing some code I noticed that our error message for:

```
&gt;&gt;&gt; var foo ??= 1
Unexpected token &apos;??=&apos;. Expected &apos;;&apos; after variable declaration.:1
```

Is a bit misleading since other tokens can follow variable declarations.
With this change it now says:

```
&gt;&gt;&gt; let x ??= 1
Unexpected token &apos;??=&apos;. Expected &apos;;&apos;, &apos;,&apos; or &apos;=&apos; after variable declaration.:1
```

* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclaration):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df8db1bae7058945351a52fe8345434e176c918e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12248 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12519 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49782 "Found 2 new test failures: js/arrowfunction-syntax-errors.html js/parser-syntax-check.html (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8503 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64772 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38146 "Found 2 new test failures: js/arrowfunction-syntax-errors.html js/parser-syntax-check.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30613 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34805 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10683 "Found 2 new test failures: js/arrowfunction-syntax-errors.html js/parser-syntax-check.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11179 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54798 "Found 14 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout-ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56608 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10985 "Found 2 new test failures: js/arrowfunction-syntax-errors.html js/parser-syntax-check.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67410 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60944 "Found 14 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout-ftl-eager-no-cjit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5646 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10746 "Found 3 new test failures: js/arrowfunction-syntax-errors.html js/parser-syntax-check.html workers/worker-to-worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57147 "Found 3 new test failures: imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https.html?client js/arrowfunction-syntax-errors.html js/parser-syntax-check.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57374 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4649 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36857 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14466 "Found 1474 jsc stress test failures: jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/arrowfunction-syntax-errors.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/parser-syntax-check.js.layout ...") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->