### PR TITLE
Support JITless Wasm import calls

### DIFF
--- a/JSTests/wasm/noJIT/noJIT.js
+++ b/JSTests/wasm/noJIT/noJIT.js
@@ -1,2 +1,3 @@
+//@ skip unless $isWasmPlatform
 if (typeof WebAssembly == "undefined")
     throw new Error("Expect WebAssembly global object is defined");

--- a/JSTests/wasm/stress/cc-int-to-int-to-js.js
+++ b/JSTests/wasm/stress/cc-int-to-int-to-js.js
@@ -1,0 +1,29 @@
+//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let type = 'i32'
+
+let wat = `
+(module
+    (type $sig_test (func (param ${type}) (result ${type})))
+    (import "o" "callee" (func $callee (param $x ${type}) (result ${type})))
+    (func $test (export "test") (param $x ${type}) (result ${type})
+        (local.get $x)
+        (call $callee)
+    )
+)
+`
+
+function callee(x) {
+    return x + 1;
+}
+
+async function test() {
+    const instance = await instantiate(wat, { o: { callee } })
+    const { test } = instance.exports
+
+    assert.eq(test(5), 6)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/wasm-js-call-many-return-types-on-stack-no-args.js
+++ b/JSTests/wasm/stress/wasm-js-call-many-return-types-on-stack-no-args.js
@@ -34,7 +34,7 @@ async function buildWat(types) {
 
 async function test() {
     await Promise.all([
-        //buildWat(["i32", "i32", "f32", "i32"]),
+        buildWat(["i32", "i32", "f32", "i32"]),
         buildWat(["i32", "i32", "f32", "i32", "f64", "f32", "i32", "i32"]),
 
         // gpr in registers but fpr spilled. arm64 has 32 fprs so go above that

--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -122,6 +122,8 @@ LLINT_DECLARE_ROUTINE_VALIDATE(normal_osr_exit_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(fuzzer_return_early_from_loop_hint);
 LLINT_DECLARE_ROUTINE_VALIDATE(js_to_wasm_wrapper_entry_crash_for_simd_parameters);
 LLINT_DECLARE_ROUTINE_VALIDATE(js_to_wasm_wrapper_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(wasm_to_wasm_wrapper_entry);
+LLINT_DECLARE_ROUTINE_VALIDATE(wasm_to_js_wrapper_entry);
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 #define LLINT_OP_EXTRAS(validateLabel) bitwise_cast<void*>(validateLabel)
@@ -179,6 +181,8 @@ static LLIntOperations llintOperations()
             LLINT_ROUTINE(fuzzer_return_early_from_loop_hint)
             LLINT_ROUTINE(js_to_wasm_wrapper_entry)
             LLINT_ROUTINE(js_to_wasm_wrapper_entry_crash_for_simd_parameters)
+            LLINT_ROUTINE(wasm_to_wasm_wrapper_entry)
+            LLINT_ROUTINE(wasm_to_js_wrapper_entry)
 
             LLINT_OP(op_catch)
             LLINT_OP(wasm_catch)

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1452,6 +1452,8 @@ op :wasm_function_prologue_simd_trampoline
 op :wasm_function_prologue_simd
 op :js_to_wasm_wrapper_entry_crash_for_simd_parameters
 op :js_to_wasm_wrapper_entry
+op :wasm_to_wasm_wrapper_entry
+op :wasm_to_js_wrapper_entry
 
 op :js_trampoline_op_call
 op :js_trampoline_op_call_ignore_result

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2765,6 +2765,14 @@ op(js_to_wasm_wrapper_entry, macro ()
     crash()
 end)
 
+op(wasm_to_wasm_wrapper_entry, macro ()
+    crash()
+end)
+
+op(wasm_to_js_wrapper_entry, macro ()
+    crash()
+end)
+
 op(wasm_function_prologue_trampoline, macro ()
     crash()
 end)

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -782,7 +782,6 @@ end
     call ws0, WasmEntryPtrTag
 
     clobberVolatileRegisters()
-    clobberArgumentOnlyRegisters()
 
     # Restore SP
     loadp Callee[cfr], ws0 # CalleeBits(JSEntrypointInterpreterCallee*)
@@ -883,6 +882,238 @@ end
 .handleException:
     throwException(OutOfMemory)
     break
+end)
+
+# This is the interpreted analogue to WasmBinding.cpp:wasmToWasm
+op(wasm_to_wasm_wrapper_entry, macro()
+    loadp (Callee - PrologueStackPointerDelta)[sp], ws0
+
+    loadi Wasm::Callee::m_index[ws0], ws1
+
+    const ImportFunctionInfoSize = constexpr (sizeof(JSWebAssemblyInstance::ImportFunctionInfo))
+    muli ImportFunctionInfoSize, ws1
+
+    # Store Callee's wasm callee for import function
+    const ImportFunctionInfoBase = constexpr (sizeof(JSWebAssemblyInstance) + 7) & (~7)
+    leap ImportFunctionInfoBase[wasmInstance], ws0
+    addp ws0, ws1
+    # offsetOfBoxedTargetCalleeLoadLocation
+    loadp JSWebAssemblyInstance::ImportFunctionInfo::boxedTargetCalleeLoadLocation[ws1], ws0
+    loadp [ws0], ws0
+
+    const addressOfCalleeCalleeFromCallerPerspectiveBase = constexpr CallFrameSlot::callee * SlotSize + PayloadOffset
+if JSVALUE64
+    storep ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta[sp]
+else
+    storei ws0, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + PayloadOffset[sp]
+    storei constexpr JSValue::NativeCalleeTag, addressOfCalleeCalleeFromCallerPerspectiveBase - PrologueStackPointerDelta + TagOffset[sp]
+end
+
+    loadp JSWebAssemblyInstance::ImportFunctionInfo::wasmEntrypointLoadLocation[ws1], ws0
+    loadp JSWebAssemblyInstance::ImportFunctionInfo::targetInstance[ws1], wasmInstance
+
+    # Memory
+    if ARM64 or ARM64E
+        loadpairq JSWebAssemblyInstance::m_cachedMemory[wasmInstance], memoryBase, boundsCheckingSize
+    elsif X86_64
+        loadp JSWebAssemblyInstance::m_cachedMemory[wasmInstance], memoryBase
+        loadp JSWebAssemblyInstance::m_cachedBoundsCheckingSize[wasmInstance], boundsCheckingSize
+    end
+    if not ARMv7
+        cagedPrimitiveMayBeNull(memoryBase, ws1)
+    end
+
+    loadp [ws0], ws0
+    jmp ws0, WasmEntryPtrTag
+end)
+
+# This is the interpreted analogue to WasmBinding.cpp:wasmToJS
+op(wasm_to_js_wrapper_entry, macro()
+    # Load this before we create the stack frame, since we lose old cfr, which we wrote Callee to
+    loadp (Callee - PrologueStackPointerDelta)[sp], ws1
+
+    tagReturnAddress sp
+    preserveCallerPCAndCFR()
+
+    subp 0x10, sp
+if ARM64 or ARM64E
+    storepairq ws1, wasmInstance, -0x10[cfr]
+elsif JSVALUE64
+    storeq ws1, -0x10[cfr]
+    storeq wasmInstance, -8[cfr]
+else
+    storep ws1, -0x10[cfr]
+    storep wasmInstance, -8[cfr]
+end
+
+    subp 0x80, sp
+
+    # Store all the registers here
+
+if ARM64 or ARM64E
+    forEachArgumentJSR(macro (offset, gpr1, gpr2)
+        storepairq gpr1, gpr2, offset[sp]
+    end)
+elsif JSVALUE64
+    forEachArgumentJSR(macro (offset, gpr)
+        storeq gpr, offset[sp]
+    end)
+else
+    forEachArgumentJSR(macro (offset, gprMsw, gpLsw)
+        store2ia gpLsw, gprMsw, offset[sp]
+    end)
+end
+
+if ARM64 or ARM64E
+    forEachArgumentFPR(macro (offset, fpr1, fpr2)
+        storepaird fpr1, fpr2, offset[sp]
+    end)
+else
+    forEachArgumentFPR(macro (offset, fpr)
+        stored fpr, offset[sp]
+    end)
+end
+
+    move wasmInstance, a0
+    move ws1, a1
+    cCall2(_operationGetWasmCalleeStackSize)
+
+    move sp, a2
+    subp r0, sp
+    move sp, a0
+    move cfr, a1
+    move wasmInstance, a3
+    cCall4(_operationWasmToJSExitMarshalArguments)
+    btpnz r1, .oom
+
+    bineq r0, 0, .safe
+    move wasmInstance, r0
+    move (constexpr Wasm::ExceptionType::TypeErrorInvalidV128Use), r1
+    cCall2(_operationWasmToJSException)
+    jmp r0, ExceptionHandlerPtrTag
+    break
+
+.safe:
+
+    move r0, t2
+    loadp JSWebAssemblyInstance::ImportFunctionInfo::importFunction[t2], t0
+if not JSVALUE64
+    move (constexpr JSValue::CellTag), t1
+end
+
+    leap JSWebAssemblyInstance::ImportFunctionInfo::callLinkInfo[t2], t2
+    # emitDataICFastPath
+    #   emitFastPathImpl(nullptr, jit, false, nullptr)
+
+if not JSVALUE64
+    # branchIfNotCell(t0)
+    bineq t0, constexpr(JSValue::CellTag), .notacell
+end
+
+    # calleeGPR = t0
+    # callLinkInfoGPR = t2
+    # callTargetGPR = t5
+    loadp CallLinkInfo::m_monomorphicCallDestination[t2], t5
+
+if RISCV64
+    bpeq CallLinkInfo::m_callee[t2], t0, .found
+    btpnz CallLinkInfo::m_callee[t2], (constexpr CallLinkInfo::polymorphicCalleeMask), .found
+else
+    # scratch = t3
+    loadp CallLinkInfo::m_callee[t2], t3
+    bpeq t3, t0, .found
+    btpnz t3, (constexpr CallLinkInfo::polymorphicCalleeMask), .found
+end
+
+if not JSVALUE64
+.notacell:
+end
+
+.found:
+if ARM64 or ARM64E
+    pcrtoaddr _llint_default_call_trampoline, t5
+else
+    leap (_llint_default_call_trampoline), t5
+end
+    # not a tail call
+    # jit.transferPtr (constexpr CallLinkInfo::offsetOfCodeBlock())[t2], CodeBlock[cfr]
+    loadp CallLinkInfo::m_codeBlock[t2], t3
+    const offset = constexpr (CallerFrameAndPC::sizeInRegisters*sizeof(Register))
+    storep t3, (CodeBlock - offset)[sp]
+    call t5
+    
+    subp 0x80, sp
+    storep r0, [sp]
+    move sp, a0
+    move cfr, a1
+    move wasmInstance, a2
+    cCall3(_operationWasmToJSExitMarshalReturnValues)
+    btpnz r1, .handleException
+
+    macro forEachReturnWasmJSR(fn)
+        if ARM64 or ARM64E
+            fn(0 * 8, wa0, wa1)
+            fn(2 * 8, wa2, wa3)
+            fn(4 * 8, wa4, wa5)
+            fn(6 * 8, wa6, wa7)
+        elsif X86_64
+            fn(0 * 8, wa0)
+            fn(1 * 8, wa1)
+            fn(2 * 8, wa2)
+            fn(3 * 8, wa3)
+            fn(4 * 8, wa4)
+            fn(5 * 8, wa5)
+        elsif JSVALUE64
+            fn(0 * 8, wa0)
+            fn(1 * 8, wa1)
+            fn(2 * 8, wa2)
+            fn(3 * 8, wa3)
+            fn(4 * 8, wa4)
+            fn(5 * 8, wa5)
+        else
+            fn(0 * 8, wa1, wa0)
+            fn(1 * 8, wa3, wa2)
+        end
+    end
+
+if ARM64 or ARM64E
+    forEachReturnWasmJSR(macro (offset, gpr1, gpr2)
+        loadpairq offset[sp], gpr1, gpr2
+    end)
+elsif JSVALUE64
+    forEachReturnWasmJSR(macro (offset, gpr)
+        loadq offset[sp], gpr
+    end)
+else
+    forEachReturnWasmJSR(macro (offset, gprMsw, gprLsw)
+        load2ia offset[sp], gprLsw, gprMsw
+    end)
+end
+
+if ARM64 or ARM64E
+    forEachArgumentFPR(macro (offset, fpr1, fpr2)
+        loadpaird offset[sp], fpr1, fpr2
+    end)
+else
+    forEachArgumentFPR(macro (offset, fpr)
+        loadd offset[sp], fpr
+    end)
+end
+
+    loadp -8[cfr], wasmInstance
+    addp 0x10, sp
+
+    restoreCallerPCAndCFR()
+    ret
+
+.handleException:
+    move wasmInstance, a0
+    call _operationWasmUnwind
+    jmp r0, ExceptionHandlerPtrTag
+
+.oom:
+    throwException(OutOfMemory)
+
 end)
 
 macro traceExecution()

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -662,6 +662,8 @@ static inline void disableAllJITOptions()
     if (!Options::useInterpretedJSEntryWrappers() && Options::useWasm())
         disableAllWasmOptions();
 
+    Options::useWasmSIMD() = false;
+
     Options::usePollingTraps() = true;
 
     Options::dumpDisassembly() = false;

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -58,6 +58,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LLIntCallee);
 Callee::Callee(Wasm::CompilationMode compilationMode)
     : NativeCallee(NativeCallee::Category::Wasm, ImplementationVisibility::Private)
     , m_compilationMode(compilationMode)
+    , m_index(0xBADBADBA)
 {
 }
 
@@ -65,6 +66,7 @@ Callee::Callee(Wasm::CompilationMode compilationMode, size_t index, std::pair<co
     : NativeCallee(NativeCallee::Category::Wasm, ImplementationVisibility::Public)
     , m_compilationMode(compilationMode)
     , m_indexOrName(index, WTFMove(name))
+    , m_index(index)
 {
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -55,8 +55,10 @@ namespace Wasm {
 
 class Callee : public NativeCallee {
     WTF_MAKE_TZONE_ALLOCATED(Callee);
+    friend class JSC::LLIntOffsetsExtractor;
 public:
     IndexOrName indexOrName() const { return m_indexOrName; }
+    uint32_t index() const { return m_index; }
     CompilationMode compilationMode() const { return m_compilationMode; }
 
     CodePtr<WasmEntryPtrTag> entrypoint() const;
@@ -83,6 +85,7 @@ protected:
 private:
     const CompilationMode m_compilationMode;
     const IndexOrName m_indexOrName;
+    const uint32_t m_index;
 
 protected:
     FixedVector<HandlerInfo> m_exceptionHandlers;
@@ -227,10 +230,13 @@ class WasmToJSCallee final : public Callee {
     WTF_MAKE_TZONE_ALLOCATED(WasmToJSCallee);
 public:
     friend class Callee;
+    friend class JSC::LLIntOffsetsExtractor;
 
+    WasmToJSCallee(size_t index, std::pair<const Name*, RefPtr<NameSection>>&& name) : Callee(Wasm::CompilationMode::WasmToJSMode, index, WTFMove(name)) { };
     static WasmToJSCallee& singleton();
 
 private:
+
     WasmToJSCallee();
 
     std::tuple<void*, void*> rangeImpl() const

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WasmEntryPlan.h"
 
+#include "LLIntData.h"
 #include "WasmBinding.h"
 #include "WasmToJS.h"
 #include <wtf/DataLog.h>
@@ -289,7 +290,6 @@ void EntryPlan::generateStubsIfNecessary()
     }
 }
 
-#if ENABLE(JIT)
 
 bool EntryPlan::generateWasmToWasmStubs()
 {
@@ -300,29 +300,45 @@ bool EntryPlan::generateWasmToWasmStubs()
         if (import->kind != ExternalKind::Function)
             continue;
         dataLogLnIf(WasmEntryPlanInternal::verbose, "Processing import function number "_s, importFunctionIndex, ": "_s, makeString(import->module), ": "_s, makeString(import->field));
-        auto binding = wasmToWasm(importFunctionIndex);
-        if (UNLIKELY(!binding))
-            return false;
-        m_wasmToWasmExitStubs[importFunctionIndex++] = binding.value();
+#if ENABLE(JIT)
+        if (Options::useJIT()) {
+            auto binding = wasmToWasm(importFunctionIndex);
+            if (UNLIKELY(!binding))
+                return false;
+            m_wasmToWasmExitStubs[importFunctionIndex++] = binding.value();
+        }
+#else
+        if (false);
+#endif // ENABLE(JIT)
+        else
+            m_wasmToWasmExitStubs[importFunctionIndex++] = LLInt::getCodeRef<WasmEntryPtrTag>(wasm_to_wasm_wrapper_entry);
     }
     ASSERT(importFunctionIndex == m_wasmToWasmExitStubs.size());
     return true;
 }
 
+
 bool EntryPlan::generateWasmToJSStubs()
 {
     m_wasmToJSExitStubs.resize(m_moduleInformation->importFunctionCount());
     for (unsigned importIndex = 0; importIndex < m_moduleInformation->importFunctionCount(); ++importIndex) {
+#if ENABLE(JIT)
         Wasm::TypeIndex typeIndex = m_moduleInformation->importFunctionTypeIndices.at(importIndex);
-        auto binding = wasmToJS(typeIndex, importIndex);
-        if (UNLIKELY(!binding))
-            return false;
-        m_wasmToJSExitStubs[importIndex] = binding.value();
+        if (Options::useJIT()) {
+            auto binding = wasmToJS(typeIndex, importIndex);
+            if (UNLIKELY(!binding))
+                return false;
+            m_wasmToJSExitStubs[importIndex] = binding.value();
+        }
+#else
+        if (false);
+#endif // ENABLE(JIT)
+        else
+            m_wasmToJSExitStubs[importIndex] = LLInt::getCodeRef<WasmEntryPtrTag>(wasm_to_js_wrapper_entry);
     }
     return true;
 }
 
-#endif // ENABLE(JIT)
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -124,10 +124,9 @@ protected:
         return true;
     }
 
-#if ENABLE(JIT)
     bool generateWasmToJSStubs();
     bool generateWasmToWasmStubs();
-#endif
+
     void generateStubsIfNecessary() WTF_REQUIRES_LOCK(m_lock);
 
     Vector<uint8_t> m_source;

--- a/Source/JavaScriptCore/wasm/WasmIndexOrName.h
+++ b/Source/JavaScriptCore/wasm/WasmIndexOrName.h
@@ -31,13 +31,18 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
 
-namespace JSC { namespace Wasm {
+namespace JSC {
+
+class LLIntOffsetsExtractor;
+
+namespace Wasm {
 
 struct NameSection;
 
 // Keep this class copyable when the world is stopped: do not allocate any memory while copying this.
 // SamplingProfiler copies it while suspending threads.
 struct IndexOrName {
+    friend class JSC::LLIntOffsetsExtractor;
     typedef size_t Index;
 
 private:
@@ -110,10 +115,12 @@ private:
     RefPtr<NameSection> m_nameSection;
 
 #if USE(JSVALUE64)
+    public:
     // Use the top bits as tags. Neither pointers nor the function index space should use them.
     static constexpr Index indexTag = 1ull << (CHAR_BIT * sizeof(Index) - 1);
     static constexpr Index emptyTag = 1ull << (CHAR_BIT * sizeof(Index) - 2);
     static constexpr Index allTags = indexTag | emptyTag;
+    private:
 #elif USE(JSVALUE32_64)
     // Use an explicit tag as pointers might have high bits set
     Kind m_kind;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -281,6 +281,392 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
     }
 }
 
+JSC_DEFINE_JIT_OPERATION(operationGetWasmCalleeStackSize, EncodedJSValue, (JSWebAssemblyInstance* instance, Wasm::Callee* callee))
+{
+    auto& module = instance->module();
+
+    auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(callee->index());
+    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
+    const auto& signature = *typeDefinition.as<FunctionSignature>();
+    unsigned argCount = signature.argumentCount();
+    const auto& wasmCC = wasmCallingConvention();
+    CallInformation wasmCallInfo = wasmCC.callInformationFor(typeDefinition, CallRole::Callee);
+    RegisterAtOffsetList savedResultRegisters = wasmCallInfo.computeResultsOffsetList();
+
+    const unsigned numberOfParameters = argCount + 1; // There is a "this" argument.
+    const unsigned numberOfRegsForCall = CallFrame::headerSizeInRegisters + roundArgumentCountToAlignFrame(numberOfParameters);
+    ASSERT(!(numberOfRegsForCall % stackAlignmentRegisters()));
+    const unsigned numberOfBytesForCall = numberOfRegsForCall * sizeof(Register) - sizeof(CallerFrameAndPC);
+    const unsigned numberOfBytesForSavedResults = savedResultRegisters.sizeOfAreaInBytes();
+    const unsigned stackOffset = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(numberOfBytesForCall, numberOfBytesForSavedResults));
+
+    VM& vm = instance->vm();
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, stackOffset);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, (void* sp, CallFrame* cfr, void* argumentRegisters, JSWebAssemblyInstance* instance))
+{
+    auto access = []<typename V>(auto* arr, int i) -> V* {
+        return &reinterpret_cast<V*>(arr)[i / sizeof(V)];
+    };
+
+    CallFrame* calleeFrame = bitwise_cast<CallFrame*>(reinterpret_cast<uintptr_t>(sp) - sizeof(CallerFrameAndPC));
+    ASSERT(instance);
+    ASSERT(instance->globalObject());
+    VM& vm = instance->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    Wasm::Callee* callee = *access.operator()<Wasm::Callee*>(cfr, -0x10);
+    auto functionIndex = callee->index();
+    auto& module = instance->module();
+    auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(functionIndex);
+    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
+    const auto& signature = *typeDefinition.as<FunctionSignature>();
+    unsigned argCount = signature.argumentCount();
+
+    const auto& wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
+    const auto& jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
+
+    if (Options::useWasmSIMD() && (wasmCC.argumentsOrResultsIncludeV128))
+        OPERATION_RETURN(scope, 0);
+
+    for (unsigned argNum = 0; argNum < argCount; ++argNum) {
+        Type argType = signature.argumentType(argNum);
+        auto wasmParam = wasmCC.params[argNum].location;
+        auto dst = jsCC.params[argNum].location.offsetFromSP();
+
+        switch (argType.kind) {
+        case TypeKind::Void:
+        case TypeKind::Func:
+        case TypeKind::Struct:
+        case TypeKind::Structref:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
+        case TypeKind::Eqref:
+        case TypeKind::Anyref:
+        case TypeKind::Nullref:
+        case TypeKind::Nullfuncref:
+        case TypeKind::Nullexternref:
+        case TypeKind::I31ref:
+        case TypeKind::Rec:
+        case TypeKind::Sub:
+        case TypeKind::Subfinal:
+        case TypeKind::V128:
+            RELEASE_ASSERT_NOT_REACHED();
+        case TypeKind::RefNull:
+        case TypeKind::Ref:
+        case TypeKind::Externref:
+        case TypeKind::Funcref:
+        case TypeKind::I32: {
+            if (wasmParam.isStackArgument()) {
+                uint32_t raw = *access.operator()<uint32_t>(cfr, wasmParam.offsetFromFP());
+#if USE(JSVALUE64)
+                if (argType.isI32())
+                    *access.operator()<uint64_t>(sp, dst) = raw | JSValue::NumberTag;
+#else
+                if (false);
+#endif
+                else
+                    *access.operator()<uint64_t>(sp, dst) = raw;
+            } else {
+                auto raw = *access.operator()<uint32_t>(argumentRegisters, wasmParam.jsr().payloadGPR() * sizeof(UCPURegister));
+#if USE(JSVALUE64)
+                if (argType.isI32())
+                    *access.operator()<uint64_t>(sp, dst) = raw | JSValue::NumberTag;
+                else
+                    *access.operator()<uint64_t>(sp, dst) = raw;
+#else
+                *access.operator()<uint32_t>(sp, dst) = raw;
+#endif
+            }
+            break;
+        }
+        case TypeKind::I64: {
+            auto result = JSBigInt::makeHeapBigIntOrBigInt32(instance->globalObject(), *access.operator()<int64_t>(argumentRegisters, gprToIndex(wasmParam.jsr().payloadGPR()) * bytesForWidth(Width::Width64)));
+            OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+            *access.operator()<uint64_t>(sp, dst) = JSValue::encode(result);
+            break;
+        }
+        case TypeKind::F32: {
+            float val;
+            if (wasmParam.isStackArgument())
+                val = *access.operator()<float>(cfr, wasmParam.offsetFromFP());
+            else
+                val = *access.operator()<float>(argumentRegisters, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(wasmParam.fpr()) * bytesForWidth(Width::Width64));
+
+            double marshalled = purifyNaN(val);
+            uint64_t raw = bitwise_cast<uint64_t>(marshalled);
+#if USE(JSVALUE64)
+            raw += JSValue::DoubleEncodeOffset;
+#endif
+            *access.operator()<uint64_t>(sp, dst) = raw;
+            break;
+        }
+        case TypeKind::F64:
+            double val;
+            if (wasmParam.isStackArgument())
+                val = *access.operator()<double>(cfr, wasmParam.offsetFromFP());
+            else
+                val = *access.operator()<double>(argumentRegisters, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(wasmParam.fpr()) * bytesForWidth(Width::Width64));
+
+            double marshalled = purifyNaN(val);
+            uint64_t raw = bitwise_cast<uint64_t>(marshalled);
+#if USE(JSVALUE64)
+            raw += JSValue::DoubleEncodeOffset;
+#endif
+            *access.operator()<uint64_t>(sp, dst) = raw;
+            break;
+        }
+    }
+
+    // store this argument
+    *access.operator()<uint64_t>(calleeFrame, CallFrameSlot::thisArgument* static_cast<int>(sizeof(Register))) = JSValue::encode(jsUndefined());
+
+    // materializeImportJSCell and store
+    auto* newCallee = instance->importFunctionInfo(functionIndex);
+#if USE(JSVALUE64)
+    *access.operator()<uint64_t>(calleeFrame, CallFrameSlot::callee * static_cast<int>(sizeof(Register))) = bitwise_cast<uint64_t>(newCallee->importFunction);
+#else
+    *access.operator()<uint32_t>(calleeFrame, CallFrameSlot::callee * static_cast<int>(sizeof(Register))) = bitwise_cast<uint32_t>(newCallee->importFunction);
+#endif
+
+    *access.operator()<uint32_t>(calleeFrame, CallFrameSlot::argumentCountIncludingThis * static_cast<int>(sizeof(Register)) + PayloadOffset) = argCount + 1; // including this = +1
+
+    // set up codeblock
+    auto singletonCallee = CalleeBits::boxNativeCallee(&WasmToJSCallee::singleton());
+#if USE(JSVALUE64)
+    *access.operator()<uint64_t>(cfr, CallFrameSlot::codeBlock * sizeof(Register)) = bitwise_cast<uint64_t>(instance);
+    *access.operator()<uint64_t>(cfr, CallFrameSlot::callee * sizeof(Register)) = bitwise_cast<uint64_t>(singletonCallee);
+#else
+    *access.operator()<uint32_t>(cfr, CallFrameSlot::codeBlock * sizeof(Register)) = bitwise_cast<uint32_t>(instance);
+    *access.operator()<uint32_t>(cfr, CallFrameSlot::callee * sizeof(Register)) = bitwise_cast<uint32_t>(singletonCallee);
+#endif
+
+#if USE(JSVALUE64)
+    OPERATION_RETURN(scope, bitwise_cast<uint64_t>(newCallee));
+#else
+    OPERATION_RETURN(scope, bitwise_cast<uint32_t>(newCallee));
+#endif
+}
+
+JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValue, (void* sp, CallFrame* cfr, JSWebAssemblyInstance* instance))
+{
+    auto access = []<typename V>(auto* arr, int i) -> V* {
+        return &reinterpret_cast<V*>(arr)[i / sizeof(V)];
+    };
+
+    void* registerSpace = sp;
+
+    auto scope = DECLARE_THROW_SCOPE(instance->vm());
+
+    Wasm::Callee* callee = *access.operator()<Wasm::Callee*>(cfr, -0x10);
+    auto functionIndex = callee->index();
+    auto& module = instance->module();
+    auto typeIndex = module.moduleInformation().typeIndexFromFunctionIndexSpace(functionIndex);
+    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
+    const auto& signature = *typeDefinition.as<FunctionSignature>();
+
+    auto* globalObject = instance->globalObject();
+
+    auto wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
+    auto jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
+
+    JSValue returned = *(reinterpret_cast<JSValue*>(registerSpace));
+
+    if (signature.returnCount() == 1) {
+        const auto& returnType = signature.returnType(0);
+        switch (returnType.kind) {
+        case TypeKind::I32: {
+            if (!returned.isNumber() || !returned.isInt32()) {
+                // slow path
+                uint32_t result = JSValue::decode(bitwise_cast<EncodedJSValue>(returned)).toInt32(globalObject);
+                *access.operator()<uint32_t>(registerSpace, 0) = result;
+            } else {
+                uint64_t result = static_cast<uint64_t>(*access.operator()<uint32_t>(registerSpace, 0));
+                *access.operator()<uint32_t>(registerSpace, 0) = result;
+            }
+            break;
+        }
+        case TypeKind::I64: {
+            uint64_t result = JSValue::decode(bitwise_cast<EncodedJSValue>(returned)).toBigInt64(globalObject);
+            *access.operator()<uint64_t>(registerSpace, 0) = result;
+            break;
+        }
+        case TypeKind::F32: {
+            FPRReg dest = wasmCC.results[0].location.fpr();
+            auto offset = GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(dest) * bytesForWidth(Width::Width64);
+            if (returned.isNumber()) {
+                if (returned.isInt32()) {
+                    float result = static_cast<float>(*access.operator()<uint32_t>(registerSpace, 0));
+                    *access.operator()<float>(registerSpace, offset) = result;
+                } else {
+#if USE(JSVALUE64)
+                    uint64_t intermediate = *access.operator()<uint64_t>(registerSpace, 0) + JSValue::NumberTag;
+#else
+                    uint64_t intermediate = *access.operator()<uint64_t>(registerSpace, 0);
+#endif
+                    double d = bitwise_cast<double>(intermediate);
+                    *access.operator()<float>(registerSpace, offset) = static_cast<float>(d);
+                }
+            } else {
+                float result = static_cast<float>(JSValue::decode(bitwise_cast<EncodedJSValue>(returned)).toNumber(globalObject));
+                *access.operator()<float>(registerSpace, offset) = result;
+            }
+            break;
+        }
+        case TypeKind::F64: {
+            FPRReg dest = wasmCC.results[0].location.fpr();
+            auto offset = GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(dest) * bytesForWidth(Width::Width64);
+            if (returned.isNumber()) {
+                if (returned.isInt32()) {
+                    double result = static_cast<float>(*access.operator()<uint32_t>(registerSpace, 0));
+                    *access.operator()<double>(registerSpace, offset) = result;
+                } else {
+#if USE(JSVALUE64)
+                    uint64_t intermediate = *access.operator()<uint64_t>(registerSpace, 0) + JSValue::NumberTag;
+#else
+                    uint64_t intermediate = *access.operator()<uint64_t>(registerSpace, 0);
+#endif
+                    double d = bitwise_cast<double>(intermediate);
+                    *access.operator()<double>(registerSpace, offset) = d;
+                }
+            } else {
+                double result = static_cast<double>(JSValue::decode(bitwise_cast<EncodedJSValue>(returned)).toNumber(globalObject));
+                *access.operator()<double>(registerSpace, offset) = result;
+            }
+            break;
+        }
+        default:  {
+            if (Wasm::isRefType(returnType)) {
+                if (Wasm::isExternref(returnType)) {
+                    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
+                } else if (Wasm::isFuncref(returnType) || (!Options::useWasmGC() && isRefWithTypeIndex(returnType))) {
+                    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
+                    // operationConvertToFuncref
+                    JSValue value = JSValue::decode(bitwise_cast<EncodedJSValue>(returned));
+                    WebAssemblyFunction* wasmFunction = nullptr;
+                    WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
+                    if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
+                        throwTypeError(globalObject, scope, "Funcref value is not a function"_s);
+                        OPERATION_RETURN(scope, 0);
+                    }
+
+                    if (isRefWithTypeIndex(returnType) && !value.isNull()) {
+                        Wasm::TypeIndex paramIndex = returnType.index;
+                        Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
+                        if (paramIndex != argIndex) {
+                            throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
+                            OPERATION_RETURN(scope, 0);
+                        }
+                    }
+                } else {
+                    // operationConvertToAnyref
+                    JSValue value = JSValue::decode(bitwise_cast<EncodedJSValue>(returned));
+                    value = Wasm::internalizeExternref(value);
+                    if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
+                        throwTypeError(globalObject, scope, "Argument value did not match reference type"_s);
+                        OPERATION_RETURN(scope, 0);
+                    }
+                }
+                // do nothing, the register is already there
+            } else
+                RELEASE_ASSERT_NOT_REACHED();
+        }
+        }
+    } else if (signature.returnCount() > 1) {
+        // operationIterateResults
+        JSValue result = JSValue::decode(bitwise_cast<EncodedJSValue>(returned));
+
+        unsigned iterationCount = 0;
+        MarkedArgumentBuffer buffer;
+        buffer.ensureCapacity(signature.returnCount());
+        forEachInIterable(globalObject, result, [&](VM&, JSGlobalObject*, JSValue value) -> void {
+            if (buffer.size() < signature.returnCount()) {
+                buffer.append(value);
+                if (UNLIKELY(buffer.hasOverflowed()))
+                    throwOutOfMemoryError(globalObject, scope);
+            }
+            ++iterationCount;
+        });
+
+        OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+        if (buffer.hasOverflowed()) {
+            throwOutOfMemoryError(globalObject, scope, "JS results to Wasm are too large"_s);
+            OPERATION_RETURN(scope, 0);
+        }
+
+        if (iterationCount != signature.returnCount()) {
+            throwVMTypeError(globalObject, scope, "Incorrect number of values returned to Wasm from JS"_s);
+            OPERATION_RETURN(scope, 0);
+        }
+        for (unsigned index = 0; index < buffer.size(); ++index) {
+            JSValue value = buffer.at(index);
+
+            uint64_t unboxedValue = 0;
+            const auto& returnType = signature.returnType(index);
+            switch (returnType.kind) {
+            case TypeKind::I32:
+                unboxedValue = value.toInt32(globalObject);
+                break;
+            case TypeKind::I64:
+                unboxedValue = value.toBigInt64(globalObject);
+                break;
+            case TypeKind::F32:
+                unboxedValue = bitwise_cast<uint32_t>(value.toFloat(globalObject));
+                break;
+            case TypeKind::F64:
+                unboxedValue = bitwise_cast<uint64_t>(value.toNumber(globalObject));
+                break;
+            default: {
+                if (Wasm::isRefType(returnType)) {
+                    if (isExternref(returnType))
+                        ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
+                    else if (isFuncref(returnType) || (!Options::useWasmGC() && isRefWithTypeIndex(returnType))) {
+                        ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
+                        WebAssemblyFunction* wasmFunction = nullptr;
+                        WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
+                        if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
+                            throwTypeError(globalObject, scope, "Funcref value is not a function"_s);
+                            OPERATION_RETURN(scope, 0);
+                        }
+                        if (Wasm::isRefWithTypeIndex(returnType) && !value.isNull()) {
+                            Wasm::TypeIndex paramIndex = returnType.index;
+                            Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
+                            if (paramIndex != argIndex) {
+                                throwTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
+                                OPERATION_RETURN(scope, 0);
+                            }
+                        }
+                    } else {
+                        ASSERT(Options::useWasmGC());
+                        value = Wasm::internalizeExternref(value);
+                        if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
+                            throwTypeError(globalObject, scope, "Argument value did not match reference type"_s);
+                            OPERATION_RETURN(scope, 0);
+                        }
+                    }
+                } else
+                    RELEASE_ASSERT_NOT_REACHED();
+                unboxedValue = bitwise_cast<uint64_t>(value);
+            }
+            }
+            OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+            auto rep = wasmCC.results[index];
+            if (rep.location.isGPR())
+                *access.operator()<uint64_t>(registerSpace, rep.location.jsr().payloadGPR() * sizeof(UCPURegister)) = unboxedValue;
+            else if (rep.location.isFPR())
+                *access.operator()<uint64_t>(registerSpace, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(rep.location.fpr()) * bytesForWidth(Width::Width64)) = unboxedValue;
+            else
+                *access.operator()<uint64_t>(cfr, rep.location.offsetFromFP()) = unboxedValue;
+        }
+    }
+
+    OPERATION_RETURN(scope, 0);
+}
+
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 static bool shouldTriggerOMGCompile(TierUpCount& tierUp, OMGCallee* replacement, uint32_t functionIndex)
 {

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -51,6 +51,9 @@ typedef int64_t EncodedWasmValue;
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, void, (void*, CallFrame*));
 JSC_DECLARE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJSValue, (void*, CallFrame*));
+JSC_DECLARE_JIT_OPERATION(operationGetWasmCalleeStackSize, EncodedJSValue, (JSWebAssemblyInstance*, Wasm::Callee*));
+JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, (void*, CallFrame*, void*, JSWebAssemblyInstance*));
+JSC_DECLARE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValue, (void* sp, CallFrame* cfr, JSWebAssemblyInstance*));
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 void loadValuesIntoBuffer(Probe::Context&, const StackMap&, uint64_t* buffer, SavedFPWidth);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -187,8 +187,11 @@ void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObjec
 
     for (unsigned importFunctionNum = 0; importFunctionNum < numImportFunctions(); ++importFunctionNum) {
         auto* info = importFunctionInfo(importFunctionNum);
-        if (!info->targetInstance)
+        if (!info->targetInstance) {
             info->importFunctionStub = module().importFunctionStub(importFunctionNum);
+            importCallees.append(adoptRef(*new WasmToJSCallee(importFunctionNum, { nullptr, nullptr })));
+            info->boxedTargetCalleeLoadLocation = reinterpret_cast<const uintptr_t*>(importCallees.last().ptr());
+        }
         else
             info->importFunctionStub = wasmCalleeGroup->wasmToWasmExitStub(importFunctionNum);
     }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -329,6 +329,7 @@ private:
     BitVector m_passiveElements;
     BitVector m_passiveDataSegments;
     FixedVector<RefPtr<const Wasm::Tag>> m_tags;
+    Vector<Ref<Wasm::WasmToJSCallee>> importCallees;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 0b31e2848d7894a6a26fc22e04e24641ab426429
<pre>
Support JITless Wasm import calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=277830">https://bugs.webkit.org/show_bug.cgi?id=277830</a>
<a href="https://rdar.apple.com/133494023">rdar://133494023</a>

Reviewed by Yusuke Suzuki and Keith Miller.

This patch finishes JITless Wasm support by enabling JITless entry points for
imported functions, both from JS and Wasm. This allows us to run JetStream2.0
with JIT turned off.

* JSTests/wasm/stress/cc-infinite-int-glitch.js:
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.test.export.string_appeared_here.param.x.i32.result.i32.result.i32.local.x.local.x.func.test2.export.string_appeared_here.param.x.i32.result.i32.result.i32.result.i32.local.x.local.x.local.x.async test):
* JSTests/wasm/stress/cc-int-to-int-to-js.js: Added.
(local.x.call.callee.callee):
(async test):
* JSTests/wasm/stress/wasm-js-call-many-return-types-on-stack-no-args.js:
(async test):
* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::generateWasmToJSStubs):
* Source/JavaScriptCore/wasm/WasmIndexOrName.h:
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::doWasmCall):
(JSC::LLInt::doWasmCallIndirect):
(JSC::LLInt::doWasmCallRef):

Canonical link: <a href="https://commits.webkit.org/282172@main">https://commits.webkit.org/282172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7da5beb3878179f70b0d104f928a163a2db764f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12810 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50174 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11205 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11741 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55361 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67975 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61507 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57766 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5134 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83271 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37419 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14607 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->