### PR TITLE
Add performance object with now to JSC CLI

### DIFF
--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -97,6 +97,11 @@ public:
     {
         return Seconds(std::numeric_limits<double>::quiet_NaN());
     }
+
+    static constexpr Seconds highTimePrecision()
+    {
+        return Seconds::fromMicroseconds(20);
+    }
     
     bool isNaN() const { return std::isnan(m_value); }
     bool isInfinity() const { return std::isinf(m_value); }
@@ -219,6 +224,12 @@ public:
     Seconds isolatedCopy() const
     {
         return *this;
+    }
+
+    constexpr Seconds reduceTimeResolution(Seconds resolution)
+    {
+        double reduced = std::floor(seconds() / resolution.seconds()) * resolution.seconds();
+        return Seconds(reduced);
     }
 
     struct MarkableTraits;

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -57,7 +57,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Performance);
 
-constexpr Seconds highTimePrecision { 20_us };
 static Seconds timePrecision { 1_ms };
 
 Performance::Performance(ScriptExecutionContext* context, MonotonicTime timeOrigin)
@@ -94,14 +93,12 @@ ReducedResolutionSeconds Performance::nowInReducedResolutionSeconds() const
 
 Seconds Performance::reduceTimeResolution(Seconds seconds)
 {
-    double resolution = timePrecision.seconds();
-    double reduced = std::floor(seconds.seconds() / resolution) * resolution;
-    return Seconds(reduced);
+    return seconds.reduceTimeResolution(timePrecision);
 }
 
 void Performance::allowHighPrecisionTime()
 {
-    timePrecision = highTimePrecision;
+    timePrecision = Seconds::highTimePrecision();
 }
 
 Seconds Performance::timeResolution()


### PR DESCRIPTION
#### 37a6ff8b177984d11f4f6c82c3df4e898c7cfc4f
<pre>
Add performance object with now to JSC CLI
<a href="https://bugs.webkit.org/show_bug.cgi?id=277811">https://bugs.webkit.org/show_bug.cgi?id=277811</a>
<a href="https://rdar.apple.com/133472694">rdar://133472694</a>

Reviewed by Yijia Huang.

We want this to be as close as possible to what WebCore does when using
a high resolution timer (as we expect JetStream to do). This gives us
more accurate numbers.

One kinda weird thing is that the first time we call `performance.now()`
in the CLI it will return 0 since we&apos;re also initializing our timeOrigin
at that time. It&apos;s not even clear we need a timeOrigin since any benchmark
is likely going to do `end - start` anyway so the timeOrigin would cancel
out but maybe some FP rounding issues would show up that way.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/Seconds.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::reduceTimeResolution):
(WebCore::Performance::allowHighPrecisionTime):

Canonical link: <a href="https://commits.webkit.org/282438@main">https://commits.webkit.org/282438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef534a068e4017a71a540c68000006b1fc81a23b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49789 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8519 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10699 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11206 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54825 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67437 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60971 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57161 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53416 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57392 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4669 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82733 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36884 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->