### PR TITLE
Viewport fails to shrink down to normal height when opening account settings UI on google.com

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4734,15 +4734,15 @@ void WebPage::updateLayoutViewportHeightExpansionTimerFired()
         if (!view->hasViewportConstrainedObjects())
             return false;
 
-        Vector<Ref<Element>> largeViewportConstrainedElements;
+        HashSet<Ref<Element>> largeViewportConstrainedElements;
         for (auto& renderer : *view->viewportConstrainedObjects()) {
             RefPtr element = renderer.element();
             if (!element)
                 continue;
 
             auto bounds = renderer.absoluteBoundingBoxRect();
-            if (intersection(viewportRect, bounds).area() > 0.9 * viewportRect.area())
-                largeViewportConstrainedElements.append(element.releaseNonNull());
+            if (intersection(viewportRect, bounds).height() > 0.9 * viewportRect.height())
+                largeViewportConstrainedElements.add(element.releaseNonNull());
         }
 
         if (largeViewportConstrainedElements.isEmpty())
@@ -4753,9 +4753,23 @@ void WebPage::updateLayoutViewportHeightExpansionTimerFired()
             return false;
 
         auto& hitTestedNodes = hitTestResult.listBasedTestResult();
-        return std::ranges::any_of(largeViewportConstrainedElements, [&hitTestedNodes](auto& element) {
-            return hitTestedNodes.contains(element);
-        });
+        HashSet<Ref<Element>> elementsOutsideOfAnyLargeViewportConstrainedContainers;
+        for (auto& node : hitTestedNodes) {
+            RefPtr firstParentOrSelf = dynamicDowncast<Element>(node) ?: node->parentElementInComposedTree();
+            Vector<Ref<Element>> ancestorsForHitTestedNode;
+            for (RefPtr parent = firstParentOrSelf; parent; parent = parent->parentElementInComposedTree()) {
+                if (largeViewportConstrainedElements.contains(*parent))
+                    return true;
+
+                if (elementsOutsideOfAnyLargeViewportConstrainedContainers.contains(*parent))
+                    break;
+
+                ancestorsForHitTestedNode.append(*parent);
+            }
+            for (auto& ancestor : ancestorsForHitTestedNode)
+                elementsOutsideOfAnyLargeViewportConstrainedContainers.add(ancestor);
+        }
+        return false;
     }();
 
     if (hitTestedToLargeViewportConstrainedElement) {


### PR DESCRIPTION
#### 7eb3b2d4084cfc1a0d687b5024751ca5e28c9e80
<pre>
Viewport fails to shrink down to normal height when opening account settings UI on google.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=277826">https://bugs.webkit.org/show_bug.cgi?id=277826</a>
<a href="https://rdar.apple.com/133488609">rdar://133488609</a>

Reviewed by Aditya Keerthi.

Make a couple more adjustments to the dynamic viewport height expansion heuristic:

1.  Only compare the height of the fixed-position container against the fixed-position layout rect,
    instead of the area of the rects. This allows the viewport to shrink in cases where there&apos;s a
    tall fixed-position popup that&apos;s intended to cover the full height of the viewport, but doesn&apos;t
    take up the entire width of the viewport.

2.  Once one or more large fixed-position popups are found, check if any of the nodes surfaced via
    area-based hit-test are contained within any of the popups, rather than trying to check whether
    any one of the hit-tested nodes is (itself) a large fixed-position popup. This prevents a false
    negative in the case where a large fixed-position element contains a child element that covers
    the entire fixed element.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateLayoutViewportHeightExpansionTimerFired):

Canonical link: <a href="https://commits.webkit.org/282015@main">https://commits.webkit.org/282015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b74476efddb53475825dd19bc7b484bd969ec8fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12570 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8537 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53490 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/30632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34842 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5697 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53437 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4687 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->