### PR TITLE
[Cocoa] audioTrack.configuration() missing values for WebM files

### DIFF
--- a/LayoutTests/media/track/audio-track-configuration-webm-expected.txt
+++ b/LayoutTests/media/track/audio-track-configuration-webm-expected.txt
@@ -1,0 +1,10 @@
+
+RUN(video.src = "../media-source/content/test-vorbis.webm")
+EVENT(canplay)
+EXPECTED (video.audioTracks.length > '0') OK
+EXPECTED (video.audioTracks[0].configuration != 'null') OK
+EXPECTED (video.audioTracks[0].configuration.codec == 'vorbis') OK
+EXPECTED (video.audioTracks[0].configuration.sampleRate == '44100') OK
+EXPECTED (video.audioTracks[0].configuration.numberOfChannels == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/track/audio-track-configuration-webm.html
+++ b/LayoutTests/media/track/audio-track-configuration-webm.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>video-track-configuration</title>
+	<script src="../video-test.js"></script>
+	<script>
+    window.addEventListener('load', async event => {
+      findMediaElement();
+      const timeout = 100;
+      run('video.src = "../media-source/content/test-vorbis.webm"');
+      await waitFor(video, 'canplay');
+      await testExpectedEventually('video.audioTracks.length', 0, '>', timeout);
+      await testExpectedEventually('video.audioTracks[0].configuration', null, '!=', timeout);
+      await testExpectedEventually('video.audioTracks[0].configuration.codec', 'vorbis', '==', timeout);
+      await testExpectedEventually('video.audioTracks[0].configuration.sampleRate', 44100, '==', timeout);
+      await testExpectedEventually('video.audioTracks[0].configuration.numberOfChannels', 1, '==', timeout);
+      endTest();
+	  });
+	</script>
+</head>
+<body>
+	<video controls muted></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/media/track/audio-track-configuration-webm-expected.txt
+++ b/LayoutTests/platform/glib/media/track/audio-track-configuration-webm-expected.txt
@@ -1,0 +1,10 @@
+
+RUN(video.src = "../media-source/content/test-vorbis.webm")
+EVENT(canplay)
+EXPECTED (video.audioTracks.length > '0') OK
+EXPECTED (video.audioTracks[0].configuration != 'null') OK
+EXPECTED (video.audioTracks[0].configuration.codec == 'vorbis'), OBSERVED '', AFTER TIMEOUT FAIL
+EXPECTED (video.audioTracks[0].configuration.sampleRate == '44100') OK
+EXPECTED (video.audioTracks[0].configuration.numberOfChannels == '1') OK
+END OF TEST
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -259,6 +259,7 @@ webaudio/audiocontext-restriction.html [ Skip ]
 webaudio/suspend-context-while-interrupted.html [ Skip ]
 webaudio/codec-tests/vorbis [ Skip ]
 webaudio/decode-audio-data-webm-vorbis.html [ Failure ]
+media/track/audio-track-configuration-webm.html
 
 # No wheel events on iOS
 fast/events/wheel [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1086,6 +1086,7 @@ media/media-vp8-webm-seek-to-start.html [ Skip ]
 media/media-vp8-webm-with-poster.html [ Skip ]
 media/media-vp8-webm-with-preload.html [ Skip ]
 media/video-src-webm-blob.html [ Failure ]
+media/track/audio-track-configuration-webm.html [ Skip ]
 
 media/track/media-audio-track.html [ Failure ]
 media/media-sources-selection.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -42,6 +42,7 @@ AudioTrackPrivateWebM::AudioTrackPrivateWebM(webm::TrackEntry&& trackEntry)
 {
     if (m_track.is_enabled.is_present())
         setEnabled(m_track.is_enabled.value());
+    updateConfiguration();
 }
 
 TrackID AudioTrackPrivateWebM::id() const


### PR DESCRIPTION
#### 8d1b2782970a45926ad9cbfeecb4eb1b5dff3dc5
<pre>
[Cocoa] audioTrack.configuration() missing values for WebM files
<a href="https://bugs.webkit.org/show_bug.cgi?id=277859">https://bugs.webkit.org/show_bug.cgi?id=277859</a>
&lt;<a href="https://rdar.apple.com/problem/133545263">rdar://problem/133545263</a>&gt;

Reviewed by Eric Carlson.

Ensure the AudioTrackPrivateWebM&apos;s configuration is update upon creation.

* LayoutTests/media/track/audio-track-configuration-webm-expected.txt: Added.
* LayoutTests/media/track/audio-track-configuration-webm.html: Added.
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::AudioTrackPrivateWebM):

Canonical link: <a href="https://commits.webkit.org/282311@main">https://commits.webkit.org/282311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00d5eb7c329cf5a08df7e61bb9980d71eb1a631

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50342 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8977 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11431 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57718 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57914 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5337 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37639 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38724 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->