### PR TITLE
Stream IPC should have per-connection timeout and not per operation timeout

### DIFF
--- a/LayoutTests/ipc/restrictedendpoints/allow-access-webGPU.html
+++ b/LayoutTests/ipc/restrictedendpoints/allow-access-webGPU.html
@@ -14,8 +14,9 @@ function runTest() {
     let rrbStreamConnectionHandle;
     let webGPUStreamConnection;
     let webGPUStreamConnectionHandle;
+    const defaultTimeout = 1000;
     try {
-        [rrbStreamConnection, rrbStreamConnectionHandle] = IPC.createStreamClientConnection(16);
+        [rrbStreamConnection, rrbStreamConnectionHandle] = IPC.createStreamClientConnection(16, defaultTimeout);
         let renderingBackendID = randomIPCID();
         IPC.sendMessage(
             'GPU',
@@ -30,7 +31,7 @@ function runTest() {
             ]);
 
         let webGPUID = randomIPCID();
-        [webGPUStreamConnection, webGPUStreamConnectionHandle] = IPC.createStreamClientConnection(16);
+        [webGPUStreamConnection, webGPUStreamConnectionHandle] = IPC.createStreamClientConnection(16, defaultTimeout);
         var result = IPC.sendMessage(
             'GPU',
             IPC.webPageProxyID,

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-webGPU.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-webGPU.html
@@ -14,8 +14,9 @@ function runTest() {
     let rrbStreamConnectionHandle;
     let webGPUStreamConnection;
     let webGPUStreamConnectionHandle;
+    const defaultTimeout = 1000;
     try {
-        [rrbStreamConnection, rrbStreamConnectionHandle] = IPC.createStreamClientConnection(16);
+        [rrbStreamConnection, rrbStreamConnectionHandle] = IPC.createStreamClientConnection(16, defaultTimeout);
         let renderingBackendID = randomIPCID();
         IPC.sendMessage(
             'GPU',
@@ -30,7 +31,7 @@ function runTest() {
             ]);
 
         let webGPUID = randomIPCID();
-        [webGPUStreamConnection, webGPUStreamConnectionHandle] = IPC.createStreamClientConnection(16);
+        [webGPUStreamConnection, webGPUStreamConnectionHandle] = IPC.createStreamClientConnection(16, defaultTimeout);
         var result = IPC.sendMessage(
             'GPU',
             IPC.webPageProxyID,

--- a/LayoutTests/ipc/send-filter.html
+++ b/LayoutTests/ipc/send-filter.html
@@ -5,7 +5,8 @@
         testRunner.dumpAsText()
 
     if (window.IPC) {
-        [streamConnection, streamConnectionHandle] = IPC.createStreamClientConnection(14);
+        const defaultTimeout = 1000;
+        [streamConnection, streamConnectionHandle] = IPC.createStreamClientConnection(14, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(
             'GPU',
@@ -21,7 +22,6 @@
         streamConnection.sendMessage(
             1289,
             IPC.messages.RemoteRenderingBackend_CacheFilter.name,
-            0.1,
             [
             {type: 'uint8_t',value: 0},
             {type: 'Vector',value: []},

--- a/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html
+++ b/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html
@@ -13,7 +13,7 @@ function fuzz() {
     const defaultTimeout = 1000;
     o4=IPC.pageID;
     o5=IPC.webPageProxyID;
-    let pair = IPC.createStreamClientConnection(14);
+    let pair = IPC.createStreamClientConnection(14, defaultTimeout);
     o35=pair[0];
     o36=pair[1];
     o35.open();
@@ -33,7 +33,7 @@ function fuzz() {
             debug("Failed: " + error)
     }
     try {
-        resp = o35.waitForMessage(backendID, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, defaultTimeout)
+        resp = o35.waitForMessage(backendID, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name)
     } catch (error) {
         if (!(error instanceof TypeError))
             debug("Failed: " + error)
@@ -45,7 +45,7 @@ function fuzz() {
             debug("Failed: " + error)
     }
     try {
-        o35.sendMessage(backendID, IPC.messages.RemoteRenderingBackend_CreateImageBuffer.name, 0.1,
+        o35.sendMessage(backendID, IPC.messages.RemoteRenderingBackend_CreateImageBuffer.name,
                   [{type: 'float', value: 804},
                    {type: 'float', value: 486},
                    {type: 'uint8_t', value: 0},
@@ -59,13 +59,13 @@ function fuzz() {
             debug("Failed: " + error)
     }
     try {
-        o35.waitForMessage(imageBufferID, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, defaultTimeout);
+        o35.waitForMessage(imageBufferID, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name);
     } catch (error) {
         if (!(error instanceof TypeError))
             debug("Failed: " + error)
     }
     try {
-        o35.sendSyncMessage(imageBufferID,IPC.messages.RemoteImageBuffer_GetShareableBitmap.name,0.1,[{type: 'bool',value: 0}]);
+        o35.sendSyncMessage(imageBufferID,IPC.messages.RemoteImageBuffer_GetShareableBitmap.name, [{type: 'bool',value: 0}]);
     } catch (error) {
         if (!(error instanceof TypeError))
             debug("Failed: " + error)

--- a/LayoutTests/ipc/send-gradient.html
+++ b/LayoutTests/ipc/send-gradient.html
@@ -5,7 +5,8 @@
         testRunner.dumpAsText()
 
     if (window.IPC) {
-        [streamConnection, streamConnectionHandle] = IPC.createStreamClientConnection(14);
+        const defaultTimeout = 1000;
+        [streamConnection, streamConnectionHandle] = IPC.createStreamClientConnection(14, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(
             'GPU',
@@ -21,7 +22,6 @@
         streamConnection.sendMessage(
             1872,
             IPC.messages.RemoteRenderingBackend_CacheGradient.name,
-            0.1,
             [
                 {type: 'uint8_t',value: 1},
                 {type: 'float',value: 20.91822109052055},

--- a/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html
+++ b/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html
@@ -13,19 +13,19 @@ promise_test(async t => {
         return;
 
     for (const processTarget of IPC.processTargets) {
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },
             { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
         ]);
-        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name);
         streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
 
         // Test starts here.
         try {
             assert_throws_js(TypeError,
-            () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, defaultTimeout, [  ]) },
+            () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, [  ]) },
             `failed sync message must throw error`);
         } finally {
             IPC.sendSyncMessage(processTarget, 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);

--- a/LayoutTests/ipc/stream-async-with-reply.html
+++ b/LayoutTests/ipc/stream-async-with-reply.html
@@ -15,13 +15,13 @@ async function runTest() {
     const IPCStreamTester_AsyncPingReplyName = IPC.messages.IPCStreamTester_AsyncPingReply.name;
 
     for (const processTarget of IPC.processTargets) {
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },
             { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
         ]);
-        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name);
         streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
         // Test starts here.
         try {
@@ -29,7 +29,7 @@ async function runTest() {
             let asyncReplyIDs = { };
             const requestCount = 100;
             for (let request = 0; request < requestCount; ++request) {
-                asyncReplyIDs[request] = streamConnection.sendWithAsyncReply(streamTesterID, IPCStreamTester_AsyncPingName, defaultTimeout, [{type: 'uint32_t', value: request}], (message) => {
+                asyncReplyIDs[request] = streamConnection.sendWithAsyncReply(streamTesterID, IPCStreamTester_AsyncPingName, [{type: 'uint32_t', value: request}], (message) => {
                     results[request] = message;
                 });
                 assert_greater_than(asyncReplyIDs[request], 0, "asyncReplyID is valid");
@@ -38,7 +38,7 @@ async function runTest() {
             }
             for (let request = 0; request < requestCount; ++request) {
                 if (typeof results[request] === "undefined")
-                    streamConnection.waitForAsyncReplyAndDispatchImmediately(asyncReplyIDs[request], IPCStreamTester_AsyncPingReplyName, defaultTimeout);
+                    streamConnection.waitForAsyncReplyAndDispatchImmediately(asyncReplyIDs[request], IPCStreamTester_AsyncPingReplyName);
             }
             for (let request = 0; request < requestCount; ++request) {
                 const subcase = `${processTarget} request:${request}`

--- a/LayoutTests/ipc/stream-buffer-read-write.html
+++ b/LayoutTests/ipc/stream-buffer-read-write.html
@@ -16,7 +16,8 @@ if (window.IPC) {
 
     const testBytes = Uint8Array.from({length: 64}, (x, i) => i + 0x41);
     const bufferSizeLog2 = 6;
-    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+    const defaultTimeout = 1000;
+    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2, defaultTimeout);
     streamConnection.open();
 
     let streamBuffer = streamConnection.streamBuffer();

--- a/LayoutTests/ipc/stream-check-autoreleasepool.html
+++ b/LayoutTests/ipc/stream-check-autoreleasepool.html
@@ -11,18 +11,18 @@ promise_test(async t => {
     const bufferSizeLog2 = 9;
     const streamTesterID = 447;
     for (const processTarget of IPC.processTargets) {
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },
             { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
         ]);
-        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name);
         streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
 
         // Test starts here.
         try {
-            let result = streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_CheckAutoreleasePool.name, defaultTimeout, []);
+            let result = streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_CheckAutoreleasePool.name, []);
             let previousValue = result.arguments[0];
 
             assert_equals(previousValue.type, "int32_t", `for ${ processTarget }`);
@@ -30,7 +30,7 @@ promise_test(async t => {
             // Autoreleasepool drains between message processing. Add an idle wait so that it no
             // messages are posted, so the pool drains.
             await new Promise((resolve) => setTimeout(resolve, 300));
-            result = streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_CheckAutoreleasePool.name, defaultTimeout, []);
+            result = streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_CheckAutoreleasePool.name, []);
             previousValue = result.arguments[0];
             assert_equals(previousValue.type, "int32_t", `for ${ processTarget }`);
             assert_equals(previousValue.value, 1, `for ${ processTarget }`);

--- a/LayoutTests/ipc/stream-sync-crash-no-timeout.html
+++ b/LayoutTests/ipc/stream-sync-crash-no-timeout.html
@@ -6,28 +6,28 @@
 <script>
 setup({ single_test: true });
 if (window.IPC) { // For compiles with !ENABLE(IPC_TESTING_API)
-    const defaultTimeout = 10;
+    const defaultTimeout = 1000;
     const bufferSize = 400;
     const streamTesterID = 4557;
     for (const processTarget of IPC.processTargets) {
         if (processTarget == "UI")
             continue; // Crashing UI is not supported.
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSize);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSize, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },
             { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
         ]);
-        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name);
         streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
 
         // Test starts here.
-        const result = streamConnection.sendIPCStreamTesterSyncCrashOnZero(streamTesterID, 78, defaultTimeout);
+        const result = streamConnection.sendIPCStreamTesterSyncCrashOnZero(streamTesterID, 78);
         assert_equals(result, 78,  `sync messages work for ${ processTarget }`);
 
         const start = Date.now();
         assert_throws_js(TypeError,
-            () => { streamConnection.sendIPCStreamTesterSyncCrashOnZero(streamTesterID, 0, defaultTimeout); },
+            () => { streamConnection.sendIPCStreamTesterSyncCrashOnZero(streamTesterID, 0); },
             `crashing sync message must return failure for ${ processTarget }`);
         assert_less_than(Date.now() - start, 500, `crashing sync message must complete in 500ms for ${ processTarget }`);
         console.log(`ttt: ${Date.now() - start}`);

--- a/LayoutTests/ipc/stream-sync-reply-shared-memory.html
+++ b/LayoutTests/ipc/stream-sync-reply-shared-memory.html
@@ -10,18 +10,18 @@ if (window.IPC) { // For compiles with !ENABLE(IPC_TESTING_API)
     const bufferSizeLog2 = 9;
     const streamTesterID = 447;
     for (const processTarget of IPC.processTargets) {
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2, defaultTimeout);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },
             { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
         ]);
-        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name);
         streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
 
         // Test starts here.
         try {
-            const result = streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageReturningSharedMemory1.name, defaultTimeout, [{ type: 'uint32_t', value: 8 }]);
+            const result = streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageReturningSharedMemory1.name, [{ type: 'uint32_t', value: 8 }]);
             const firstReply = result.arguments[0];
             assert_equals(firstReply.type, "SharedMemory", `for ${ processTarget }`);
             assert_equals(firstReply.protection, "ReadOnly", `for ${ processTarget }`);

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
@@ -605,13 +605,14 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     TextureContent content { reinterpret_cast<intptr_t>(surface), IOSurfaceGetID(surface), IOSurfaceGetSeed(surface), level, internalFormat, format, type, unpackFlipY, orientation };
     auto it = m_knownContent.find(outputTexture);
     if (it != m_knownContent.end() && it->value == content) {
+        WTFLogAlways("SKIPPING!");
         // If the texture hasn't been modified since the last time we copied to it, and the
         // image hasn't been modified since the last time it was copied, this is a no-op.
         return true;
     }
     if (!m_context || !GraphicsContextGLCocoa::makeCurrent(m_display, m_context))
         return false;
-
+    WTFLogAlways("Drawing.");
     // Compute transform that undoes the `orientation`, e.g. moves the origin to top left.
     // Even number of operations (flipX, flipY, swapXY) means a rotation.
     // Odd number of operations means a rotation and a flip.

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -56,7 +56,7 @@ void StreamClientConnection::DedicatedConnectionClient::didReceiveInvalidMessage
     ASSERT_NOT_REACHED(); // The sender is expected to be trusted, so all invalid messages are programming errors.
 }
 
-std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnection::create(unsigned bufferSizeLog2)
+std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnection::create(unsigned bufferSizeLog2, Seconds defaultTimeoutDuration)
 {
     auto connectionIdentifiers = Connection::createConnectionIdentifierPair();
     if (!connectionIdentifiers)
@@ -71,7 +71,7 @@ std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnecti
     // The "Client" in StreamClientConnection means the party that mostly does sending, e.g. untrusted party.
     // The "Server" in StreamServerConnection means the party that mostly does receiving, e.g. the trusted party which holds the destination object to communicate with.
     auto dedicatedConnection = Connection::createServerConnection(connectionIdentifiers->server);
-    auto clientConnection = adoptRef(*new StreamClientConnection(WTFMove(dedicatedConnection), WTFMove(*buffer)));
+    auto clientConnection = adoptRef(*new StreamClientConnection(WTFMove(dedicatedConnection), WTFMove(*buffer), defaultTimeoutDuration));
     StreamServerConnection::Handle serverHandle {
         WTFMove(connectionIdentifiers->client),
         clientConnection->m_buffer.createHandle()
@@ -79,9 +79,10 @@ std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnecti
     return StreamClientConnection::StreamConnectionPair { WTFMove(clientConnection), WTFMove(serverHandle) };
 }
 
-StreamClientConnection::StreamClientConnection(Ref<Connection> connection, StreamClientConnectionBuffer&& buffer)
+StreamClientConnection::StreamClientConnection(Ref<Connection> connection, StreamClientConnectionBuffer&& buffer, Seconds defaultTimeoutDuration)
     : m_connection(WTFMove(connection))
     , m_buffer(WTFMove(buffer))
+    , m_defaultTimeoutDuration(defaultTimeoutDuration)
 {
 }
 
@@ -112,8 +113,9 @@ void StreamClientConnection::open(Connection::Client& receiver, SerialFunctionDi
     protectedConnection()->open(*m_dedicatedConnectionClient, dispatcher);
 }
 
-Error StreamClientConnection::flushSentMessages(Timeout timeout)
+Error StreamClientConnection::flushSentMessages()
 {
+    auto timeout = defaultTimeout();
     wakeUpServer(WakeUpServer::Yes);
     return protectedConnection()->flushSentMessages(WTFMove(timeout));
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -65,7 +65,7 @@ public:
     };
 
     // The messages from the server are delivered to the caller through the passed IPC::MessageReceiver.
-    static std::optional<StreamConnectionPair> create(unsigned bufferSizeLog2);
+    static std::optional<StreamConnectionPair> create(unsigned bufferSizeLog2, Seconds defaultTimeoutDuration);
 
     ~StreamClientConnection();
 
@@ -74,22 +74,23 @@ public:
     void setMaxBatchSize(unsigned);
 
     void open(Connection::Client&, SerialFunctionDispatcher& = RunLoop::current());
-    Error flushSentMessages(Timeout);
+    Error flushSentMessages();
     void invalidate();
 
-    template<typename T, typename U, typename V, typename W> Error send(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID, Timeout);
-
+    template<typename T, typename U, typename V, typename W>
+    Error send(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID);
     using AsyncReplyID = Connection::AsyncReplyID;
     template<typename T, typename C, typename U, typename V, typename W>
-    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V, W> destinationID, Timeout);
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V, W> destinationID);
 
-    template<typename T> using SendSyncResult = Connection::SendSyncResult<T>;
+    template<typename T>
+    using SendSyncResult = Connection::SendSyncResult<T>;
     template<typename T, typename U, typename V, typename W>
-    SendSyncResult<T> sendSync(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID, Timeout);
-
+    SendSyncResult<T> sendSync(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID);
     template<typename T, typename U, typename V, typename W>
-    Error waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V, W> destinationID, Timeout, OptionSet<WaitForOption> = { });
-    template<typename> Error waitForAsyncReplyAndDispatchImmediately(AsyncReplyID, Timeout);
+    Error waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V, W> destinationID, OptionSet<WaitForOption> = { });
+    template<typename>
+    Error waitForAsyncReplyAndDispatchImmediately(AsyncReplyID);
 
     void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiver&, uint64_t destinationID = 0);
     void removeWorkQueueMessageReceiver(ReceiverName, uint64_t destinationID = 0);
@@ -97,8 +98,14 @@ public:
     StreamClientConnectionBuffer& bufferForTesting();
     Connection& connectionForTesting();
 
+    // Returns the timeout moment for current time.
+    Timeout defaultTimeout() const { return m_defaultTimeoutDuration; }
+
+    // Returns the timeout duration. Useful for waiting for consistent per-connection amounts with other APIs
+    // used in conjunction with the connection.
+    Seconds defaultTimeoutDuration() const { return m_defaultTimeoutDuration; }
 private:
-    StreamClientConnection(Ref<Connection>, StreamClientConnectionBuffer&&);
+    StreamClientConnection(Ref<Connection>, StreamClientConnectionBuffer&&, Seconds defaultTimeoutDuration);
 
     template<typename T, typename... AdditionalData>
     bool trySendStream(std::span<uint8_t>, T& message, AdditionalData&&...);
@@ -129,12 +136,13 @@ private:
     StreamClientConnectionBuffer m_buffer;
     unsigned m_maxBatchSize { 20 }; // Number of messages marked as StreamBatched to accumulate before notifying the server.
     unsigned m_batchSize { 0 };
+    const Seconds m_defaultTimeoutDuration;
 
     friend class WebKit::IPCTestingAPI::JSIPCStreamClientConnection;
 };
 
 template<typename T, typename U, typename V, typename W>
-Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID, Timeout timeout)
+Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID)
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     auto signpostIdentifier = Connection::generateSignpostIdentifier();
@@ -145,6 +153,7 @@ Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W>
 #endif
 
     static_assert(!T::isSync, "Message is sync!");
+    Timeout timeout = defaultTimeout();
     auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
     if (error != Error::NoError)
         return error;
@@ -152,7 +161,7 @@ Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W>
     auto span = m_buffer.tryAcquire(timeout);
     if (!span)
         return Error::FailedToAcquireBufferSpan;
-    if constexpr(T::isStreamEncodable) {
+    if constexpr (T::isStreamEncodable) {
         if (trySendStream(*span, message))
             return Error::NoError;
     }
@@ -161,7 +170,7 @@ Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W>
 }
 
 template<typename T, typename C, typename U, typename V, typename W>
-StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V, W> destinationID, Timeout timeout)
+StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V, W> destinationID)
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     auto signpostIdentifier = Connection::generateSignpostIdentifier();
@@ -169,6 +178,7 @@ StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(
 #endif
 
     static_assert(!T::isSync, "Message is sync!");
+    Timeout timeout = defaultTimeout();
     auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
     if (error != Error::NoError)
         return { }; // FIXME: Propagate errors.
@@ -181,14 +191,14 @@ StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(
     auto handler = Connection::makeAsyncReplyHandler<T>(std::forward<C>(completionHandler));
     auto replyID = handler.replyID;
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    handler.completionHandler = CompletionHandler<void(Decoder*)>([signpostIdentifier, handler = WTFMove(handler.completionHandler)](Decoder *decoder) mutable {
+    handler.completionHandler = CompletionHandler<void(Decoder*)>([signpostIdentifier, handler = WTFMove(handler.completionHandler)](Decoder* decoder) mutable {
         WTFEndSignpost(signpostIdentifier, StreamClientConnection);
         handler(decoder);
     });
 #endif
     connection->addAsyncReplyHandler(WTFMove(handler));
 
-    if constexpr(T::isStreamEncodable) {
+    if constexpr (T::isStreamEncodable) {
         if (trySendStream(*span, message, replyID))
             return replyID;
     }
@@ -217,7 +227,7 @@ bool StreamClientConnection::trySendStream(std::span<uint8_t> span, T& message, 
     StreamConnectionEncoder messageEncoder { T::name(), span.data(), span.size() };
     if (((messageEncoder << message.arguments()) << ... << std::forward<decltype(args)>(args))) {
         auto wakeUpResult = m_buffer.release(messageEncoder.size());
-        if constexpr(T::isStreamBatched)
+        if constexpr (T::isStreamBatched)
             wakeUpServerBatched(wakeUpResult);
         else
             wakeUpServer(wakeUpResult);
@@ -227,7 +237,7 @@ bool StreamClientConnection::trySendStream(std::span<uint8_t> span, T& message, 
 }
 
 template<typename T, typename U, typename V, typename W>
-StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID, Timeout timeout)
+StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID)
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     auto signpostIdentifier = Connection::generateSignpostIdentifier();
@@ -238,6 +248,7 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
 #endif
 
     static_assert(T::isSync, "Message is not sync!");
+    Timeout timeout = defaultTimeout();
     auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
     if (error != Error::NoError)
         return { error };
@@ -246,7 +257,7 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
     if (!span)
         return { Error::FailedToAcquireBufferSpan };
 
-    if constexpr(T::isStreamEncodable) {
+    if constexpr (T::isStreamEncodable) {
         auto maybeSendResult = trySendSyncStream(message, timeout, *span);
         if (maybeSendResult)
             return WTFMove(*maybeSendResult);
@@ -256,14 +267,16 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
 }
 
 template<typename T, typename U, typename V, typename W>
-Error StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V, W> destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
+Error StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V, W> destinationID, OptionSet<WaitForOption> waitForOptions)
 {
+    Timeout timeout = defaultTimeout();
     return protectedConnection()->waitForAndDispatchImmediately<T>(destinationID, timeout, waitForOptions);
 }
 
 template<typename T>
-Error StreamClientConnection::waitForAsyncReplyAndDispatchImmediately(AsyncReplyID replyID, Timeout timeout)
+Error StreamClientConnection::waitForAsyncReplyAndDispatchImmediately(AsyncReplyID replyID)
 {
+    Timeout timeout = defaultTimeout();
     return protectedConnection()->waitForAsyncReplyAndDispatchImmediately<T>(replyID, timeout);
 }
 
@@ -284,7 +297,7 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
 
         auto wakeUpResult = m_buffer.release(messageEncoder.size());
         wakeUpServer(wakeUpResult);
-        if constexpr(T::isReplyStreamEncodable) {
+        if constexpr (T::isReplyStreamEncodable) {
             auto replySpan = m_buffer.tryAcquireAll(timeout);
             if (!replySpan)
                 return makeUnexpected(Error::FailedToAcquireReplyBufferSpan);

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
@@ -40,7 +40,7 @@ namespace WebKit::ShapeDetection {
 
 Ref<RemoteBarcodeDetectorProxy> RemoteBarcodeDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier, const WebCore::ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions)
 {
-    streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteBarcodeDetector(identifier, barcodeDetectorOptions), renderingBackendIdentifier, Seconds::infinity());
+    streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteBarcodeDetector(identifier, barcodeDetectorOptions), renderingBackendIdentifier);
     return adoptRef(*new RemoteBarcodeDetectorProxy(WTFMove(streamClientConnection), renderingBackendIdentifier, identifier));
 }
 
@@ -53,17 +53,17 @@ RemoteBarcodeDetectorProxy::RemoteBarcodeDetectorProxy(Ref<IPC::StreamClientConn
 
 RemoteBarcodeDetectorProxy::~RemoteBarcodeDetectorProxy()
 {
-    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteBarcodeDetector(m_backing), m_renderingBackendIdentifier, Seconds::infinity());
+    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteBarcodeDetector(m_backing), m_renderingBackendIdentifier);
 }
 
 void RemoteBarcodeDetectorProxy::getSupportedFormats(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&& completionHandler)
 {
-    streamClientConnection->sendWithAsyncReply(Messages::RemoteRenderingBackend::GetRemoteBarcodeDetectorSupportedFormats(), WTFMove(completionHandler), renderingBackendIdentifier, Seconds::infinity());
+    streamClientConnection->sendWithAsyncReply(Messages::RemoteRenderingBackend::GetRemoteBarcodeDetectorSupportedFormats(), WTFMove(completionHandler), renderingBackendIdentifier);
 }
 
 void RemoteBarcodeDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteBarcodeDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing, Seconds::infinity());
+    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteBarcodeDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -40,7 +40,7 @@ namespace WebKit::ShapeDetection {
 
 Ref<RemoteFaceDetectorProxy> RemoteFaceDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier, const WebCore::ShapeDetection::FaceDetectorOptions& faceDetectorOptions)
 {
-    streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteFaceDetector(identifier, faceDetectorOptions), renderingBackendIdentifier, Seconds::infinity());
+    streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteFaceDetector(identifier, faceDetectorOptions), renderingBackendIdentifier);
     return adoptRef(*new RemoteFaceDetectorProxy(WTFMove(streamClientConnection), renderingBackendIdentifier, identifier));
 }
 
@@ -53,12 +53,12 @@ RemoteFaceDetectorProxy::RemoteFaceDetectorProxy(Ref<IPC::StreamClientConnection
 
 RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy()
 {
-    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier, Seconds::infinity());
+    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier);
 }
 
 void RemoteFaceDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing, Seconds::infinity());
+    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
@@ -40,7 +40,7 @@ namespace WebKit::ShapeDetection {
 
 Ref<RemoteTextDetectorProxy> RemoteTextDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier)
 {
-    streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteTextDetector(identifier), renderingBackendIdentifier, Seconds::infinity());
+    streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteTextDetector(identifier), renderingBackendIdentifier);
     return adoptRef(*new RemoteTextDetectorProxy(WTFMove(streamClientConnection), renderingBackendIdentifier, identifier));
 }
 
@@ -53,12 +53,12 @@ RemoteTextDetectorProxy::RemoteTextDetectorProxy(Ref<IPC::StreamClientConnection
 
 RemoteTextDetectorProxy::~RemoteTextDetectorProxy()
 {
-    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteTextDetector(m_backing), m_renderingBackendIdentifier, Seconds::infinity());
+    m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteTextDetector(m_backing), m_renderingBackendIdentifier);
 }
 
 void RemoteTextDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteTextDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing, Seconds::infinity());
+    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteTextDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing);
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -78,7 +78,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
     RefPtr imageBuffer = m_imageBuffer.get();
     if (LIKELY(imageBuffer))
         imageBuffer->backingStoreWillChange();
-    auto result = connection->send(std::forward<T>(message), m_destinationBufferIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
+    auto result = connection->send(std::forward<T>(message), m_destinationBufferIdentifier);
     if (UNLIKELY(result != IPC::Error::NoError)) {
         RELEASE_LOG(RemoteLayerBuffers, "RemoteDisplayListRecorderProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -81,9 +81,10 @@ RefPtr<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::create(const 
 {
     constexpr unsigned defaultConnectionBufferSizeLog2 = 21;
     unsigned connectionBufferSizeLog2 = defaultConnectionBufferSizeLog2;
+    constexpr Seconds defaultTimeoutDuration = 30_s;
     if (attributes.failContextCreationForTesting == WebCore::GraphicsContextGLAttributes::SimulatedCreationFailure::IPCBufferOOM)
         connectionBufferSizeLog2 = 50; // Expect this to fail.
-    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
+    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2, defaultTimeoutDuration);
     if (!connectionPair)
         return nullptr;
     auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
@@ -519,7 +520,7 @@ void RemoteGraphicsContextGLProxy::waitUntilInitialized()
         return;
     if (m_didInitialize)
         return;
-    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGraphicsContextGLProxy::WasCreated>(m_identifier, defaultSendTimeout) == IPC::Error::NoError)
+    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGraphicsContextGLProxy::WasCreated>(m_identifier) == IPC::Error::NoError)
         return;
     markContextLost();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -385,16 +385,15 @@ protected:
     bool isContextLost() const { return !m_streamConnection; }
     void markContextLost();
 
-    static inline Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return m_streamConnection->send(std::forward<T>(message), m_identifier, defaultSendTimeout);
+        return m_streamConnection->send(std::forward<T>(message), m_identifier);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return m_streamConnection->sendSync(std::forward<T>(message), m_identifier, defaultSendTimeout);
+        return m_streamConnection->sendSync(std::forward<T>(message), m_identifier);
     }
 
     GraphicsContextGLIdentifier m_identifier { GraphicsContextGLIdentifier::generate() };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -85,7 +85,7 @@ ALWAYS_INLINE void RemoteImageBufferProxy::send(T&& message)
     if (UNLIKELY(!connection))
         return;
 
-    auto result = connection->send(std::forward<T>(message), renderingResourceIdentifier(), RemoteRenderingBackendProxy::defaultTimeout);
+    auto result = connection->send(std::forward<T>(message), renderingResourceIdentifier());
     if (UNLIKELY(result != IPC::Error::NoError)) {
         RELEASE_LOG(RemoteLayerBuffers, "RemoteImageBufferProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING, IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
         didBecomeUnresponsive();
@@ -99,7 +99,7 @@ ALWAYS_INLINE auto RemoteImageBufferProxy::sendSync(T&& message)
     if (UNLIKELY(!connection))
         return IPC::StreamClientConnection::SendSyncResult<T> { IPC::Error::InvalidConnection };
 
-    auto result = connection->sendSync(std::forward<T>(message), renderingResourceIdentifier(), RemoteRenderingBackendProxy::defaultTimeout);
+    auto result = connection->sendSync(std::forward<T>(message), renderingResourceIdentifier());
     if (UNLIKELY(!result.succeeded())) {
         RELEASE_LOG(RemoteLayerBuffers, "RemoteDisplayListRecorderProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING, IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
         didBecomeUnresponsive();
@@ -177,7 +177,7 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackend() const
         return m_backend.get();
     RefPtr connection = this->connection();
     if (connection) {
-        auto error = connection->waitForAndDispatchImmediately<Messages::RemoteImageBufferProxy::DidCreateBackend>(m_renderingResourceIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
+        auto error = connection->waitForAndDispatchImmediately<Messages::RemoteImageBufferProxy::DidCreateBackend>(m_renderingResourceIdentifier);
         if (error != IPC::Error::NoError) {
             RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteImageBufferProxy::ensureBackendCreated - waitForAndDispatchImmediately returned error: %" PUBLIC_LOG_STRING,
                 m_remoteRenderingBackendProxy->renderingBackendIdentifier().toUInt64(), IPC::errorAsString(error).characters());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -42,16 +42,16 @@ class RemoteImageBufferSetProxyFlushFence : public ThreadSafeRefCounted<RemoteIm
     WTF_MAKE_NONCOPYABLE(RemoteImageBufferSetProxyFlushFence);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteImageBufferSetProxyFlushFence> create(RenderingUpdateID renderingUpdateID)
+    static Ref<RemoteImageBufferSetProxyFlushFence> create(RenderingUpdateID renderingUpdateID, Seconds timeoutDuration)
     {
-        return adoptRef(*new RemoteImageBufferSetProxyFlushFence { renderingUpdateID });
+        return adoptRef(*new RemoteImageBufferSetProxyFlushFence { renderingUpdateID, timeoutDuration });
     }
 
-    bool waitFor(Seconds relativeTimeout)
+    bool wait()
     {
         Locker locker { m_lock };
         if (!m_handles)
-            m_condition.waitFor(m_lock, relativeTimeout);
+            m_condition.waitFor(m_lock, m_timeoutDuration);
         tracePoint(FlushRemoteImageBufferEnd, reinterpret_cast<uintptr_t>(this), 1u);
         return !!m_handles;
     }
@@ -72,8 +72,9 @@ public:
     RenderingUpdateID renderingUpdateID() const { return m_renderingUpdateID; }
 
 private:
-    RemoteImageBufferSetProxyFlushFence(RenderingUpdateID renderingUpdateID)
+    RemoteImageBufferSetProxyFlushFence(RenderingUpdateID renderingUpdateID, Seconds timeoutDuration)
         : m_renderingUpdateID(renderingUpdateID)
+        , m_timeoutDuration(timeoutDuration)
     {
         tracePoint(FlushRemoteImageBufferStart, reinterpret_cast<uintptr_t>(this));
     }
@@ -81,6 +82,7 @@ private:
     Condition m_condition;
     std::optional<BufferSetBackendHandle> m_handles WTF_GUARDED_BY_LOCK(m_lock);
     RenderingUpdateID m_renderingUpdateID;
+    const Seconds m_timeoutDuration;
 };
 
 namespace {
@@ -96,7 +98,7 @@ public:
 
     bool flushAndCollectHandles(HashMap<RemoteImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>& handlesMap) final
     {
-        if (m_flushState->waitFor(RemoteRenderingBackendProxy::defaultTimeout)) {
+        if (m_flushState->wait()) {
             handlesMap.add(m_identifier, makeUnique<BufferSetBackendHandle>(*m_flushState->takeHandles()));
             return true;
         }
@@ -119,7 +121,7 @@ ALWAYS_INLINE auto RemoteImageBufferSetProxy::send(T&& message)
     if (UNLIKELY(!connection))
         return IPC::Error::InvalidConnection;
 
-    auto result = connection->send(std::forward<T>(message), identifier(), RemoteRenderingBackendProxy::defaultTimeout);
+    auto result = connection->send(std::forward<T>(message), identifier());
     if (UNLIKELY(result != IPC::Error::NoError)) {
         RELEASE_LOG(RemoteLayerBuffers, "RemoteImageBufferSetProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             IPC::description(T::name()).characters(), IPC::errorAsString(result).characters());
@@ -135,7 +137,7 @@ ALWAYS_INLINE auto RemoteImageBufferSetProxy::sendSync(T&& message)
     if (UNLIKELY(!connection))
         return IPC::StreamClientConnection::SendSyncResult<T> { IPC::Error::InvalidConnection };
 
-    auto result = connection->sendSync(std::forward<T>(message), identifier(), RemoteRenderingBackendProxy::defaultTimeout);
+    auto result = connection->sendSync(std::forward<T>(message), identifier());
     if (UNLIKELY(!result.succeeded())) {
         RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] Proxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             m_remoteRenderingBackendProxy->renderingBackendIdentifier().toUInt64(), IPC::description(T::name()).characters(), IPC::errorAsString(result.error()).characters());
@@ -250,7 +252,7 @@ std::unique_ptr<ThreadSafeImageBufferSetFlusher> RemoteImageBufferSetProxy::flus
     RefPtr connection = this->connection();
     if (!connection)
         return nullptr;
-    Ref pendingFlush = RemoteImageBufferSetProxyFlushFence::create(m_remoteRenderingBackendProxy->renderingUpdateID());
+    Ref pendingFlush = RemoteImageBufferSetProxyFlushFence::create(m_remoteRenderingBackendProxy->renderingUpdateID(), connection->defaultTimeoutDuration());
     {
         Locker locker { m_lock };
         m_pendingFlush = pendingFlush.ptr();

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -65,16 +65,15 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing());
     }
 
     void requestDevice(const WebCore::WebGPU::DeviceDescriptor&, CompletionHandler<void(RefPtr<WebCore::WebGPU::Device>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -64,16 +64,15 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -61,21 +61,20 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing());
     }
     template<typename T, typename C>
     WARN_UNUSED_RETURN IPC::StreamClientConnection::AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing());
     }
 
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -60,16 +60,15 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing());
     }
 
     RefPtr<WebCore::WebGPU::RenderPassEncoder> beginRenderPass(const WebCore::WebGPU::RenderPassDescriptor&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -78,16 +78,15 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing());
     }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setPipeline(const WebCore::WebGPU::ComputePipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -62,11 +62,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     Ref<WebCore::WebGPU::BindGroupLayout> getBindGroupLayout(uint32_t index) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -67,16 +67,15 @@ private:
     RemoteDeviceProxy& operator=(const RemoteDeviceProxy&) = delete;
     RemoteDeviceProxy& operator=(RemoteDeviceProxy&&) = delete;
 
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T, typename C>
     WARN_UNUSED_RETURN IPC::StreamClientConnection::AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing());
     }
 
     Ref<WebCore::WebGPU::Queue> queue() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -54,7 +54,8 @@ RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(WebGPU::ConvertToBackingContext& c
 RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(WebGPU::ConvertToBackingContext& convertToBackingContext, RemoteRenderingBackendProxy& renderingBackend, SerialFunctionDispatcher& dispatcher)
 {
     constexpr size_t connectionBufferSizeLog2 = 21;
-    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
+    constexpr Seconds defaultTimeoutDuration = 30_s;
+    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2, defaultTimeoutDuration);
     if (!connectionPair)
         return nullptr;
     auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
@@ -129,7 +130,7 @@ void RemoteGPUProxy::waitUntilInitialized()
 {
     if (m_didInitialize)
         return;
-    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGPUProxy::WasCreated>(m_backing, defaultSendTimeout) == IPC::Error::NoError)
+    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGPUProxy::WasCreated>(m_backing) == IPC::Error::NoError)
         return;
     abandonGPUProcess();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -90,16 +90,15 @@ private:
 
     void waitUntilInitialized();
 
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(std::forward<T>(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(std::forward<T>(message), backing());
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(std::forward<T>(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(std::forward<T>(message), backing());
     }
 
     void requestAdapter(const WebCore::WebGPU::RequestAdapterOptions&, CompletionHandler<void(RefPtr<WebCore::WebGPU::Adapter>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -69,11 +69,10 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t) final;
 
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     bool configure(const WebCore::WebGPU::CanvasConfiguration&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void destroy() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -61,16 +61,15 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T, typename C>
     WARN_UNUSED_RETURN IPC::StreamClientConnection::AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing());
     }
 
     void submit(Vector<std::reference_wrapper<WebCore::WebGPU::CommandBuffer>>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setPipeline(const WebCore::WebGPU::RenderPipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setPipeline(const WebCore::WebGPU::RenderPipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -62,11 +62,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     Ref<WebCore::WebGPU::BindGroupLayout> getBindGroupLayout(uint32_t index) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -60,16 +60,15 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
     template<typename T, typename C>
     WARN_UNUSED_RETURN IPC::StreamClientConnection::AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendWithAsyncReply(WTFMove(message), completionHandler, backing());
     }
 
     void compilationInfo(CompletionHandler<void(Ref<WebCore::WebGPU::CompilationInfo>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -63,11 +63,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     RefPtr<WebCore::WebGPU::TextureView> createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -60,11 +60,10 @@ private:
 
     WebGPUIdentifier backing() const { return m_backing; }
     
-    static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
     WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
-        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+        return root().streamClientConnection().send(WTFMove(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -461,6 +461,15 @@ static std::optional<uint64_t> convertToUint64(JSC::JSValue jsValue)
     return std::nullopt;
 }
 
+static std::optional<double> convertToDouble(JSC::JSValue jsValue)
+{
+    if (jsValue.isNumber())
+        return jsValue.asNumber();
+    if (jsValue.isBigInt())
+        return JSC::JSBigInt::toBigUInt64(jsValue);
+    return std::nullopt;
+}
+
 namespace {
 
 struct SyncIPCMessageInfo {
@@ -1074,13 +1083,12 @@ JSValueRef JSIPCStreamClientConnection::setSemaphores(JSContextRef context, JSOb
 struct IPCStreamMessageInfo {
     uint64_t destinationID;
     IPC::MessageName messageName;
-    IPC::Timeout timeout;
 };
 
 static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    if (argumentCount < 3) {
-        *exception = createTypeError(context, "Must specify destination ID, message ID, and timeout as the first three arguments"_s);
+    if (argumentCount < 2) {
+        *exception = createTypeError(context, "Must specify destination ID, message ID as the first two arguments"_s);
         return std::nullopt;
     }
 
@@ -1093,17 +1101,7 @@ static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContext
     if (!messageName)
         return std::nullopt;
 
-    Seconds timeoutDuration;
-    {
-        auto jsValue = toJS(globalObject, arguments[2]);
-        if (!jsValue.isNumber()) {
-            *exception = createTypeError(context, "Timeout must be a number"_s);
-            return std::nullopt;
-        }
-        timeoutDuration = Seconds { jsValue.asNumber() };
-    }
-
-    return { { *destinationID, *messageName, { timeoutDuration } } };
+    return { { *destinationID, *messageName } };
 }
 
 bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(uint64_t destinationID, IPC::Timeout timeout)
@@ -1127,10 +1125,11 @@ JSValueRef JSIPCStreamClientConnection::sendMessage(JSContextRef context, JSObje
     auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
-    auto [destinationID, messageName, timeout] = *info;
+    auto [destinationID, messageName] = *info;
+    auto timeout = jsIPC->m_streamConnection->defaultTimeout();
     if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout))
         return JSValueMakeUndefined(context);
-    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    JSValueRef messageArguments = argumentCount > 2 ? arguments[2] : nullptr;
     return jsSend(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, messageArguments, exception);
 }
 
@@ -1141,21 +1140,21 @@ JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context,
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 5) {
-        *exception = createTypeError(context, "Must specify destination ID, message ID, timeout, messageArguments, callback as the first five arguments"_s);
+    if (argumentCount < 4) {
+        *exception = createTypeError(context, "Must specify destination ID, message ID, messageArguments, callback as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
     auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
-    auto [destinationID, messageName, timeout] = *info;
+    auto [destinationID, messageName] = *info;
     if (!messageReplyArgumentDescriptions(messageName)) {
         *exception = createError(context, "Message does not have a reply"_s);
         return JSValueMakeUndefined(context);
     }
     JSObjectRef callback = nullptr;
-    if (JSValueIsObject(context, arguments[4])) {
-        callback = JSValueToObject(context, arguments[4], exception);
+    if (JSValueIsObject(context, arguments[3])) {
+        callback = JSValueToObject(context, arguments[3], exception);
         if (!JSObjectIsFunction(context, callback))
             callback = nullptr;
     }
@@ -1163,11 +1162,12 @@ JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context,
         *exception = createTypeError(context, "Must specify callback as the fifth argument"_s);
         return JSValueMakeUndefined(context);
     }
+    auto timeout = jsIPC->m_streamConnection->defaultTimeout();
     if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout)) {
         *exception = createError(context, "IPC error: prepare failed"_s);
         return JSValueMakeUndefined(context);
     }
-    return jsSendWithAsyncReply(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, callback, arguments[3], exception);
+    return jsSendWithAsyncReply(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, callback, arguments[2], exception);
 }
 
 JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -1180,12 +1180,13 @@ JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JS
     auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
-    auto [destinationID, messageName, timeout] = *info;
+    auto [destinationID, messageName] = *info;
+    auto timeout = jsIPC->m_streamConnection->defaultTimeout();
     if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout)) {
         *exception = createError(context, "IPC error: prepare failed"_s);
         return JSValueMakeUndefined(context);
     }
-    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    JSValueRef messageArguments = argumentCount > 2 ? arguments[2] : nullptr;
     return jsSendSync(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
@@ -1201,8 +1202,8 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
         return JSValueMakeUndefined(context);
     }
 
-    if (argumentCount < 3) {
-        *exception = createTypeError(context, "Must specify destination ID, value, and timeout as the first three arguments"_s);
+    if (argumentCount < 2) {
+        *exception = createTypeError(context, "Must specify destination ID, value as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
 
@@ -1220,21 +1221,11 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
         value = static_cast<int32_t>(jsValue.asNumber());
     }
 
-    Seconds timeoutDuration;
-    {
-        auto jsValue = toJS(globalObject, arguments[2]);
-        if (!jsValue.isNumber()) {
-            *exception = createTypeError(context, "timeout must be a number"_s);
-            return JSValueMakeUndefined(context);
-        }
-        timeoutDuration = Seconds { jsValue.asNumber() };
-    }
-
     auto& streamConnection = jsStreamConnection->connection();
     enum JSIPCStreamTesterIdentifierType { };
     auto destination = ObjectIdentifier<JSIPCStreamTesterIdentifierType>(*destinationID);
 
-    auto sendResult = streamConnection.sendSync(Messages::IPCStreamTester::SyncCrashOnZero(value), destination, timeoutDuration);
+    auto sendResult = streamConnection.sendSync(Messages::IPCStreamTester::SyncCrashOnZero(value), destination);
     if (!sendResult.succeeded()) {
         *exception = createTypeError(context, "sync send failed"_s);
         return JSValueMakeUndefined(context);
@@ -1255,11 +1246,11 @@ JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSO
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
-    auto [destinationID, messageName, timeout] = *info;
-    return jsWaitForMessage(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, exception);
+    auto [destinationID, messageName] = *info;
+    return jsWaitForMessage(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, jsIPC->m_streamConnection->defaultTimeout(), context, exception);
 }
 
 JSValueRef JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -1269,15 +1260,15 @@ JSValueRef JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately(
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 3) {
-        *exception = createTypeError(context, "Must specify the message name, async reply ID and timeout as the first three arguments"_s);
+    if (argumentCount < 2) {
+        *exception = createTypeError(context, "Must specify the message name, async reply ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
     auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
-    auto [destinationID, messageName, timeout] = *info;
-    return jsWaitForAsyncReplyAndDispatchImmediately(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, exception);
+    auto [destinationID, messageName] = *info;
+    return jsWaitForAsyncReplyAndDispatchImmediately(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, jsIPC->m_streamConnection->defaultTimeout(), context, exception);
 }
 
 JSObjectRef JSIPCStreamConnectionBuffer::createJSWrapper(JSContextRef context)
@@ -2603,7 +2594,13 @@ JSValueRef JSIPC::createStreamClientConnection(JSContextRef context, JSObjectRef
         *exception = createTypeError(context, "Must specify the size"_s);
         return JSValueMakeUndefined(context);
     }
-    auto connectionPair = IPC::StreamClientConnection::create(*bufferSizeLog2);
+    auto defaultTimeoutDuration = argumentCount > 1 ? convertToDouble(toJS(globalObject, arguments[1])) : std::optional<double> { };
+    if (!defaultTimeoutDuration) {
+        *exception = createTypeError(context, "Must specify the defaultTimeoutDuration"_s);
+        return JSValueMakeUndefined(context);
+    }
+
+    auto connectionPair = IPC::StreamClientConnection::create(*bufferSizeLog2, Seconds(*defaultTimeoutDuration));
     if (!connectionPair) {
         *exception = createError(context, "Failed to create the connection"_s);
         return JSValueMakeUndefined(context);

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -40,7 +40,7 @@
 namespace TestWebKitAPI {
 
 namespace {
-static constexpr Seconds defaultSendTimeout = 1_s;
+static constexpr Seconds defaultTimeout = 1_s;
 
 enum TestObjectIdentifierTag { };
 using TestObjectIdentifier = ObjectIdentifier<TestObjectIdentifierTag>;
@@ -224,7 +224,7 @@ public:
 
 TEST_F(StreamConnectionTest, OpenConnections)
 {
-    auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
+    auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2, defaultTimeout);
     ASSERT_TRUE(!!connectionPair);
     auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
     auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
@@ -242,7 +242,7 @@ TEST_F(StreamConnectionTest, OpenConnections)
 
 TEST_F(StreamConnectionTest, InvalidateUnopened)
 {
-    auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
+    auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2, defaultTimeout);
     ASSERT_TRUE(!!connectionPair);
     auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
     auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
@@ -264,7 +264,7 @@ public:
     void SetUp() override
     {
         setupBase();
-        auto connectionPair = IPC::StreamClientConnection::create(bufferSizeLog2());
+        auto connectionPair = IPC::StreamClientConnection::create(bufferSizeLog2(), defaultTimeout);
         ASSERT(!!connectionPair);
         auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
         auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
@@ -320,7 +320,7 @@ TEST_P(StreamMessageTest, Send)
 {
     auto cleanup = localReferenceBarrier();
     for (uint64_t i = 0u; i < 55u; ++i) {
-        auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
+        auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID());
         EXPECT_EQ(result, IPC::Error::NoError);
     }
     serverQueue().dispatch([&] {
@@ -361,10 +361,10 @@ TEST_P(StreamMessageTest, SendWithSwitchingDestinationIDs)
     });
 
     for (uint64_t i = 0u; i < 777u; ++i) {
-        auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
+        auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID());
         EXPECT_EQ(result, IPC::Error::NoError);
         if (i % 77) {
-            result = m_clientConnection->send(MockStreamTestMessage1 { }, other, defaultSendTimeout);
+            result = m_clientConnection->send(MockStreamTestMessage1 { }, other);
             EXPECT_EQ(result, IPC::Error::NoError);
         }
     }
@@ -386,10 +386,10 @@ TEST_P(StreamMessageTest, SendAndInvalidate)
     auto cleanup = localReferenceBarrier();
 
     for (uint64_t i = 0u; i < messageCount; ++i) {
-        auto result = m_clientConnection->send(MockStreamTestMessage2 { IPC::Semaphore { } }, defaultDestinationID(), defaultSendTimeout);
+        auto result = m_clientConnection->send(MockStreamTestMessage2 { IPC::Semaphore { } }, defaultDestinationID());
         EXPECT_EQ(result, IPC::Error::NoError);
     }
-    auto flushResult = m_clientConnection->flushSentMessages(defaultSendTimeout);
+    auto flushResult = m_clientConnection->flushSentMessages();
     EXPECT_EQ(flushResult, IPC::Error::NoError);
     m_clientConnection->invalidate();
 
@@ -408,7 +408,7 @@ TEST_P(StreamMessageTest, SendAsyncReply)
         auto result = m_clientConnection->sendWithAsyncReply(MockStreamTestMessageWithAsyncReply1 { i }, [&, j = i] (uint64_t value) {
             EXPECT_GE(value, 100u) << j;
             replies.add(value);
-        }, defaultDestinationID(), defaultSendTimeout);
+        }, defaultDestinationID());
         EXPECT_TRUE(result.isValid());
     }
     while (replies.size() < 55u)
@@ -440,7 +440,7 @@ TEST_P(StreamMessageTest, SendAsyncReplyCancel)
         auto result = m_clientConnection->sendWithAsyncReply(MockStreamTestMessageWithAsyncReply1 { i }, [&, j = i] (uint64_t value) {
             EXPECT_EQ(value, 0u) << j; // Cancel handler returns 0 for uint64_t.
             replies.add(j);
-        }, defaultDestinationID(), defaultSendTimeout);
+        }, defaultDestinationID());
         EXPECT_TRUE(result.isValid());
     }
     m_clientConnection->invalidate();


### PR DESCRIPTION
#### ba72767578244c0e851b84ef8cccc6c29139870c
<pre>
Stream IPC should have per-connection timeout and not per operation timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=277853">https://bugs.webkit.org/show_bug.cgi?id=277853</a>
<a href="https://rdar.apple.com/problem/133534897">rdar://problem/133534897</a>

Reviewed by Geoffrey Garen.

IPC::StreamClientConnection would have per send timeout. Turns out
per-message send timeout is not useful. There are no distinction between
how much to wait when sending message A vs sending message B.

Same case for per-send timeout vs per-wait timeout. Turns out there
are no practical configurability wrt how much to wait to receive message
vs how much wait to send a message. There are no practical ignorable
wait failures in really correct code -- all wait timeouts are lost
senders.

Move the timeout as a parameter to StreamClientConnection.

Subsequent patches will use the parameter to configure the timeout
in more dynamic fashion. The intention is to be able to start WebKit
so that, for example, GPUP connections do not time out, and thus
GPUP can be debugged.

* LayoutTests/ipc/restrictedendpoints/allow-access-webGPU.html:
* LayoutTests/ipc/restrictedendpoints/deny-access-webGPU.html:
* LayoutTests/ipc/send-filter.html:
* LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html:
* LayoutTests/ipc/send-gradient.html:
* LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html:
* LayoutTests/ipc/stream-async-with-reply.html:
* LayoutTests/ipc/stream-buffer-read-write.html:
* LayoutTests/ipc/stream-check-autoreleasepool.html:
* LayoutTests/ipc/stream-sync-crash-no-timeout.html:
* LayoutTests/ipc/stream-sync-reply-shared-memory.html:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
(IPC::StreamClientConnection::StreamClientConnection):
(IPC::StreamClientConnection::flushSentMessages):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::waitForAndDispatchImmediately):
(IPC::StreamClientConnection::waitForAsyncReplyAndDispatchImmediately):
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::create):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::~RemoteBarcodeDetectorProxy):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::getSupportedFormats):
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::create):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy):
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteTextDetectorProxy::create):
(WebKit::ShapeDetection::RemoteTextDetectorProxy::~RemoteTextDetectorProxy):
(WebKit::ShapeDetection::RemoteTextDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::send):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::create):
(WebKit::RemoteGraphicsContextGLProxy::waitUntilInitialized):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
(WebKit::RemoteGraphicsContextGLProxy::send):
(WebKit::RemoteGraphicsContextGLProxy::sendSync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::send):
(WebKit::RemoteImageBufferProxy::sendSync):
(WebKit::RemoteImageBufferProxy::ensureBackend const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxyFlushFence::create):
(WebKit::RemoteImageBufferSetProxyFlushFence::wait):
(WebKit::RemoteImageBufferSetProxyFlushFence::RemoteImageBufferSetProxyFlushFence):
(WebKit::RemoteImageBufferSetProxy::send):
(WebKit::RemoteImageBufferSetProxy::sendSync):
(WebKit::RemoteImageBufferSetProxy::flushFrontBufferAsync):
(WebKit::RemoteImageBufferSetProxyFlushFence::waitFor): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::ensureGPUProcessConnection):
(WebKit::RemoteRenderingBackendProxy::send):
(WebKit::RemoteRenderingBackendProxy::sendSync):
(WebKit::RemoteRenderingBackendProxy::sendWithAsyncReply):
(WebKit::RemoteRenderingBackendProxy::connection):
(WebKit::Function&lt;bool):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::create):
(WebKit::RemoteGPUProxy::waitUntilInitialized):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::convertToDouble):
(WebKit::IPCTestingAPI::extractIPCStreamMessageInfo):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSIPC::createStreamClientConnection):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/282161@main">https://commits.webkit.org/282161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd762311466c495c8c2fedb205f24b028f736808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13213 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11804 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57805 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5198 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38566 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->