### PR TITLE
tabs.getSelected does not work for MV2 extensions.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -130,7 +130,7 @@ bool WebExtensionWindow::matches(const WebExtensionTabQueryParameters& parameter
     if (!extensionHasAccess())
         return false;
 
-    if (parameters.windowIdentifier && identifier() != parameters.windowIdentifier.value())
+    if (parameters.windowIdentifier && identifier() != parameters.windowIdentifier.value() && !isCurrent(parameters.windowIdentifier.value()))
         return false;
 
     if (parameters.windowType && !matches(parameters.windowType.value()))
@@ -139,7 +139,7 @@ bool WebExtensionWindow::matches(const WebExtensionTabQueryParameters& parameter
     if (parameters.frontmostWindow && isFrontmost() != parameters.frontmostWindow.value())
         return false;
 
-    if (parameters.currentWindow) {
+    if (parameters.currentWindow || isCurrent(parameters.windowIdentifier)) {
         auto currentWindow = extensionContext()->getWindow(WebExtensionWindowConstants::CurrentIdentifier, webPageProxyIdentifier);
         if (!currentWindow)
             return false;


### PR DESCRIPTION
#### 721d1e7f60f07b37be24a5cc3dcbb12d95ee48b7
<pre>
tabs.getSelected does not work for MV2 extensions.
<a href="https://webkit.org/b/277863">https://webkit.org/b/277863</a>
<a href="https://rdar.apple.com/133546874">rdar://133546874</a>

Reviewed by Brian Weinstein.

The `tabs.query` API included an optimization where `windowId: browser.windows.WINDOW_ID_CURRENT`
was simplified to `currentWindow: true`. However, this optimization occurred only at the parsing
level of the options, not within the UI process. This had an unintended impact on `tabs.getSelected`,
which was only passing the `active` and `windowIdentifier` parameters without the `currentWindow`
flag. As a result, the window identifier match check failed, leading to no results being returned.

To address this, we need a similar check for the current window identifier within the UI process.
This will allow us to correctly follow the current window path when performing window match checks.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::matches const): Check `isCurrent` when using the `windowIdentifier`.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, GetSelected)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, QueryWithCurrentWindow)): Added.

Canonical link: <a href="https://commits.webkit.org/282055@main">https://commits.webkit.org/282055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da848da683643315cba3ded89d25424277a524ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12708 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8598 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38298 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/30693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10839 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56750 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5834 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57485 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4779 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9325 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38129 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->