### PR TITLE
Overlay Regions should be based on the EventRegion's bounds

### DIFF
--- a/LayoutTests/overlay-region/fixed-overlay-drawn-rect-expected.txt
+++ b/LayoutTests/overlay-region/fixed-overlay-drawn-rect-expected.txt
@@ -1,0 +1,103 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 618 y: 418 width: 150 height: 150])
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 768 height: 150])
+                                          (layer position [x: 384 y: 384])
+                                          (subviews
+                                            (view [class: UIView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (layer position [x: 400 y: 400]))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))))))

--- a/LayoutTests/overlay-region/fixed-overlay-drawn-rect.html
+++ b/LayoutTests/overlay-region/fixed-overlay-drawn-rect.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed-link {
+            position: fixed;
+            display: block;
+            bottom: 2rem;
+            right: 2rem;
+            width: 150px;
+            height: 150px;
+
+            background: #F67280;
+            z-index: 100;
+
+            text-indent: -7500px;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <a href="#" class="fixed-link">Fixed</a>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1246,7 +1246,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
 
         // Overlay regions are positioned relative to the viewport of the scrollview,
         // not the frame (external) nor the bounds (origin moves while scrolling).
-        CGRect rect = [overlayView.superview convertRect:overlayView.frame toView:scrollView.superview];
+        CGRect rect = [overlayView convertRect:node->eventRegion().region().bounds() toView:scrollView.superview];
         CGRect offsetRect = CGRectOffset(rect, -scrollView.frame.origin.x, -scrollView.frame.origin.y);
         CGRect viewport = CGRectOffset(scrollView.frame, -scrollView.frame.origin.x, -scrollView.frame.origin.y);
         CGRect snappedRect = snapRectToScrollViewEdges(offsetRect, viewport);


### PR DESCRIPTION
#### 697d0939fc72804e300294e60042d131c0426a12
<pre>
Overlay Regions should be based on the EventRegion&apos;s bounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=277854">https://bugs.webkit.org/show_bug.cgi?id=277854</a>
&lt;<a href="https://rdar.apple.com/132863165">rdar://132863165</a>&gt;

Reviewed by Mike Wyrzykowski.

We were using composited bounds to position and size Overlay Regions,
and these sometimes do not match the drawn rect.
Instead, go back to using the EventRegion&apos;s bounds, that&apos;s what they are
for.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(configureScrollViewWithOverlayRegionsIDs):
Switch to using the node&apos;s EventRegion.

* LayoutTests/overlay-region/fixed-overlay-drawn-rect-expected.txt: Added.
* LayoutTests/overlay-region/fixed-overlay-drawn-rect.html: Added.
Add a test covering the case where the composited bounds are different
from the bounds.

Canonical link: <a href="https://commits.webkit.org/282080@main">https://commits.webkit.org/282080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58eb22440ab4a8f79dc21e36404932bedda8f298

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12413 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49852 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8591 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57234 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57475 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13779 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4765 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37022 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38106 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->