### PR TITLE
[JSC] Add TruncFloatToUInt64 etc. into B3

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -3859,6 +3859,31 @@ private:
             return;
         }
 
+        case TruncDoubleToInt32:
+            appendUnOp<Air::Oops, Air::Oops, Air::TruncateDoubleToInt32, Air::Oops>(m_value->child(0));
+            return;
+        case TruncDoubleToUInt32:
+            appendUnOp<Air::Oops, Air::Oops, Air::TruncateDoubleToUint32, Air::Oops>(m_value->child(0));
+            return;
+        case TruncDoubleToInt64:
+            appendUnOp<Air::Oops, Air::Oops, Air::TruncateDoubleToInt64, Air::Oops>(m_value->child(0));
+            return;
+        case TruncDoubleToUInt64:
+            appendUnOp<Air::Oops, Air::Oops, Air::TruncateDoubleToUint64, Air::Oops>(m_value->child(0));
+            return;
+        case TruncFloatToInt32:
+            appendUnOp<Air::Oops, Air::Oops, Air::Oops, Air::TruncateFloatToInt32>(m_value->child(0));
+            return;
+        case TruncFloatToUInt32:
+            appendUnOp<Air::Oops, Air::Oops, Air::Oops, Air::TruncateFloatToUint32>(m_value->child(0));
+            return;
+        case TruncFloatToInt64:
+            appendUnOp<Air::Oops, Air::Oops, Air::Oops, Air::TruncateFloatToInt64>(m_value->child(0));
+            return;
+        case TruncFloatToUInt64:
+            appendUnOp<Air::Oops, Air::Oops, Air::Oops, Air::TruncateFloatToUint64>(m_value->child(0));
+            return;
+
         case Store: {
             // Pre-Index Canonical Form:
             //     address = Add(base, Offset)              --->    Move %base %address

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -213,6 +213,30 @@ void printInternal(PrintStream& out, Opcode opcode)
     case BitwiseCast:
         out.print("BitwiseCast");
         return;
+    case TruncDoubleToInt32:
+        out.print("TruncDoubleToInt32");
+        return;
+    case TruncDoubleToUInt32:
+        out.print("TruncDoubleToUInt32");
+        return;
+    case TruncDoubleToInt64:
+        out.print("TruncDoubleToInt64");
+        return;
+    case TruncDoubleToUInt64:
+        out.print("TruncDoubleToUInt64");
+        return;
+    case TruncFloatToInt32:
+        out.print("TruncFloatToInt32");
+        return;
+    case TruncFloatToUInt32:
+        out.print("TruncFloatToUInt32");
+        return;
+    case TruncFloatToInt64:
+        out.print("TruncFloatToInt64");
+        return;
+    case TruncFloatToUInt64:
+        out.print("TruncFloatToUInt64");
+        return;
     case SExt8:
         out.print("SExt8");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -128,6 +128,17 @@ enum Opcode : uint8_t {
     ZExt32,
     // Does a bitwise truncation of Int64->Int32 and Double->Float:
     Trunc,
+
+    // Trunc Float/Double to Int32/Int64/UInt32/UInt64
+    TruncDoubleToInt32,
+    TruncDoubleToUInt32,
+    TruncDoubleToInt64,
+    TruncDoubleToUInt64,
+    TruncFloatToInt32,
+    TruncFloatToUInt32,
+    TruncFloatToInt64,
+    TruncFloatToUInt64,
+
     // On JSVALUE32_64 platforms only: gets the high 32-bits of an Int64.
     TruncHigh,
     // On JSVALUE32_64 platforms only: puts together an Int32 from two Int32s.

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -329,6 +329,24 @@ public:
                 VALIDATE(value->child(0)->type().isInt(), ("At ", *value));
                 VALIDATE(value->type() == Double, ("At ", *value));
                 break;
+            case TruncDoubleToInt32:
+            case TruncDoubleToUInt32:
+            case TruncFloatToInt32:
+            case TruncFloatToUInt32:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->child(0)->type().isFloat(), ("At ", *value));
+                VALIDATE(value->type().isInt(), ("At ", *value));
+                break;
+            case TruncDoubleToInt64:
+            case TruncDoubleToUInt64:
+            case TruncFloatToInt64:
+            case TruncFloatToUInt64:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->child(0)->type().isFloat(), ("At ", *value));
+                VALIDATE(value->type().isInt(), ("At ", *value));
+                break;
             case IToF:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 1, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -654,6 +654,14 @@ Effects Value::effects() const
     case Floor:
     case Sqrt:
     case BitwiseCast:
+    case TruncDoubleToInt32:
+    case TruncDoubleToUInt32:
+    case TruncDoubleToInt64:
+    case TruncDoubleToUInt64:
+    case TruncFloatToInt32:
+    case TruncFloatToUInt32:
+    case TruncFloatToInt64:
+    case TruncFloatToUInt64:
     case SExt8:
     case SExt16:
     case SExt8To64:
@@ -881,6 +889,14 @@ ValueKey Value::key() const
     case DoubleToFloat:
     case Check:
     case BitwiseCast:
+    case TruncDoubleToInt32:
+    case TruncDoubleToUInt32:
+    case TruncDoubleToInt64:
+    case TruncDoubleToUInt64:
+    case TruncFloatToInt32:
+    case TruncFloatToUInt32:
+    case TruncFloatToInt64:
+    case TruncFloatToUInt64:
     case Neg:
     case Depend:
         return ValueKey(kind(), type(), child(0));
@@ -1106,6 +1122,10 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case BelowEqual:
     case EqualOrUnordered:
     case TruncHigh:
+    case TruncDoubleToInt32:
+    case TruncDoubleToUInt32:
+    case TruncFloatToInt32:
+    case TruncFloatToUInt32:
         return Int32;
     case Trunc:
         return firstChild->type() == Int64 ? Int32 : Float;
@@ -1114,6 +1134,10 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case SExt32:
     case ZExt32:
     case Stitch:
+    case TruncDoubleToInt64:
+    case TruncDoubleToUInt64:
+    case TruncFloatToInt64:
+    case TruncFloatToUInt64:
         return Int64;
     case FloatToDouble:
     case IToD:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -434,6 +434,14 @@ protected:
         case DoubleToFloat:
         case IToF:
         case BitwiseCast:
+        case TruncDoubleToInt32:
+        case TruncDoubleToUInt32:
+        case TruncDoubleToInt64:
+        case TruncDoubleToUInt64:
+        case TruncFloatToInt32:
+        case TruncFloatToUInt32:
+        case TruncFloatToInt64:
+        case TruncFloatToUInt64:
         case Branch:
         case Depend:
         case Load8Z:
@@ -683,6 +691,14 @@ private:
         case DoubleToFloat:
         case IToF:
         case BitwiseCast:
+        case TruncDoubleToInt32:
+        case TruncDoubleToUInt32:
+        case TruncDoubleToInt64:
+        case TruncDoubleToUInt64:
+        case TruncFloatToInt32:
+        case TruncFloatToUInt32:
+        case TruncFloatToInt64:
+        case TruncFloatToUInt64:
         case Branch:
         case Depend:
         case VectorExtractLane:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -86,6 +86,14 @@ namespace JSC { namespace B3 {
     case DoubleToFloat: \
     case IToF: \
     case BitwiseCast: \
+    case TruncDoubleToInt32: \
+    case TruncDoubleToUInt32: \
+    case TruncDoubleToInt64: \
+    case TruncDoubleToUInt64: \
+    case TruncFloatToInt32: \
+    case TruncFloatToUInt32: \
+    case TruncFloatToInt64: \
+    case TruncFloatToUInt64: \
     case Branch: \
     case Depend: \
     case Add: \

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -665,6 +665,30 @@ ConvertFloatToDouble U:F:32, D:F:64
     Tmp, Tmp
     x86: Addr, Tmp
 
+TruncateDoubleToInt32 U:F:64, ZD:G:32
+    Tmp, Tmp
+
+TruncateDoubleToUint32 U:F:64, D:G:32
+    Tmp, Tmp
+
+64: TruncateDoubleToInt64 U:F:64, D:G:64
+    Tmp, Tmp
+
+arm64: TruncateDoubleToUint64 U:F:64, ZD:G:64
+    Tmp, Tmp
+
+TruncateFloatToInt32 U:F:32, ZD:G:32
+    Tmp, Tmp
+
+TruncateFloatToUint32 U:F:32, D:G:32
+    Tmp, Tmp
+
+64: TruncateFloatToInt64 U:F:32, D:G:64
+    Tmp, Tmp
+
+arm64: TruncateFloatToUint64 U:F:32, ZD:G:64
+    Tmp, Tmp
+
 # Note that Move operates over the full register size, which is either 32-bit or 64-bit depending on
 # the platform. I'm not entirely sure that this is a good thing; it might be better to just have a
 # Move64 instruction. OTOH, our MacroAssemblers already have this notion of "move()" that basically

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -344,38 +344,17 @@ LValue Output::doubleMin(LValue lhs, LValue rhs)
 
 LValue Output::doubleToInt(LValue value)
 {
-    PatchpointValue* result = patchpoint(Int32);
-    result->append(value, ValueRep::SomeRegister);
-    result->setGenerator(
-        [] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-            jit.truncateDoubleToInt32(params[1].fpr(), params[0].gpr());
-        });
-    result->effects = Effects::none();
-    return result;
+    return m_block->appendNew<B3::Value>(m_proc, B3::TruncDoubleToInt32, origin(), value);
 }
 
 LValue Output::doubleToInt64(LValue value)
 {
-    PatchpointValue* result = patchpoint(Int64);
-    result->append(value, ValueRep::SomeRegister);
-    result->setGenerator(
-        [] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-            jit.truncateDoubleToInt64(params[1].fpr(), params[0].gpr());
-        });
-    result->effects = Effects::none();
-    return result;
+    return m_block->appendNew<B3::Value>(m_proc, B3::TruncDoubleToInt64, origin(), value);
 }
 
 LValue Output::doubleToUInt(LValue value)
 {
-    PatchpointValue* result = patchpoint(Int32);
-    result->append(value, ValueRep::SomeRegister);
-    result->setGenerator(
-        [] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-            jit.truncateDoubleToUint32(params[1].fpr(), params[0].gpr());
-        });
-    result->effects = Effects::none();
-    return result;
+    return m_block->appendNew<B3::Value>(m_proc, B3::TruncDoubleToUInt32, origin(), value);
 }
 
 LValue Output::signExt32To64(LValue value)

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3039,13 +3039,11 @@ auto OMGIRGenerator::atomicFence(ExtAtomicOpType, uint8_t) -> PartialResult
     return { };
 }
 
-auto OMGIRGenerator::truncSaturated(Ext1OpType op, ExpressionType argVar, ExpressionType& result, Type returnType, Type) -> PartialResult
+auto OMGIRGenerator::truncSaturated(Ext1OpType op, ExpressionType argVar, ExpressionType& result, Type, Type) -> PartialResult
 {
     Value* arg = get(argVar);
     Value* maxFloat = nullptr;
     Value* minFloat = nullptr;
-    Value* signBitConstant = nullptr;
-    bool requiresMacroScratchRegisters = false;
     switch (op) {
     case Ext1OpType::I32TruncSatF32S:
         maxFloat = constant(Float, bitwise_cast<uint32_t>(-static_cast<float>(std::numeric_limits<int32_t>::min())));
@@ -3070,12 +3068,6 @@ auto OMGIRGenerator::truncSaturated(Ext1OpType op, ExpressionType argVar, Expres
     case Ext1OpType::I64TruncSatF32U:
         maxFloat = constant(Float, bitwise_cast<uint32_t>(static_cast<float>(std::numeric_limits<int64_t>::min()) * static_cast<float>(-2.0)));
         minFloat = constant(Float, bitwise_cast<uint32_t>(static_cast<float>(-1.0)));
-        // Since x86 doesn't have an instruction to convert floating points to unsigned integers, we at least try to do the smart thing if
-        // the numbers would be positive anyway as a signed integer. Since we cannot materialize constants into fprs we have b3 do it
-        // so we can pool them if needed.
-        if (isX86())
-            signBitConstant = constant(Float, bitwise_cast<uint32_t>(static_cast<float>(std::numeric_limits<uint64_t>::max() - std::numeric_limits<int64_t>::max())));
-        requiresMacroScratchRegisters = true;
         break;
     case Ext1OpType::I64TruncSatF64S:
         maxFloat = constant(Double, bitwise_cast<uint64_t>(-static_cast<double>(std::numeric_limits<int64_t>::min())));
@@ -3084,78 +3076,42 @@ auto OMGIRGenerator::truncSaturated(Ext1OpType op, ExpressionType argVar, Expres
     case Ext1OpType::I64TruncSatF64U:
         maxFloat = constant(Double, bitwise_cast<uint64_t>(static_cast<double>(std::numeric_limits<int64_t>::min()) * -2.0));
         minFloat = constant(Double, bitwise_cast<uint64_t>(-1.0));
-        // Since x86 doesn't have an instruction to convert floating points to unsigned integers, we at least try to do the smart thing if
-        // the numbers are would be positive anyway as a signed integer. Since we cannot materialize constants into fprs we have b3 do it
-        // so we can pool them if needed.
-        if (isX86())
-            signBitConstant = constant(Double, bitwise_cast<uint64_t>(static_cast<double>(std::numeric_limits<uint64_t>::max() - std::numeric_limits<int64_t>::max())));
-        requiresMacroScratchRegisters = true;
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
         break;
     }
 
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, toB3Type(returnType), origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    if (requiresMacroScratchRegisters) {
-        if (isX86()) {
-            ASSERT(signBitConstant);
-            patchpoint->append(signBitConstant, ValueRep::SomeRegister);
-            patchpoint->numFPScratchRegisters = 1;
-        }
-        patchpoint->clobber(RegisterSetBuilder::macroClobberedGPRs());
+    Value* truncated = nullptr;
+    switch (op) {
+    case Ext1OpType::I32TruncSatF32S:
+        truncated = append<Value>(m_proc, TruncFloatToInt32, origin(), arg);
+        break;
+    case Ext1OpType::I32TruncSatF32U:
+        truncated = append<Value>(m_proc, TruncFloatToUInt32, origin(), arg);
+        break;
+    case Ext1OpType::I32TruncSatF64S:
+        truncated = append<Value>(m_proc, TruncDoubleToInt32, origin(), arg);
+        break;
+    case Ext1OpType::I32TruncSatF64U:
+        truncated = append<Value>(m_proc, TruncDoubleToUInt32, origin(), arg);
+        break;
+    case Ext1OpType::I64TruncSatF32S:
+        truncated = append<Value>(m_proc, TruncFloatToInt64, origin(), arg);
+        break;
+    case Ext1OpType::I64TruncSatF64S:
+        truncated = append<Value>(m_proc, TruncDoubleToInt64, origin(), arg);
+        break;
+    case Ext1OpType::I64TruncSatF32U:
+        truncated = append<Value>(m_proc, TruncFloatToUInt64, origin(), arg);
+        break;
+    case Ext1OpType::I64TruncSatF64U:
+        truncated = append<Value>(m_proc, TruncDoubleToUInt64, origin(), arg);
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
     }
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        switch (op) {
-        case Ext1OpType::I32TruncSatF32S:
-            jit.truncateFloatToInt32(params[1].fpr(), params[0].gpr());
-            break;
-        case Ext1OpType::I32TruncSatF32U:
-            jit.truncateFloatToUint32(params[1].fpr(), params[0].gpr());
-            break;
-        case Ext1OpType::I32TruncSatF64S:
-            jit.truncateDoubleToInt32(params[1].fpr(), params[0].gpr());
-            break;
-        case Ext1OpType::I32TruncSatF64U:
-            jit.truncateDoubleToUint32(params[1].fpr(), params[0].gpr());
-            break;
-        case Ext1OpType::I64TruncSatF32S:
-            jit.truncateFloatToInt64(params[1].fpr(), params[0].gpr());
-            break;
-        case Ext1OpType::I64TruncSatF32U: {
-            AllowMacroScratchRegisterUsage allowScratch(jit);
-            ASSERT(requiresMacroScratchRegisters);
-            FPRReg scratch = InvalidFPRReg;
-            FPRReg constant = InvalidFPRReg;
-            if (isX86()) {
-                scratch = params.fpScratch(0);
-                constant = params[2].fpr();
-            }
-            jit.truncateFloatToUint64(params[1].fpr(), params[0].gpr(), scratch, constant);
-            break;
-        }
-        case Ext1OpType::I64TruncSatF64S:
-            jit.truncateDoubleToInt64(params[1].fpr(), params[0].gpr());
-            break;
-        case Ext1OpType::I64TruncSatF64U: {
-            AllowMacroScratchRegisterUsage allowScratch(jit);
-            ASSERT(requiresMacroScratchRegisters);
-            FPRReg scratch = InvalidFPRReg;
-            FPRReg constant = InvalidFPRReg;
-            if (isX86()) {
-                scratch = params.fpScratch(0);
-                constant = params[2].fpr();
-            }
-            jit.truncateDoubleToUint64(params[1].fpr(), params[0].gpr(), scratch, constant);
-            break;
-        }
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-            break;
-        }
-    });
-    patchpoint->effects = Effects::none();
 
     Value* maxResult = nullptr;
     Value* minResult = nullptr;
@@ -3195,7 +3151,7 @@ auto OMGIRGenerator::truncSaturated(Ext1OpType op, ExpressionType argVar, Expres
         append<Value>(m_proc, GreaterThan, origin(), arg, minFloat),
         append<Value>(m_proc, B3::Select, origin(),
             append<Value>(m_proc, LessThan, origin(), arg, maxFloat),
-            patchpoint, maxResult),
+            truncated, maxResult),
         requiresNaNCheck ? append<Value>(m_proc, B3::Select, origin(), append<Value>(m_proc, Equal, origin(), arg, arg), minResult, zero) : minResult));
 
     return { };
@@ -6312,13 +6268,8 @@ auto OMGIRGenerator::addI32TruncSF64(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int32, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        jit.truncateDoubleToInt32(params[1].fpr(), params[0].gpr());
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncDoubleToInt32, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6335,13 +6286,8 @@ auto OMGIRGenerator::addI32TruncSF32(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int32, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        jit.truncateFloatToInt32(params[1].fpr(), params[0].gpr());
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncFloatToInt32, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6359,13 +6305,8 @@ auto OMGIRGenerator::addI32TruncUF64(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int32, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        jit.truncateDoubleToUint32(params[1].fpr(), params[0].gpr());
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncDoubleToUInt32, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6382,13 +6323,8 @@ auto OMGIRGenerator::addI32TruncUF32(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int32, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        jit.truncateFloatToUint32(params[1].fpr(), params[0].gpr());
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncFloatToUInt32, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6405,13 +6341,8 @@ auto OMGIRGenerator::addI64TruncSF64(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int64, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        jit.truncateDoubleToInt64(params[1].fpr(), params[0].gpr());
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncDoubleToInt64, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6428,33 +6359,8 @@ auto OMGIRGenerator::addI64TruncUF64(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-
-    Value* signBitConstant;
-    if (isX86()) {
-        // Since x86 doesn't have an instruction to convert floating points to unsigned integers, we at least try to do the smart thing if
-        // the numbers are would be positive anyway as a signed integer. Since we cannot materialize constants into fprs we have b3 do it
-        // so we can pool them if needed.
-        signBitConstant = constant(Double, bitwise_cast<uint64_t>(static_cast<double>(std::numeric_limits<uint64_t>::max() - std::numeric_limits<int64_t>::max())));
-    }
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int64, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    if (isX86()) {
-        patchpoint->append(signBitConstant, ValueRep::SomeRegister);
-        patchpoint->numFPScratchRegisters = 1;
-    }
-    patchpoint->clobber(RegisterSetBuilder::macroClobberedGPRs());
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        AllowMacroScratchRegisterUsage allowScratch(jit);
-        FPRReg scratch = InvalidFPRReg;
-        FPRReg constant = InvalidFPRReg;
-        if (isX86()) {
-            scratch = params.fpScratch(0);
-            constant = params[2].fpr();
-        }
-        jit.truncateDoubleToUint64(params[1].fpr(), params[0].gpr(), scratch, constant);
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncDoubleToUInt64, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6471,13 +6377,8 @@ auto OMGIRGenerator::addI64TruncSF32(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int64, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        jit.truncateFloatToInt64(params[1].fpr(), params[0].gpr());
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncFloatToInt64, origin(), arg);
+    result = push(truncated);
     return { };
 }
 
@@ -6494,33 +6395,8 @@ auto OMGIRGenerator::addI64TruncUF32(ExpressionType argVar, ExpressionType& resu
     trap->setGenerator([=, this] (CCallHelpers& jit, const StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsTrunc);
     });
-
-    Value* signBitConstant;
-    if (isX86()) {
-        // Since x86 doesn't have an instruction to convert floating points to unsigned integers, we at least try to do the smart thing if
-        // the numbers would be positive anyway as a signed integer. Since we cannot materialize constants into fprs we have b3 do it
-        // so we can pool them if needed.
-        signBitConstant = constant(Float, bitwise_cast<uint32_t>(static_cast<float>(std::numeric_limits<uint64_t>::max() - std::numeric_limits<int64_t>::max())));
-    }
-    PatchpointValue* patchpoint = append<PatchpointValue>(m_proc, Int64, origin());
-    patchpoint->append(arg, ValueRep::SomeRegister);
-    if (isX86()) {
-        patchpoint->append(signBitConstant, ValueRep::SomeRegister);
-        patchpoint->numFPScratchRegisters = 1;
-    }
-    patchpoint->clobber(RegisterSetBuilder::macroClobberedGPRs());
-    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-        AllowMacroScratchRegisterUsage allowScratch(jit);
-        FPRReg scratch = InvalidFPRReg;
-        FPRReg constant = InvalidFPRReg;
-        if (isX86()) {
-            scratch = params.fpScratch(0);
-            constant = params[2].fpr();
-        }
-        jit.truncateFloatToUint64(params[1].fpr(), params[0].gpr(), scratch, constant);
-    });
-    patchpoint->effects = Effects::none();
-    result = push(patchpoint);
+    Value* truncated = append<Value>(m_proc, TruncFloatToUInt64, origin(), arg);
+    result = push(truncated);
     return { };
 }
 


### PR DESCRIPTION
#### c24ca3ce07973cdbf52ea4cd4e1a7652f15b4841
<pre>
[JSC] Add TruncFloatToUInt64 etc. into B3
<a href="https://bugs.webkit.org/show_bug.cgi?id=277851">https://bugs.webkit.org/show_bug.cgi?id=277851</a>
<a href="https://rdar.apple.com/133525309">rdar://133525309</a>

Reviewed by NOBODY (OOPS!).

This patch integrates these truncate instructions into B3 instead of using patchpoints to handle these semantics well.

* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::doubleToInt):
(JSC::FTL::Output::doubleToInt64):
(JSC::FTL::Output::doubleToUInt):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::truncSaturated):
(JSC::Wasm::OMGIRGenerator::addI32TruncSF64):
(JSC::Wasm::OMGIRGenerator::addI32TruncSF32):
(JSC::Wasm::OMGIRGenerator::addI32TruncUF64):
(JSC::Wasm::OMGIRGenerator::addI32TruncUF32):
(JSC::Wasm::OMGIRGenerator::addI64TruncSF64):
(JSC::Wasm::OMGIRGenerator::addI64TruncUF64):
(JSC::Wasm::OMGIRGenerator::addI64TruncSF32):
(JSC::Wasm::OMGIRGenerator::addI64TruncUF32):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c24ca3ce07973cdbf52ea4cd4e1a7652f15b4841

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12406 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49847 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8587 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11337 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54956 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61103 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57231 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57472 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4756 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37015 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14508 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->