### PR TITLE
Add ability to determine the video configuration of the media playing

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -74,6 +74,10 @@ SOFT_LINK_CLASS_FOR_HEADER(PAL, AVSpeechUtterance)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, AVStreamDataParser)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, AVURLAsset)
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+SOFT_LINK_CLASS_FOR_HEADER_WITH_AVAILABILITY(PAL, AVAssetPlaybackAssistant, API_AVAILABLE(macos(13.0), ios(16.0), tvos(16.0), watchos(9.0), visionos(1.0)))
+#endif
+
 #if HAVE(AVAUDIOSESSION)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, AVAudioSession)
 #endif
@@ -412,5 +416,12 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVSampleBufferDisplayL
 
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
 #define AVSampleBufferAttachContentKey PAL::softLink_AVFoundation_AVSampleBufferAttachContentKey
+
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVAssetPlaybackConfigurationOptionStereoVideo, NSString *)
+#define AVAssetPlaybackConfigurationOptionStereoVideo PAL::get_AVFoundation_AVAssetPlaybackConfigurationOptionStereoVideo()
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVAssetPlaybackConfigurationOptionStereoMultiviewVideo, NSString *)
+#define AVAssetPlaybackConfigurationOptionStereoMultiviewVideo PAL::get_AVFoundation_AVAssetPlaybackConfigurationOptionStereoMultiviewVideo()
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVAssetPlaybackConfigurationOptionSpatialVideo, NSString *)
+#define AVAssetPlaybackConfigurationOptionSpatialVideo PAL::get_AVFoundation_AVAssetPlaybackConfigurationOptionSpatialVideo()
 
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
@@ -104,6 +104,10 @@ SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, AVFoundation, AVSampleBuffe
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, AVFoundation, AVSampleBufferRenderSynchronizer, PAL_EXPORT)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, AVFoundation, AVStreamDataParser, PAL_EXPORT)
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT_AND_AVAILABILITY(PAL, AVFoundation, AVAssetPlaybackAssistant, PAL_EXPORT, API_AVAILABLE(macos(13.0), ios(16.0), tvos(16.0), watchos(9.0), visionos(1.0)))
+#endif
+
 #if HAVE(AVAUDIOSESSION)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, AVFoundation, AVAudioSession, PAL_EXPORT)
 #endif
@@ -296,5 +300,9 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVSampleBu
 #endif
 
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
+
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAssetPlaybackConfigurationOptionStereoVideo, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAssetPlaybackConfigurationOptionStereoMultiviewVideo, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAssetPlaybackConfigurationOptionSpatialVideo, NSString *, PAL_EXPORT)
 
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -141,6 +141,7 @@ public:
     virtual void setSoundStageSize(AudioSessionSoundStageSize) = 0;
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     virtual bool supportsLinearMediaPlayer() const { return false; }
+    virtual bool isSpatial() const { return false; }
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1344,6 +1344,16 @@ MediaPlayer::MovieLoadType MediaPlayer::movieLoadType() const
     return m_private->movieLoadType();
 }
 
+MediaPlayer::VideoPlaybackConfiguration MediaPlayer::videoPlaybackConfiguration() const
+{
+    return m_private->videoPlaybackConfiguration();
+}
+
+void MediaPlayer::videoPlaybackConfigurationChanged()
+{
+    return client().mediaPlayerVideoPlaybackConfigurationChanged();
+}
+
 MediaTime MediaPlayer::mediaTimeForTimeValue(const MediaTime& timeValue) const
 {
     return m_private->mediaTimeForTimeValue(timeValue);
@@ -2114,6 +2124,14 @@ String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::PurgeResources) == 3, "MediaPlayer::PurgeResources is not 3 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
+}
+
+String convertOptionSetToString(const MediaPlayer::VideoPlaybackConfiguration& value)
+{
+    return makeString('[', value.contains(MediaPlayer::VideoPlaybackConfigurationOption::Stereo) ? "Stereo|"_s : ""_s,
+        value.contains(MediaPlayer::VideoPlaybackConfigurationOption::StereoMultiview) ? "StereoMultiview|"_s : ""_s,
+        value.contains(MediaPlayer::VideoPlaybackConfigurationOption::Spatial) ? "Spatial|"_s : ""_s,
+        ']');
 }
 
 String MediaPlayer::lastErrorMessage() const

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -208,6 +208,8 @@ public:
     // A characteristic of the media file, eg. video, audio, closed captions, etc, has changed.
     virtual void mediaPlayerCharacteristicChanged() { }
 
+    virtual void mediaPlayerVideoPlaybackConfigurationChanged() { }
+
     // whether the rendering system can accelerate the display of this MediaPlayer.
     virtual bool mediaPlayerRenderingCanBeAccelerated() { return false; }
 
@@ -537,6 +539,11 @@ public:
 
     using MediaPlayerEnums::MovieLoadType;
     MovieLoadType movieLoadType() const;
+
+    using MediaPlayerEnums::VideoPlaybackConfiguration;
+    using MediaPlayerEnums::VideoPlaybackConfigurationOption;
+    void videoPlaybackConfigurationChanged();
+    VideoPlaybackConfiguration videoPlaybackConfiguration() const;
 
     using MediaPlayerEnums::Preload;
     Preload preload() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+#include <wtf/OptionSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -110,6 +112,13 @@ enum class MediaPlayerNeedsRenderingModeChanged : bool {
     Yes,
 };
 
+enum class MediaPlayerVideoPlaybackConfigurationOption : uint8_t {
+    Stereo = 1 << 0,
+    StereoMultiview = 1 << 1,
+    Spatial = 1 << 2,
+};
+using MediaPlayerVideoPlaybackConfiguration = OptionSet<MediaPlayerVideoPlaybackConfigurationOption>;
+
 class MediaPlayerEnums {
 public:
     using NetworkState = MediaPlayerNetworkState;
@@ -123,6 +132,8 @@ public:
     using WirelessPlaybackTargetType = MediaPlayerWirelessPlaybackTargetType;
     using PitchCorrectionAlgorithm = MediaPlayerPitchCorrectionAlgorithm;
     using NeedsRenderingModeChanged = MediaPlayerNeedsRenderingModeChanged;
+    using VideoPlaybackConfigurationOption = MediaPlayerVideoPlaybackConfigurationOption;
+    using VideoPlaybackConfiguration = MediaPlayerVideoPlaybackConfiguration;
 
     enum {
         VideoFullscreenModeNone = 0,
@@ -140,6 +151,7 @@ String convertEnumerationToString(MediaPlayerEnums::NetworkState);
 String convertEnumerationToString(MediaPlayerEnums::Preload);
 String convertEnumerationToString(MediaPlayerEnums::SupportsType);
 String convertEnumerationToString(MediaPlayerEnums::BufferingPolicy);
+WEBCORE_EXPORT String convertOptionSetToString(const MediaPlayerEnums::VideoPlaybackConfiguration&);
 
 } // namespace WebCore
 
@@ -170,6 +182,14 @@ struct LogArgument<WebCore::MediaPlayerEnums::BufferingPolicy> {
     static String toString(const WebCore::MediaPlayerEnums::BufferingPolicy policy)
     {
         return convertEnumerationToString(policy);
+    }
+};
+
+template <>
+struct LogArgument<WebCore::MediaPlayerEnums::VideoPlaybackConfiguration> {
+    static String toString(const WebCore::MediaPlayerEnums::VideoPlaybackConfiguration& configuration)
+    {
+        return convertOptionSetToString(configuration);
     }
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -235,6 +235,10 @@ public:
 
     virtual MediaPlayer::MovieLoadType movieLoadType() const { return MediaPlayer::MovieLoadType::Unknown; }
 
+    using VideoPlaybackConfiguration = MediaPlayer::VideoPlaybackConfiguration;
+    using VideoPlaybackConfigurationOption = MediaPlayer::VideoPlaybackConfigurationOption;
+    virtual VideoPlaybackConfiguration videoPlaybackConfiguration() const { return { }; };
+
     virtual void prepareForRendering() { }
 
     // Time value in the movie's time scale. It is only necessary to override this if the media

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "MediaDescription.h"
+#include "MediaPlayerEnums.h"
 #include "PlatformMediaError.h"
 #include <wtf/MediaTime.h>
 #include <wtf/Ref.h>
@@ -69,6 +70,7 @@ public:
 
     struct InitializationSegment {
         MediaTime duration;
+        MediaPlayerVideoPlaybackConfiguration videoConfiguration;
 
         struct AudioTrackInformation {
             RefPtr<MediaDescription> description;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -387,6 +387,7 @@ private:
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const final { return true; }
 #endif
+    VideoPlaybackConfiguration videoPlaybackConfiguration() const { return m_cachedConfiguration; }
 
     RetainPtr<AVURLAsset> m_avAsset;
     RetainPtr<AVPlayer> m_avPlayer;
@@ -521,6 +522,7 @@ private:
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
 #endif
+    VideoPlaybackConfiguration m_cachedConfiguration;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -65,6 +65,7 @@
 #import "SecurityOrigin.h"
 #import "SerializedPlatformDataCueMac.h"
 #import "SharedBuffer.h"
+#import "SourceBufferParserAVFObjC.h"
 #import "SourceBufferParserWebM.h"
 #import "TextTrack.h"
 #import "TextTrackRepresentation.h"
@@ -174,6 +175,8 @@ SOFT_LINK_CONSTANT(Celestial, AVController_RouteDescriptionKey_AVAudioRouteName,
 #endif // HAVE(CELESTIAL)
 
 #endif // PLATFORM(IOS_FAMILY)
+
+OBJC_CLASS AVAssetPlaybackAssistant;
 
 using namespace WebCore;
 
@@ -2309,8 +2312,20 @@ void MediaPlayerPrivateAVFoundationObjC::updateVideoLayerGravity(ShouldAnimate s
 
 void MediaPlayerPrivateAVFoundationObjC::metadataLoaded()
 {
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    ASSERT(m_avAsset);
+    SourceBufferParserAVFObjC::getVideoPlaybackConfiguration(m_avAsset.get())->whenSettled(RunLoop::main(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (result)
+                protectedThis->m_cachedConfiguration = *result;
+            protectedThis->MediaPlayerPrivateAVFoundation::metadataLoaded();
+            protectedThis->processChapterTracks();
+        }
+    });
+#else
     MediaPlayerPrivateAVFoundation::metadataLoaded();
     processChapterTracks();
+#endif
 }
 
 void MediaPlayerPrivateAVFoundationObjC::processChapterTracks()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -114,6 +114,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void setNaturalSize(const FloatSize&);
     void flushPendingSizeChanges();
     void characteristicsChanged();
+    void setVideoPlaybackConfiguration(VideoPlaybackConfiguration);
+    VideoPlaybackConfiguration videoPlaybackConfiguration() const final { return m_cachedVideoConfiguration; }
 
     MediaTime currentTime() const override;
     bool timeIsProgressing() const final;
@@ -414,6 +416,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool m_usingLinearMediaPlayer { false };
     RetainPtr<FigVideoTargetRef> m_videoTarget;
 #endif
+    VideoPlaybackConfiguration m_cachedVideoConfiguration;
 };
 
 String convertEnumerationToString(MediaPlayerPrivateMediaSourceAVFObjC::SeekState);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1572,6 +1572,16 @@ void MediaPlayerPrivateMediaSourceAVFObjC::characteristicsChanged()
         player->characteristicChanged();
 }
 
+void MediaPlayerPrivateMediaSourceAVFObjC::setVideoPlaybackConfiguration(VideoPlaybackConfiguration configuration)
+{
+    if (std::exchange(m_cachedVideoConfiguration, configuration) == configuration)
+        return;
+    if (m_readyState < MediaPlayer::ReadyState::HaveMetadata)
+        return;
+    if (auto player = m_player.get(); player)
+        player->videoPlaybackConfigurationChanged();
+}
+
 RetainPtr<PlatformLayer> MediaPlayerPrivateMediaSourceAVFObjC::createVideoFullscreenLayer()
 {
     return adoptNS([[CALayer alloc] init]);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -73,6 +73,11 @@ public:
     void didProvideContentKeyRequestInitializationDataForTrackID(NSData*, uint64_t trackID);
     void didProvideContentKeyRequestSpecifierForTrackID(NSData*, uint64_t trackID);
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    using VideoPlaybackConfigurationPromise = NativePromise<MediaPlayerVideoPlaybackConfiguration, PlatformMediaError>;
+    static Ref<VideoPlaybackConfigurationPromise> getVideoPlaybackConfiguration(AVAsset*);
+#endif
+
 private:
 #if !RELEASE_LOG_DISABLED
     const Logger* loggerPtr() const { return m_logger.get(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -49,6 +49,7 @@
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/MakeString.h>
 
@@ -319,7 +320,17 @@ void SourceBufferParserAVFObjC::didParseStreamDataAsAsset(AVAsset* asset)
             // FIXME(125161)    : Add TextTrack support
         }
 
-        m_didParseInitializationDataCallback(WTFMove(segment));
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+        getVideoPlaybackConfiguration(asset.get())->whenSettled(RunLoop::current(), [protectedThis, this, segment = WTFMove(segment)](auto&& result) mutable {
+            if (result)
+                segment.videoConfiguration = *result;
+            m_callOnClientThreadCallback([protectedThis, segment = WTFMove(segment)]() mutable {
+                protectedThis->m_didParseInitializationDataCallback(WTFMove(segment));
+            });
+        });
+#else
+        protectedThis->m_didParseInitializationDataCallback(WTFMove(segment));
+#endif
     });
 }
 
@@ -369,6 +380,30 @@ void SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID(N
     });
 }
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+Ref<SourceBufferParserAVFObjC::VideoPlaybackConfigurationPromise> SourceBufferParserAVFObjC::getVideoPlaybackConfiguration(AVAsset* asset)
+{
+    assertIsMainThread();
+
+    if (!asset || PAL::canLoad_AVFoundation_AVAssetPlaybackConfigurationOptionStereoVideo() || !PAL::canLoad_AVFoundation_AVAssetPlaybackConfigurationOptionStereoMultiviewVideo() || !PAL::canLoad_AVFoundation_AVAssetPlaybackConfigurationOptionSpatialVideo())
+        return VideoPlaybackConfigurationPromise::createAndReject(PlatformMediaError::NotSupportedError);
+    RetainPtr<AVAssetPlaybackAssistant> assistant = [PAL::getAVAssetPlaybackAssistantClass() assetPlaybackAssistantWithAsset:asset];
+    VideoPlaybackConfigurationPromise::Producer producer;
+    Ref promise = producer.promise();
+    [assistant loadPlaybackConfigurationOptionsWithCompletionHandler:makeBlockPtr([producer = WTFMove(producer)](NSArray<AVAssetPlaybackConfigurationOption>* playbackConfigurationOptions) mutable {
+        MediaPlayerVideoPlaybackConfiguration configuration;
+        if ([playbackConfigurationOptions containsObject:AVAssetPlaybackConfigurationOptionStereoVideo])
+            configuration.add(MediaPlayerVideoPlaybackConfigurationOption::Stereo);
+        if ([playbackConfigurationOptions containsObject:AVAssetPlaybackConfigurationOptionStereoMultiviewVideo])
+            configuration.add(MediaPlayerVideoPlaybackConfigurationOption::StereoMultiview);
+        if ([playbackConfigurationOptions containsObject:AVAssetPlaybackConfigurationOptionSpatialVideo])
+            configuration.add(MediaPlayerVideoPlaybackConfigurationOption::Spatial);
+        producer.resolve(configuration);
+    }).get()];
+    return promise;
 }
+#endif
+
+} // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -374,8 +374,11 @@ Ref<MediaPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>&&
     return invokeAsync(m_appendQueue, [data = WTFMove(data), parser = m_parser, weakThis = ThreadSafeWeakPtr { *this }, abortSemaphore = m_abortSemaphore]() mutable {
         parser->setDidParseInitializationDataCallback([weakThis] (InitializationSegment&& segment) {
             ASSERT(isMainThread());
-            if (RefPtr protectedThis = weakThis.get())
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->player())
+                    player->setVideoPlaybackConfiguration(segment.videoConfiguration);
                 protectedThis->didReceiveInitializationSegment(WTFMove(segment));
+            }
         });
 
         parser->setDidProvideMediaDataCallback([weakThis] (Ref<MediaSampleAVFObjC>&& sample, TrackID trackId, const String& mediaType) {

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -51,6 +51,7 @@ public:
     NullPlaybackSessionInterface& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 
+    void setVideoSpatial(bool) { }
     void setVideoPresentationModel(VideoPresentationModel* model) { m_videoPresentationModel = model; }
     void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
     void enterFullscreen() { }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -81,6 +81,7 @@ public:
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
     WEBCORE_EXPORT virtual void hasVideoChanged(bool) = 0;
     WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&);
+    WEBCORE_EXPORT virtual void setVideoSpatial(bool);
     WEBCORE_EXPORT virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
     WEBCORE_EXPORT virtual void setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     WEBCORE_EXPORT virtual void externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName);

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -158,6 +158,10 @@ std::optional<MediaPlayerIdentifier>VideoPresentationInterfaceIOS::playerIdentif
     return m_playbackSessionInterface->playerIdentifier();
 }
 
+void VideoPresentationInterfaceIOS::setVideoSpatial(bool)
+{
+}
+
 void VideoPresentationInterfaceIOS::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
 {
     m_playbackSessionInterface->setPlayerIdentifier(WTFMove(identifier));

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -432,6 +432,7 @@ void RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged()
     m_cachedState.canSaveMediaData = m_player->canSaveMediaData();
     m_cachedState.didPassCORSAccessCheck = m_player->didPassCORSAccessCheck();
     m_cachedState.documentIsCrossOrigin = m_player->isCrossOrigin(m_configuration.documentSecurityOrigin.securityOrigin());
+    m_cachedState.videoConfiguration = m_player->videoPlaybackConfiguration();
 
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::ReadyStateChanged(m_cachedState, newReadyState), m_id);
 }
@@ -591,6 +592,13 @@ void RemoteMediaPlayerProxy::mediaPlayerCharacteristicChanged()
     m_cachedState.languageOfPrimaryAudioTrack = m_player->languageOfPrimaryAudioTrack();
 
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::CharacteristicChanged(m_cachedState), m_id);
+}
+
+void RemoteMediaPlayerProxy::mediaPlayerVideoPlaybackConfigurationChanged()
+{
+    updateCachedVideoMetrics();
+    updateCachedState();
+    m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::VideoPlaybackConfigurationChanged(m_cachedState.videoConfiguration), m_id);
 }
 
 bool RemoteMediaPlayerProxy::mediaPlayerRenderingCanBeAccelerated()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -242,6 +242,7 @@ private:
 
     // MediaPlayerClient
     void mediaPlayerCharacteristicChanged() final;
+    void mediaPlayerVideoPlaybackConfigurationChanged() final;
     void mediaPlayerRenderingModeChanged() final;
     void mediaPlayerNetworkStateChanged() final;
     void mediaPlayerReadyStateChanged() final;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -59,6 +59,7 @@ private:
     bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
     void setupFullscreen(UIView&, const WebCore::FloatRect&, const WebCore::FloatSize&, UIView*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
     void hasVideoChanged(bool) final { }
+    void setVideoSpatial(bool) final;
     void finalizeSetup() final;
     void updateRouteSharingPolicy() final { }
     void setupPlayerViewController() final;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -89,6 +89,11 @@ WKSLinearMediaPlayer *VideoPresentationInterfaceLMK::linearMediaPlayer() const
     return playbackSessionInterface().linearMediaPlayer();
 }
 
+void VideoPresentationInterfaceLMK::setVideoSpatial(bool isSpatial)
+{
+    linearMediaPlayer().isSpatial = isSpatial;
+}
+
 void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const WebCore::FloatRect& initialRect, const WebCore::FloatSize& videoDimensions, UIView* parentView, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     linearMediaPlayer().contentDimensions = videoDimensions;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4447,6 +4447,12 @@ enum class WebCore::MediaPlayerPitchCorrectionAlgorithm : uint8_t {
     BestForSpeech,
 };
 
+[OptionSet] enum class WebCore::MediaPlayerVideoPlaybackConfigurationOption : uint8_t {
+    Stereo,
+    StereoMultiview,
+    Spatial
+};
+
 class WebCore::GeolocationPositionData {
     double timestamp;
     double latitude;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -163,6 +163,7 @@ private:
     bool isInWindowFullscreenActive() const final { return m_isInWindowFullscreenActive; }
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const final { return m_supportsLinearMediaPlayer; }
+    bool isSpatial() const final { return m_isSpatial; }
 #endif
 
     WebCore::AudioSessionSoundStageSize soundStageSize() const final { return m_soundStageSize; }
@@ -210,6 +211,7 @@ private:
     WebCore::AudioSessionSoundStageSize m_soundStageSize { 0 };
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool m_supportsLinearMediaPlayer { false };
+    bool m_isSpatial { false };
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -224,7 +224,7 @@ private:
     RetainPtr<WKLayerHostView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
 
     // Messages from VideoPresentationManager
-    void setupFullscreenWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
+    void setupFullscreenWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture, bool isSpatial);
     void setInlineRect(PlaybackSessionContextIdentifier, const WebCore::FloatRect& inlineRect, bool visible);
     void setHasVideoContentLayer(PlaybackSessionContextIdentifier, bool value);
     void setHasVideo(PlaybackSessionContextIdentifier, bool);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -25,7 +25,7 @@ messages -> VideoPresentationManagerProxy {
     SetHasVideo(WebKit::PlaybackSessionContextIdentifier contextId, bool hasVideo)
     SetDocumentVisibility(WebKit::PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)
     SetVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize videoDimensions)
-    SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
+    SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture, bool isSpatial)
     SetPlayerIdentifier(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier)
 #if !PLATFORM(IOS_FAMILY)
     EnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -880,7 +880,7 @@ void VideoPresentationManagerProxy::willRemoveLayerForID(PlaybackSessionContextI
 
 #pragma mark Messages from VideoPresentationManager
 
-void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingDeviceScaleFactor, HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
+void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingDeviceScaleFactor, HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture, bool isSpatial)
 {
     if (!m_page)
         return;
@@ -928,10 +928,12 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 #if PLATFORM(IOS_FAMILY)
     auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*m_page->drawingArea()).remoteLayerTreeHost().rootNode();
     UIView *parentView = rootNode ? rootNode->uiView() : nil;
+    interface->setVideoSpatial(isSpatial);
     interface->setupFullscreen(*model->layerHostView(), screenRect, videoDimensions, parentView, videoFullscreenMode, allowsPictureInPicture, standby, blocksReturnToFullscreenFromPictureInPicture);
 #else
     UNUSED_PARAM(videoDimensions);
     UNUSED_PARAM(blocksReturnToFullscreenFromPictureInPicture);
+    UNUSED_PARAM(isSpatial);
     IntRect initialWindowRect;
     m_page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
     interface->setupFullscreen(*model->layerHostView(), initialWindowRect, m_page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -107,6 +107,7 @@ enum LinearMediaPlayerErrors: Error {
     var allowPip = true
     var allowFullScreenFromInline = true
     var isLiveStream = false
+    var isSpatial = true
     var recommendedViewingRatio: NSNumber?
     var fullscreenSceneBehaviors: WKSLinearMediaFullscreenBehaviors = []
     var startTime: Double = .nan

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -150,6 +150,7 @@ API_AVAILABLE(visionos(1.0))
 @property (nonatomic) BOOL allowPip;
 @property (nonatomic) BOOL allowFullScreenFromInline;
 @property (nonatomic) BOOL isLiveStream;
+@property (nonatomic) BOOL isSpatial;
 @property (nonatomic, strong, nullable) NSNumber *recommendedViewingRatio;
 @property (nonatomic) WKSLinearMediaFullscreenBehaviors fullscreenSceneBehaviors;
 @property (nonatomic) double startTime;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -686,6 +686,7 @@ void MediaPlayerPrivateRemote::updateCachedState(RemoteMediaPlayerState&& state)
     m_cachedState.wirelessVideoPlaybackDisabled = state.wirelessVideoPlaybackDisabled;
     m_cachedState.didPassCORSAccessCheck = state.didPassCORSAccessCheck;
     m_cachedState.documentIsCrossOrigin = state.documentIsCrossOrigin;
+    m_cachedState.videoConfiguration = state.videoConfiguration;
 
     if (state.bufferedRanges)
         m_cachedBufferedTimeRanges = *state.bufferedRanges;
@@ -1832,6 +1833,15 @@ bool MediaPlayerPrivateRemote::supportsLinearMediaPlayer() const
     return false;
 }
 #endif
+
+void MediaPlayerPrivateRemote::videoPlaybackConfigurationChanged(const VideoPlaybackConfiguration& configuration)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, configuration);
+
+    m_cachedState.videoConfiguration = configuration;
+    if (auto player = m_player.get())
+        player->videoPlaybackConfigurationChanged();
+}
 
 void MediaPlayerPrivateRemote::commitAllTransactions(CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -474,6 +474,8 @@ private:
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const final;
 #endif
+    VideoPlaybackConfiguration videoPlaybackConfiguration() const final { return m_cachedState.videoConfiguration; }
+    void videoPlaybackConfigurationChanged(const VideoPlaybackConfiguration&);
 
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -40,6 +40,7 @@ messages -> MediaPlayerPrivateRemote NotRefCounted {
     CharacteristicChanged(struct WebKit::RemoteMediaPlayerState state)
     SizeChanged(WebCore::FloatSize naturalSize)
     RenderingModeChanged()
+    VideoPlaybackConfigurationChanged(WebCore::MediaPlayer::VideoPlaybackConfiguration configuration);
 
     CurrentTimeChanged(struct WebKit::MediaTimeUpdateData timeData)
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
@@ -64,6 +64,7 @@ struct RemoteMediaPlayerState {
     bool hasAvailableVideoFrame { false };
     bool wirelessVideoPlaybackDisabled { false };
     bool didPassCORSAccessCheck { false };
+    WebCore::MediaPlayerEnums::VideoPlaybackConfiguration videoConfiguration;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
@@ -49,5 +49,6 @@ struct WebKit::RemoteMediaPlayerState {
     bool hasAvailableVideoFrame;
     bool wirelessVideoPlaybackDisabled;
     bool didPassCORSAccessCheck;
+    WebCore::MediaPlayerVideoPlaybackConfiguration videoConfiguration;
 }
 #endif

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -394,9 +394,11 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     auto setupFullscreen = [protectedThis = Ref { *this }, page = WeakPtr { m_page }, contextId = contextId, initialSize = initialSize, videoRect = videoRect, videoElement = WeakPtr { videoElement }, allowsPictureInPicture = allowsPictureInPicture, standby = standby, fullscreenMode = interface->fullscreenMode()] (LayerHostingContextID contextID, const FloatSize& size) {
         if (!page || !videoElement)
             return;
-        page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(contextId, contextID, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, videoElement->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
+        RefPtr player = videoElement->player();
+        bool isSpatial = player && player->videoPlaybackConfiguration().contains(MediaPlayer::VideoPlaybackConfigurationOption::Spatial);
+        page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(contextId, contextID, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, videoElement->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), isSpatial));
 
-        if (RefPtr player = videoElement->player()) {
+        if (player) {
             if (auto identifier = player->identifier())
                 protectedThis->setPlayerIdentifier(contextId, identifier);
         }


### PR DESCRIPTION
#### 4ea4e1d08e8404cb71ef2a9a8df5520ce3a1f5ee
<pre>
Add ability to determine the video configuration of the media playing
<a href="https://bugs.webkit.org/show_bug.cgi?id=277680">https://bugs.webkit.org/show_bug.cgi?id=277680</a>
<a href="https://rdar.apple.com/133288736">rdar://133288736</a>

Reviewed by NOBODY (OOPS!).

Plumb-in the ability to retrieve the spatial video configuration from the CRABS and MSE AVF player
and pass it all the way to the LinearMediaKit player.

Code is non-functional at present as it&apos;s still lacking the LMK player side of things.

On visionOS, we will delay the readyState from reaching HAVE_METADATA until the video playback
configuration has been determined from the init segment.

No new tests as no functionality change.

* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModel::isSpatial const):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::videoPlaybackConfiguration const):
(WebCore::MediaPlayer::videoPlaybackConfigurationChanged):
(WebCore::convertOptionSetToString):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerVideoPlaybackConfigurationChanged):
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
(WTF::LogArgument&lt;WebCore::MediaPlayerEnums::VideoPlaybackConfiguration&gt;::toString):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::videoPlaybackConfiguration const):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::metadataLoaded):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoPlaybackConfiguration):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::didParseStreamDataAsAsset):
(WebCore::SourceBufferParserAVFObjC::getVideoPlaybackConfiguration):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::setVideoSpatial):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerVideoPlaybackConfigurationChanged):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::setVideoSpatial):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::updateCachedState):
(WebKit::MediaPlayerPrivateRemote::videoPlaybackConfigurationChanged):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ea4e1d08e8404cb71ef2a9a8df5520ce3a1f5ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61784 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/41138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/63903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/48824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/12600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/64853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/48824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/48824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/48824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/5727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/12600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/67491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/5752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->