### PR TITLE
Document render-blocking with <link rel=expect>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6904,6 +6904,17 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any
 imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.html [ DumpJSConsoleLogInStdErr ]
 
+# These tests don't actually have render blocking (due to adding the blocking too late, or non-matching
+# media queries etc). They expect the test to render midway through parsing, but our existing layer tree
+# freezing prevents that. These tests fail intentionally, unless we decide to change our existing heuristics.
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-007.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-014.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-017.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-018.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-021.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-022.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-036.html [ Failure ]
+
 # AudioDecoder, AudioEncoder and AudioData implementations missing.
 imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/blocking-idl-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/blocking-idl-attr-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Supported tokens of the 'blocking' IDL attribute of the link element undefined is not an object (evaluating 'link.blocking.supports')
-FAIL Setting the 'blocking' IDL attribute of the link element assert_equals: expected (string) "asdf" but got (undefined) undefined
+PASS Supported tokens of the 'blocking' IDL attribute of the link element
+PASS Setting the 'blocking' IDL attribute of the link element
 FAIL Supported tokens of the 'blocking' IDL attribute of the script element undefined is not an object (evaluating 'script.blocking.supports')
 FAIL Setting the 'blocking' IDL attribute of the script element assert_equals: expected (string) "asdf" but got (undefined) undefined
 FAIL Supported tokens of the 'blocking' IDL attribute of the style element undefined is not an object (evaluating 'style.blocking.supports')

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL blocking defers until needed element is parsed assert_false: expected false got true
+PASS blocking defers until needed element is parsed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-004-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing link in the head makes it no longer blocking assert_false: expected false got true
+PASS removing link in the head makes it no longer blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-005-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing 'blocking' makes it no longer blocking assert_false: expected false got true
+PASS removing 'blocking' makes it no longer blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-007-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL link with non-matching media has no effect assert_false: expected false got true
+PASS link with non-matching media has no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-009-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL changing media to non-matching makes it non blocking assert_false: expected false got true
+PASS changing media to non-matching makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-010-expected.txt
@@ -1,4 +1,4 @@
 CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/dom/render-blocking/element-render-blocking-010.html' because non CSS MIME types are not allowed in strict mode.
 
-FAIL changing rel to non-expect makes it non blocking assert_false: expected false got true
+PASS changing rel to non-expect makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-013-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing href makes it no longer blocking assert_false: expected false got true
+PASS removing href makes it no longer blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-014-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-014-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL link in the body has no effect assert_false: expected false got true
+PASS link in the body has no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-015-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-015-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing link the body makes it non blocking assert_false: expected false got true
+PASS removing link the body makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-016-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-016-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing 'blocking' in the body makes it non blocking assert_false: expected false got true
+PASS removing 'blocking' in the body makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-017-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-017-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL adding 'blocking=render' in the body has no effect assert_false: expected false got true
+PASS adding 'blocking=render' in the body has no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-018-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-018-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL changing media to matching in the body has no effect assert_false: expected false got true
+PASS changing media to matching in the body has no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-019-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-019-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL changing media to non-matching in the body makes it non blocking assert_false: expected false got true
+PASS changing media to non-matching in the body makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-020-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-020-expected.txt
@@ -1,4 +1,4 @@
 CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/dom/render-blocking/element-render-blocking-020.html' because non CSS MIME types are not allowed in strict mode.
 
-FAIL changing rel to non-expect in the body makes it non blocking assert_false: expected false got true
+PASS changing rel to non-expect in the body makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-021-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-021-expected.txt
@@ -1,4 +1,4 @@
 CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/dom/render-blocking/element-render-blocking-021.html' because non CSS MIME types are not allowed in strict mode.
 
-FAIL changing rel to expect in the body has no effect assert_false: expected false got true
+PASS changing rel to expect in the body has no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-022-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-022-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL adding href in the body has no effect assert_false: expected false got true
+PASS adding href in the body has no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-023-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-023-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing href in the body makes it non blocking assert_false: expected false got true
+PASS removing href in the body makes it non blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-025-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-025-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL adding an id in the body satisfies render block assert_false: expected false got true
+PASS adding an id in the body satisfies render block
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-026-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-026-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing id after it was renderer keeps render block satisfied assert_false: expected false got true
+PASS removing id after it was renderer keeps render block satisfied
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-028-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-028-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL removing some links but not all keeps at least the matching link blocking assert_false: expected false got true
+PASS removing some links but not all keeps at least the matching link blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-029-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-029-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL blocking defers frames until full parsing assert_false: expected false got true
+PASS blocking defers frames until full parsing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-030-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-030-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL blocking defers frames until full parsing assert_false: expected false got true
+PASS blocking defers frames until full parsing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-031-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-031-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL blocking defers frames until full parsing assert_false: expected false got true
+PASS blocking defers frames until full parsing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-032-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-032-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL blocking defers frames until full parsing assert_false: expected false got true
+PASS blocking defers frames until full parsing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-034-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-034-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL relative URLs that match this document are OK assert_false: expected false got true
+PASS relative URLs that match this document are OK
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-035-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-035-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL relative URLs that match this document are OK, regarless of <base> assert_false: expected false got true
+PASS relative URLs that match this document are OK, regarless of <base>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-036-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-036-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL link URLs are relative to base URL, not to document URL assert_false: expected false got true
+PASS link URLs are relative to base URL, not to document URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-037-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-037-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL relative URLs that match this document are OK, regarless of <base> assert_false: expected false got true
+PASS relative URLs that match this document are OK, regarless of <base>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-038-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-038-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL link rel=expect: only connected elements are eligible assert_false: The last element should not be there yet, even though it's created (in a shadow root) expected false got true
+PASS link rel=expect: only connected elements are eligible
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/remove-element-unblocks-rendering.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/remove-element-unblocks-rendering.optional-expected.txt
@@ -7,5 +7,5 @@ PASS Render-blocking on parser-inserted async module script is cancellable
 PASS Render-blocking on script-inserted stylesheet link is cancellable
 PASS Render-blocking on script-inserted script is cancellable
 PASS Render-blocking on script-inserted module script is cancellable
-PASS Render-blocking on script-inserted inline style is cancellable
+FAIL Render-blocking on script-inserted inline style is cancellable assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/support/utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/support/utils.js
@@ -1,4 +1,5 @@
 function generateParserDelay(seconds = 1) {
+  seconds += (Math.random() / 10.0);
   document.write(`
     <script src="/loading/resources/dummy.js?pipe=trickle(d${seconds})"></script>
   `);

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/resources/dummy.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/resources/dummy.js
@@ -1,0 +1,1 @@
+/* Nothing to see here */

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4121,6 +4121,8 @@ imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-011.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-020.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-021.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-024.html [ Failure ]
+imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-027.html [ Failure ]
 
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/pageload-video.html [ Failure ]
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -145,6 +145,7 @@ class Frame;
 class GPUCanvasContext;
 class GraphicsClient;
 class HTMLAllCollection;
+class HTMLAnchorElement;
 class HTMLAttachmentElement;
 class HTMLBaseElement;
 class HTMLBodyElement;
@@ -1824,6 +1825,12 @@ public:
     void updateServiceWorkerClientData() final;
     WEBCORE_EXPORT void navigateFromServiceWorker(const URL&, CompletionHandler<void(ScheduleLocationChangeResult)>&&);
 
+    bool allowsAddingRenderBlockedElements() const;
+    bool isRenderBlocked() const;
+    void blockRenderingOn(Element&);
+    void unblockRenderingOn(Element&);
+    void processInternalResourceLinks(HTMLAnchorElement&);
+
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);
 #endif
@@ -2061,8 +2068,9 @@ private:
         Client         = 1 << 0,
         ReadyState     = 1 << 1,
         Suspension     = 1 << 2,
+        RenderBlocking = 1 << 3,
     };
-    static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventReasonsClearedByTimer() { return { VisualUpdatesPreventedReason::ReadyState }; }
+    static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventReasonsClearedByTimer() { return { VisualUpdatesPreventedReason::ReadyState, VisualUpdatesPreventedReason::RenderBlocking }; }
     static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventRequiresLayoutMilestones() { return { VisualUpdatesPreventedReason::Client, VisualUpdatesPreventedReason::ReadyState }; }
 
     void addVisualUpdatePreventedReason(VisualUpdatesPreventedReason);
@@ -2451,6 +2459,8 @@ private:
     Vector<Function<void()>> m_whenIsVisibleHandlers;
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithPendingUserAgentShadowTreeUpdates;
+
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_renderBlockingElements;
 
     RefPtr<ReportingScope> m_reportingScope;
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -260,7 +260,8 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
             m_linkRelations.add(Relation::Opener);
         if (m_relList)
             m_relList->associatedAttributeValueChanged();
-    }
+    } else if (name == nameAttr)
+        document().processInternalResourceLinks(*this);
 }
 
 bool HTMLAnchorElement::isURLAttribute(const Attribute& attribute) const
@@ -744,6 +745,13 @@ String HTMLAnchorElement::referrerPolicyForBindings() const
 ReferrerPolicy HTMLAnchorElement::referrerPolicy() const
 {
     return parseReferrerPolicy(attributeWithoutSynchronization(referrerpolicyAttr), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
+}
+
+Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+{
+    auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    document().processInternalResourceLinks(*this);
+    return result;
 }
 
 }

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -83,6 +83,8 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const;
 
+    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) override;
+
 protected:
     HTMLAnchorElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -83,6 +83,7 @@ axis
 background
 behavior
 bgcolor
+blocking
 border
 bordercolor
 capture

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -45,6 +45,7 @@
 #include "HTMLAnchorElement.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
+#include "IdTargetObserver.h"
 #include "JSRequestPriority.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
@@ -66,6 +67,7 @@
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
 #include "SubresourceIntegrity.h"
+#include "TreeScopeInlines.h"
 #include <wtf/Ref.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
@@ -83,6 +85,30 @@ static LinkEventSender& linkLoadEventSender()
 {
     static NeverDestroyed<LinkEventSender> sharedLoadEventSender;
     return sharedLoadEventSender;
+}
+
+class ExpectIdTargetObserver final : public IdTargetObserver {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ExpectIdTargetObserver);
+public:
+    ExpectIdTargetObserver(const AtomString& id, HTMLLinkElement&);
+
+    void idTargetChanged() override;
+
+private:
+    WeakPtr<HTMLLinkElement, WeakPtrImplWithEventTargetData> m_element;
+};
+
+ExpectIdTargetObserver::ExpectIdTargetObserver(const AtomString& id, HTMLLinkElement& element)
+    : IdTargetObserver(element.treeScope().idTargetObserverRegistry(), id)
+    , m_element(element)
+{
+}
+
+void ExpectIdTargetObserver::idTargetChanged()
+{
+    if (m_element)
+        m_element->processInternalResourceLink();
 }
 
 inline HTMLLinkElement::HTMLLinkElement(const QualifiedName& tagName, Document& document, bool createdByParser)
@@ -195,6 +221,11 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
             m_sizes->associatedAttributeValueChanged();
         process();
         break;
+    case AttributeNames::blockingAttr:
+        if (m_blockingList)
+            m_blockingList->associatedAttributeValueChanged();
+        process();
+        break;
     case AttributeNames::mediaAttr: {
         auto media = newValue.string().convertToASCIILowercase();
         if (media == m_media)
@@ -261,6 +292,10 @@ void HTMLLinkElement::process()
 
     // Prevent recursive loading of link.
     if (m_isHandlingBeforeLoad)
+        return;
+
+    processInternalResourceLink();
+    if (m_relAttribute.isInternalResourceLink)
         return;
 
     Ref document = this->document();
@@ -377,6 +412,51 @@ void HTMLLinkElement::clearSheet()
     m_sheet = nullptr;
 }
 
+// https://html.spec.whatwg.org/multipage/links.html#process-internal-resource-link
+void HTMLLinkElement::processInternalResourceLink(HTMLAnchorElement* anchor)
+{
+    if (document().wasRemovedLastRefCalled())
+        return;
+
+    if (!m_relAttribute.isInternalResourceLink) {
+        unblockRendering();
+        return;
+    }
+
+    if (!equalIgnoringFragmentIdentifier(m_url, document().url())) {
+        unblockRendering();
+        return;
+    }
+
+    RefPtr<Element> indicatedElement;
+    // If the change originated from an anchor, then we can just check if that's
+    // the right one instead doing a tree search using the name
+    if (anchor) {
+        if (anchor->name() == m_url.fragmentIdentifier())
+            indicatedElement = anchor;
+    } else
+        indicatedElement = document().findAnchor(m_url.fragmentIdentifier());
+
+    // FIXME: "is on a stack of open elements of an HTML parser whose associated Document is doc"
+    if (document().readyState() == Document::ReadyState::Loading && isConnected() && mediaAttributeMatches() && blocking().contains("render"_s) && !indicatedElement) {
+        if (!m_isRenderBlocking) {
+            document().blockRenderingOn(*this);
+            m_isRenderBlocking = true;
+        }
+        if (!m_expectIdTargetObserver)
+            m_expectIdTargetObserver = makeUnique<ExpectIdTargetObserver>(makeAtomString(m_url.fragmentIdentifier()), *this);
+    } else
+        unblockRendering();
+}
+
+void HTMLLinkElement::unblockRendering()
+{
+    if (m_isRenderBlocking) {
+        document().unblockRenderingOn(*this);
+        m_isRenderBlocking = false;
+    }
+}
+
 Node::InsertedIntoAncestorResult HTMLLinkElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
@@ -415,6 +495,8 @@ void HTMLLinkElement::removedFromAncestor(RemovalType removalType, ContainerNode
         m_styleScope->removeStyleSheetCandidateNode(*this);
         m_styleScope = nullptr;
     }
+
+    processInternalResourceLink();
 }
 
 void HTMLLinkElement::finishParsingChildren()
@@ -571,6 +653,19 @@ DOMTokenList& HTMLLinkElement::relList()
             return LinkRelAttribute::isSupported(document, token);
         });
     return *m_relList;
+}
+
+// https://html.spec.whatwg.org/multipage/semantics.html#dom-link-blocking
+DOMTokenList& HTMLLinkElement::blocking()
+{
+    if (!m_blockingList) {
+        m_blockingList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::blockingAttr, [](Document&, StringView token) {
+            if (equalLettersIgnoringASCIICase(token, "render"_s))
+                return true;
+            return false;
+        });
+    }
+    return *m_blockingList;
 }
 
 void HTMLLinkElement::notifyLoadedSheetAndAllCriticalSubresources(bool errorOccurred)

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -35,6 +35,7 @@
 namespace WebCore {
 
 class DOMTokenList;
+class ExpectIdTargetObserver;
 class HTMLLinkElement;
 class Page;
 struct MediaQueryParserContext;
@@ -83,6 +84,7 @@ public:
     static void dispatchPendingLoadEvents(Page*);
 
     WEBCORE_EXPORT DOMTokenList& relList();
+    WEBCORE_EXPORT DOMTokenList& blocking();
 
 #if ENABLE(APPLICATION_MANIFEST)
     bool isApplicationManifest() const { return m_relAttribute.isApplicationManifest; }
@@ -98,6 +100,8 @@ public:
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriorityHint() const;
 
+    void processInternalResourceLink(HTMLAnchorElement* = nullptr);
+
 private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
@@ -105,6 +109,8 @@ private:
     void process();
     static void processCallback(Node*);
     void clearSheet();
+
+    void unblockRendering();
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
@@ -156,6 +162,8 @@ private:
     URL m_url;
     std::unique_ptr<DOMTokenList> m_sizes;
     std::unique_ptr<DOMTokenList> m_relList;
+    std::unique_ptr<DOMTokenList> m_blockingList;
+    std::unique_ptr<ExpectIdTargetObserver> m_expectIdTargetObserver;
     DisabledState m_disabledState;
     LinkRelAttribute m_relAttribute;
     bool m_loading : 1;
@@ -163,6 +171,7 @@ private:
     bool m_loadedResource : 1;
     bool m_isHandlingBeforeLoad : 1;
     bool m_allowPrefetchLoadAndErrorForTesting : 1;
+    bool m_isRenderBlocking : 1 { false };
     PendingSheetType m_pendingSheetType;
 };
 

--- a/Source/WebCore/html/HTMLLinkElement.idl
+++ b/Source/WebCore/html/HTMLLinkElement.idl
@@ -39,6 +39,7 @@
     [CEReactions=NotNeeded, Reflect, EnabledBySetting=LinkPreloadResponsiveImagesEnabled] attribute DOMString imageSrcset;
     [CEReactions=NotNeeded, Reflect, EnabledBySetting=LinkPreloadResponsiveImagesEnabled] attribute DOMString imageSizes;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
+    [PutForwards=value] readonly attribute DOMTokenList blocking;
     [CEReactions=NotNeeded, EnabledBySetting=FetchPriorityEnabled, ImplementedAs=fetchPriorityForBindings] attribute [AtomString] DOMString fetchPriority;
 
     // DOM Level 2 Style

--- a/Source/WebCore/html/LinkRelAttribute.cpp
+++ b/Source/WebCore/html/LinkRelAttribute.cpp
@@ -68,7 +68,9 @@ LinkRelAttribute::LinkRelAttribute(Document& document, StringView rel)
     } else if (equalLettersIgnoringASCIICase(rel, "manifest"_s)) {
         isApplicationManifest = true;
 #endif
-    } else {
+    } else if (equalLettersIgnoringASCIICase(rel, "expect"_s))
+        isInternalResourceLink = true;
+    else {
         // Tokenize the rel attribute and set bits based on specific keywords that we find.
         for (auto line : rel.split('\n')) {
             for (auto word : line.split(' ')) {

--- a/Source/WebCore/html/LinkRelAttribute.h
+++ b/Source/WebCore/html/LinkRelAttribute.h
@@ -52,6 +52,7 @@ struct LinkRelAttribute {
 #if ENABLE(APPLICATION_MANIFEST)
     bool isApplicationManifest : 1 { false };
 #endif
+    bool isInternalResourceLink : 1 { false };
 
     LinkRelAttribute() = default;
     LinkRelAttribute(Document&, StringView);


### PR DESCRIPTION
#### 0e9bbd960894d8981be0d59b235924329a6c1b4f
<pre>
Document render-blocking with &lt;link rel=expect&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=268743">https://bugs.webkit.org/show_bug.cgi?id=268743</a>
&lt;<a href="https://rdar.apple.com/122797243">rdar://122797243</a>&gt;

Reviewed by Tim Nguyen.

Implements the render-blocking concept on Document, and the rel=expect attribute for &lt;link&gt;.
<a href="https://html.spec.whatwg.org/multipage/dom.html#block-rendering">https://html.spec.whatwg.org/multipage/dom.html#block-rendering</a>

utils.js changed to generate a unique URL for each parser delay, otherwise we
cache the loads (which may not be spec compliant, but unrelated to
render-blocking).

Render blocking uses the existing code addVisualUpdatePreventedReason to prevent rendering, and rAF.

Some of the test fail because they have no render blocking (since an attempt was
rejected due to a mismatched media query or similar). These tests expect
rendering to happen mid-parsing, but don&apos;t due to our existing layer tree
freezing code. I&apos;ve opted not to change the existing behaviour for now, and only
have this kick in when there is explicit (and active) render blocking elements.

As an optimization, when an &lt;a&gt; element changes, we pass that element into the &apos;process internal
resource links&apos; algorithm. Rather than doing a tree search for each link looking for matching anchors,
we can just directly check if the link matches the mutated &lt;a&gt;.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-010-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-013-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-014-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-015-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-016-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-017-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-018-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-019-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-020-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-021-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-022-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-023-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-025-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-026-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-028-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-029-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-030-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-031-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-032-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-034-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-035-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-036-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-037-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-038-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/remove-element-unblocks-rendering.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/support/utils.js:
(generateParserDelay):
* LayoutTests/imported/w3c/web-platform-tests/loading/resources/dummy.js: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setReadyState):
(WebCore::Document::setVisualUpdatesAllowed):
(WebCore::Document::addVisualUpdatePreventedReason):
(WebCore::Document::removeVisualUpdatePreventedReason):
(WebCore::Document::visualUpdatesSuppressionTimerFired):
(WebCore::Document::setVisualUpdatesAllowedByClient):
(WebCore::Document::suspend):
(WebCore::Document::resume):
(WebCore::Document::allowsAddingRenderBlockedElements const):
(WebCore::Document::isRenderBlocked const):
(WebCore::Document::blockRenderingOn):
(WebCore::Document::unblockRenderingOn):
(WebCore::Document::processInternalResourceLinks):
* Source/WebCore/dom/Document.h:
(WebCore::Document::visualUpdatesAllowed const):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::ExpectIdTargetObserver::ExpectIdTargetObserver):
(WebCore::ExpectIdTargetObserver::idTargetChanged):
(WebCore::HTMLLinkElement::attributeChanged):
(WebCore::HTMLLinkElement::process):
(WebCore::HTMLLinkElement::processInternalResourceLink):
(WebCore::HTMLLinkElement::unblockRendering):
(WebCore::HTMLLinkElement::removedFromAncestor):
(WebCore::HTMLLinkElement::blocking):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLLinkElement.idl:
* Source/WebCore/html/LinkRelAttribute.cpp:
(WebCore::LinkRelAttribute::LinkRelAttribute):
* Source/WebCore/html/LinkRelAttribute.h:

Canonical link: <a href="https://commits.webkit.org/282279@main">https://commits.webkit.org/282279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff218130143a17a36f56d5337fcb805f766cfba4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50583 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9175 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68388 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57906 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54350 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13907 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5544 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38929 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->