### PR TITLE
[webkitpy] Update various library dependencies for setuptools mismatch

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
@@ -71,14 +71,11 @@ if platform.machine() == 'arm64':
     AutoInstall.register(Package('cassandra', Version(3, 25, 0), pypi_name='cassandra-driver', slow_install=True))
 else:
     AutoInstall.register(Package('cassandra', Version(3, 25, 0), pypi_name='cassandra-driver', wheel=True))
-AutoInstall.register(Package('click', Version(7, 1, 2)))
 AutoInstall.register(Package('Crypto', Version(3, 10, 1), pypi_name='pycryptodome'))
 AutoInstall.register(Package('fakeredis', Version(1, 5, 2)))
 AutoInstall.register(Package('geomet', Version(0, 2, 1)))
 AutoInstall.register(Package('gremlinpython', Version(3, 4, 6)))
-AutoInstall.register(Package('hiredis', Version(1, 1, 0)))
 AutoInstall.register(Package('isodate', Version(0, 6, 0)))
-AutoInstall.register(Package('lupa', Version(1, 13)))
 AutoInstall.register(Package('pyasn1_modules', Version(0, 2, 8), pypi_name='pyasn1-modules'))
 AutoInstall.register(Package('redis', Version(3, 5, 3)))
 if sys.version_info < (3, 8):

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/archive_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/archive_controller.py
@@ -85,7 +85,7 @@ class ArchiveController(HasCommitContext):
 
         if not result:
             abort(404, description='No archives matching the specified criteria')
-        return send_file(result, attachment_filename=f'{filename}.zip', as_attachment=True)
+        return send_file(result, download_name=f'{filename}.zip', as_attachment=True)
 
     def upload(self):
         AssertRequest.is_type(['POST'])

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -56,7 +56,7 @@ version = Version(1, 0, 0)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):
-    AutoInstall.register(Package('mock', Version(4)))
+    AutoInstall.register(Package('mock', Version(5, 1, 0), wheel=True))
 else:
     AutoInstall.register(Package('mock', Version(3, 0, 5)))
     if platform.system() == 'Windows':
@@ -65,7 +65,7 @@ else:
 if sys.version_info >= (3, 12):
     AutoInstall.register(Package('setuptools', Version(68, 1, 2)))
 elif sys.version_info >= (3, 9):
-    AutoInstall.register(Package('setuptools', Version(61, 3, 1)))
+    AutoInstall.register(Package('setuptools', Version(59, 8, 0)))
 elif sys.version_info >= (3, 0):
     AutoInstall.register(Package('setuptools', Version(56, 0, 0)))
 else:
@@ -77,7 +77,7 @@ else:
     AutoInstall.register(Package('certifi', Version(2021, 10, 8)))
 
 AutoInstall.register(Package('chardet', Version(3, 0, 4)))
-AutoInstall.register(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil'))
+AutoInstall.register(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil', wheel=True))
 AutoInstall.register(Package('entrypoints', Version(0, 3, 0)))
 AutoInstall.register(Package('funcsigs', Version(1, 0, 2)))
 AutoInstall.register(Package('idna', Version(2, 10)))

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
@@ -49,19 +49,17 @@ except ImportError:
 
 version = Version(0, 7, 0)
 
-AutoInstall.register(Package('click', Version(7, 1, 2)))
-AutoInstall.register(Package('flask', Version(1, 1, 2)))
-AutoInstall.register(Package('hiredis', Version(1, 1, 0)))
+AutoInstall.register(Package('blinker', Version(1, 8, 2)))
+AutoInstall.register(Package('click', Version(8, 1, 7)))
+AutoInstall.register(Package('flask', Version(2, 3, 3)))
+AutoInstall.register(Package('hiredis', Version(3, 0, 0), wheel=True))
 AutoInstall.register(Package('itsdangerous', Version(1, 1, 0)))
-AutoInstall.register(Package('jinja2', Version(2, 11, 3)))
-if sys.version_info > (3, 10):
-    AutoInstall.register(Package('lupa', Version(2, 0)))
-else:
-    AutoInstall.register(Package('lupa', Version(1, 13)))
-AutoInstall.register(Package('markupsafe', Version(1, 1, 1)))
+AutoInstall.register(Package('markupsafe', Version(2, 1, 5), pypi_name='MarkupSafe', wheel=True))
+AutoInstall.register(Package('jinja2', Version(3, 1, 4), implicit_deps=['markupsafe']))
+AutoInstall.register(Package('lupa', Version(2, 2), wheel=True))
 AutoInstall.register(Package('redis', Version(3, 5, 3)))
 AutoInstall.register(Package('sortedcontainers', Version(2, 4, 0)))
-AutoInstall.register(Package('werkzeug', Version(1, 0, 1)))
+AutoInstall.register(Package('werkzeug', Version(3, 0, 3)))
 
 if sys.version_info > (3, 0):
     AutoInstall.register(Package('fakeredis', Version(1, 5, 2)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -55,10 +55,10 @@ if sys.version_info < (3, 0):
     raise ImportError('webkitscmpy no longer supports Python 2')
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
-AutoInstall.register(Package('jinja2', Version(2, 11, 3)))
+AutoInstall.register(Package('markupsafe', Version(2, 1, 5), pypi_name='MarkupSafe', wheel=True))
+AutoInstall.register(Package('jinja2', Version(3, 1, 4), implicit_deps=['markupsafe']))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
-AutoInstall.register(Package('markupsafe', Version(1, 1, 1), pypi_name='MarkupSafe'))
 AutoInstall.register(Package('webkitbugspy', Version(0, 8, 0)), local=True)
 
 if sys.version_info > (3, 6):

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -64,9 +64,9 @@ if sys.version_info >= (3, 7):
                 + (["importlib_metadata"] if sys.version_info < (3, 8) else [])
                 )
     )
-    AutoInstall.register(Package('pytest_asyncio', Version(0, 18, 3), pypi_name='pytest-asyncio', implicit_deps=['pytest']))
-    AutoInstall.register(Package('pytest_timeout', Version(2, 1, 0), pypi_name='pytest-timeout', implicit_deps=['pytest']))
-    AutoInstall.register(Package('websockets', Version(8, 1)))
+    AutoInstall.register(Package('pytest_asyncio', Version(0, 18, 3), pypi_name='pytest-asyncio', implicit_deps=['pytest'], wheel=True))
+    AutoInstall.register(Package('pytest_timeout', Version(2, 1, 0), pypi_name='pytest-timeout', implicit_deps=['pytest'], wheel=True))
+    AutoInstall.register(Package('websockets', Version(12, 0), wheel=True))
     if sys.version_info < (3, 11):
         AutoInstall.register(Package('exceptiongroup', Version(1, 1, 0), wheel=True))
 elif sys.version_info >= (2, 7) and sys.version_info < (3,):
@@ -95,12 +95,12 @@ else:
     AutoInstall.register(Package('bs4', Version(4, 9, 3), pypi_name='beautifulsoup4'))
 AutoInstall.register(Package('configparser', Version(4, 0, 2), implicit_deps=['pyparsing']))
 AutoInstall.register(Package('contextlib2', Version(0, 6, 0)))
-AutoInstall.register(Package('coverage', Version(5, 2, 1)))
+AutoInstall.register(Package('coverage', Version(7, 6, 1), wheel=True))
 AutoInstall.register(Package('funcsigs', Version(1, 0, 2)))
 AutoInstall.register(Package('html5lib', Version(1, 1)))
 AutoInstall.register(Package('iniconfig', Version(1, 1, 1)))
 AutoInstall.register(Package('mechanize', Version(0, 4, 5)))
-AutoInstall.register(Package('more_itertools', Version(4, 2, 0), pypi_name='more-itertools'))
+AutoInstall.register(Package('more_itertools', Version(4, 2, 0), pypi_name='more-itertools', wheel=True))
 AutoInstall.register(Package('mozprocess', Version(1, 3, 0)))
 AutoInstall.register(Package('mozlog', Version(7, 1, 0), wheel=True))
 AutoInstall.register(Package('mozterm', Version(1, 0, 0)))
@@ -112,8 +112,6 @@ if sys.version_info >= (3, 7):
     AutoInstall.register(Package('pyfakefs', Version(5, 2, 4)))
 else:
     AutoInstall.register(Package('pyfakefs', Version(3, 7, 2)))
-
-AutoInstall.register(Package('scandir', Version(1, 10, 0)))
 
 if sys.version_info >= (3, 6):
     AutoInstall.register(Package('soupsieve', Version(2, 2, 1)))
@@ -132,7 +130,7 @@ AutoInstall.register(Package('toml', Version(0, 10, 1), implicit_deps=['pyparsin
 AutoInstall.register(Package('wcwidth', Version(0, 2, 5)))
 AutoInstall.register(Package('webencodings', Version(0, 5, 1)))
 AutoInstall.register(Package('zipp', Version(1, 2, 0)))
-AutoInstall.register(Package('zope.interface', Version(5, 1, 0), aliases=['zope'], pypi_name='zope-interface'))
+AutoInstall.register(Package('zope.interface', Version(7, 0, 1), aliases=['zope'], pypi_name='zope-interface', wheel=True))
 
 if sys.version_info > (3, 0):
     AutoInstall.register(Package('reporelaypy', Version(0, 4, 1)), local=True)

--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -26,17 +26,16 @@ import webkitscmpy
 from webkitcorepy import AutoInstall, Package, Version
 from webkitpy.autoinstalled import twisted
 
+AutoInstall.install('jinja2')
+
 AutoInstall.install(Package('attr', Version(21, 3, 0), pypi_name='attrs'))
 AutoInstall.install(Package('constantly', Version(15, 1, 0)))
 AutoInstall.install(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil'))
 AutoInstall.install(Package('future', Version(0, 18, 2)))
-AutoInstall.install(Package('jinja2', Version(2, 11, 3), pypi_name='Jinja2'))
 AutoInstall.install(Package('pbr', Version(5, 9, 0)))
 AutoInstall.install(Package('lz4', Version(4, 3, 2)))
 AutoInstall.install(Package('jwt', Version(1, 7, 1), pypi_name='PyJWT'))
 AutoInstall.install(Package('pyyaml', Version(5, 3, 1), pypi_name='PyYAML'))
-
-AutoInstall.install('markupsafe')
 
 if sys.version_info >= (3, 0):
     # autobahn has wheel=False because of https://bugs.webkit.org/show_bug.cgi?id=263392

--- a/Tools/Scripts/webkitpy/common/system/filesystem.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem.py
@@ -41,10 +41,6 @@ import time
 
 from webkitcorepy import string_utils
 
-if sys.version_info < (3,):
-    # Avoid having to compile scandir where it is unneeded.
-    import scandir
-
 
 class FileSystem(object):
     """FileSystem interface for webkitpy.
@@ -113,10 +109,7 @@ class FileSystem(object):
 
         dirs = []
 
-        if sys.version_info >= (3,):
-            it = os.walk(path)
-        else:
-            it = scandir.walk(path)
+        it = os.walk(path)
 
         for dirpath, dirnames, filenames in it:
             if dir_filter(self, dirpath):
@@ -148,10 +141,7 @@ class FileSystem(object):
         if self.basename(path) in dirs_to_skip:
             return []
 
-        if sys.version_info >= (3,):
-            it = os.walk(path)
-        else:
-            it = scandir.walk(path)
+        it = os.walk(path)
 
         for dirpath, dirnames, filenames in it:
             for d in dirs_to_skip:
@@ -191,10 +181,7 @@ class FileSystem(object):
         return os.listdir(path)
 
     def scandir(self, path):
-        if sys.version_info >= (3,):
-            return os.scandir(path)
-        else:
-            return scandir.scandir(path)
+        return os.scandir(path)
 
     def mkdtemp(self, **kwargs):
         """Create and return a uniquely named directory.


### PR DESCRIPTION
#### 59130f23ffecb92e8e6790ac6e590b3deef1d7c0
<pre>
[webkitpy] Update various library dependencies for setuptools mismatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=277833">https://bugs.webkit.org/show_bug.cgi?id=277833</a>
<a href="https://rdar.apple.com/133496921">rdar://133496921</a>

Reviewed by Sam Sneddon.

Update various libraries and change some to wheels to sidestep setuptools mistmatch.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py: Remove libraries managed in webkitflaskpy.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Bump various libraries.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/webkitpy/__init__.py: Ditto.
* Tools/Scripts/webkitpy/autoinstalled/buildbot.py: Correct jinja dependencies.
* Tools/Scripts/webkitpy/common/system/filesystem.py:
(FileSystem.dirs_under): Remove scandir.
(FileSystem.files_under): Ditto.
(FileSystem.scandir): Ditto.

Canonical link: <a href="https://commits.webkit.org/282021@main">https://commits.webkit.org/282021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc3aec1a26028c95ed4fe2a5fd5129f3b8557ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14388 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/38220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/61307 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/34867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/10754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/67504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/61474 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5764 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/53471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/4713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9308 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->