### PR TITLE
background-clip: text fails to paint text decorations

### DIFF
--- a/LayoutTests/fast/text/text-decoration-currentcolor-fill-color-expected.html
+++ b/LayoutTests/fast/text/text-decoration-currentcolor-fill-color-expected.html
@@ -1,11 +1,12 @@
 <style>
 div {
-  background-color: red;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  font-size: 24pt;
+  background-color: green;
+  color: transparent;
+  background-clip: text;
 }
 a {
-  text-decoration: none;
+    color: transparent;
 }
 </style>
-<div><a href="">PASS if no underline</a></div>
+<div><a href="">PASS if underline is visible</a></div>

--- a/LayoutTests/fast/text/text-decoration-currentcolor-fill-color.html
+++ b/LayoutTests/fast/text/text-decoration-currentcolor-fill-color.html
@@ -1,8 +1,9 @@
 <style>
 div {
-  background-color: red;
-  -webkit-background-clip: text;
+  font-size: 24pt;
+  background-color: green;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 </style>
-<div><a href="">PASS if no underline</a></div>
+<div><a href="">PASS if underline is visible</a></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .test {
+        line-height: 2em;
+        font-size: 40px;
+        font-family: Ahem;
+        color: green;
+        text-decoration-thickness: 20px;
+    }
+</style>
+<body>
+    <div class="test" style="text-decoration: underline">AAAA</div>
+    <div class="test" style="text-decoration: line-through">AAAA</div>
+    <div class="test" style="text-decoration: overline">AAAA</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .test {
+        line-height: 2em;
+        font-size: 40px;
+        font-family: Ahem;
+        color: green;
+        text-decoration-thickness: 20px;
+    }
+</style>
+<body>
+    <div class="test" style="text-decoration: underline">AAAA</div>
+    <div class="test" style="text-decoration: line-through">AAAA</div>
+    <div class="test" style="text-decoration: overline">AAAA</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>background-clip: text shows text decorations</title>
+<link rel="match" href="clip-rounded-corner-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">
+<style>
+    .test {
+        line-height: 2em;
+        font-size: 40px;
+        font-family: Ahem;
+        color: transparent;
+        background-color: green;
+        background-clip: text;
+        text-decoration-thickness: 20px;
+    }
+</style>
+<body>
+    <div class="test" style="text-decoration: underline">AAAA</div>
+    <div class="test" style="text-decoration: line-through">AAAA</div>
+    <div class="test" style="text-decoration: overline">AAAA</div>
+</body>

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -38,7 +38,7 @@
 namespace WebCore {
 
 /*
- * Draw one cubic Bezier curve and repeat the same pattern long the the decoration's axis.
+ * Draw one cubic Bezier curve and repeat the same pattern along the the decoration's axis.
  * The start point (p1), controlPoint1, controlPoint2 and end point (p2) of the Bezier curve
  * form a diamond shape:
  *
@@ -382,6 +382,12 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
 
 Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet<PaintBehavior> paintBehavior)
 {
+    if (paintBehavior.contains(PaintBehavior::ForceBlackText))
+        return Color::black;
+
+    if (paintBehavior.contains(PaintBehavior::ForceWhiteText))
+        return Color::white;
+
     return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 


### PR DESCRIPTION
#### 91e95190faaa8209accdf4ac3863a06e1095796d
<pre>
background-clip: text fails to paint text decorations
<a href="https://bugs.webkit.org/show_bug.cgi?id=179334">https://bugs.webkit.org/show_bug.cgi?id=179334</a>
<a href="https://rdar.apple.com/93823895">rdar://93823895</a>

Reviewed by Tim Nguyen.

Respect the ForceBlackText/ForceWhiteText PaintBehavior flags, which allows us to paint text decorations into
the `background-clip: text` mask, so they show up when that is used.

This change broke fast/text/text-decoration-currentcolor-fill-color.html, which was testing that text
decorations did *not* show with `background-clip: text`, although it was also testing that the inherited
`-webkit-text-fill-color: transparent` overrides the `color` on an anchor. So fix that test to reflect
what it was doing.

* LayoutTests/fast/text/text-decoration-currentcolor-fill-color-expected.html:
* LayoutTests/fast/text/text-decoration-currentcolor-fill-color.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-text-decorations.html: Added.
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::decorationColor):

Canonical link: <a href="https://commits.webkit.org/282060@main">https://commits.webkit.org/282060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bbccf9ded6309d96c9f564dd20581a1fd1c2373

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49866 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10837 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67595 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57243 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13772 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4778 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37041 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->