### PR TITLE
Use getPendingPushMessage when built-in notifications are enabled

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -393,6 +393,7 @@ public:
     bool ftpEnabled() const { return m_ftpEnabled; }
     bool builtInNotificationsEnabled() const { return m_builtInNotificationsEnabled; }
 
+    void getPendingPushMessage(PAL::SessionID, CompletionHandler<void(const std::optional<WebPushMessage>&)>&&);
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
     void processPushMessage(PAL::SessionID, WebPushMessage&&, WebCore::PushPermissionState, CompletionHandler<void(bool, std::optional<WebCore::NotificationPayload>&&)>&&);
     void processNotificationEvent(WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -224,6 +224,7 @@ messages -> NetworkProcess LegacyReceiver {
 
     TerminateRemoteWorkerContextConnectionWhenPossible(enum:uint8_t WebKit::RemoteWorkerType workerType, PAL::SessionID sessionID,  WebCore::RegistrableDomain registrableDomain, WebCore::ProcessIdentifier processIdentifier);
 
+    GetPendingPushMessage(PAL::SessionID sessionID) -> (std::optional<WebKit::WebPushMessage> message)
     GetPendingPushMessages(PAL::SessionID sessionID) -> (Vector<WebKit::WebPushMessage> messages)
     ProcessPushMessage(PAL::SessionID sessionID, struct WebKit::WebPushMessage pushMessage, enum:uint8_t WebCore::PushPermissionState pushPermissionState) -> (bool didSucceed, std::optional<WebCore::NotificationPayload> displayPayload)
     ProcessNotificationEvent(struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType eventType) -> (bool didSucceed)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -67,6 +67,16 @@ void NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin(const S
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetPushAndNotificationsEnabledForOrigin(origin.toString(), enabled), WTFMove(completionHandler));
 }
 
+void NetworkNotificationManager::getPendingPushMessage(CompletionHandler<void(const std::optional<WebPushMessage>&)>&& completionHandler)
+{
+    CompletionHandler<void(std::optional<WebPushMessage>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (auto&& message) mutable {
+        RELEASE_LOG(Push, "Done getting %u push messages", message ? 1 : 0);
+        completionHandler(WTFMove(message));
+    };
+
+    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessage(), WTFMove(replyHandler));
+}
+
 void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&& completionHandler)
 {
     CompletionHandler<void(Vector<WebPushMessage>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (Vector<WebPushMessage>&& messages) mutable {

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -56,6 +56,7 @@ public:
     NetworkSession& networkSession() const { return m_networkSession; }
 
     void setPushAndNotificationsEnabledForOrigin(const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
+    void getPendingPushMessage(CompletionHandler<void(const std::optional<WebPushMessage>&)>&&);
     void getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
 
     void subscribeToPushService(URL&& scopeURL, Vector<uint8_t>&& applicationServerKey, CompletionHandler<void(Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1063,6 +1063,20 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     return _websiteDataStore->hasServiceWorkerBackgroundActivityForTesting();
 }
 
+- (void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler
+{
+    RELEASE_LOG(Push, "Getting pending push message");
+
+    _websiteDataStore->networkProcess().getPendingPushMessage(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (const auto& message) {
+        RetainPtr<NSDictionary> result;
+        if (message)
+            result = message->toDictionary();
+        RELEASE_LOG(Push, "Giving application %d pending push messages", result ? 1 : 0);
+        completionHandler(result.get());
+    });
+}
+
+
 -(void)_getPendingPushMessages:(void(^)(NSArray<NSDictionary *> *))completionHandler
 {
     RELEASE_LOG(Push, "Getting pending push messages");

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -123,6 +123,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_countNonDefaultSessionSets:(void(^)(size_t))completionHandler;
 
 -(bool)_hasServiceWorkerBackgroundActivityForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
+-(void)_getPendingPushMessage:(void(^)(NSDictionary *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 -(void)_getPendingPushMessages:(void(^)(NSArray<NSDictionary *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_processPushMessage:(NSDictionary *)pushMessage completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_processPersistentNotificationClick:(NSDictionary *)notificationDictionaryRepresentation completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1805,6 +1805,11 @@ void NetworkProcessProxy::didExceedMemoryLimit()
 }
 #endif
 
+void NetworkProcessProxy::getPendingPushMessage(PAL::SessionID sessionID, CompletionHandler<void(const std::optional<WebPushMessage>&)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::GetPendingPushMessage { sessionID }, WTFMove(completionHandler));
+}
+
 void NetworkProcessProxy::getPendingPushMessages(PAL::SessionID sessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::NetworkProcess::GetPendingPushMessages { sessionID }, WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -299,6 +299,7 @@ public:
     xpc_object_t xpcEndpointMessage() const { return m_endpointMessage.get(); }
 #endif
 
+    void getPendingPushMessage(PAL::SessionID, CompletionHandler<void(const std::optional<WebPushMessage>&)>&&);
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
     void processPushMessage(PAL::SessionID, const WebPushMessage&, CompletionHandler<void(bool wasProcessed, std::optional<WebCore::NotificationPayload>&&)>&&);
     void processNotificationEvent(const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool wasProcessed)>&&);

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -116,7 +116,6 @@ private:
     void requestPushPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
     void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
-    void didShowNotificationForTesting(URL&& scopeURL, CompletionHandler<void()>&&);
 
     void showNotification(const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -38,7 +38,6 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     RemovePushSubscriptionsForOrigin(WebCore::SecurityOriginData origin) -> (unsigned removed)
     SetPublicTokenForTesting(String token) -> ()
     GetPushTopicsForTesting() -> (Vector<String> enabled, Vector<String> ignored)
-    DidShowNotificationForTesting(URL scopeURL) -> ()
     ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
     CancelNotification(WTF::UUID notificationID)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -239,11 +239,6 @@ void PushClientConnection::setPublicTokenForTesting(const String& publicToken, C
     WebPushDaemon::singleton().setPublicTokenForTesting(*this, publicToken, WTFMove(replySender));
 }
 
-void PushClientConnection::didShowNotificationForTesting(URL&& scopeURL, CompletionHandler<void()>&& replySender)
-{
-    WebPushDaemon::singleton().didShowNotificationForTesting(*this, WTFMove(scopeURL), WTFMove(replySender));
-}
-
 void PushClientConnection::getPushPermissionState(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& replySender)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -90,7 +90,6 @@ public:
     void removeAllPushSubscriptions(PushClientConnection&, CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
     void setPublicTokenForTesting(PushClientConnection&, const String& publicToken, CompletionHandler<void()>&&);
-    void didShowNotificationForTesting(PushClientConnection&, const URL& scopeURL, CompletionHandler<void()>&& replySender);
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     void showNotification(PushClientConnection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
@@ -119,7 +118,7 @@ private:
     Seconds silentPushTimeout() const;
     void rescheduleSilentPushTimer();
     void silentPushTimerFired();
-    void didShowNotificationImpl(const WebCore::PushSubscriptionSetIdentifier&, const String& scope);
+    void didShowNotification(const WebCore::PushSubscriptionSetIdentifier&, const String& scope);
 
     PushClientConnection* toPushClientConnection(xpc_connection_t);
     HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -996,42 +996,17 @@ public:
         TestWebKitAPI::Util::run(&done);
     }
 
-    // FIXME: remove this once we add fetchPushMessage to WKWebsiteDataStore.
-    void didShowNotificationForTesting()
+    RetainPtr<NSDictionary> fetchPushMessage()
     {
-        auto configuration = defaultWebPushDaemonConfiguration();
-        configuration.pushPartitionString = m_pushPartition;
-        configuration.dataStoreIdentifier = m_dataStoreIdentifier;
+        __block bool gotMessage = false;
+        __block RetainPtr<NSDictionary> message;
+        [m_dataStore _getPendingPushMessage:^(NSDictionary *rawMessage) {
+            message = rawMessage;
+            gotMessage = true;
+        }];
+        TestWebKitAPI::Util::run(&gotMessage);
 
-        auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service", WTFMove(configuration));
-        auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-
-        bool done = false;
-        sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::DidShowNotificationForTesting(m_url.get()), [&]() {
-            done = true;
-        });
-        TestWebKitAPI::Util::run(&done);
-    }
-
-    // FIXME: switch to WKWebsiteDataStore method once we add that.
-    std::optional<WebKit::WebPushMessage> fetchPushMessage()
-    {
-        auto configuration = defaultWebPushDaemonConfiguration();
-        configuration.pushPartitionString = m_pushPartition;
-        configuration.dataStoreIdentifier = m_dataStoreIdentifier;
-
-        auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service", WTFMove(configuration));
-        auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-
-        std::optional<WebKit::WebPushMessage> result;
-        bool done = false;
-        sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessage(), [&](std::optional<WebKit::WebPushMessage> message) {
-            result = WTFMove(message);
-            done = true;
-        });
-        TestWebKitAPI::Util::run(&done);
-
-        return result;
+        return message;
     }
 
     RetainPtr<NSArray<NSDictionary *>> fetchPushMessages()
@@ -1562,59 +1537,6 @@ TEST_F(WebPushDTest, IgnoresSubscriptionOnPermissionDenied)
     ASSERT_TRUE(v->hasPushSubscription());
 }
 
-TEST_F(WebPushDTest, ImplicitSilentPushTimerCancelledOnShowingNotification)
-{
-    for (auto& v : webViews())
-        v->subscribe();
-    ASSERT_EQ(subscribedTopicsCount(), webViews().size());
-
-    for (auto& v : webViews()) {
-        ASSERT_TRUE(v->hasPushSubscription());
-
-        for (unsigned i = 0; i < WebKit::WebPushD::maxSilentPushCount; i++) {
-            v->injectPushMessage(@{ });
-            auto message = v->fetchPushMessage();
-            ASSERT_TRUE(message.has_value());
-            v->didShowNotificationForTesting();
-        }
-
-        [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTesting.seconds() + 0.5)];
-        ASSERT_TRUE(v->hasPushSubscription());
-    }
-}
-
-TEST_F(WebPushDTest, ImplicitSilentPushTimerCausesUnsubscribe)
-{
-    for (auto& v : webViews()) {
-        v->subscribe();
-        v->disableShowNotifications();
-    }
-    ASSERT_EQ(subscribedTopicsCount(), webViews().size());
-
-    int i = 1;
-    for (auto& v : webViews()) {
-        ASSERT_TRUE(v->hasPushSubscription());
-
-        for (unsigned i = 0; i < WebKit::WebPushD::maxSilentPushCount; i++) {
-            v->injectPushMessage(@{ });
-            auto message = v->fetchPushMessage();
-            ASSERT_TRUE(message.has_value());
-        }
-
-        bool unsubscribed = false;
-        TestWebKitAPI::Util::waitForConditionWithLogging([&] {
-            unsubscribed = !v->hasPushSubscription();
-            [NSThread sleepForTimeInterval:0.25];
-            return unsubscribed;
-        }, 5, @"Timed out waiting for push subscription to be unsubscribed.");
-        ASSERT_TRUE(unsubscribed);
-
-        // Unsubscribing from this data store should not affect subscriptions in other data stores.
-        ASSERT_EQ(subscribedTopicsCount(), webViews().size() - i);
-        i++;
-    }
-}
-
 TEST_F(WebPushDTest, TooManySilentPushesCausesUnsubscribe)
 {
     for (auto& v : webViews()) {
@@ -1803,6 +1725,61 @@ TEST_F(WebPushDBuiltInTest, TestPermissionsAfterSubscribe)
     EXPECT_TRUE([view->queryPermission(@"notifications") isEqual:@"granted"]);
     EXPECT_TRUE([view->queryPermissionFromServiceWorker(@"notifications") isEqual:@"granted"]);
 }
+
+TEST_F(WebPushDBuiltInTest, ImplicitSilentPushTimerCancelledOnShowingNotification)
+{
+    for (auto& v : webViews())
+        v->subscribe();
+    ASSERT_EQ(subscribedTopicsCount(), webViews().size());
+
+    for (auto& v : webViews()) {
+        ASSERT_TRUE(v->hasPushSubscription());
+
+        for (unsigned i = 0; i < WebKit::WebPushD::maxSilentPushCount; i++) {
+            v->injectPushMessage(@{ });
+            auto message = v->fetchPushMessage();
+            ASSERT_TRUE(v->expectDecryptedMessage(@"null data", message.get()));
+        }
+
+        [NSThread sleepForTimeInterval:(WebKit::WebPushD::silentPushTimeoutForTesting.seconds() + 0.5)];
+        ASSERT_TRUE(v->hasPushSubscription());
+    }
+}
+
+TEST_F(WebPushDBuiltInTest, ImplicitSilentPushTimerCausesUnsubscribe)
+{
+    for (auto& v : webViews()) {
+        v->subscribe();
+        v->disableShowNotifications();
+    }
+    ASSERT_EQ(subscribedTopicsCount(), webViews().size());
+
+    int i = 1;
+    for (auto& v : webViews()) {
+        ASSERT_TRUE(v->hasPushSubscription());
+
+        for (unsigned i = 0; i < WebKit::WebPushD::maxSilentPushCount; i++) {
+            v->injectPushMessage(@{ });
+            auto message = v->fetchPushMessage();
+
+            // _processPushMessage should return false since we disabled showing notifications above.
+            ASSERT_FALSE(v->expectDecryptedMessage(@"null data", message.get()));
+        }
+
+        bool unsubscribed = false;
+        TestWebKitAPI::Util::waitForConditionWithLogging([&] {
+            unsubscribed = !v->hasPushSubscription();
+            [NSThread sleepForTimeInterval:0.25];
+            return unsubscribed;
+        }, 5, @"Timed out waiting for push subscription to be unsubscribed.");
+        ASSERT_TRUE(unsubscribed);
+
+        // Unsubscribing from this data store should not affect subscriptions in other data stores.
+        ASSERT_EQ(subscribedTopicsCount(), webViews().size() - i);
+        i++;
+    }
+}
+
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 
 


### PR DESCRIPTION
#### 15b540d6465fc94bc065ceabcd724e95e187b2c0
<pre>
Use getPendingPushMessage when built-in notifications are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=277820">https://bugs.webkit.org/show_bug.cgi?id=277820</a>
<a href="https://rdar.apple.com/133485499">rdar://133485499</a>

Reviewed by Brady Eidson.

In 280760@main I added the getPendingPushMessage IPC to webpushd that is mean to be used when
built-in notifications are enabled. This both gets a pending push message and starts a timer waiting
for the client to call showNotification within 30 seconds. If the timeout expires, then we increase
the silent push count for the associated push subscription.

Previously only tests were using that IPC. In this patch I make WKWebsiteDataStore use it.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::getPendingPushMessage):
(WebKit::NetworkProcess::processPushMessage):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::getPendingPushMessage):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getPendingPushMessage:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getPendingPushMessage):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::didShowNotificationForTesting): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::didShowNotification):
(WebPushD::WebPushDaemon::showNotification):
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::requestPushPermission):
(WebPushD::WebPushDaemon::didShowNotificationImpl): Deleted.
(WebPushD::WebPushDaemon::didShowNotificationForTesting): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/282022@main">https://commits.webkit.org/282022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef15c3e30168379e77aed78330285592fb875127

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49796 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8529 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30628 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10714 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5689 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53431 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57412 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13746 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4681 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39080 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->