### PR TITLE
Remove unreachable code `accumulateOffsetTowardsAncestor` for Fixed Position condition

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2501,7 +2501,7 @@ static inline const RenderLayer* accumulateOffsetTowardsAncestor(const RenderLay
     }
 
     RenderLayer* parentLayer;
-    if (position == PositionType::Absolute || position == PositionType::Fixed) {
+    if (position == PositionType::Absolute) {
         // Do what enclosingAncestorForPosition() does, but check for ancestorLayer along the way.
         parentLayer = layer->parent();
         bool foundAncestorFirst = false;


### PR DESCRIPTION
<pre>
Remove unreachable code `accumulateOffsetTowardsAncestor` for Fixed Position condition
<a href="https://bugs.webkit.org/show_bug.cgi?id=277767">https://bugs.webkit.org/show_bug.cgi?id=277767</a>
rdar://problem/133409516

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://github.com/chromium/chromium/commit/b95fad57c742afbe8ee0828725295bc99ad3a590">https://github.com/chromium/chromium/commit/b95fad57c742afbe8ee0828725295bc99ad3a590</a>

It is unreachable because it will be returned early because of
'if' above, which deals with 'FixedPosition'.

* Source/WebCore/rendering/RenderLayer.cpp:
(accumulateOffsetTowardsAncestor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8641701bf778ed02208c5543997dae01b8f084f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12632 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49823 "Found 9 new test failures: imported/blink/fast/block/positioning/fixed-position-transformed-container.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-029.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-030.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-031.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-032.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-034.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-036.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-041.html scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64885 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38235 "Found 3 new test failures: imported/blink/fast/block/positioning/fixed-position-transformed-container.html scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed.html scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30655 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34881 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-029.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-030.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-031.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-032.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-034.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-036.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-041.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10772 "Found 8 new test failures: imported/blink/fast/block/positioning/fixed-position-transformed-container.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-029.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-030.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-031.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-032.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-034.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-036.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-041.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11292 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56690 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11075 "Found 10 new test failures: imported/blink/fast/block/positioning/fixed-position-transformed-container.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-029.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-030.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-031.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-032.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-034.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-036.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-041.html scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed.html scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5759 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10816 "Found 11 new test failures: imported/blink/fast/block/positioning/fixed-position-transformed-container.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-029.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-030.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-031.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-032.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-034.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-036.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-041.html scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed.html scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57207 "Found 8 new test failures: imported/blink/fast/block/positioning/fixed-position-transformed-container.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-029.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-030.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-031.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-032.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-034.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-036.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-041.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57443 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4723 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36970 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->