### PR TITLE
[UnifiedPDF] Two debug assertions on coordinate conversation fire unnecessarily for some locked documents

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -657,7 +657,11 @@ T UnifiedPDFPlugin::convertDown(CoordinateSpace sourceSpace, CoordinateSpace des
             return mappedValue;
 
         ASSERT(pageIndex);
-        ASSERT(*pageIndex < m_documentLayout.pageCount());
+        static auto pageIndexIsValid = [](auto pageIndex, auto pageCount, bool isLocked) {
+            return isLocked && !pageCount ?: *pageIndex < pageCount;
+        };
+        ASSERT_UNUSED(pageIndexIsValid, pageIndexIsValid(pageIndex, m_documentLayout.pageCount(), isLocked()));
+
         mappedValue = m_documentLayout.documentToPDFPage(mappedValue, *pageIndex);
         FALLTHROUGH;
 
@@ -682,7 +686,11 @@ T UnifiedPDFPlugin::convertUp(CoordinateSpace sourceSpace, CoordinateSpace desti
             return mappedValue;
 
         ASSERT(pageIndex);
-        ASSERT(*pageIndex < m_documentLayout.pageCount());
+        static auto pageIndexIsValid = [](auto pageIndex, auto pageCount, bool isLocked) {
+            return isLocked && !pageCount ?: *pageIndex < pageCount;
+        };
+        ASSERT_UNUSED(pageIndexIsValid, pageIndexIsValid(pageIndex, m_documentLayout.pageCount(), isLocked()));
+
         mappedValue = m_documentLayout.pdfPageToDocument(mappedValue, *pageIndex);
         FALLTHROUGH;
 


### PR DESCRIPTION
#### 81baa2baf3a06bfd5c7acf8728d154b0834b0bbb
<pre>
[UnifiedPDF] Two debug assertions on coordinate conversation fire unnecessarily for some locked documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=277814">https://bugs.webkit.org/show_bug.cgi?id=277814</a>
<a href="https://rdar.apple.com/133475258">rdar://133475258</a>

Reviewed by NOBODY (OOPS!).

For some password protected documents, we get a zero page count when
locked. As such, the debug assertions touched by this patch fire
unnecessarily. We work around this by only doing the page index validity
check if we&apos;re not working with a document that exhibits this symptom.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::UnifiedPDFPlugin::convertDown const):
(WebKit::UnifiedPDFPlugin::convertUp const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81baa2baf3a06bfd5c7acf8728d154b0834b0bbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12277 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49784 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30615 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34822 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5675 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10765 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57160 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57390 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4667 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36886 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->