### PR TITLE
[WebGPU] Validation error inside runClearEncoder

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277864-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277864-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277864.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277864.html
@@ -1,0 +1,22807 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let promise0 = adapter0.requestDevice({
+  label: '\u071b\u0d80\u{1f7d3}\u{1fe37}\u00e8\u31eb\ubfa8\u26ea\u1995\u{1ff3e}\ufa6e',
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxUniformBufferBindingSize: 4102174,
+    maxStorageBufferBindingSize: 161835062,
+    maxSampledTexturesPerShaderStage: 16,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let adapter1 = await navigator.gpu.requestAdapter();
+let device0 = await promise0;
+let commandEncoder0 = device0.createCommandEncoder({label: '\u{1f764}\u4fdd\u0fb1\u0d79\ue70a\u84d4\u04b7\u{1facd}\u0f93\u{1ff8d}\ub8e6'});
+let commandBuffer0 = commandEncoder0.finish({label: '\u{1f8d6}\u{1f6c5}\u99a7\u0221\u0b2f\u07a4\u2d61\uff1c\u32ef\u5228'});
+let imageData0 = new ImageData(48, 92);
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\uc87b\ud597\ue39d\u782d\u0345\ua2f4', entries: []});
+let bindGroup0 = device0.createBindGroup({label: '\uc95c\u2ff1\u0f99\uc24e\u0f82\u{1f786}\ud549\uc50d', layout: bindGroupLayout0, entries: []});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u4828\ucdc4\uf78c\u04ba\u0261\u256b'});
+let sampler0 = device0.createSampler({
+  label: '\u{1fcde}\ub036\u8b15\u0a1b\u6868\u03a7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.782,
+  lodMaxClamp: 68.39,
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u3114\u{1fc6e}\u{1fbf9}\u13b7\u7cc6\u{1ffb7}\u461f'});
+let commandEncoder3 = device0.createCommandEncoder({});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\uf7a9\u2b2c',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder4 = device0.createCommandEncoder();
+let imageBitmap0 = await createImageBitmap(imageData0);
+let commandEncoder5 = device0.createCommandEncoder({});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({label: '\ud5ff\u0efc\u1327\u0e6e\u8806\u53cc', bindGroupLayouts: []});
+let computePassEncoder0 = commandEncoder4.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+window.someLabel = pipelineLayout2.label;
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u035c\u{1f9c7}\u0e94\u{1fd9f}\u052e\u0a2a\u0b1c\u{1ffac}\u{1fc80}\u{1fe81}\u0931',
+  bindGroupLayouts: [],
+});
+let buffer0 = device0.createBuffer({
+  label: '\u5941\u0838\uf34c\u0979\u058f\uef59\u0aef\u56da',
+  size: 38428,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandBuffer1 = commandEncoder2.finish({label: '\u0bf1\u63be'});
+let promise1 = adapter0.requestAdapterInfo();
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0]});
+try {
+buffer0.unmap();
+} catch {}
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer0, 18096, new BigUint64Array(16583), 2986, 32);
+} catch {}
+let bindGroup1 = device0.createBindGroup({label: '\u02a8\ucd1f\u0021', layout: bindGroupLayout0, entries: []});
+let commandBuffer2 = commandEncoder5.finish({label: '\u0feb\u0e0d\u00d3\u0c1a\u9208'});
+try {
+buffer0.unmap();
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0]});
+let commandBuffer3 = commandEncoder3.finish({label: '\u0fb3\u04df\u237d'});
+try {
+device0.queue.submit([commandBuffer0, commandBuffer3]);
+} catch {}
+let imageData1 = new ImageData(12, 40);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u0a79\ue093',
+  entries: [
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder6 = device0.createCommandEncoder();
+let commandBuffer4 = commandEncoder6.finish({label: '\u0353\u34f9\u{1f957}\ub961\u0bf5'});
+try {
+buffer0.destroy();
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({label: '\u029f\u8ce1\u{1fe3e}\u009e\u{1f613}\u456b\u0683'});
+let commandEncoder8 = device0.createCommandEncoder({});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(263, 274);
+let commandBuffer5 = commandEncoder8.finish({label: '\u057b\u6cad\uc511\u01f9'});
+let computePassEncoder2 = commandEncoder7.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let promise2 = adapter1.requestAdapterInfo();
+try {
+device0.queue.submit([commandBuffer2, commandBuffer1]);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u{1fe4b}\u{1f9fe}\ued8c\u{1f9dc}\u9cb5\ue690\u0ff9\u{1f7bc}\ucdfd\u2fa2\u9f42',
+  entries: [
+    {
+      binding: 59,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 317,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 270, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 609,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 590,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 256,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 161,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 319,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 138,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 307,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 142,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 378,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u1782\u{1fc86}\ua75e\udb65\u7352'});
+let commandBuffer6 = commandEncoder9.finish();
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5, commandBuffer6]);
+} catch {}
+let texture0 = device0.createTexture({
+  label: '\u0d28\u0f8d\ucdae\u0be9\uae89\u2594',
+  size: {width: 30, height: 30, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let commandEncoder10 = device0.createCommandEncoder();
+let commandBuffer7 = commandEncoder10.finish();
+let texture1 = device0.createTexture({
+  label: '\u{1fb35}\ua02f\u2a7d\u9c3a\u39fa\u0fae\ub9c9\u{1f931}\u07f1',
+  size: {width: 15},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let commandEncoder11 = device0.createCommandEncoder({label: '\u7105\u1e32\ua727\u{1fff8}\u026c'});
+let texture2 = device0.createTexture({
+  label: '\u0401\u1aae\u9b68\u1240',
+  size: {width: 30, height: 30, depthOrArrayLayers: 77},
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(4), /* required buffer size: 4 */
+{offset: 4, rowsPerImage: 19}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder3 = commandEncoder11.beginComputePass({label: '\u0665\u124a\u0d76\u1b2d\u1940\u{1f84b}'});
+try {
+device0.queue.submit([commandBuffer4, commandBuffer7]);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  label: '\ucc92\u6b2e\u058d\u9cb6\ucb3c\uf94f',
+  size: {width: 60, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 11, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(44_781), /* required buffer size: 44_781 */
+{offset: 88, bytesPerRow: 28, rowsPerImage: 76}, {width: 5, height: 1, depthOrArrayLayers: 22});
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({label: '\ue6b5\u{1fc19}\u0e56\u{1fbd8}\u8c18\u06ab\ud9a3\u{1fc37}\u03fb\uc4b5\u0cb6'});
+let commandEncoder14 = device0.createCommandEncoder({label: '\uf5d5\u4ebf\u0496\u{1fbe8}\u5711\u08c0\u3787\u93b7\u0a4d\u3365'});
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 10 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2345 */
+  offset: 2345,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 10, height: 39, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer8 = commandEncoder13.finish({label: '\u55f6\u81e0\u{1fe02}\ue5e3\u{1fdb0}'});
+let sampler1 = device0.createSampler({
+  label: '\u{1fc9d}\u0ee6\uae16\u7755\u4815\u1d76\ufbdb\u8bd4\ud661',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 4.338,
+  lodMaxClamp: 49.97,
+});
+let commandBuffer9 = commandEncoder14.finish({label: '\u21af\u0656\u0fc7\u0587\u0f37\u435f\u06df\u3810'});
+let computePassEncoder4 = commandEncoder12.beginComputePass({label: '\u821e\u371a\u3281\u0ff6\u{1fd7d}'});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(381), 21, 0);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u{1f7e3}\uc089\u090c\u0eea\u0ca6\ue383\u053d\u3952\u5208',
+  entries: [
+    {
+      binding: 66,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 98,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(338), 178, 0);
+} catch {}
+let texture4 = gpuCanvasContext0.getCurrentTexture();
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+}, new ArrayBuffer(32_162), /* required buffer size: 32_162 */
+{offset: 50, bytesPerRow: 77, rowsPerImage: 52}, {width: 3, height: 2, depthOrArrayLayers: 9});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder();
+let texture5 = device0.createTexture({
+  label: '\u0163\uf9c7\u01dc\u0f87\u5e49\ucd86\u0391\u0d02\ud3e4',
+  size: [7, 7, 17],
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+  await promise2;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({label: '\u{1fbe0}\u27fc\u0156\u{1fca1}\u04c9'});
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u0e08\ud6d2\u{1f93f}\u50d3\u354e\uf9a6\udb9e\ubca2\u96a4\u0ff0\u08f5',
+  entries: [
+    {binding: 150, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 174,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u666e\u{1f8d3}\ue24b'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\uecf2\u{1f8b9}\u{1fb4d}\u321b',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  stencilReadOnly: true,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1fba1}\uf3ca\u2502\u6425'});
+try {
+sampler1.label = '\u89f1\u{1fd9d}\u428b\u0689\u{1f854}\u480c\u66eb\u9c12\u301a';
+} catch {}
+let buffer1 = device0.createBuffer({
+  label: '\uef03\uce42\u7f3e\u078f\u06e2\ufe20\u{1ff71}\u3d84\ud09c\udcd3\uec43',
+  size: 8732,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\ub1c6\u0216'});
+let commandBuffer10 = commandEncoder18.finish({label: '\u4769\u{1f9fe}\uee91\u0ba1\u0e24\u{1f702}'});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1fad6}\u0cf4\u0326\u4a22\u2166\u494f\u{1fbf0}'});
+let promise3 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u{1ff07}\ud537\ubfd5\u{1f622}',
+  entries: [
+    {
+      binding: 344,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\ucc6a\u0f31\u022a\u8013'});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({label: '\ue8dd\uc6ab\u6ba6'});
+let commandBuffer11 = commandEncoder16.finish({label: '\u07b5\uf072\u{1ffed}\u6049\u{1fbf1}\u{1fbeb}\u{1fdb5}\u8ea5\u1808\u853b\ufc80'});
+let computePassEncoder5 = commandEncoder15.beginComputePass({});
+let renderBundle3 = renderBundleEncoder0.finish({label: '\ub8f1\u{1f6f4}\u3133\u{1ffbc}'});
+let commandBuffer12 = commandEncoder7.finish({});
+let computePassEncoder6 = commandEncoder19.beginComputePass({label: '\u{1fa7b}\u98e6\u6858\u3ad7\u{1f9a5}'});
+let computePassEncoder7 = commandEncoder17.beginComputePass({label: '\u{1f8f3}\u6bf8\u01ee\uaf87'});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(163), 16, 0);
+} catch {}
+try {
+adapter0.label = '\u092e\ua3e0\u{1fd4f}\u{1fdd0}\u03f8\ubd60';
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\ufc6e\uc178\u45fd\u08ba\ufe0c\u0d46\u1a02\ufc17\u{1ff82}',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let commandEncoder20 = device0.createCommandEncoder({label: '\u1056\u00cc\ue995\uf10a\u0a6c\u{1f8af}\u57e6\u09a8\u0670'});
+let commandBuffer13 = commandEncoder20.finish();
+let textureView0 = texture5.createView({label: '\u0afa\u9488\u0dd6\u54c9', dimension: '2d', aspect: 'depth-only'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u76da\u0160',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler2 = device0.createSampler({
+  label: '\u079f\uaa95',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 72.29,
+  lodMaxClamp: 73.33,
+  compare: 'always',
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u0d70\uf265\u{1fe4f}\u{1fa24}\uc1d7\ubc4e\ud8b2\ua6fc\u{1fe97}\u0703',
+  entries: [
+    {
+      binding: 13,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 368,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 30, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 115, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 51, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 532,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 416,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 302,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 484,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 26, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 387,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 185,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 36,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 195,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 60, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 90,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 125, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 360,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 4051156, hasDynamicOffset: false },
+    },
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 221,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 199,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 161,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 182, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 118, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 453,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 291,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 23633530, hasDynamicOffset: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 380,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 236,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 13853124, hasDynamicOffset: false },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 93, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 130, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 616,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 194, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 167, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 69, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 242, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 271,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 343545, hasDynamicOffset: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 8, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 20, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 109, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {binding: 21, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 139,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 233011, hasDynamicOffset: false },
+    },
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 226, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 105, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 175, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 25, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 28, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let textureView1 = texture2.createView({label: '\u0ff7\u2ff7', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 19});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u042a\u0625\u0b33\u857b\u928f\ud3dc\u487a\u{1f736}\u{1fc89}\u{1f7f3}',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 320, 7_806);
+} catch {}
+let video0 = await videoWithData();
+let renderBundle4 = renderBundleEncoder2.finish({label: '\u52db\uaa06\u94b3\u231a\u3c5e'});
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 2_364, 22_403);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u0c0f\ucdac\u{1fc3a}\ue5fa\u3f9c\u0b7e\u5102', bindGroupLayouts: [bindGroupLayout4]});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 3_268, 2_796);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(0, undefined, 279_341_873, 508_276_224);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+await gc();
+let commandEncoder21 = device0.createCommandEncoder({label: '\u08c9\u01fa\ua104'});
+let commandBuffer14 = commandEncoder21.finish({label: '\u8032\u{1fd99}\ud620\u{1fb58}\u5d29\u0812'});
+let renderBundle5 = renderBundleEncoder1.finish({});
+try {
+device0.queue.submit([commandBuffer10, commandBuffer8]);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let querySet0 = device0.createQuerySet({
+  label: '\u01da\ue5b2\u{1fca3}\u097a\ufa2b\u3d76\u{1ff68}\ua8e3\u49bf\u443c',
+  type: 'occlusion',
+  count: 2843,
+});
+let renderBundle6 = renderBundleEncoder0.finish({label: '\u8887\u1479\u0065'});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup2, new Uint32Array(864), 125, 0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer1, 492, buffer0, 1104, 1804);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(querySet0, 243, 450, buffer1, 2048);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder();
+let commandBuffer15 = commandEncoder1.finish({});
+try {
+device0.queue.submit([commandBuffer11, commandBuffer14, commandBuffer12]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\uf7d6\u042a\ue0f8\u7cc9\ud2a0'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u8e5c\u0500\ue0e1\u{1fdf0}\u31d8\uc74d\u8852\u0c1b\u2dbc\u09e1\u9bc0',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer1, 'uint16', 2_520, 228);
+} catch {}
+let computePassEncoder8 = commandEncoder23.beginComputePass({label: '\u0f44\u908c\u0116\u0b91\ufa02\u3702\u2e82\u2be8\u{1f76e}\ub247'});
+let renderBundle7 = renderBundleEncoder1.finish({label: '\u2132\u{1fdeb}\u0d22\u03b6\u03e2\u5d04\ua1a8\u09ed\ua37c\ub64a\uc696'});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 1_312, 8_870);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder();
+let querySet1 = device0.createQuerySet({label: '\u621d\uf2e3\u{1f6f5}\u07fa\uf705', type: 'occlusion', count: 1303});
+let texture6 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 28152 */
+  offset: 3576,
+  bytesPerRow: 256,
+  rowsPerImage: 48,
+  buffer: buffer0,
+}, {width: 7, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\uca2a');
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 3_680, 6_628);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(24_787), /* required buffer size: 24_787 */
+{offset: 31, bytesPerRow: 73, rowsPerImage: 28}, {width: 9, height: 4, depthOrArrayLayers: 13});
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1, bindGroupLayout2]});
+let commandBuffer16 = commandEncoder22.finish({label: '\ud093\u{1f985}\u{1fdbf}'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(364), 2, 0);
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer1, 3392, 184);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder();
+let commandBuffer17 = commandEncoder24.finish();
+try {
+computePassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(534), 12, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(0, undefined, 0, 333_816_963);
+} catch {}
+document.body.prepend(video0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageBitmap1 = await createImageBitmap(imageData1);
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+
+struct T0 {
+  f0: atomic<u32>,
+}
+struct T1 {
+  f0: array<mat2x4f>,
+}
+
+@group(0) @binding(150) var et0: texture_external;
+@group(0) @binding(174) var<storage, read_write> buffer2: array<mat4x2f>;
+@group(0) @binding(157) var tex0: texture_cube<i32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+struct S0 {
+  @location(8) @interpolate(flat, centroid) f0: vec3i
+}
+struct VertexOutput0 {
+  @location(5) f0: vec4f,
+  @builtin(position) f1: vec4f,
+  @location(1) @interpolate(perspective, centroid) f2: vec2f,
+  @location(8) @interpolate(perspective, sample) f3: vec3h,
+  @location(3) f4: vec2u
+}
+
+@vertex
+fn vertex0(a0: S0) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureDimensions(et0);
+  if bool(textureDimensions(et0)[1]) {
+    out.f3 = vec3h(-49415.7);
+  }
+  out.f4 = textureDimensions(et0);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(7) @interpolate(flat, centroid) f1: vec3i,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec4f
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec2f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let textureView2 = texture1.createView({label: '\u{1fed5}\u{1feed}\u{1ff56}\u14c3\u5c25\u{1f91b}\u5f96', format: 'r8unorm', baseArrayLayer: 0});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u0ee5\u5dd9\u3338\u00f1\u6b7a\u0b38\u0601\u502f\u{1fe99}'});
+try {
+renderBundleEncoder3.setVertexBuffer(2, undefined, 0, 268_916_138);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer0, 1788, buffer1, 5452, 1216);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9094 */
+  offset: 378,
+  bytesPerRow: 256,
+  rowsPerImage: 28,
+  buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 20},
+  aspect: 'all',
+}, {width: 12, height: 7, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let commandBuffer18 = commandEncoder26.finish({label: '\u86d0\u{1fbf0}\u0330\u94a4\u3d6e\u17d2'});
+let renderBundle8 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 5_540, 7_026);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker('\u0765');
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 522});
+let textureView3 = texture1.createView({label: '\uea4b\uc064'});
+let renderBundle9 = renderBundleEncoder0.finish({label: '\ua529\uacb9\u553f\u844e\u1c4e\uad19\u{1fc00}\u{1fb65}\ube75\u48cc\u6aef'});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 14_170, 260);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4_294_967_295, undefined, 869_070_320, 190_164_030);
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({label: '\u{1ffec}\u0c91\u{1fbe7}\ub93d'});
+let commandBuffer19 = commandEncoder25.finish({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(2563), 428, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 256, new Int16Array(56));
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder();
+let textureView4 = texture0.createView({label: '\ue41d\u{1fb55}\u0622', mipLevelCount: 1});
+let externalTexture0 = device0.importExternalTexture({label: '\u3e5e\ucae9', source: video0});
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4_294_967_295, undefined, 667_428_832, 378_678_830);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let computePassEncoder9 = commandEncoder28.beginComputePass({label: '\u{1f77e}\u0a7d\u0881'});
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup2, new Uint32Array(449), 8, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, undefined, 0, 666_425_385);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 292 */
+  offset: 292,
+  buffer: buffer0,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer1, 'uint32', 2_244, 1_345);
+} catch {}
+let commandBuffer20 = commandEncoder27.finish();
+try {
+computePassEncoder6.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(3, bindGroup2, new Uint32Array(11), 7, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 5_268, 153);
+} catch {}
+try {
+adapter1.label = '\ue167\u00c6\u{1fd94}';
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({label: '\u0681\u7f09\ua542\uf84d'});
+let texture7 = device0.createTexture({
+  label: '\u{1fe8b}\u323d\u972e\u0edb\u0a29\ued15\u3531\u7107\u04dc\u8efa',
+  size: [15],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView5 = texture3.createView({
+  label: '\u{1fd79}\u0354\u9fb2\u021b\udeae\u{1f60b}\u060e\ufc4e',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 5_964, 1_704);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 572, new BigUint64Array(8748), 755, 72);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise4 = adapter0.requestAdapterInfo();
+let sampler3 = device0.createSampler({
+  label: '\u{1f957}\u51e3\u{1fae0}',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 90.57,
+});
+let externalTexture1 = device0.importExternalTexture({label: '\ue3ad\u02bc\u03a6\u51c7\u{1ffb7}\u0240', source: video0, colorSpace: 'srgb'});
+let commandEncoder30 = device0.createCommandEncoder({});
+let commandBuffer21 = commandEncoder30.finish({label: '\u1b3f\ue514\ufde1\uef0a\u3bc0\ue7ba\ufc37\u0896\u0814'});
+let computePassEncoder10 = commandEncoder29.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 9_428, 822);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(229), /* required buffer size: 229 */
+{offset: 229}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle10 = renderBundleEncoder1.finish({label: '\u{1f901}\uf55a\u0710\u{1fe55}\u{1fd68}'});
+try {
+renderBundleEncoder3.setVertexBuffer(4_294_967_294, undefined, 133_730_025, 1_300_283_355);
+} catch {}
+let imageData2 = new ImageData(36, 24);
+try {
+device0.queue.writeBuffer(buffer1, 1076, new Float32Array(5551), 14, 364);
+} catch {}
+let texture8 = device0.createTexture({
+  label: '\u09f2\u001c',
+  size: [60, 60, 18],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder7.pushDebugGroup('\ue72e');
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u{1f896}\u0a24\u0d05\u8ba9\u5314\u08a3\u0ddb\u2e07',
+  entries: [{binding: 24, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }}],
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u3197\u0e5a\u82fe\u0f38\u1f9d'});
+let commandBuffer22 = commandEncoder31.finish({label: '\u035d\u{1fdbb}\u3f88\u0a3a'});
+let texture9 = device0.createTexture({
+  label: '\u{1fb9e}\ude9d\u06b1\u656c\u0994\u2bd7\u7738\ud650',
+  size: [60, 60, 12],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f697}\u0d76\u{1f7fe}\u{1f7c8}\u39e6\u{1f7a4}\u{1ffa0}\u{1f6cc}\u5945\u{1fa87}',
+  colorFormats: ['r32sint'],
+});
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4_294_967_295, undefined, 276_423_126, 96_797_307);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 2412, new DataView(new ArrayBuffer(13156)), 316, 996);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\ud455\u04cf\u7cb0\u0081\u0b15\u027a',
+  entries: [
+    {
+      binding: 299,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 142, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 239, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 610,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 117,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 17, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 63,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 154, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 170,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 286, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 233,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 12, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 646,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 40, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 42,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 205, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 281, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 379,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 190,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 46,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 238, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 109, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {binding: 71, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 502, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 717,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 212,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 265,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 97, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 231, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 11,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 74,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 578,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 111, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 339, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 245, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 399,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 556,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 555, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 18,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 81,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 274, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 125, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 184, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 101, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 112,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 158, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 249, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 92,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 335,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 901589, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView6 = texture3.createView({
+  label: '\u{1f6d3}\u0fb4\ub81c\u{1f6e2}\ubf38\u4503\u261d',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+try {
+buffer1.unmap();
+} catch {}
+let promise5 = adapter1.requestAdapterInfo();
+let texture10 = device0.createTexture({
+  label: '\u5a86\u0c9a',
+  size: {width: 7},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView7 = texture0.createView({label: '\u349a\u{1fc7c}\ufcf3\u{1ff9f}', arrayLayerCount: 1});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 4_958, 2_117);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\u21df\u8795\u9d1d\u0128\u3a4f'});
+let textureView8 = texture10.createView({label: '\u526d\ubc5b', baseArrayLayer: 0});
+let renderBundle11 = renderBundleEncoder2.finish({label: '\u37d0\u{1f7e1}\u{1f9c4}\u{1f600}\u8103\u69d3\u0bc2\u{1f719}\u{1f777}\u768a\u{1fa7d}'});
+let externalTexture2 = device0.importExternalTexture({label: '\u84b4\u1f36\ua6c4\u{1fa7f}\ud5b3\u{1ff42}\u1049', source: video0, colorSpace: 'srgb'});
+let renderBundle12 = renderBundleEncoder3.finish({label: '\u{1fdb3}\u0217\u{1fc7a}\ua94a\u{1f7ed}\u3a91\u0599\u0284\u0e2a\u{1fd79}'});
+let externalTexture3 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+let computePassEncoder11 = commandEncoder32.beginComputePass();
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({});
+let commandBuffer23 = commandEncoder33.finish({});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup1, new Uint32Array(1713), 274, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 1_570, 2_212);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 6612, new Float32Array(1048), 6, 232);
+} catch {}
+let img0 = await imageWithData(91, 21, '#10101010', '#20202020');
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(7, undefined, 0, 101_428_369);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture11 = device0.createTexture({
+  label: '\u08c4\ue5ce\u{1fa9a}',
+  size: [60, 60, 14],
+  mipLevelCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth16unorm'],
+});
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\u6f09\u4145\u{1fe64}\uc33d\uffaf\u6613\u{1fc08}\u06ce',
+  size: 29909,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture12 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder5.setBindGroup(2, bindGroup1, new Uint32Array(367), 17, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(7, buffer3, 2_424, 1_904);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21, commandBuffer16]);
+} catch {}
+let textureView9 = texture9.createView({
+  label: '\u{1fb1b}\u{1f746}\u7378\ue8a5\u67f6',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+  arrayLayerCount: 8,
+});
+let renderBundle13 = renderBundleEncoder1.finish();
+try {
+computePassEncoder11.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup0, new Uint32Array(4856), 81, 0);
+} catch {}
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u0190\u0854\ud827\u65bc\u{1fb0e}\u{1fb3e}\u57b4\uf29d\u{1f7ef}\u4a65',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer1, 'uint16', 890, 266);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(1, buffer3, 0, 2_953);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u{1fa7b}\u8e64\uab0b\u{1fedc}\ucf5e\ua750',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout3],
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\ufa29\ue798'});
+let commandBuffer24 = commandEncoder34.finish({label: '\ue6f1\u6df0\u2c7c\u34c3\u8e9e'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer3, 'uint32', 9_320, 8_608);
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker('\u{1fe00}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1112, new DataView(new ArrayBuffer(11584)), 4952);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u262e\uccdb\u0471\u0866\u1fa5\u2a2f\u0411\uaa78\u014e', bindGroupLayouts: []});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup1, new Uint32Array(10000), 542, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer0, 'uint32', 8_436, 1_468);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup2, new Uint32Array(172), 50, 0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(0, undefined, 301_257_898, 858_163_854);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\uece2\ue105\u5778\u0473\ud7ff\uef08\u90ca'});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer3, 'uint16', 5_770, 4_136);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer22]);
+} catch {}
+let querySet3 = device0.createQuerySet({label: '\ub73e\u7936\uf7cc\uc7f3\u{1f8fc}', type: 'occlusion', count: 290});
+let commandBuffer25 = commandEncoder35.finish({});
+let renderBundle14 = renderBundleEncoder0.finish({label: '\u8d56\u01f3'});
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer3, 0, 842);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 2716, new BigUint64Array(4378), 772, 360);
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u053e\u4436\u0026\u{1f7a7}', bindGroupLayouts: [bindGroupLayout6]});
+let renderBundle15 = renderBundleEncoder5.finish({label: '\u0736\uba50\u{1f67a}\u68f6\u39ed\ud607\u{1f725}\u{1fb03}\u0c04'});
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer23]);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup2, new Uint32Array(2408), 122, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer3, 'uint32', 344, 6_303);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise6;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let externalTexture4 = device0.importExternalTexture({label: '\u80ef\u6e53\uf888\u0c22\u0eae\u861b\u9048', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup1, new Uint32Array(2185), 367, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+adapter0.label = '\u84e6\u4b18\u240c\u20a6\uc5e8\u308a\u5adb\u2f6c\u7920\u0f4b';
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(0, buffer3, 0);
+} catch {}
+let textureView10 = texture8.createView({
+  label: '\u077b\u{1f9b8}\u0719\u4aeb\u5105\u{1fa92}\u3498\u04f6\u{1fc1f}\u{1fa2d}',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 1,
+});
+let canvas0 = document.createElement('canvas');
+let commandEncoder36 = device0.createCommandEncoder();
+let commandBuffer26 = commandEncoder36.finish({label: '\u8494\u061f'});
+let renderBundle16 = renderBundleEncoder5.finish();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(978), 179, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint16', 2_982, 207);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer3);
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+let querySet4 = device0.createQuerySet({
+  label: '\u9796\u{1fa05}\u9268\ud3b2\u6be3\u{1fca6}\udb2b\u0845\u97b9\u0225\u0ed3',
+  type: 'occlusion',
+  count: 412,
+});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(257), /* required buffer size: 257 */
+{offset: 257, rowsPerImage: 63}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({label: '\u0261\u{1f884}\ue2c8\ud99c', colorFormats: ['r8unorm'], depthStencilFormat: 'depth16unorm'});
+let renderBundle17 = renderBundleEncoder6.finish({label: '\u89ed\uc0b1\u50f5\u{1fb04}\u{1fb71}\u0d97'});
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer3, 0, 1_807);
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\u{1fc47}\u{1f9db}\ud0c9\u0419\u0e2e\u{1fdc3}\ub7de\u0821\uc784',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout2],
+});
+let commandEncoder37 = device0.createCommandEncoder();
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 304, 956);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let commandBuffer27 = commandEncoder37.finish({label: '\u68c1\u25fb\u3748\ua0f1\u0851\ube41\u6c1d\u6964\u0f09\ucecb'});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 11_868, 2_027);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer3, 10_532, 369);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let querySet5 = device0.createQuerySet({label: '\u965f\u09f9\u04e9\u0eb9', type: 'occlusion', count: 1627});
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup2, new Uint32Array(1991), 410, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer3, 'uint16', 2_790, 2_577);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let bindGroup3 = device0.createBindGroup({
+  label: '\u1b43\ue313\ud270\u{1f929}\u038d\u0878\ucf1e',
+  layout: bindGroupLayout7,
+  entries: [{binding: 24, resource: sampler1}],
+});
+let commandEncoder38 = device0.createCommandEncoder({label: '\ud2f2\u623f\u{1f8b8}\u{1fd28}\u4090\u{1f8f0}\u46cf'});
+let computePassEncoder12 = commandEncoder38.beginComputePass({label: '\u4f99\u95ad\u{1fc37}\u0f07\u086e'});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(querySet2, 6, 66, buffer3, 2304);
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({label: '\u6d36\u83df', bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0]});
+let buffer4 = device0.createBuffer({
+  label: '\u35f0\u0c59\u076e\u9c27\u{1fe60}\u0984',
+  size: 22704,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let computePassEncoder13 = commandEncoder32.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2);
+} catch {}
+document.body.prepend(canvas0);
+let promise7 = adapter1.requestAdapterInfo();
+let commandEncoder39 = device0.createCommandEncoder({label: '\u0db0\u53b5\u2b63\u1c69\u{1fb04}\u647a\ue2dd\ucc02'});
+let textureView11 = texture11.createView({dimension: 'cube', baseMipLevel: 3});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 64, 570);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer1, 228, buffer4, 7412, 240);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer28 = commandEncoder39.finish({});
+let renderBundle18 = renderBundleEncoder0.finish({label: '\u0f9f\u2a70'});
+try {
+device0.queue.writeBuffer(buffer1, 516, new BigUint64Array(17224), 4877, 80);
+} catch {}
+let externalTexture5 = device0.importExternalTexture({label: '\ua4db\u0368\u{1fc91}\u{1fb70}\u093c\u0b8d\u89b7\u6180', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2716 */
+  offset: 2716,
+  buffer: buffer1,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+canvas0.height = 1138;
+let commandEncoder40 = device0.createCommandEncoder({});
+let commandBuffer29 = commandEncoder29.finish({label: '\ucf35\ufa47\u038d\u0a0f'});
+let renderBundle19 = renderBundleEncoder0.finish({label: '\u57e9\u24c0\u11af\u31f8\u{1f71d}\u03be\u0cc3'});
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer3, 5_604);
+} catch {}
+let arrayBuffer0 = buffer4.getMappedRange(5344);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({});
+let commandBuffer30 = commandEncoder41.finish({label: '\ua4ee\u0a70\u{1f73d}\u{1fcd7}\u0f10\u1204\u407e\u0914'});
+let renderBundle20 = renderBundleEncoder4.finish();
+try {
+computePassEncoder13.setBindGroup(3, bindGroup2, new Uint32Array(371), 85, 0);
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder();
+let commandBuffer31 = commandEncoder42.finish({label: '\uc923\u97c3\u{1fad6}\u{1fb5b}\u3ee7'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup2, new Uint32Array(4920), 299, 0);
+} catch {}
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 334 */
+  offset: 334,
+  buffer: buffer1,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet6 = device0.createQuerySet({label: '\u513b\u613f\u9f01', type: 'occlusion', count: 627});
+let commandBuffer32 = commandEncoder40.finish();
+let textureView12 = texture11.createView({
+  label: '\u510c\u00c3\u0d93\u{1fdda}\u6fd5\u00fb\u{1f9c6}\u038b\u086e',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+let renderBundle21 = renderBundleEncoder6.finish({label: '\u033f\u{1f92c}\u8d43\u7bf8\u2d7d\u{1f863}\ufa25\ufa37\u0733\u{1fdf2}\u4773'});
+try {
+buffer3.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let renderBundle22 = renderBundleEncoder4.finish({label: '\u054b\u386e\u15e3\ue299\u5f94\u85a0\u8ae9\u0c02\u061d\uf35d'});
+let commandEncoder43 = device0.createCommandEncoder({});
+let textureView13 = texture11.createView({
+  label: '\ufdb1\u0693\u{1fb16}\u00ec\ufb14\u58be\ue3ae\u9040',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({
+  label: '\u09e6\ub1ab\u6a64\ud478\u917a\ucb39\u{1ff88}\u0f07\u2c29\u{1fe02}\u0f61',
+  bindGroupLayouts: [],
+});
+document.body.prepend(canvas0);
+let commandEncoder44 = device0.createCommandEncoder({label: '\u35c3\ufb33\u3268\uc07f'});
+let renderBundle23 = renderBundleEncoder0.finish({});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u{1ffc4}\u2102\u0112\uf405\u9169\u{1f91c}\u5367\ua938\u{1f8ca}\u4109',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+device0.queue.submit([commandBuffer30, commandBuffer26, commandBuffer25]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u5ee0\u7ac2\u03e7\u{1fe2c}\u0d3e\u{1fedd}\ufbc4'});
+let commandBuffer33 = commandEncoder44.finish({label: '\uad32\u0d77\uca6d\uc3c1\uce56'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video1 = await videoWithData();
+let commandBuffer34 = commandEncoder45.finish({label: '\u6af6\u3286\u7e2b\u3eae'});
+let texture13 = device0.createTexture({
+  label: '\u880a\u{1fe77}\u64bd\u2bba\u3774\u0729\udffd\u069a\u0ec4\u090b\u0383',
+  size: {width: 60, height: 60, depthOrArrayLayers: 380},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup0, new Uint32Array(96), 12, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer34]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 212, new Int16Array(15054), 3679, 840);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let promise8 = navigator.gpu.requestAdapter({});
+try {
+commandEncoder43.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12088 */
+  offset: 5432,
+  bytesPerRow: 256,
+  rowsPerImage: 26,
+  buffer: buffer0,
+}, {width: 7, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.submit([commandBuffer24, commandBuffer32, commandBuffer31]);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder46 = device0.createCommandEncoder({label: '\u7330\u0a79\u0220\u199e\u51db\u6aa8\udcd1\u09e3'});
+let commandBuffer35 = commandEncoder46.finish();
+let texture14 = device0.createTexture({
+  label: '\u{1ff48}\u22f4\u3948\u5ae2\u5d8f\u74a0\ua92d\u{1fb25}',
+  size: [30, 30, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler4 = device0.createSampler({
+  label: '\u{1f938}\ud784',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 11.35,
+  lodMaxClamp: 51.36,
+  compare: 'less',
+});
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'depth-only',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise10 = navigator.gpu.requestAdapter({});
+let commandBuffer36 = commandEncoder43.finish({label: '\u{1fdec}\ud2d3\u{1fcfe}\udbd3\u{1ff38}\u049b\u3a2b\u9c13\u{1fd36}\uce13'});
+let arrayBuffer1 = buffer4.getMappedRange(0, 3628);
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 48 */
+{offset: 48}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let adapter2 = await promise8;
+let imageData3 = new ImageData(256, 4);
+let texture15 = device0.createTexture({
+  size: {width: 30, height: 30, depthOrArrayLayers: 190},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle24 = renderBundleEncoder2.finish({label: '\u0a45\u{1f637}\u4a32'});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+let arrayBuffer2 = buffer4.getMappedRange(4344, 8);
+try {
+device0.queue.writeBuffer(buffer1, 2944, new Int16Array(15595), 1973, 576);
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+  label: '\u0b5a\u01ae\u{1f7f1}\u06f1',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, constants: {}},
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r32sint']});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 944, 13_309);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer3, 0, 2_048);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer29]);
+} catch {}
+let imageData4 = new ImageData(72, 36);
+let commandEncoder47 = device0.createCommandEncoder();
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+window.someLabel = commandEncoder11.label;
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer1);
+} catch {}
+try {
+commandEncoder47.insertDebugMarker('\u{1f84a}');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 34, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(159), /* required buffer size: 159 */
+{offset: 159, bytesPerRow: 165}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video0);
+let commandEncoder48 = device0.createCommandEncoder({label: '\uea21\u2d34\u{1f82e}'});
+let computePassEncoder14 = commandEncoder47.beginComputePass({label: '\u{1f85b}\u{1fb9a}\u66a0\u05bf\u086b\u0cf6'});
+let renderBundle25 = renderBundleEncoder1.finish({label: '\uadd9\u0b10\u72a8\uf2fe\u{1fd18}\u29ac\u096f'});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 3_064, 1_918);
+} catch {}
+let commandBuffer37 = commandEncoder48.finish({});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint32', 3_252, 1_409);
+} catch {}
+let externalTexture7 = device0.importExternalTexture({label: '\u5757\u0ec6', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup3, new Uint32Array(2289), 971, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1112, new Float32Array(24800), 199, 308);
+} catch {}
+try {
+device0.queue.submit([commandBuffer33, commandBuffer35, commandBuffer27]);
+} catch {}
+let renderBundle26 = renderBundleEncoder4.finish({label: '\u014c\u21cc\u{1fa07}\u{1ff88}\u{1f6b0}\u8851\ucf6a\uadf8\u809a\uf977\u01d8'});
+let sampler5 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 80.29,
+  lodMaxClamp: 87.57,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+let externalTexture8 = device0.importExternalTexture({label: '\u3849\ud074\ua203\u0843', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint32', 4_768, 348);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1276, new BigUint64Array(5164), 202, 60);
+} catch {}
+try {
+adapter0.label = '\u88c9\u00b6';
+} catch {}
+let commandBuffer38 = commandEncoder4.finish({label: '\u{1f7ba}\u78d8\uf1e5\uc6fd\u6ed0\ue410\uf754\u{1fbfb}\uc4b6\u0484\u09a3'});
+let renderBundle27 = renderBundleEncoder1.finish({label: '\ue524\u{1f9b7}\u4e29\u{1fb70}\ucd0c'});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup1, new Uint32Array(3226), 235, 0);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup3, new Uint32Array(6), 1, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint16', 166, 294);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer4, 1_460, 3_118);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 28, new DataView(new ArrayBuffer(2756)), 26, 580);
+} catch {}
+let commandBuffer39 = commandEncoder28.finish({label: '\u095a\u{1fc8b}\u{1ff6e}\u0faf\u4a2d\u0945'});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint16', 780, 339);
+} catch {}
+let renderBundle28 = renderBundleEncoder0.finish({label: '\u8972\uf7b4\u{1f71b}\u{1fef4}'});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+let renderBundle29 = renderBundleEncoder1.finish({label: '\u0983\u089a\u0120\u002d'});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 5_516, 7_280);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+computePassEncoder3.setBindGroup(2, bindGroup2, new Uint32Array(144), 34, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+let texture16 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandBuffer29.label = '\u1c92\u21ea\u6936\ud2cd\u1f47';
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({label: '\ud107\u{1f97b}\uf621\u0e52'});
+let computePassEncoder15 = commandEncoder49.beginComputePass({label: '\u{1fce3}\u72f3\u{1fd39}\u0dfe\ua27e\u06e0\u2fc8\u4fb3'});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint16', 2_590, 1_154);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer4, 4588, buffer0, 8124, 1640);
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer4);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let pipelineLayout14 = device0.createPipelineLayout({label: '\uc7e5\u044f', bindGroupLayouts: [bindGroupLayout6]});
+let commandEncoder50 = device0.createCommandEncoder({label: '\ufc50\u272a\u0806\u{1fff5}\u0e8f\uee01\u09e6\u0610\u{1f7b1}\u{1fdb0}'});
+let textureView14 = texture2.createView({
+  label: '\u4597\uc548\u06e1\u0adc\u0d8f\u{1fc7f}\u4dda\uae05\u9086\u054a',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 2,
+});
+let renderBundle30 = renderBundleEncoder0.finish({label: '\u6e77\ueac1\uaca4\u02d9\u1a0c\u{1f766}\u39e7'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageBitmap1);
+try {
+computePassEncoder13.setBindGroup(0, bindGroup3, new Uint32Array(389), 23, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer38]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(193), /* required buffer size: 193 */
+{offset: 193}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u{1f88f}\u5942\uc46f\u0bb4\u{1f8c7}\u7282',
+  entries: [
+    {
+      binding: 464,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer40 = commandEncoder50.finish({});
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint16', 1_228, 975);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer4, 808);
+} catch {}
+let commandBuffer41 = commandEncoder38.finish({});
+let texture17 = device0.createTexture({
+  label: '\u255f\u37c8\ue373\u{1f6f2}\u247a\u0cf9\uc28a\u{1f7aa}\u6ebf\u0561\u0f23',
+  size: [15],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 2692, new Float32Array(16036), 2336, 340);
+} catch {}
+offscreenCanvas0.width = 831;
+let sampler6 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.84,
+  lodMaxClamp: 81.32,
+  maxAnisotropy: 15,
+});
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint16', 1_362, 750);
+} catch {}
+let adapter3 = await promise10;
+let videoFrame1 = new VideoFrame(video0, {timestamp: 0});
+let renderBundle31 = renderBundleEncoder6.finish({label: '\uea2e\u87b6\uc720\u0215\ud358\u048e\u1063\u2959\u0468'});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint16', 4_824, 11_620);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 212, new Float32Array(2243), 425, 128);
+} catch {}
+let imageData5 = new ImageData(12, 60);
+let commandEncoder51 = device0.createCommandEncoder({label: '\u76df\u078e\u0e75\ub04b\uab3a\u08ad\u0e55\uabdf'});
+let textureView15 = texture1.createView({label: '\uccb5\u4508\u{1fc54}\u04dc'});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint16', 8_406, 2_018);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4_294_967_295, undefined, 153_326_086, 67_157_015);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 1, y: 6, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder();
+let externalTexture9 = device0.importExternalTexture({
+  label: '\u{1f910}\ucdc5\u2273\u03b9\u8d23\u27a4\ub63b\u07b7\u7dc5\u2bec\ub045',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint32', 13_492, 3_349);
+} catch {}
+let imageData6 = new ImageData(48, 44);
+let pipelineLayout15 = device0.createPipelineLayout({label: '\u5ebc\u0c5e', bindGroupLayouts: [bindGroupLayout4, bindGroupLayout9]});
+let commandEncoder53 = device0.createCommandEncoder({label: '\u925d\u07b8'});
+let texture18 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder16 = commandEncoder51.beginComputePass({label: '\u002d\ub8b0\u00fd'});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint16', 216, 8_903);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({label: '\u063b\u1e7a\ua4c3\u{1fbce}'});
+let computePassEncoder17 = commandEncoder54.beginComputePass({label: '\u04bb\u8094\u0773\u0dbe\u455e\u02b6\u8eac\u3657\u{1f8a7}'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let img1 = await imageWithData(16, 52, '#10101010', '#20202020');
+let videoFrame2 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let commandEncoder55 = device0.createCommandEncoder({});
+let commandBuffer42 = commandEncoder53.finish({label: '\ua23d\u0740\u0c3a\u{1f90d}\u0aeb\uc710\u4502\u0d55\uea39\u9629'});
+let arrayBuffer3 = buffer4.getMappedRange(4352, 44);
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 2216, new BigUint64Array(5588), 2210, 140);
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({label: '\u{1fba9}\ua4de\ud074\ufb96\u{1f7ff}\ued6b\u0543\u36ec\u03f1\uc2da\u820d'});
+let computePassEncoder18 = commandEncoder55.beginComputePass();
+let renderBundle32 = renderBundleEncoder6.finish({label: '\u0b7a\ufc5b'});
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+let commandBuffer43 = commandEncoder56.finish({});
+let computePassEncoder19 = commandEncoder12.beginComputePass({label: '\uf834\u770f\u79f7\u8108\ud831\ua11b\u0a1b\u8ef2\ub8e0\u0eba'});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint16', 2_374, 6_381);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1628 */
+  offset: 1628,
+  bytesPerRow: 256,
+  rowsPerImage: 156,
+  buffer: buffer4,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer37, commandBuffer39, commandBuffer28, commandBuffer43]);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint16', 3_718, 9_387);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 15, y: 5, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise13;
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({label: '\u81cb\u0150\ua313\u0ab2\u0f90\uf2ae\u027c\u6151\u07a2', entries: []});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u26d8\u6733\u{1fa5e}\u4e8c\u{1ffd6}\u{1fb37}\u{1fa00}\ua588\u{1fb2f}\u967f'});
+let commandBuffer44 = commandEncoder57.finish({label: '\ua4aa\u09bb\u33f8'});
+try {
+buffer0.unmap();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+  await promise9;
+} catch {}
+let sampler7 = device0.createSampler({
+  label: '\ufa46\u3ca6\u11d5\u3bd1\ub9c5\u046e\u078c\u0441\uf313\uda0d',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.88,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint32', 1_544, 73);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer1, 2196, buffer4, 6156, 748);
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u3d42\u0e16\u{1f963}\u{1f622}\u382e\u06dc\u07fb',
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder58 = device0.createCommandEncoder({label: '\ub6fd\u{1f660}\udd7b\u{1f705}\u0c9a\u0480\u5a30\u2b30\u0c3a\u{1fc50}'});
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 616 */
+  offset: 616,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 30, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer40, commandBuffer44]);
+} catch {}
+let buffer5 = device0.createBuffer({
+  size: 15453,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet7 = device0.createQuerySet({
+  label: '\u{1f784}\u171e\u498e\u{1fb6f}\u4799\u5c0c\u750d\u050c\u41a2\u1845',
+  type: 'occlusion',
+  count: 118,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup2, new Uint32Array(3211), 588, 0);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 850 */
+  offset: 850,
+  buffer: buffer5,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u09f6');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(5_143), /* required buffer size: 5_143 */
+{offset: 215, bytesPerRow: 11, rowsPerImage: 28}, {width: 5, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({label: '\u{1fccd}\u{1f931}\u08a1\u0e5f\u0006\ufe9e', bindGroupLayouts: [bindGroupLayout8]});
+try {
+adapter1.label = '\u0ce6\ua610\u68ab\ufcdb\ue7b7\u0e40\u3f77\u0c2b\uebf7';
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({label: '\ub752\u8f43\u0ee5\u{1f9b9}\u702e\uda2b\u{1f768}\u{1ffb8}\u6ef0\ub3f8\u02fc'});
+let commandBuffer45 = commandEncoder52.finish({label: '\u7f03\u{1fd07}\u19ef\u{1fe20}\u{1fb75}\uf70f\u0d03\u{1f66a}\u4988\u090c\u{1fe98}'});
+let computePassEncoder20 = commandEncoder59.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer4, 712, new BigUint64Array(4422), 1265, 216);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder60 = device0.createCommandEncoder();
+let commandBuffer46 = commandEncoder60.finish({label: '\ub514\u05db\ub246\u0dac\ufc53\u0c9e\u7ade\u93f0\u95c8'});
+let computePassEncoder21 = commandEncoder58.beginComputePass({label: '\u0388\u183e\u{1fbe6}\u0e5e\u0003\u65d4'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+  label: '\u8f3d\u853c\ua10f\ue452\ub9e5\u1b43',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, constants: {}},
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup3, new Uint32Array(1523), 157, 0);
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder();
+try {
+buffer0.unmap();
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet7, 19, 12, buffer1, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3260, new DataView(new ArrayBuffer(8996)), 3350, 2320);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let buffer6 = device0.createBuffer({
+  label: '\u{1fd7e}\u1b7d\u097f\u0e93\u{1f8ed}\u0697\u0b9b\u0ca7\u0631\u0aa8',
+  size: 9447,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder62 = device0.createCommandEncoder();
+let commandBuffer47 = commandEncoder62.finish({label: '\u095e\u{1ffa2}\u90e6\u0d80\u{1fe26}\u8369\uef5a\u5c07\u086f\u562d\u1618'});
+let computePassEncoder22 = commandEncoder61.beginComputePass({label: '\u6f21\u{1f71c}\u{1f7dc}\u{1fec6}\u0e7d\u0bad\u0dce\u3e5a\u{1f82a}\u01f8'});
+try {
+device0.queue.writeBuffer(buffer1, 3100, new Int16Array(3324), 347, 72);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'depth-only',
+}, new ArrayBuffer(54_073), /* required buffer size: 54_073 */
+{offset: 58, bytesPerRow: 99, rowsPerImage: 86}, {width: 30, height: 30, depthOrArrayLayers: 7});
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+let renderBundle33 = renderBundleEncoder5.finish();
+try {
+querySet1.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2168, new DataView(new ArrayBuffer(10349)), 383, 724);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(12, 51);
+let commandEncoder63 = device0.createCommandEncoder({});
+let renderBundle34 = renderBundleEncoder6.finish({label: '\u846d\uddbd\u5ff5'});
+let sampler8 = device0.createSampler({
+  label: '\u049b\u{1fb79}\u0431\u{1fba1}\u0787\u0daa\u{1f886}\u686e',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.32,
+  lodMaxClamp: 99.70,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint32', 664, 12_989);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 4, y: 2, z: 42},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 216 */
+  offset: 216,
+  bytesPerRow: 0,
+  rowsPerImage: 13,
+  buffer: buffer6,
+}, {width: 0, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet7, 19, 9, buffer5, 2816);
+} catch {}
+let video2 = await videoWithData();
+let renderBundle35 = renderBundleEncoder0.finish();
+let sampler9 = device0.createSampler({
+  label: '\u0ff0\u09f1\u028a\ud830\u0443\u1e52',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.42,
+  lodMaxClamp: 71.36,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer6, 'uint32', 408, 1_082);
+} catch {}
+let buffer7 = device0.createBuffer({
+  label: '\u0177\u{1feac}\u{1f85a}\u0f63\u157f\u0c8d\uab22\u05bb',
+  size: 2604,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder64 = device0.createCommandEncoder({label: '\u0c43\u{1fe50}\ufb2b\uf746'});
+let computePassEncoder23 = commandEncoder64.beginComputePass({});
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({label: '\uaed7\u{1f675}\ue70f\u6036\u{1fe6a}\u93c5'});
+let textureView16 = texture15.createView({label: '\u04f4\u0773\ub18b\u01d5\u0602\u0812', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer7, 'uint16', 1_108, 411);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer7);
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u{1f8af}');
+} catch {}
+document.body.prepend(img0);
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u994c\u83b7'});
+let commandBuffer48 = commandEncoder63.finish({label: '\u{1fb3d}\u0d5a\ue0df\u0fe9\u0fe7\u22a6\u{1fd2d}\u0632\u05f8'});
+let texture19 = device0.createTexture({
+  size: {width: 7, height: 7, depthOrArrayLayers: 22},
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView17 = texture7.createView({label: '\u1d3a\u{1f63c}\uca7d\u{1f9fe}\u49c2\uac23', format: 'r8unorm'});
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(1, buffer5, 0, 215);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 55},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 636 */
+  offset: 636,
+  bytesPerRow: 256,
+  rowsPerImage: 0,
+  buffer: buffer4,
+}, {width: 8, height: 0, depthOrArrayLayers: 14});
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u0357\ue3e3\u5f78\u9269\u{1fee1}',
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 163,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 14104615, hasDynamicOffset: false },
+    },
+    {
+      binding: 138,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 27778994, hasDynamicOffset: false },
+    },
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 375, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 30, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 442,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 368,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 81,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 295,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 190,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 397,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 223, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+  ],
+});
+let buffer8 = device0.createBuffer({
+  label: '\u{1f93d}\u05af\ude5d\u0f74',
+  size: 9348,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder67 = device0.createCommandEncoder({label: '\ue68a\u11d4'});
+let computePassEncoder24 = commandEncoder67.beginComputePass({label: '\ub2d2\u94fa'});
+let renderBundle36 = renderBundleEncoder4.finish({label: '\u{1fa0d}\u6ea4\ud223\ubb28\ud6e7'});
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5000 */
+  offset: 5000,
+  buffer: buffer1,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 2},
+  aspect: 'depth-only',
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({label: '\u{1fff8}\uf95b\ub45c\u5231'});
+let texture20 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer8, 1_872, 415);
+} catch {}
+try {
+device0.queue.submit([commandBuffer47]);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let imageData7 = new ImageData(48, 12);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandBuffer49 = commandEncoder68.finish({label: '\u3bbd\u0db9\ub628'});
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer3, 0, 10_895);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet3, 55, 137, buffer3, 7680);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(172), /* required buffer size: 172 */
+{offset: 172, bytesPerRow: 125}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle37 = renderBundleEncoder7.finish({});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u204a\u445c\ud96f\u800e\u00e8\u0035\u8de1\u115e\u{1f8fb}\u0b3f'});
+let commandBuffer50 = commandEncoder69.finish({});
+let computePassEncoder25 = commandEncoder65.beginComputePass({label: '\u5a25\u0368\u024f\u0cd2\u{1ffac}\u{1f891}\u062b\u{1fff6}'});
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer3, 0);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let commandBuffer51 = commandEncoder66.finish({label: '\ue3a6\u0e33'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({label: '\u19bf\u{1fe2f}\u5ff1\u6a2d\u{1f865}\u0f78\u0953\u{1fa09}\u0162', colorFormats: ['r32sint']});
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+let textureView18 = texture10.createView({label: '\ue9c6\u2a36\u05aa\uc775\u0482\u072c\u{1fae5}\u522d\u1284\u25d4\udc77', arrayLayerCount: 1});
+try {
+computePassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup2, new Uint32Array(1266), 159, 0);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder70 = device0.createCommandEncoder({});
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({label: '\ud4a3\u01af\u5189\u065b\u{1fe7a}\u752e\u0dd5\u0439'});
+let commandBuffer52 = commandEncoder71.finish({});
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup2, new Uint32Array(637), 59, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer7, 'uint32', 60, 237);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer7, 16, 585);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let computePassEncoder26 = commandEncoder70.beginComputePass({label: '\u8368\u0502\udbc3\u{1f785}'});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer42, commandBuffer52]);
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({label: '\u9956\ub28a\uf6d5\u4059\u491c\u03a4\u0c99\u045f\uf9d7\u0261\u0945'});
+let commandBuffer53 = commandEncoder72.finish({});
+let texture21 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder8.setIndexBuffer(buffer7, 'uint16', 196, 276);
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({label: '\u440b\u0a9f\u828c\u0e64\ua693\u{1fbca}\ud0a9'});
+let textureView19 = texture15.createView({label: '\u536f\uee6c\u3198', baseMipLevel: 1});
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer5, 0);
+} catch {}
+let commandBuffer54 = commandEncoder73.finish({});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer51, commandBuffer46]);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder();
+let commandBuffer55 = commandEncoder74.finish();
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup3, new Uint32Array(104), 30, 0);
+} catch {}
+let texture22 = device0.createTexture({
+  label: '\uc5aa\ub694\u89c9\uc8fd\uce83',
+  size: {width: 30, height: 30, depthOrArrayLayers: 1},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let texture23 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle38 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+let commandEncoder75 = device0.createCommandEncoder({});
+let commandBuffer56 = commandEncoder75.finish({label: '\u807b\u0e82\u{1f67e}'});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandBuffer36.label = '\u35c1\ude18\u99f3\u5af4\uf4f4\u0a31\u695f';
+} catch {}
+let textureView20 = texture0.createView({label: '\u{1fa7b}\u{1fe55}\u{1f884}\u0ca4\u{1fff3}\u395f\u062d\u91e0\u{1f738}\u{1f87a}'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], stencilReadOnly: true});
+try {
+renderBundleEncoder10.setVertexBuffer(3, buffer7, 112, 231);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup3);
+} catch {}
+await gc();
+let imageData8 = new ImageData(24, 32);
+let renderBundle39 = renderBundleEncoder10.finish({});
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup3, new Uint32Array(3351), 305, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer8, 'uint16', 510, 1_795);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1040, new Int16Array(13365), 3924, 1200);
+} catch {}
+canvas0.width = 198;
+let textureView21 = texture1.createView({label: '\u025b\u9727\u{1fe27}\u91b0\u623d\uc3c1\u4619\u0194\u22f4\u0792', format: 'r8unorm'});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer49, commandBuffer54, commandBuffer50]);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let renderBundle40 = renderBundleEncoder7.finish({label: '\ue709\u0b6d\u{1f769}\u14e0\uba38\u0e21\ubbc7\u102d'});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(30), /* required buffer size: 30 */
+{offset: 30, rowsPerImage: 71}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u52c1\u09db\u08a9',
+  entries: [{binding: 92, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let querySet8 = device0.createQuerySet({
+  label: '\u{1f6c8}\ubae4\u{1fe07}\u25f0\u{1f8e8}\u7106\u{1fddb}\u{1fcd4}\u{1fd9b}\u2183\u{1f980}',
+  type: 'occlusion',
+  count: 72,
+});
+let renderBundle41 = renderBundleEncoder1.finish({label: '\u053f\ud0c5\u114f\udbc0\uba38'});
+let commandEncoder76 = device0.createCommandEncoder();
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+commandEncoder76.insertDebugMarker('\u0d95');
+} catch {}
+try {
+device0.queue.submit([commandBuffer48]);
+} catch {}
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 998});
+let renderBundle42 = renderBundleEncoder8.finish();
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(1889), 623, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let imageData9 = new ImageData(72, 112);
+let commandEncoder77 = device0.createCommandEncoder({label: '\u0e09\u{1fb8e}\u3f22\u{1ff24}\u03ee\u588b\u05a4\u7975'});
+try {
+renderBundleEncoder9.setVertexBuffer(7, buffer4, 9_116, 2_146);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+adapter0.label = '\u50cf\uf18c\u0928\u60b3';
+} catch {}
+let commandBuffer57 = commandEncoder76.finish({label: '\u3b75\u0972\ufa1c\u0fdb\u0b37'});
+let computePassEncoder27 = commandEncoder77.beginComputePass({label: '\u0805\u0568\u0096\ud646\u0e1c\u8115\u3f01\u0a04\u0f56'});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer3, 'uint32', 7_036, 1_485);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\u{1fbd3}');
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({label: '\u614d\u08d9\u9a6b\u{1fbf1}\u009e\u0c1c\u0549\u0818'});
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup2, new Uint32Array(234), 12, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+querySet2.destroy();
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1748 */
+  offset: 1748,
+  buffer: buffer4,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet5, 15, 59, buffer5, 1280);
+} catch {}
+try {
+device0.queue.submit([commandBuffer57]);
+} catch {}
+await gc();
+let renderBundle43 = renderBundleEncoder7.finish({label: '\u0059\u0702'});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer3, 'uint16', 16_994, 1_106);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(7, buffer7);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({label: '\u{1fd49}\udc00\u370a\u{1f62f}\u072e'});
+let renderBundle44 = renderBundleEncoder5.finish({label: '\u{1f8b5}\u9172\ub323\u9f6f\u{1f7b8}'});
+try {
+commandEncoder78.copyBufferToBuffer(buffer1, 688, buffer4, 11312, 444);
+} catch {}
+try {
+device0.queue.submit([commandBuffer55]);
+} catch {}
+let bindGroup4 = device0.createBindGroup({label: '\u{1fca5}\u0ad6\u{1fefa}\ucc9c', layout: bindGroupLayout0, entries: []});
+let commandBuffer58 = commandEncoder78.finish();
+let renderBundle45 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+commandEncoder79.clearBuffer(buffer1);
+} catch {}
+let video3 = await videoWithData();
+let commandBuffer59 = commandEncoder79.finish({label: '\ub29c\u{1fb26}\u{1ff68}\u0039\u3243\u{1f7fa}'});
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer4, 0, 2_203);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u020e\u17bf\u0a58\u40af\uc463\u4869\u{1fc4b}\u{1f6a2}\uc7d2',
+  entries: [
+    {
+      binding: 556,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder80 = device0.createCommandEncoder({label: '\u0669\u1937\u052c\uac4c\ucd24\u0684\u75c8\uf7bf\u{1f725}\u0e6b'});
+let commandBuffer60 = commandEncoder80.finish({label: '\u{1fac4}\u7e41\u{1fa5c}\u{1f87c}\ud5e8\u84e6\u2de1'});
+try {
+device0.queue.submit([commandBuffer59, commandBuffer60, commandBuffer53]);
+} catch {}
+await gc();
+let commandEncoder81 = device0.createCommandEncoder({});
+let renderBundle46 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder9.setIndexBuffer(buffer1, 'uint16', 3_418, 1_256);
+} catch {}
+let commandBuffer61 = commandEncoder81.finish({label: '\u4bb8\u63bf\u029b\u{1f927}\ud34f'});
+let renderBundle47 = renderBundleEncoder1.finish({label: '\ub2ed\ue997\u0069\u399c\u{1fd69}\u1d3c\u{1fbc4}'});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer5, 0, 2_467);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await promise16;
+} catch {}
+let imageBitmap3 = await createImageBitmap(offscreenCanvas1);
+let bindGroup5 = device0.createBindGroup({
+  label: '\u0c69\u41b1\u7226\u96c0\u6fb5\u0fa4\ub6ae\uc8f9\u7ab9\ue4bd\u04ea',
+  layout: bindGroupLayout15,
+  entries: [{binding: 556, resource: textureView17}],
+});
+let renderBundle48 = renderBundleEncoder7.finish({label: '\u9991\u55df'});
+try {
+renderBundleEncoder9.setIndexBuffer(buffer1, 'uint32', 1_936, 1_427);
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder();
+let computePassEncoder28 = commandEncoder82.beginComputePass({label: '\ueb0d\u0b10\u{1ff95}\u7772\u08d3\u5cb3'});
+let renderBundle49 = renderBundleEncoder9.finish();
+try {
+computePassEncoder19.insertDebugMarker('\u{1f80b}');
+} catch {}
+try {
+device0.queue.submit([commandBuffer58]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img2 = await imageWithData(16, 6, '#10101010', '#20202020');
+try {
+canvas1.getContext('webgl2');
+} catch {}
+let textureView22 = texture8.createView({label: '\ufa07\ud7ce\u{1f63d}\u{1ff7e}\ub658', format: 'r32sint', arrayLayerCount: 2});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(181), /* required buffer size: 181 */
+{offset: 181, bytesPerRow: 25}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder83 = device0.createCommandEncoder({label: '\u{1fa71}\u0f8a\u1db0'});
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 536 */
+  offset: 536,
+  buffer: buffer6,
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout17 = device0.createPipelineLayout({
+  label: '\u9230\u034a\u0b64\u{1ffa5}\u09fc\ua832\ue236\u{1fcc1}',
+  bindGroupLayouts: [bindGroupLayout6],
+});
+let texture24 = device0.createTexture({
+  label: '\u06a8\ufb70\u37df\u775e\uec57',
+  size: [7, 7, 73],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder29 = commandEncoder83.beginComputePass({label: '\u5353\u0efc\u093f\u0156\u61a1\u0bd4\ubae2'});
+await gc();
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer56]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(187), /* required buffer size: 187 */
+{offset: 187, rowsPerImage: 17}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u{1fbc9}\u{1fe00}\ud1ea\uab7b\u{1f72e}\u042d', bindGroupLayouts: [bindGroupLayout8]});
+let commandEncoder84 = device0.createCommandEncoder();
+try {
+computePassEncoder29.setBindGroup(3, bindGroup4, new Uint32Array(2161), 974, 0);
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder();
+let renderBundle50 = renderBundleEncoder3.finish({label: '\u9832\u0c46\u662e\u0edc\u02d9\uac82\u2c2b'});
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 719 */
+  offset: 719,
+  buffer: buffer1,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer61]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<i32>,
+}
+
+@group(0) @binding(150) var et1: texture_external;
+@group(0) @binding(174) var<storage, read_write> buffer9: atomic<i32>;
+@group(0) @binding(157) var tex1: texture_2d<f32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(num_workgroups) a0: vec3u, @builtin(global_invocation_id) a1: vec3u) {
+  _ = a0;
+}
+
+struct VertexOutput0 {
+  @builtin(position) f5: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureDimensions(et1);
+  if bool(textureLoad(tex1, vec2i(), 0)[2]) {
+    var v: vec4f;
+  }
+  out.f5 = bitcast<vec4f>(textureDimensions(et1).rggr);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) @interpolate(linear) f0: vec2f,
+  @location(0) @interpolate(flat, sample) f1: vec4f,
+  @builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f1 = vec4f(bitcast<f32>(a0));
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer62 = commandEncoder84.finish({label: '\u4679\uc35b\u08f6\u2ea7\u0724\u0f44\u0ada'});
+let textureView23 = texture3.createView({dimension: '2d-array', baseMipLevel: 1, baseArrayLayer: 0});
+let renderBundle51 = renderBundleEncoder6.finish();
+try {
+computePassEncoder3.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder85.clearBuffer(buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(67), /* required buffer size: 67 */
+{offset: 67}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let texture25 = device0.createTexture({
+  label: '\ua0b3\u{1fb82}\u95a5',
+  size: [15, 15, 88],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle52 = renderBundleEncoder5.finish();
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3782 */
+  offset: 3782,
+  buffer: buffer0,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({
+  label: '\u0dc3\u7050\u006f\u3a1d\u98a0\u43fe\u0a0f',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1, bindGroupLayout4],
+});
+let textureView24 = texture25.createView({
+  label: '\u9ed8\u44d0\u4643\ub363\u7762\u1753\u0f72\u{1fa8d}\u{1ff8f}\u8d3f',
+  aspect: 'all',
+  baseArrayLayer: 10,
+  arrayLayerCount: 7,
+});
+let sampler10 = device0.createSampler({
+  label: '\u05df\ucb42\u2bda\u08b6\ud0b8\u0262',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 81.02,
+  lodMaxClamp: 85.57,
+});
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 488, new BigUint64Array(14977), 360, 320);
+} catch {}
+let commandBuffer63 = commandEncoder85.finish({label: '\uabd3\u0294\u{1fce5}\u51f7'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\u09ff\u{1ff91}', colorFormats: ['r8unorm'], depthStencilFormat: 'depth16unorm'});
+let renderBundle53 = renderBundleEncoder10.finish({label: '\u7609\u{1fcbe}'});
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(1622), 14, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint32', 172, 60);
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({label: '\u01e6\u027d\u007a\u{1fd24}'});
+let textureView25 = texture19.createView({label: '\u0ee8\uaf23', aspect: 'depth-only', baseArrayLayer: 3, arrayLayerCount: 4});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(991), 132, 0);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer7, 200, buffer6, 2736, 124);
+} catch {}
+let texture26 = device0.createTexture({
+  label: '\ufd89\u{1f7eb}\u{1fd6e}\u{1fdf3}\u5c9c\u9783\ue2c5\u084b\u{1fe4d}\u0d02',
+  size: {width: 7},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView26 = texture3.createView({
+  label: '\ua137\u{1f8d5}\u{1fe11}\u9145\u{1f680}\u9271\u9f49\ua880\u7984',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint32', 268, 668);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1576 */
+  offset: 1576,
+  rowsPerImage: 33,
+  buffer: buffer1,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder87 = device0.createCommandEncoder({label: '\u{1fbfb}\ufb78\u91e9\u6d21\ufbf9\u2443\u{1fb9b}\u0aa2\u05de\u6cbd\ubd7d'});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7276 */
+  offset: 1132,
+  bytesPerRow: 256,
+  rowsPerImage: 6,
+  buffer: buffer8,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'depth-only',
+}, {width: 7, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 48, new BigUint64Array(8573), 462, 336);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let renderBundle54 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer1, 'uint32', 1_248, 1_310);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let texture27 = device0.createTexture({
+  label: '\ue52a\u{1faad}\u0e6e\uc796\u{1f6e3}\u{1f83d}\u3451\udf1a\ue64d\u{1f704}\u6c05',
+  size: {width: 60},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView27 = texture13.createView({label: '\u9965\u4fc0\u06d2\u{1fdaa}\uf29f', baseMipLevel: 3, arrayLayerCount: 1});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer5, 2_468);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let commandBuffer64 = commandEncoder87.finish({label: '\u{1fd06}\uebfe'});
+let computePassEncoder30 = commandEncoder86.beginComputePass({label: '\u8c22\u0c12\u3152\u{1fa4f}\u{1fbd9}'});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup5, new Uint32Array(74), 6, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer62]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4728, new Float32Array(3228));
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({label: '\u0c71\uf4f6'});
+let externalTexture10 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(2610), 254, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup3, new Uint32Array(903), 128, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer3, 8_308, 3_913);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet4, 13, 34, buffer3, 3840);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1800, new DataView(new ArrayBuffer(17581)), 1399, 1604);
+} catch {}
+let pipelineLayout20 = device0.createPipelineLayout({label: '\u{1fd72}\u22c6', bindGroupLayouts: [bindGroupLayout10, bindGroupLayout5, bindGroupLayout1]});
+let commandBuffer65 = commandEncoder88.finish({label: '\u11c9\u0e30'});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint16', 5_286, 3_521);
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({label: '\u{1fcf6}\u041f\u0a85\u0a14\u0f9b\u{1f625}'});
+let renderBundle55 = renderBundleEncoder8.finish({label: '\u59b9\u6556'});
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup4);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder();
+let externalTexture11 = device0.importExternalTexture({
+  label: '\u024e\u{1f7a6}\u08cf\u9494\u8d03\u1e15\u058b\u1ba5\ub868',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+externalTexture5.label = '\u{1fa01}\u083b\ufa68\ub7c1\u{1fcc9}\u2594\u2c77';
+} catch {}
+let commandBuffer66 = commandEncoder90.finish({label: '\u{1f9de}\u{1fd18}\u0793\u81b3\u{1fdff}\u{1fa04}\uf892\u60cd'});
+try {
+commandEncoder89.copyBufferToBuffer(buffer5, 3868, buffer0, 4260, 868);
+} catch {}
+try {
+renderBundle34.label = '\ua12b\u0fa5\u{1f645}';
+} catch {}
+let texture28 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer4, 2876, buffer6, 3800, 376);
+} catch {}
+try {
+device0.queue.submit([commandBuffer65]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderBundle56 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup5, new Uint32Array(2102), 18, 0);
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 148 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8644 */
+  offset: 2096,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {width: 37, height: 26, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer1);
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder({label: '\u6c06\u{1ff7e}\u0418\ud64c\u79d0\u2833\ua0ec\u3610\u087f\u0043\u0f4e'});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer6, 'uint32', 284, 182);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1008, new BigUint64Array(2369), 126, 248);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise17;
+} catch {}
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let computePassEncoder31 = commandEncoder89.beginComputePass();
+try {
+computePassEncoder7.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img1);
+let commandEncoder92 = device0.createCommandEncoder({label: '\u018a\uf0a6\u9740\ud71a\u07d9\ucf86\uf1f5'});
+let commandBuffer67 = commandEncoder91.finish({label: '\u9d1d\u56dd\u589d\u0a06\u43f9\u{1fa66}\uadac\u995e\uea26'});
+let texture29 = device0.createTexture({
+  label: '\u81d3\u0050\u0393\ud815\u{1f777}\ude44\u9353',
+  size: [7, 7, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+commandEncoder92.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 14, y: 1, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1072 */
+  offset: 1072,
+  bytesPerRow: 0,
+  rowsPerImage: 127,
+  buffer: buffer4,
+}, {width: 0, height: 11, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.submit([commandBuffer67]);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({label: '\u63b0\u7c7b\u{1fef1}\u{1faa2}\u9110\u28e3\u4901\u0150\u9f5d'});
+let textureView28 = texture27.createView({label: '\u082a\uccdb', mipLevelCount: 1});
+try {
+renderBundleEncoder11.insertDebugMarker('\u0e78');
+} catch {}
+document.body.prepend(video3);
+let commandBuffer68 = commandEncoder93.finish();
+let renderBundle57 = renderBundleEncoder10.finish();
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint32', 196, 235);
+} catch {}
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer69 = commandEncoder92.finish({label: '\u0350\u00e6\u{1fd44}\u9005'});
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({label: '\u9434\u1b59\u3bda\u0d5e\u052f\ud7e0\u89f3\uc370\u{1f650}\u0ca6\u{1f73f}'});
+let querySet10 = device0.createQuerySet({label: '\u6cbb\u4ec4\u550c\u0f4e\u{1fac2}\u{1fc41}\u156b\u51d3', type: 'occlusion', count: 747});
+let computePassEncoder32 = commandEncoder94.beginComputePass({label: '\uab8e\u0edb\u07db\ufd91\u{1fea2}\u82f1\ufeae\u00d0'});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint16', 438, 102);
+} catch {}
+try {
+device0.queue.submit([commandBuffer69]);
+} catch {}
+video0.width = 62;
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 357,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+externalTexture5.label = '\ufbe7\u{1fa7f}\uacee\u070b\u0d9c\ued66\u0bff\u8d3d\u7d88';
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer8, 'uint16', 3_056, 1_205);
+} catch {}
+video1.width = 28;
+let commandEncoder95 = device0.createCommandEncoder({label: '\u{1fd66}\ud00f\u0512\u0cb4\u0b7d\u{1f89c}\u97fb\uc120\u0309\u060e\uf479'});
+let commandBuffer70 = commandEncoder65.finish({label: '\u03ff\u80c0\uaec7\u{1f6f9}\u{1fd0c}\u0506\u{1fe61}\u{1fed1}\u0d0c\uad2e'});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4_294_967_294, undefined, 0, 353_915_256);
+} catch {}
+try {
+commandEncoder95.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 228 */
+  offset: 228,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let img3 = await imageWithData(78, 69, '#10101010', '#20202020');
+let buffer10 = device0.createBuffer({
+  label: '\uac5b\u03ca\u2675',
+  size: 8111,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder96 = device0.createCommandEncoder({label: '\u{1fbee}\u0716\u{1f906}\u{1fa21}\u055e'});
+let querySet11 = device0.createQuerySet({label: '\u{1fd47}\u6a1a\u07fd\uf9e5', type: 'occlusion', count: 510});
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(buffer8, 64, buffer6, 828, 132);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u6463');
+} catch {}
+try {
+device0.queue.submit([commandBuffer64]);
+} catch {}
+let buffer11 = device0.createBuffer({
+  label: '\u{1fec3}\u7f76\u6635\u0c86',
+  size: 7072,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+try {
+commandEncoder96.clearBuffer(buffer10, 1912, 1500);
+} catch {}
+let texture30 = device0.createTexture({
+  label: '\u51dd\u3c1c\u0b13\u{1ff35}\u278d',
+  size: {width: 15, height: 15, depthOrArrayLayers: 34},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer6, 'uint32', 5_332, 1_683);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 8, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer70, commandBuffer68]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1820, new Float32Array(1341), 60, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle58 = renderBundleEncoder3.finish({label: '\ua207\u522c\u0929'});
+let commandEncoder98 = device0.createCommandEncoder({label: '\uf7d3\ueca2'});
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer7, 0, 118);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer66]);
+} catch {}
+let commandBuffer71 = commandEncoder95.finish({label: '\u1e00\u23e8\u09f6\u07ee'});
+let renderBundle59 = renderBundleEncoder6.finish({label: '\u9c30\u0dd0\u022f\u73dd\u{1fdb1}\u49ea\ue21b\u0b54'});
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 6, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+let commandBuffer72 = commandEncoder98.finish({label: '\u0063\u{1facf}\u{1fa67}\u034e'});
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer11, 0, 434);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(93), /* required buffer size: 93 */
+{offset: 93}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video2);
+try {
+adapter0.label = '\u5c7a\u4cf6';
+} catch {}
+let querySet12 = device0.createQuerySet({label: '\u09ad\ufe54\uaab5\u4688', type: 'occlusion', count: 562});
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer8, 'uint32', 972, 507);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer4, 0, 10_323);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5492 */
+  offset: 5492,
+  buffer: buffer4,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler11 = device0.createSampler({
+  label: '\u062e\u0beb\u280f\u0799',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.833,
+});
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1632, new BigUint64Array(60075), 3972, 8);
+} catch {}
+document.body.prepend(canvas1);
+let video4 = await videoWithData();
+let bindGroupLayout17 = device0.createBindGroupLayout({label: '\u0bbc\u3a09', entries: []});
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer8, 'uint16', 96, 6_701);
+} catch {}
+try {
+device0.queue.submit([commandBuffer72]);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let imageData10 = new ImageData(16, 204);
+let renderBundle60 = renderBundleEncoder6.finish({label: '\u{1f666}\u{1fa64}\u0a99\u65b8\uc1c7\uf306'});
+let commandEncoder99 = device0.createCommandEncoder({label: '\ue2a8\u{1fd5c}\u{1f6c3}\u049d'});
+let renderBundle61 = renderBundleEncoder7.finish({label: '\u{1fcbe}\u6eaa'});
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandBuffer73 = commandEncoder96.finish({label: '\u0f27\ucd73\u75b2\u{1fac8}'});
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer73, commandBuffer71]);
+} catch {}
+document.body.prepend(img3);
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u0288\u{1fe7b}\u{1f61f}',
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 307,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 161,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 90,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 259,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 30, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 236,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 254,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 269,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 111, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 84,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 361,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 38, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 78,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 489,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 75, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 324,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 56, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 774,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 142,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 171,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 48, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 148,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 146, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 288,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 24, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+  ],
+});
+let commandBuffer74 = commandEncoder99.finish({label: '\u{1fa38}\uaf8e\ufcff\u1d2e\u{1fd63}\u{1f8ff}\u3310\u17fe'});
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(110), /* required buffer size: 110 */
+{offset: 110}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+try {
+texture3.destroy();
+} catch {}
+let commandEncoder101 = device0.createCommandEncoder({label: '\u715a\uf76b\u04f3\u98e9\u0e10\u0cfb\u20f4\u0b33\ue29a'});
+let commandBuffer75 = commandEncoder97.finish({label: '\ub6d8\u019d\u{1f862}\u0582\u718f\u0cd6\u0b1c\uad9b\u125a\u0e03\u4413'});
+let texture31 = device0.createTexture({
+  label: '\u04ad\u3377\u66fb\u15de\u8434\ueadd\u9bf1\u{1faae}\u0e68\u0878\u{1ff36}',
+  size: [15, 15, 95],
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u0045\u0d60\u{1fc12}\u3d12\u24f1\u5e28\u8aca\u01e2\u644e',
+  colorFormats: ['r32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup0, new Uint32Array(111), 17, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer4, 72, 1_108);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u6138');
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let commandBuffer76 = commandEncoder100.finish({label: '\u{1ffa4}\u0dd2\u{1fd16}\u{1fd05}\u942f\u{1f7f2}\u{1f7f0}\u{1fa9e}'});
+let texture32 = device0.createTexture({
+  size: {width: 7},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView29 = texture31.createView({label: '\uc051\u9261\ub4fb\u{1f883}\u827b\u44d0\udf63', format: 'rgba8snorm'});
+let renderPassEncoder0 = commandEncoder102.beginRenderPass({
+  label: '\u3c00\ue524\u031c\ueb24\u055e\u08b1\u0650\ua59a\u{1fcee}\uaf70\u035c',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 44,
+  clearValue: { r: -717.2, g: 445.9, b: 382.2, a: -136.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView0, depthClearValue: 6.33452890188806, depthReadOnly: true},
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u093d\u{1fdc6}\udfac\ueca6\u0e58\u5507\u{1f9f7}\u{1f7a5}\u2503\u4c9b\ua77d',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder101.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1784 */
+  offset: 1784,
+  buffer: buffer10,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+adapter3.label = '\uf6fb\u01d5\u{1fad8}\uee23\u2bed\u{1fdab}\u{1f970}';
+} catch {}
+let commandBuffer77 = commandEncoder101.finish({label: '\uef3f\u5a65\u0679\u0f8f\u1206\u{1f719}\u41aa\u9a3b\u{1fc9e}\u6c73'});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint16', 1_036, 712);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.prepend(video1);
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer3, 5_624);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder();
+let renderBundle62 = renderBundleEncoder7.finish({label: '\u11a9\u0c1d\u00ec'});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint32', 84, 13_030);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer10, 84, 986);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer0, 'uint32', 364, 5_803);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 720 */
+  offset: 720,
+  buffer: buffer8,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\ub8b4\u80db\u28ac\u{1fa94}\u53c7\uea9e\u{1f9ea}\u02ae',
+  entries: [
+    {
+      binding: 330,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer78 = commandEncoder103.finish({label: '\u02d3\u0d85\u0568'});
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(4.758221531165254, 0.6906441267085806, 0.6793028265050908, 4.517014243496111, 0.16770911343434147, 0.3474326904829427);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 1_208, 450);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup4, new Uint32Array(3473), 582, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint32', 15_152, 8_042);
+} catch {}
+document.body.prepend(video0);
+try {
+computePassEncoder21.setBindGroup(3, bindGroup2, new Uint32Array(828), 5, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer8, 0);
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u0a22');
+} catch {}
+let promise18 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout6,
+  multisample: {mask: 0x173f8cce},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {failOp: 'replace', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilWriteMask: 114952237,
+    depthBias: -108788973,
+    depthBiasSlopeScale: 863.7519253119384,
+    depthBiasClamp: -14.561377435934517,
+  },
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {arrayStride: 1252, stepMode: 'instance', attributes: []},
+      {arrayStride: 48, stepMode: 'instance', attributes: []},
+      {arrayStride: 248, stepMode: 'instance', attributes: []},
+      {arrayStride: 584, attributes: []},
+      {arrayStride: 836, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 808, attributes: []},
+      {arrayStride: 572, attributes: [{format: 'sint16x4', offset: 128, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup1, new Uint32Array(956), 224, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1240, new Float32Array(27414), 1531, 40);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let imageData11 = new ImageData(8, 96);
+let texture33 = device0.createTexture({
+  label: '\u6ac6\udf54\u82bb\u0f54\u04c2\u0a54',
+  size: [60, 60, 84],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer6, 'uint16', 2_308, 1_921);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer4, 136, 442);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u30c0\u{1ff2d}\u0d2f\u08d2\u216c\u805d',
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 271,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 198,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 520,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 21, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 156, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 69,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 11,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 41, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 45, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 28,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 250, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 277,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 253,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 88, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 176,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 365,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 522,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 4, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 519,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 97,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 14,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 125,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 202, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 108,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 366180, hasDynamicOffset: true },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 240, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 82, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 18, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 92,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 1517957, hasDynamicOffset: false },
+    },
+    {
+      binding: 209,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 254, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 19, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 255, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 233,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 495, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 129,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 215, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {binding: 237, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 164, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 438,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 172, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 83,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 331,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 161,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 228,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 206, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 64, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 10, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 8, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 449, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 34, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 54, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 596, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 398,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 43, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 120, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 516, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 126, visibility: 0, externalTexture: {}},
+    {binding: 245, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 371, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 221,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 56, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 20, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 70, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 117,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 2, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 91, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 6, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 147, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 127, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 3, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 143, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 248,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 30, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 636, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 599, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 102, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 220, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 15, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 47, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 132, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 57, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 258, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let renderBundle63 = renderBundleEncoder2.finish({label: '\u0f1a\u0beb\u01b5\u0415\u0d6c'});
+let commandBuffer79 = commandEncoder104.finish();
+let renderBundle64 = renderBundleEncoder9.finish({label: '\u0fee\ue6a1\u240d\u0b4e\u03af\u0558'});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(917), 1, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer7, 836, 283);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer5, 0, 1_270);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer5, 2348, buffer0, 5232, 176);
+} catch {}
+let texture34 = device0.createTexture({
+  label: '\u8cba\u28cc\u4b1f\u{1f897}\u0009\u531c\u0ef1\uc065\ueb4c',
+  size: [15],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle65 = renderBundleEncoder6.finish({label: '\u0b12\uf08a\u0c8b\u59ed\u09ca\u0ae7\ue559\u00e1\u0678\u{1f873}\u08f4'});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup5, new Uint32Array(465), 6, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer10, 'uint32', 60, 667);
+} catch {}
+document.body.prepend(canvas1);
+let commandBuffer80 = commandEncoder17.finish({label: '\uda87\u{1f9d3}\u17c4\uf165\u{1f66e}\u0ca7\u55ad\u50e9\u0884'});
+let texture35 = device0.createTexture({
+  size: {width: 7, height: 7, depthOrArrayLayers: 33},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint32', 1_412, 275);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer7, 760, 372);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup5, new Uint32Array(2584), 85, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer1, 'uint32', 112, 265);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint32', 284, 1_584);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint32', 656, 241);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let texture36 = device0.createTexture({
+  size: [60, 60, 81],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer1, 'uint32', 680, 1_425);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\uce1b');
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame2);
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint16', 2_102, 434);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer10, 'uint16', 3_410, 499);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({label: '\u{1f6ef}\ud6b2'});
+let commandBuffer81 = commandEncoder105.finish({label: '\u0d72\u{1f834}\u{1fb77}\u0523\u06a3\u{1fe66}\u96a1\u{1fe8a}\u08e3'});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u8efd\uebd9\u{1fdc2}\u5604\ud155\u580a\u3d9f\u{1fa9d}\u6e27\u89a4\u0845',
+  size: 657,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder106 = device0.createCommandEncoder({label: '\uee02\u0435\u{1fbe5}\u0ca0\u707a\u88fa\uf8a9\u05ed'});
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer5, 0, 375);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 10, y: 7, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1008 */
+  offset: 1008,
+  buffer: buffer0,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer74, commandBuffer75, commandBuffer81, commandBuffer77]);
+} catch {}
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0aad\u3ff0\u7e14\u0b08\u3880\ude06\u094f\u{1fb77}\u{1fc54}\u0dc0',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+});
+let renderBundle66 = renderBundleEncoder9.finish({label: '\u49a6\u{1f715}\u07bb\u9787'});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup2, new Uint32Array(3588), 749, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer0, 'uint16', 29_664, 133);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 100, new Int16Array(18819), 3483, 724);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(7_229), /* required buffer size: 7_229 */
+{offset: 93, bytesPerRow: 122, rowsPerImage: 29}, {width: 30, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({label: '\u0803\u{1fed2}\u1622\u3dd5\u0270\u00d2\u066c\u1f06\u82c9\u739d\u4e05'});
+let commandBuffer82 = commandEncoder86.finish({label: '\ued2e\u0557\u09d0'});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(3, buffer5, 2_276, 855);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise19;
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder108 = device0.createCommandEncoder({label: '\u5140\u{1fc7d}\u447e\u{1f700}\ud781'});
+let computePassEncoder33 = commandEncoder107.beginComputePass({label: '\u{1f73a}\u8b9b\uabea\u{1fe65}\u059e'});
+let renderBundle67 = renderBundleEncoder3.finish({label: '\u{1fe32}\u8004\u{1fe48}\u0463\uee38\ucfe2\ud50f'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup4, new Uint32Array(3059), 2060, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer0, 'uint16', 422, 10_054);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer4, 0, 10_343);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({label: '\u5533\u0a68\ubf5c\u{1fd08}\u0810'});
+let commandBuffer83 = commandEncoder108.finish({label: '\u0273\u{1f7d4}\u0ed2\u2d1f\ua4a8\u20c9\uada1\u{1f94e}\uf66b'});
+let texture37 = device0.createTexture({size: [7, 7, 1], dimension: '2d', format: 'depth16unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView30 = texture22.createView({label: '\ue656\u4950', aspect: 'depth-only'});
+let renderBundle68 = renderBundleEncoder5.finish();
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint32', 792, 373);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer79, commandBuffer76, commandBuffer78, commandBuffer83]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+let renderBundle69 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer10, 'uint16', 1_896, 2_188);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer10, 0, 1_164);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer6, 2160, 244);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({label: '\u0532\u{1f691}'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 652, 486);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup4);
+} catch {}
+let renderBundle70 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup3, new Uint32Array(242), 28, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(5, buffer5, 0);
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({label: '\u37fe\ud1b8\u0cf9\u0d32\uced9\u59bc\u9919\u{1fcda}'});
+let computePassEncoder34 = commandEncoder109.beginComputePass({label: '\u{1fe5c}\u94d6\u86fe\u832f\u7fde\u5701\ud792\u5e7b\u08ed\ua4ea'});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 2528, new Float32Array(13966), 2008, 100);
+} catch {}
+let videoFrame3 = new VideoFrame(img3, {timestamp: 0});
+let commandEncoder112 = device0.createCommandEncoder({label: '\u1ce7\u{1f7e1}\u0fb8\u6086\u7a11\ub82b\ua1ee\u0ef4\u462f\ue7ac'});
+let commandBuffer84 = commandEncoder111.finish({label: '\u605c\u{1f8d7}\u60ad\u98a2\u0496\u{1ffb5}'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({label: '\ubaae\u0a9d\u0602\u0905\u14a0\u51b5', colorFormats: ['r32sint'], depthReadOnly: true});
+let renderBundle71 = renderBundleEncoder9.finish();
+try {
+computePassEncoder34.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+await gc();
+let renderBundle72 = renderBundleEncoder15.finish({label: '\u0360\u{1fc25}\u0aad\u{1fa69}\u{1fe2f}'});
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 2_474, 985);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer0, 'uint32', 6_696, 949);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder27.insertDebugMarker('\u2ed5');
+} catch {}
+try {
+computePassEncoder17.setBindGroup(2, bindGroup2, new Uint32Array(760), 70, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup4, new Uint32Array(814), 23, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer7, 'uint32', 308, 454);
+} catch {}
+let computePassEncoder35 = commandEncoder106.beginComputePass({label: '\u2e71\ue829\u{1f6b5}\u99d3\u0e73\u0fc8\u6ce3\u78f4\u{1f800}\uf36f\u0da1'});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 224, 2_364);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup2, new Uint32Array(2664), 328, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer3, 0, 4_268);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1856 */
+  offset: 1856,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'depth-only',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(32, 44);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\ueaed\ubbf4\u494f\u05aa\u05f3\u0c8a\u0778\u{1fda4}\u5ac8\u{1f75a}',
+  colorFormats: ['r32sint'],
+  depthReadOnly: true,
+});
+let renderBundle73 = renderBundleEncoder5.finish({label: '\uf849\u{1f93b}\u8d56\ue85b\u1ee8'});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer8, 80, 1_421);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer10, 'uint32', 832, 2_299);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer12, 72, buffer10, 684, 340);
+} catch {}
+try {
+device0.queue.submit([commandBuffer84]);
+} catch {}
+let renderBundle74 = renderBundleEncoder14.finish({label: '\u{1f870}\u6e45\u4f20\ufda7\u47d0\u0217\u31c4\u0afd\ue66b\u15c1\u0fb5'});
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 372, 5_517);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer5, 3_032);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 312, new BigUint64Array(6249), 171, 200);
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({label: '\u1a48\u4d64\u49a1\u{1ff5d}\u0461\ucc13\u0a9d\u{1f8d1}\u08a8'});
+let textureView31 = texture34.createView({label: '\u3dda\u6160\u5cb0\udc99\u883f\u068f\u0c7c\u{1fcdf}\u{1f710}\u0292\ufef5'});
+let renderBundle75 = renderBundleEncoder1.finish();
+try {
+computePassEncoder23.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u558e');
+} catch {}
+let bindGroup6 = device0.createBindGroup({layout: bindGroupLayout17, entries: []});
+let commandEncoder114 = device0.createCommandEncoder({label: '\u{1fa7a}\u{1fbc4}\ue161\u8c16\ubbb1\u3452'});
+let renderBundle76 = renderBundleEncoder6.finish({});
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint16', 136, 521);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup0);
+} catch {}
+let commandBuffer85 = commandEncoder112.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer11, 1_048);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(203), /* required buffer size: 203 */
+{offset: 203}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({label: '\ua6fd\u{1f9c3}\u516f\u3a06\u0cac\u0c57\ud3fb'});
+let renderBundle77 = renderBundleEncoder14.finish({});
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer7, 1_380, 65);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1120, new DataView(new ArrayBuffer(5400)), 31, 212);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder89.copyBufferToBuffer(buffer1, 3952, buffer6, 4004, 8);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer1, 716, 532);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({label: '\u84b4\u4943\u023e'});
+let textureView32 = texture26.createView({label: '\u{1f999}\u0acb\uf321\u0158\u0f2d\u{1faa3}\u5d27\u0616\u7fdf'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer11);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup2, new Uint32Array(5856), 1855, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer8, 1_360);
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder({label: '\u{1f8aa}\u36e6\u{1fc01}\u5431\ucdf2\u1264\u83bb\u40c8'});
+let commandBuffer86 = commandEncoder51.finish({label: '\u37ab\ub83e\uc860\u{1fa27}\u1196\u3c47\u0989\ufb3f\u0445\ubc97\ua2f0'});
+let textureView33 = texture27.createView({label: '\u0bd5\u{1feab}\u451a\u{1f890}\u1495\u07b0\u{1f68e}\u049b'});
+let renderBundle78 = renderBundleEncoder10.finish({label: '\u0c92\u00f0\u4b83'});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder113.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({label: '\u8720\ufb1f\u2e07\u034d\ub142\u2ee3\u{1f9b4}\u0f5f\u92c9'});
+let commandBuffer87 = commandEncoder113.finish({label: '\u{1fb6b}\u5249\uba41'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer3, 0, 168);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer4, 4_184);
+} catch {}
+let promise20 = shaderModule1.getCompilationInfo();
+try {
+device0.queue.submit([commandBuffer87]);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint32', 400, 2_726);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer10, 'uint32', 4_332, 256);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer7, 0, 487);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup2, new Uint32Array(2788), 668, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer7, 'uint32', 984, 5);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6388 */
+  offset: 4724,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 32, height: 7, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(44), /* required buffer size: 44 */
+{offset: 44}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer88 = commandEncoder107.finish({label: '\u0d56\u903e\u08ea\u0bc0\u0881\u0f71\u5e80'});
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1538 */
+  offset: 1538,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 876, new Int16Array(3807), 209, 232);
+} catch {}
+let renderBundle79 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+video4.width = 39;
+let imageData13 = new ImageData(56, 20);
+let commandEncoder119 = device0.createCommandEncoder({label: '\u2fb7\u7567\u3abb\u{1faf2}\u00e5'});
+let textureView34 = texture37.createView({
+  label: '\u0921\u35b5\u01f4\u84f9\u{1ffd8}\ubf84\u4e60\u{1fa84}',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  format: 'depth16unorm',
+});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer4, 0);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(buffer0, 3328, buffer4, 4328, 4592);
+} catch {}
+try {
+commandEncoder115.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({label: '\u96b6\u7917\u7698\u7e15\u{1f61f}\u9bda'});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+let promise21 = adapter2.requestAdapterInfo();
+let commandBuffer89 = commandEncoder110.finish({});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup1, new Uint32Array(9), 1, 0);
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\uc9ed');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+video1.width = 171;
+let commandEncoder121 = device0.createCommandEncoder({label: '\u0e5f\u09a8\uf23d\u0499\u0fcf'});
+let texture38 = device0.createTexture({
+  label: '\u0d1f\u0cad\u4e5e',
+  size: [7],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup4, new Uint32Array(2679), 820, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer82]);
+} catch {}
+let img4 = await imageWithData(50, 35, '#10101010', '#20202020');
+try {
+computePassEncoder35.setBindGroup(2, bindGroup6, new Uint32Array(9729), 2111, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 34, 2_588);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer8, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup1, new Uint32Array(2364), 536, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 7_110, 5_891);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 3144, new Int16Array(17420), 928, 772);
+} catch {}
+try {
+  await promise20;
+} catch {}
+document.body.prepend(img3);
+let commandBuffer90 = commandEncoder120.finish({label: '\u0292\u4ed3\u0267\u3e34\uff07\u404c\uccff'});
+let externalTexture12 = device0.importExternalTexture({label: '\u{1f74d}\ua631\u648e\u0673\u5a88', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 394.7, g: -155.7, b: -519.0, a: -391.2, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.735967840560005, 4.469399054113078, 3.544332627001055, 1.2599206035839545, 0.27474980561807505, 0.7378198415718074);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer5, 0, 2_550);
+} catch {}
+try {
+device0.queue.submit([commandBuffer86, commandBuffer89]);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let texture39 = gpuCanvasContext1.getCurrentTexture();
+let textureView35 = texture35.createView({dimension: 'cube-array', baseArrayLayer: 8, arrayLayerCount: 6});
+try {
+renderBundleEncoder12.setIndexBuffer(buffer3, 'uint32', 5_440, 3_653);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer8, 0, 1_907);
+} catch {}
+try {
+device0.queue.submit([commandBuffer88]);
+} catch {}
+document.body.prepend(video0);
+await gc();
+let texture40 = device0.createTexture({
+  label: '\u0273\ueb83\ue1cb',
+  size: {width: 60, height: 60, depthOrArrayLayers: 380},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\u4600\uef0a\u0776\ud968\u69a6\u{1f63d}\u0f37\u0026\u346b\u03a8',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer5, 392);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer10);
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageData4);
+let commandEncoder122 = device0.createCommandEncoder();
+let texture41 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer3, 0, 366);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer3, 936, 3_848);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img5 = await imageWithData(98, 37, '#10101010', '#20202020');
+let commandEncoder123 = device0.createCommandEncoder({});
+let texture42 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer5);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer10, 'uint16', 338, 474);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'depth-only',
+}, new ArrayBuffer(4_600), /* required buffer size: 4_600 */
+{offset: 62, bytesPerRow: 49, rowsPerImage: 26}, {width: 15, height: 15, depthOrArrayLayers: 4});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let videoFrame4 = new VideoFrame(img4, {timestamp: 0});
+let commandEncoder124 = device0.createCommandEncoder();
+let commandBuffer91 = commandEncoder114.finish({label: '\u7c0a\u6780\u36e1\u1a4d\u{1fe04}\uc768\u68a8'});
+let texture43 = device0.createTexture({
+  label: '\u0b01\u{1fb12}\ue3cd\uf923\u{1fa2c}\u055c\u02e5\ucd45\u4554\u0ae8\u5b85',
+  size: {width: 15, height: 15, depthOrArrayLayers: 1},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 428, 318);
+} catch {}
+let commandBuffer92 = commandEncoder89.finish({label: '\u647d\u0e27'});
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer8, 'uint32', 40, 235);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer7, 124, 333);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 556, new BigUint64Array(1707), 639, 280);
+} catch {}
+let texture44 = device0.createTexture({
+  label: '\u{1fa18}\u77b2\u9a08\uf5fb\u{1fcb2}',
+  size: [60, 60, 3],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer11, 0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer90, commandBuffer91]);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let commandEncoder125 = device0.createCommandEncoder({label: '\u{1fac8}\u0fc7\u{1fe96}\uf1e9\uc081\ucf16\u{1fb72}\u{1f911}\ud930'});
+let renderBundle80 = renderBundleEncoder2.finish({label: '\uc04d\uc9d0\u0648\u{1f76f}'});
+try {
+computePassEncoder13.end();
+} catch {}
+let imageData14 = new ImageData(4, 24);
+let buffer13 = device0.createBuffer({
+  label: '\u0dea\u0991\u0d5a\u4b20\u073f\u0599\u9e02\u0aa5\u06f1',
+  size: 40582,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandBuffer93 = commandEncoder115.finish({label: '\u066e\ubc8f\u0909\ud25b'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer94 = commandEncoder116.finish({});
+let externalTexture14 = device0.importExternalTexture({
+  label: '\u187d\u{1f630}\uefb7\uf96c\u12b6\ub873\u0cb4\u0a7d',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer3, 'uint16', 6_012, 934);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer11, 0, 2_364);
+} catch {}
+let commandBuffer95 = commandEncoder118.finish({label: '\u0334\uc928\u027b'});
+let texture45 = device0.createTexture({
+  label: '\u09ac\u065a\u{1fd52}\u360a\u{1f6cf}\u0706\u6c9e\u0e53\u00c3\u0e0e\u06f9',
+  size: {width: 30},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle81 = renderBundleEncoder0.finish({});
+let externalTexture15 = device0.importExternalTexture({label: '\uf201\ucf8a\u0a9e\u0b7d\u51c9\u{1fea2}\u02b6', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup0, new Uint32Array(1951), 166, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint16', 6_860, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 4, y: 16, z: 23},
+  aspect: 'all',
+}, new ArrayBuffer(1_360), /* required buffer size: 1_360 */
+{offset: 0, bytesPerRow: 14, rowsPerImage: 24}, {width: 2, height: 2, depthOrArrayLayers: 5});
+} catch {}
+try {
+commandEncoder122.label = '\ufde9\u53c3\u{1f861}\u{1ffd9}';
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({label: '\u7422\u0b9f\ufd76\u{1f697}\u1823\uf0e6'});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 2594});
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer7);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 188, new BigUint64Array(764), 181, 148);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(424), /* required buffer size: 424 */
+{offset: 424}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+try {
+bindGroupLayout5.label = '\u07cb\u4730\u0ef0\u27b0\u{1fd6d}';
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({label: '\u8fed\u{1fe80}\ue5f3\u{1fd78}\u1d0b\u0b67\u00b6\u0d9f'});
+let commandBuffer96 = commandEncoder124.finish({label: '\u0af4\u2f63\u046c\u6581'});
+let textureView36 = texture36.createView({
+  label: '\u0e40\u53b3\u40f6\u4ec3\uc370\u107a\u0b13\ub653\ue21c\u{1f9b8}\u9cc1',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 6,
+  arrayLayerCount: 4,
+});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+commandEncoder117.clearBuffer(buffer10, 1032, 1480);
+} catch {}
+try {
+device0.queue.submit([commandBuffer85]);
+} catch {}
+await gc();
+let commandBuffer97 = commandEncoder123.finish({label: '\ube18\u0b88\ube68\u{1f9d8}\u0646'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup6, []);
+} catch {}
+try {
+device0.queue.submit([commandBuffer93]);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView37 = texture33.createView({aspect: 'all', baseArrayLayer: 15, arrayLayerCount: 32});
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(2.9729574988493477, 4.2079496826418366, 0.7822880369729145, 2.6724532298602903, 0.5513472744951753, 0.7135100462883419);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup5, new Uint32Array(3677), 84, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandBuffer98 = commandEncoder127.finish();
+let renderBundle82 = renderBundleEncoder8.finish({label: '\u{1f9a8}\u095a\u{1ff01}\u01e5'});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer8);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer10, 840, 872);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 796, new DataView(new ArrayBuffer(7294)), 2244, 416);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let querySet14 = device0.createQuerySet({label: '\u0b22\u04d2', type: 'occlusion', count: 135});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer7, 608, 246);
+} catch {}
+try {
+device0.queue.submit([commandBuffer98, commandBuffer97]);
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({label: '\uef3d\ufdae\u09bb\uaa83\u0bcd\u{1f612}'});
+try {
+commandEncoder59.resolveQuerySet(querySet5, 73, 218, buffer1, 512);
+} catch {}
+try {
+device0.queue.submit([commandBuffer94]);
+} catch {}
+video3.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(3613), 265, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer13, 'uint16', 878, 6_190);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer3, 3_280);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 427 */
+  offset: 427,
+  rowsPerImage: 29,
+  buffer: buffer7,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer14 = device0.createBuffer({
+  label: '\u9e23\u{1f9a8}\u0468\u1513\u0914\u8792\u{1f8e7}\ufa04',
+  size: 14915,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandBuffer99 = commandEncoder32.finish({label: '\u{1f93a}\u{1fc19}\u0d4e\u{1ff49}\u021a\u280e\u{1f732}\u36d7\u5917\u00be\u8a34'});
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup4, new Uint32Array(436), 129, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint16', 380, 328);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer8);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer14, 2208, buffer1, 1480, 168);
+} catch {}
+canvas1.width = 493;
+await gc();
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\uca26\u5c65\u{1fd8c}\u0c17\u5925',
+  bindGroupLayouts: [bindGroupLayout14, bindGroupLayout18, bindGroupLayout16],
+});
+let commandBuffer100 = commandEncoder59.finish({label: '\u21c7\u6480\u9657\u5aaf\u080f\u079e'});
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let commandBuffer101 = commandEncoder128.finish({label: '\u18c6\u5a24'});
+let renderPassEncoder1 = commandEncoder125.beginRenderPass({
+  label: '\u0ed2\u0c41',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 22,
+  clearValue: { r: -506.1, g: 386.4, b: 397.4, a: -328.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView0, depthLoadOp: 'load', depthStoreOp: 'discard', stencilClearValue: 2798},
+});
+let renderBundle83 = renderBundleEncoder4.finish();
+let externalTexture16 = device0.importExternalTexture({label: '\uc557\u6589\ub6e2\u013e\u0730\u{1fbbd}', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 529.5, g: -844.1, b: 993.6, a: 333.6, });
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder({label: '\u0d08\u{1fc99}\u{1fc95}\u1667\u3b34\ud225\u{1fa9e}\u{1f8d4}\u6dd2\ucb70'});
+let texture46 = device0.createTexture({
+  label: '\u00b0\u0c4f\u02dc\ub27d\u{1ffd9}\ub512\ue963\u{1fff8}',
+  size: {width: 30, height: 30, depthOrArrayLayers: 5},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle84 = renderBundleEncoder3.finish({label: '\u{1fbd9}\u{1ffcf}\u1e50\u5756\u8f52\u037a\u033d\u{1ffef}\u483a'});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+commandEncoder48.label = '\u{1fc03}\ud089\u56fc\uf708';
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup0, new Uint32Array(3570), 573, 0);
+} catch {}
+let promise24 = shaderModule0.getCompilationInfo();
+try {
+commandEncoder121.resolveQuerySet(querySet10, 64, 50, buffer3, 4864);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u0e2e');
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+let commandBuffer102 = commandEncoder119.finish({label: '\u{1f895}\u5c65\uea7e\u{1f7d7}\u{1fd4a}\u047f\uf633'});
+let texture47 = device0.createTexture({
+  label: '\u0389\u16dd\ue369\u6c5a',
+  size: {width: 30},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle85 = renderBundleEncoder5.finish({label: '\u2b4b\u60a2\u0e6d\u6087\u0c16'});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer11, 0, 4_107);
+} catch {}
+try {
+commandEncoder126.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 40 */
+  offset: 40,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 756, new BigUint64Array(3155), 1531, 352);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(130), /* required buffer size: 130 */
+{offset: 130, rowsPerImage: 109}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u6707\u0a5a',
+  size: 10229,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder131 = device0.createCommandEncoder({label: '\ufa33\u045c\u{1f979}\u0b26\uf237\u03ce'});
+let commandBuffer103 = commandEncoder130.finish({label: '\u0005\uc46a\u29b9\u056f'});
+let renderPassEncoder2 = commandEncoder126.beginRenderPass({
+  label: '\u{1f602}\ua2b2\u1a3f\u0ed5\u79fb\u0167',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 18,
+  clearValue: { r: -208.3, g: -492.7, b: 647.9, a: 981.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: -2.1136652642410603,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 16343,
+  },
+});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, undefined, 0);
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageBitmap5);
+let commandEncoder132 = device0.createCommandEncoder({label: '\u{1fc44}\u2661\u487f\u{1f660}\u60be'});
+try {
+renderPassEncoder0.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer3, 11_452, 891);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1207 */
+  offset: 1207,
+  bytesPerRow: 0,
+  rowsPerImage: 123,
+  buffer: buffer10,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 6, depthOrArrayLayers: 14});
+} catch {}
+try {
+commandEncoder132.insertDebugMarker('\u095c');
+} catch {}
+try {
+device0.queue.submit([commandBuffer101, commandBuffer103]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 8},
+  aspect: 'all',
+}, new ArrayBuffer(27_204), /* required buffer size: 27_204 */
+{offset: 42, bytesPerRow: 58, rowsPerImage: 18}, {width: 18, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder({label: '\uae4d\u{1ffcf}\uca96\u9a9c\u0267'});
+let querySet15 = device0.createQuerySet({label: '\u0ce8\udb47', type: 'occlusion', count: 2380});
+let commandBuffer104 = commandEncoder70.finish();
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint32', 2_404, 2_496);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(10), /* required buffer size: 10 */
+{offset: 10, rowsPerImage: 9}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise24;
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 1_244, 5_058);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer10, 'uint32', 628, 245);
+} catch {}
+try {
+commandEncoder131.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 19 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 832 */
+  offset: 832,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {width: 19, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(119), /* required buffer size: 119 */
+{offset: 119, rowsPerImage: 43}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({label: '\u07f0\u{1fd12}\u1d43\u2655'});
+let computePassEncoder36 = commandEncoder122.beginComputePass({});
+let renderBundle86 = renderBundleEncoder5.finish({label: '\u1a44\uf472\u{1fc02}\u2c71\u{1fe12}'});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3, new Uint32Array(578), 87, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer8, 'uint32', 232, 1_750);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 5108, new DataView(new ArrayBuffer(11769)), 432, 1136);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5, bindGroupLayout2]});
+let textureView38 = texture9.createView({
+  label: '\u9d33\u0fc0\u0ba8\ub787\ufe76\u0074\ubd1d\ufe86\u026a\u6f68',
+  dimension: 'cube-array',
+  baseMipLevel: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder37 = commandEncoder133.beginComputePass({label: '\u{1f8ca}\u{1fb30}\u08d6\u0e3b\u6cfe\u5ab1\u062e\uae3a\u{1faa8}\u7cc8\u0e52'});
+let renderBundle87 = renderBundleEncoder5.finish({label: '\u400f\u74b5\u7e7a\u6240\u6241\u0755\u16df'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer7, 'uint16', 682, 184);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 407 */
+  offset: 407,
+  buffer: buffer8,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12, bindGroupLayout16, bindGroupLayout2, bindGroupLayout1]});
+let commandEncoder135 = device0.createCommandEncoder({label: '\u0465\u0887\ud647\u0646\u053d\u{1fd2a}\u2def'});
+let texture48 = device0.createTexture({
+  label: '\u0656\u0ac3\u{1fa32}',
+  size: [15, 15, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView39 = texture43.createView({label: '\u{1f711}\u{1fb69}\u0a60\u6fa5\u0cbe', format: 'r8unorm'});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer4, 1_260);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder135.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21288 */
+  offset: 548,
+  bytesPerRow: 256,
+  rowsPerImage: 27,
+  buffer: buffer0,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({label: '\u{1f915}\u{1fc4b}\u2e6a\u{1f912}\uba61\u887b\u076f\u7a2c\u{1f974}\ub596\u6eb8'});
+let renderPassEncoder3 = commandEncoder136.beginRenderPass({
+  label: '\u9c86\u{1fb11}\u{1f63a}\ue676\u845b',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 45,
+  clearValue: { r: 375.0, g: 531.3, b: 418.2, a: -942.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.9048132415487535,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 57764,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet10,
+});
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer10, 'uint32', 392, 394);
+} catch {}
+try {
+commandEncoder131.copyBufferToBuffer(buffer4, 4256, buffer6, 3968, 1028);
+} catch {}
+try {
+commandEncoder121.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 628 */
+  offset: 628,
+  rowsPerImage: 27,
+  buffer: buffer15,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 804 */
+  offset: 804,
+  buffer: buffer10,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer105 = commandEncoder129.finish({label: '\u{1f90e}\u2f9c\u31c0\u{1ff6e}\ua3a1\u6f05\u{1fe61}'});
+let renderBundle88 = renderBundleEncoder1.finish({label: '\u0165\u{1ff1b}\u{1ffc5}\u{1fdef}'});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint16', 1_222, 5_825);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\ufd80\u8378\u{1fbe9}\u{1f696}\u1653\u{1f6fa}\ud3be\ub703\u{1ff58}',
+  entries: [
+    {
+      binding: 389,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 26, 375);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint32', 4, 571);
+} catch {}
+let commandBuffer106 = commandEncoder135.finish();
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer10, 900);
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.WRITE, 0, 72);
+} catch {}
+try {
+commandEncoder131.resolveQuerySet(querySet7, 5, 13, buffer1, 256);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let canvas2 = document.createElement('canvas');
+let commandEncoder137 = device0.createCommandEncoder({label: '\uea22\u43a6\u4df1\u1b52\u94f5\u6138\u{1f714}\u00e3'});
+let commandBuffer107 = commandEncoder137.finish({label: '\u383d\u{1feb1}\uf462\u{1fdcd}\u{1f809}\u079a\u0859\u05bf\uef91\u0809\u335c'});
+let externalTexture17 = device0.importExternalTexture({label: '\u{1f795}\u015c\u{1f9b4}', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer5, 2_496);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder138.beginComputePass({label: '\u0b00\u3b07\u2e78\ud39a\u29fe\u64ae\u9e8f\u04d4\u189a\u{1fd1a}'});
+let renderPassEncoder4 = commandEncoder121.beginRenderPass({
+  label: '\u0a9e\u0bd9\ufc30\u037a',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 13,
+  clearValue: { r: 798.5, g: 323.4, b: 666.5, a: -990.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.24671871349504415,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 13414,
+    stencilReadOnly: true,
+  },
+});
+let renderBundle89 = renderBundleEncoder5.finish({label: '\u096e\u{1ff77}\u0955\u{1fa28}\u0ada\u{1f641}\u047c'});
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(102), /* required buffer size: 102 */
+{offset: 102, rowsPerImage: 208}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder139 = device0.createCommandEncoder({label: '\u09d6\ub5a8\u0587\u63dd\u{1fbf7}\u929b\u0506'});
+try {
+renderPassEncoder0.setViewport(2.352523232747987, 3.810763738056507, 1.547256045571594, 0.4214309338552094, 0.25236386948359635, 0.5658897462878871);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer3, 1_808, 794);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer5, 6_512);
+} catch {}
+let videoFrame5 = new VideoFrame(video3, {timestamp: 0});
+let commandEncoder140 = device0.createCommandEncoder({label: '\u06e4\u037f\u0a9d'});
+let externalTexture18 = device0.importExternalTexture({label: '\u3998\u{1fe34}\u5bf2\u939a\u189a', source: videoFrame3});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer6, 'uint16', 3_884, 1_514);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer10, 16, 4_477);
+} catch {}
+let promise25 = shaderModule0.getCompilationInfo();
+try {
+computePassEncoder8.insertDebugMarker('\u0348');
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer7, 'uint16', 882, 189);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer11, 3_380, 634);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(2_787), /* required buffer size: 2_787 */
+{offset: 255, bytesPerRow: 41, rowsPerImage: 27}, {width: 31, height: 8, depthOrArrayLayers: 3});
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\u0434\ub975\u{1f6da}\u04bb\ua5a4\u0d37\u569a\u946f\u421f',
+  entries: [
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer10, 'uint32', 628, 1_210);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer7, 'uint32', 72, 10);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(0, buffer4, 0, 7_989);
+} catch {}
+try {
+device0.queue.submit([commandBuffer100]);
+} catch {}
+document.body.prepend(img3);
+let imageData15 = new ImageData(4, 48);
+let commandBuffer108 = commandEncoder132.finish({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+let commandEncoder141 = device0.createCommandEncoder({});
+let commandBuffer109 = commandEncoder141.finish({label: '\ua297\u041e\u6455\ud408\u83c0'});
+let computePassEncoder39 = commandEncoder131.beginComputePass({label: '\u013b\u9a1d'});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup3, new Uint32Array(613), 222, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+commandEncoder117.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 22, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer110 = commandEncoder140.finish({label: '\ua830\u0505\u0c41\u0b47\u0e36\ue345\u00f4\u48b7'});
+let renderBundle90 = renderBundleEncoder5.finish({label: '\u1837\u2e64\u49d7\u870b\ud0c9\u0ba5\u096b\u1814\u6409\u{1f6ae}'});
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2, new Uint32Array(4330), 209, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 1_148, 732);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1, new Uint32Array(2700), 0, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer10, 'uint16', 2_498, 1_541);
+} catch {}
+try {
+device0.queue.submit([commandBuffer102, commandBuffer96, commandBuffer105]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(36), /* required buffer size: 36 */
+{offset: 36}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder34.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer4, 4_908, 111);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 984 */
+  offset: 984,
+  buffer: buffer1,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup4, new Uint32Array(2253), 243, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 952, new DataView(new ArrayBuffer(2565)), 461);
+} catch {}
+let buffer16 = device0.createBuffer({
+  label: '\u9c98\u07af',
+  size: 5325,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle91 = renderBundleEncoder8.finish({label: '\u948c\u{1fb56}\ua37e\u02a1\uf066\u0632\u071b\u1d02'});
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let imageData16 = new ImageData(216, 64);
+let computePassEncoder40 = commandEncoder134.beginComputePass();
+let renderBundle92 = renderBundleEncoder3.finish({label: '\u0dbc\ub8a2\u04fb\u{1f666}'});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(36), /* required buffer size: 36 */
+{offset: 36, bytesPerRow: 42, rowsPerImage: 34}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder142 = device0.createCommandEncoder({label: '\uabbb\u5e36\u{1f85e}\u2747\u0ca7'});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 2});
+let commandBuffer111 = commandEncoder142.finish({label: '\u237f\ufe14'});
+let externalTexture19 = device0.importExternalTexture({label: '\u{1f98c}\u74e5\uf6ac\u0f70', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup3, new Uint32Array(1190), 157, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup6, new Uint32Array(2251), 1, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer8, 'uint32', 2_748, 45);
+} catch {}
+try {
+device0.queue.submit([commandBuffer111, commandBuffer107, commandBuffer109]);
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({label: '\u{1f85c}\u6589\u0d23\ua184\ufc01\u3370\ufae4\u261b\u{1f718}'});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer8, 'uint32', 120, 4_239);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer7, 892, 230);
+} catch {}
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 483});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer8);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer8, 'uint16', 618, 1_251);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer15, 1_476, 117);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(5_847), /* required buffer size: 5_847 */
+{offset: 323, bytesPerRow: 16, rowsPerImage: 57}, {width: 4, height: 4, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder();
+let querySet18 = device0.createQuerySet({label: '\u{1fc46}\u0c2d\u21f2\u08c4\u0094\u02f3', type: 'occlusion', count: 519});
+let renderPassEncoder5 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 15,
+  clearValue: { r: -457.8, g: -719.7, b: -323.2, a: 607.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.054445528235744445,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 8223,
+    stencilReadOnly: false,
+  },
+});
+let renderBundle93 = renderBundleEncoder14.finish({label: '\uc9fb\u0852\u{1fd5a}'});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup2, new Uint32Array(170), 23, 0);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({label: '\u6841\u02d0\u{1f6be}\ucc4d\u8b0d\u0e31\u{1fed8}\u1ce5'});
+let commandBuffer112 = commandEncoder117.finish({label: '\u08e3\u01a3\u14cb\u8c7e\u0b60\u6a41\u{1f991}\u8fce\ub7d1\uf583'});
+let renderBundle94 = renderBundleEncoder7.finish({});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer16, 'uint16', 34, 182);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(34_950), /* required buffer size: 34_950 */
+{offset: 636, bytesPerRow: 122, rowsPerImage: 53}, {width: 32, height: 17, depthOrArrayLayers: 6});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise23;
+} catch {}
+let buffer17 = device0.createBuffer({
+  label: '\u{1f827}\u04ad\u{1fe6d}\u1e15\u0b72\u{1fc2d}\u92fd',
+  size: 10592,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder41 = commandEncoder143.beginComputePass();
+let renderBundle95 = renderBundleEncoder10.finish({label: '\u{1fbf2}\ue9ce\u{1f7e1}\u40e5\u0595\u{1fc2c}'});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup4, new Uint32Array(643), 70, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer17, 'uint32', 3_348, 635);
+} catch {}
+try {
+commandEncoder139.copyBufferToBuffer(buffer10, 592, buffer4, 6132, 756);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise27;
+} catch {}
+let commandBuffer113 = commandEncoder139.finish({});
+let texture49 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView40 = texture31.createView({label: '\u{1f957}\u1c2c\u0460\u92d2\u8fbe\uab34\u7196\u8d21\u0ff0', arrayLayerCount: 1});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer16);
+} catch {}
+try {
+commandEncoder138.insertDebugMarker('\ud5e7');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.prepend(img5);
+let commandEncoder146 = device0.createCommandEncoder({label: '\u0eef\u635c\u6bf0\ud552'});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer1, 'uint32', 1_104, 609);
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder();
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer6, 'uint32', 1_152, 952);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup('\u0cdb');
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 390.0, g: 330.8, b: 193.1, a: -531.1, });
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint32', 584, 1_349);
+} catch {}
+try {
+computePassEncoder37.popDebugGroup();
+} catch {}
+try {
+  await promise25;
+} catch {}
+try {
+adapter3.label = '\u844b\u0f76\ubed1\u5abb\u{1fc1d}';
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout15, bindGroupLayout21, bindGroupLayout14, bindGroupLayout15]});
+let renderPassEncoder6 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 0,
+  clearValue: { r: 376.2, g: 114.1, b: 809.9, a: -993.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 1.7823916164801208,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 29025,
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 293443423,
+});
+let renderBundle96 = renderBundleEncoder10.finish({label: '\u06dd\u0947\u{1ff67}\u{1fa46}\ua8c9\uc1c0\u65f8'});
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(1, bindGroup0, new Uint32Array(517), 114, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup5, new Uint32Array(108), 3, 0);
+} catch {}
+try {
+commandEncoder147.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1060 */
+  offset: 1060,
+  buffer: buffer1,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video4.height = 37;
+let commandEncoder148 = device0.createCommandEncoder();
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 282});
+let commandBuffer114 = commandEncoder138.finish({label: '\u0783\u0b00\u0e95\uea5d\u40d2'});
+let computePassEncoder42 = commandEncoder147.beginComputePass({label: '\u{1fc7f}\u{1fc50}\u5b02\u{1ff5f}\u{1fc8a}\u{1ff07}\uc63a\u029f\ub4c7\u0066'});
+let renderBundle97 = renderBundleEncoder2.finish({label: '\u{1fdb1}\ue593\u{1f850}\u3582\u3c35\ue916\u0e15\u9c81\ue630'});
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder({label: '\ubf7e\u{1fd63}\u0388\u{1fb6a}\u{1fc2d}\u05ed\u0fd4\u0534\ub919\u55b9\u6bbd'});
+let computePassEncoder43 = commandEncoder149.beginComputePass();
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer7, 0, 66);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer110, commandBuffer112]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(11_020), /* required buffer size: 11_020 */
+{offset: 61, bytesPerRow: 150, rowsPerImage: 72}, {width: 9, height: 2, depthOrArrayLayers: 2});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandBuffer115 = commandEncoder146.finish({label: '\u7ff0\u59ce\u4105\u0a1e\u07b8\u0b06\u4edc'});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup4, new Uint32Array(48), 1, 0);
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2072 */
+  offset: 2072,
+  bytesPerRow: 0,
+  rowsPerImage: 141,
+  buffer: buffer8,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer10, 0, 4_637);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let commandEncoder150 = device0.createCommandEncoder({label: '\u00a7\uaaf0\u1d1d\u0b70\u03ed\udf4d\uc36c'});
+let renderBundle98 = renderBundleEncoder2.finish({label: '\uc40d\u26cc\u0a9e\u6b77\u{1fa96}\u7c56\u{1fdcc}\u6b8b\u{1f6d4}'});
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer8, 'uint32', 976, 335);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer4, 0, 282);
+} catch {}
+let arrayBuffer4 = buffer12.getMappedRange(8, 16);
+try {
+device0.queue.submit([commandBuffer114]);
+} catch {}
+let computePassEncoder44 = commandEncoder148.beginComputePass({});
+let renderBundle99 = renderBundleEncoder4.finish({label: '\u06a2\u{1f694}\u40c0\u0a8d\u8360\u8223'});
+try {
+renderBundleEncoder13.setVertexBuffer(4, buffer8, 3_548, 2_280);
+} catch {}
+try {
+commandEncoder150.clearBuffer(buffer1);
+} catch {}
+let imageData17 = new ImageData(4, 16);
+let commandEncoder151 = device0.createCommandEncoder();
+let computePassEncoder45 = commandEncoder151.beginComputePass({label: '\u{1fd4a}\uc542\u0ecc\u3e60'});
+let renderBundle100 = renderBundleEncoder14.finish({label: '\u0f1b\u01d0\u04de\u{1f7e8}\u{1fe61}\u08d6\u{1fcc8}\uf05c\u02ae'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup5, new Uint32Array(5323), 348, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer7, 520, 174);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer3, 1_284);
+} catch {}
+try {
+device0.queue.submit([commandBuffer108]);
+} catch {}
+let computePassEncoder46 = commandEncoder150.beginComputePass({label: '\u4c8f\u{1f9b4}\u02bc\u{1ff51}\ufd70\u{1f8c2}\u9a51'});
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+window.someLabel = commandEncoder117.label;
+} catch {}
+let commandEncoder152 = device0.createCommandEncoder();
+let commandBuffer116 = commandEncoder152.finish({});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer115, commandBuffer116]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4408, new DataView(new ArrayBuffer(3836)), 175, 860);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder153 = device0.createCommandEncoder({label: '\u0ddb\u242c\ubc58\udf65'});
+let texture50 = device0.createTexture({
+  label: '\uc432\u0392\u54df\udb6b\u09ea\ucffa\ue9b9',
+  size: {width: 30, height: 30, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle101 = renderBundleEncoder1.finish({label: '\u{1fe69}\u{1ff2a}'});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer8, 132, 1_763);
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({label: '\u{1ff07}\u090c\u4e7f\u8287\u{1fea6}\uc52b\u{1fb99}\ue3a2'});
+let textureView41 = texture46.createView({
+  label: '\u{1fa73}\u4527\u982f\u0135\u{1fe60}\u61fc\uc4c4\u0111\ud565\uaff5',
+  dimension: '2d',
+  format: 'r32sint',
+});
+let renderPassEncoder7 = commandEncoder153.beginRenderPass({
+  label: '\u7e7a\u{1f722}\u2b48\u04a3\ua882\ue88b\u64e8\u{1fc33}\u7c64\u07b4',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 29,
+  clearValue: { r: 907.1, g: 795.3, b: -821.0, a: 754.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: -1.2907123639349756,
+    depthReadOnly: true,
+    stencilClearValue: 33636,
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 218344554,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u{1fe65}\ue8d2\uc79e',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  stencilReadOnly: true,
+});
+let renderBundle102 = renderBundleEncoder4.finish({label: '\u4112\u{1ff4d}\u014f\u91ca\u9e5f\uaa4a\ufc74\u072a'});
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer15, 0, 212);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+await gc();
+let buffer18 = device0.createBuffer({
+  label: '\u50ef\u988b\u{1f77f}\u0a13\udd83\ua378\u5272\u46c7',
+  size: 5488,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture51 = device0.createTexture({
+  size: {width: 60, height: 60, depthOrArrayLayers: 56},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup4, new Uint32Array(218), 1, 0);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2404 */
+  offset: 2404,
+  bytesPerRow: 0,
+  buffer: buffer4,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder154.resolveQuerySet(querySet10, 3, 46, buffer15, 1792);
+} catch {}
+let querySet20 = device0.createQuerySet({label: '\u870f\u0b6c\u9c5d\u08cd\u1e54\u0aa4\u3b83', type: 'occlusion', count: 1398});
+let computePassEncoder47 = commandEncoder154.beginComputePass({label: '\u295a\u064c\u{1f696}\u81f0\u45fd\u43cd\ufbc3\u0bde\uec16\u0ef4'});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(549);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer11, 48, 273);
+} catch {}
+let texture52 = device0.createTexture({
+  size: {width: 15},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle103 = renderBundleEncoder13.finish({label: '\u0a01\u0e96\u11f2\u026c\uca44\u8093'});
+try {
+renderPassEncoder3.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer5, 2_176);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4, new Uint32Array(603), 100, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer13, 'uint32', 10_720, 1_397);
+} catch {}
+let arrayBuffer5 = buffer12.getMappedRange(24, 0);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1504, new BigUint64Array(2322));
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer7, 'uint16', 156, 690);
+} catch {}
+let renderBundle104 = renderBundleEncoder14.finish({label: '\u{1fe0e}\u5609\u{1fc17}\u2053\u77d8'});
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer10, 0);
+} catch {}
+try {
+  await promise22;
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer14, 372, 1_008);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder155 = device0.createCommandEncoder({label: '\ubc4d\u{1ffc0}\u032f\u8a4d\u3e48\u858a\u6a1a'});
+let commandBuffer117 = commandEncoder155.finish({});
+let renderBundle105 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup2, new Uint32Array(69), 7, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint16', 800, 859);
+} catch {}
+let imageData18 = new ImageData(20, 52);
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 134,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer6, 'uint16', 1_062, 310);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer5, 1460, buffer16, 1532, 752);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 620, new Float32Array(5020), 1242, 240);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(190), /* required buffer size: 190 */
+{offset: 190, bytesPerRow: 23}, {width: 1, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 60, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData11,
+  origin: { x: 0, y: 16 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({label: '\ua519\u13cd\ubc36\u1097\ua33b\u38e5\u{1f992}', bindGroupLayouts: [bindGroupLayout20]});
+let commandBuffer118 = commandEncoder23.finish({label: '\udbde\ud37b\u5fb0\ufce0'});
+let renderBundle106 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup3, new Uint32Array(1484), 333, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer16, 'uint32', 484, 223);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer16, 112, 1_413);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint16', 1_078, 1_506);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder156 = device0.createCommandEncoder({label: '\u2e6d\ua95d\u0838\u{1fee6}\u0968\u0d1c\u046c\u{1f85f}\u0f57\uba25\uf45a'});
+let commandBuffer119 = commandEncoder156.finish({});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup2, new Uint32Array(695), 138, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup5);
+} catch {}
+let video5 = await videoWithData();
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer15, 964);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup4, new Uint32Array(113), 11, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer16, 'uint32', 2_256, 1_050);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+let pipelineLayout26 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout18, bindGroupLayout23]});
+let commandEncoder157 = device0.createCommandEncoder({label: '\ue139\u073e'});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer11, 2_620);
+} catch {}
+let renderBundle107 = renderBundleEncoder12.finish();
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer4, 1_524);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer13, 'uint32', 1_488, 1_227);
+} catch {}
+try {
+querySet10.destroy();
+} catch {}
+document.body.prepend(video5);
+let canvas4 = document.createElement('canvas');
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u0f81\u0316\u{1f882}\u01e1\ua4c1\u{1ff6a}\u{1fdd0}\uc88b\u5556',
+  entries: [
+    {binding: 102, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 598,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 198,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let renderBundle108 = renderBundleEncoder12.finish({});
+try {
+renderPassEncoder3.beginOcclusionQuery(46);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer17, 'uint16', 2_032, 4_727);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer1, 'uint32', 1_780, 97);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer118]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(99), /* required buffer size: 99 */
+{offset: 99}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = canvas4.getContext('webgpu');
+let commandEncoder159 = device0.createCommandEncoder({label: '\u7d63\u084a\u0192\u{1fcf0}\u{1f6c6}\ue2ed\u{1febb}\u{1f97f}'});
+let sampler12 = device0.createSampler({
+  label: '\u{1fda1}\uff74',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.36,
+  lodMaxClamp: 61.05,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup2, new Uint32Array(1626), 134, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint32', 244, 9);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4_294_967_295, undefined, 0, 4_531_120);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder({});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 625});
+let commandBuffer120 = commandEncoder158.finish({label: '\u9bcb\u229d\u6a8c\u0eec\uc91a'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup1, new Uint32Array(126), 8, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 10528, new Float32Array(20399), 216, 232);
+} catch {}
+let imageData19 = new ImageData(140, 16);
+try {
+renderPassEncoder3.beginOcclusionQuery(31);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandBuffer121 = commandEncoder159.finish({label: '\ua26c\u0081\uad77\u913a\uf0e0\u0c2a\u84ed\u0ebf\u9db8'});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(2, bindGroup6, new Uint32Array(371), 135, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+await gc();
+let video6 = await videoWithData();
+let commandEncoder161 = device0.createCommandEncoder({label: '\u0597\u7e3c\u070f\u07e4\u1c8d\u{1fa64}\uaa41\u491a'});
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer18, 0);
+} catch {}
+try {
+commandEncoder161.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4698 */
+  offset: 4698,
+  buffer: buffer10,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer121, commandBuffer117, commandBuffer113]);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(36);
+} catch {}
+try {
+renderPassEncoder4.setViewport(1.7595464741887734, 6.326435357405989, 0.11861315325647259, 0.4849165606906811, 0.9347060813416241, 0.9573106546624947);
+} catch {}
+try {
+commandEncoder161.resolveQuerySet(querySet12, 7, 122, buffer1, 768);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let computePassEncoder48 = commandEncoder157.beginComputePass();
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(595), 351, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer11, 316, 708);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(7, buffer10, 2_996, 55);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+await gc();
+let commandEncoder162 = device0.createCommandEncoder();
+let commandBuffer122 = commandEncoder162.finish();
+let renderPassEncoder8 = commandEncoder161.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 6,
+  clearValue: { r: 168.6, g: 281.2, b: -156.5, a: 895.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView0, depthClearValue: 6.798375578618639, depthReadOnly: true},
+});
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer13, 'uint16', 2_102, 1_613);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+querySet3.destroy();
+} catch {}
+let arrayBuffer6 = buffer12.getMappedRange(32, 4);
+try {
+commandEncoder160.copyBufferToBuffer(buffer15, 3872, buffer16, 140, 748);
+} catch {}
+try {
+commandEncoder160.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1590 */
+  offset: 1590,
+  bytesPerRow: 256,
+  buffer: buffer14,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer123 = commandEncoder160.finish({label: '\u0742\u5639\u{1fa5a}\u{1f9e1}\u{1fb4d}\u675f\uefd1'});
+let texture53 = device0.createTexture({
+  label: '\u{1ffe6}\ub974\uaae9\u0c0d\u{1fee4}\u0ab1\u44f0\ub798\u4c28',
+  size: [60],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+texture5.destroy();
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+  await promise29;
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer0, 'uint16', 3_614, 9_027);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 12, new Int16Array(3952), 751, 720);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup3, new Uint32Array(956), 165, 0);
+} catch {}
+let sampler13 = device0.createSampler({
+  label: '\u0fc6\u{1f7fb}\uba11\uc18d\u07cb\u{1f699}\u06e6\u0a0b\u{1f6d5}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.62,
+});
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(0, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 2_108, 2_447);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer8, 'uint32', 252, 633);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 60, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video6);
+let offscreenCanvas2 = new OffscreenCanvas(125, 110);
+let imageBitmap7 = await createImageBitmap(video4);
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  label: '\u0a22\ud732\u8ca0\uf8bf\u0734\u{1fb21}\u{1fc05}',
+  entries: [
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 222,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 111,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 137, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 911,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 227,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 90,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 339, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 168,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 329,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 27, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 770,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 306, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 38, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 415, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 349,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 326,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 46,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 123,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 127, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 367,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 207,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 200, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 298, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 315,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 445,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 4, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 309, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 29, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 86,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 52, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 108,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 234,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 135,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 52751, hasDynamicOffset: false },
+    },
+    {
+      binding: 263,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 367887, hasDynamicOffset: false },
+    },
+    {
+      binding: 248,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 577038, hasDynamicOffset: false },
+    },
+    {binding: 212, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 221, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 155,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 117, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 45, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 288,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 57, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 511,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 8, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 152, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 578, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 401, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 317,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 420,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 345885, hasDynamicOffset: false },
+    },
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 93, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 61, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 125, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 77, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 311,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 15, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 66, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 65, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 106, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 223, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 147, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 184, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 237, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 32, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 56, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 179, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 239, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 75, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 198, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 21, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 36, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 409, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 181,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 44, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 202, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 133, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 377,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 316,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 228,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 74, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 217, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 76, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 195, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 53, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 411,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 73, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 255, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 71,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 307, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let pipelineLayout27 = device0.createPipelineLayout({label: '\u47f6\ue85a\u3488\u0eab\u{1f866}\u2f6c\u3c5a\ue7e3', bindGroupLayouts: []});
+try {
+computePassEncoder46.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(469_424), /* required buffer size: 469_424 */
+{offset: 16, bytesPerRow: 113, rowsPerImage: 50}, {width: 6, height: 5, depthOrArrayLayers: 84});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderBundle109 = renderBundleEncoder8.finish();
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer13, 'uint16', 1_688, 1_767);
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer16, 1728, 40);
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder({label: '\ud492\u0ea0\ua87d'});
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+let pipelineLayout28 = device0.createPipelineLayout({
+  label: '\u365f\u134f\u0189\ua168\u4ca6\u4861\ud3ce\u05c0\u{1fc8f}',
+  bindGroupLayouts: [bindGroupLayout14, bindGroupLayout1, bindGroupLayout5],
+});
+let commandEncoder164 = device0.createCommandEncoder({label: '\u93a7\u00f9\u0f65'});
+let textureView42 = texture51.createView({
+  label: '\u0e09\u{1fca4}\u679c\u6782\u7703\u0726\u0d5b',
+  dimension: 'cube-array',
+  baseMipLevel: 2,
+  baseArrayLayer: 1,
+  arrayLayerCount: 36,
+});
+let computePassEncoder49 = commandEncoder77.beginComputePass({label: '\u{1fb0d}\u79ea\u0304\u85c0\u{1fb40}'});
+let renderPassEncoder9 = commandEncoder163.beginRenderPass({
+  colorAttachments: [{view: textureView27, depthSlice: 26, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: -6.79569672694684,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilReadOnly: true,
+  },
+});
+let renderBundle110 = renderBundleEncoder0.finish({label: '\u0cbb\ue789\u0da3\ub292\u027f\u7a76\u0755\u{1f815}'});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer10, 0);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer12, 212, buffer6, 7972, 20);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let pipelineLayout29 = device0.createPipelineLayout({
+  label: '\udbca\u654d\u09ae\udc69\u08ca\uf4cf\u4304\ud966\u{1fe15}\u{1ffbd}\u94f9',
+  bindGroupLayouts: [bindGroupLayout25, bindGroupLayout14],
+});
+let commandEncoder165 = device0.createCommandEncoder({label: '\uf550\u064e'});
+let renderBundle111 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(25), /* required buffer size: 25 */
+{offset: 25}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder27.label;
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({label: '\u9cdc\u343a\u0559\u2726\u{1f796}\u{1fb96}\u27a2\u{1ff61}\u2cd4'});
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+let commandBuffer124 = commandEncoder166.finish({label: '\u0b0c\uf035\u6900'});
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer16, 0, 2_548);
+} catch {}
+let pipelineLayout30 = device0.createPipelineLayout({label: '\u0bb4\u9193\u4e11\u5a79\uafd8\u0e34\u0707\u0251', bindGroupLayouts: [bindGroupLayout6]});
+let commandBuffer125 = commandEncoder165.finish();
+try {
+renderPassEncoder7.setIndexBuffer(buffer10, 'uint32', 972, 389);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer18, 0, 256);
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 496 */
+  offset: 496,
+  buffer: buffer15,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandBuffer126 = commandEncoder164.finish({label: '\uc9c8\u0929\u0315\u0b10\u{1ff45}\u66d5'});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer15, 'uint32', 3_508, 2_268);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+texture26.destroy();
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(157), /* required buffer size: 157 */
+{offset: 157}, {width: 60, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData11,
+  origin: { x: 0, y: 44 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 2, y: 3, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder167 = device0.createCommandEncoder({label: '\ud5c9\u{1fcdd}\u9bd7\u77c2'});
+let commandBuffer127 = commandEncoder167.finish({label: '\ueb6e\u48d2'});
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint32', 16_572, 2_192);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer18, 888, 1_596);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 60, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData2,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 9, y: 18, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({
+  label: '\u0b31\u08db\u0686\ub510\u70ec\u6ba0\u58d1\u02c4\uefa8\u{1fc86}\u2948',
+  type: 'occlusion',
+  count: 272,
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(8463), 2956, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer16, 'uint32', 1_352, 91);
+} catch {}
+try {
+commandEncoder168.insertDebugMarker('\ueb81');
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+let commandEncoder169 = device0.createCommandEncoder();
+let renderBundle112 = renderBundleEncoder14.finish({});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup5, new Uint32Array(1822), 19, 0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(2.391963817190352, 4.402622449749967, 2.518749158670427, 0.7109919657941006, 0.2667026052809308, 0.5994558175108667);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup0, new Uint32Array(1861), 102, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer16, 'uint16', 1_028, 1_349);
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.WRITE, 352, 48);
+} catch {}
+try {
+commandEncoder169.clearBuffer(buffer1);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let computePassEncoder50 = commandEncoder169.beginComputePass();
+try {
+computePassEncoder3.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer0, 'uint16', 866, 5_782);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet23 = device0.createQuerySet({label: '\u8b1d\u076b\u4f7f\u0f72\ud146', type: 'occlusion', count: 404});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup2, new Uint32Array(329), 59, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(142);
+} catch {}
+try {
+device0.queue.submit([commandBuffer122, commandBuffer127, commandBuffer119]);
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({label: '\u71ab\u4a03\u5113'});
+let renderBundle113 = renderBundleEncoder1.finish();
+try {
+computePassEncoder28.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer14);
+} catch {}
+try {
+commandEncoder170.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 154 */
+  offset: 154,
+  rowsPerImage: 8,
+  buffer: buffer15,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder170.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 4, y: 26, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(71_359), /* required buffer size: 71_359 */
+{offset: 278, bytesPerRow: 12, rowsPerImage: 160}, {width: 5, height: 4, depthOrArrayLayers: 38});
+} catch {}
+try {
+  await promise31;
+} catch {}
+let renderBundle114 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup1, new Uint32Array(243), 20, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(763);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer18, 'uint16', 248, 731);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup0, new Uint32Array(96), 17, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer7, 'uint16', 592, 126);
+} catch {}
+try {
+commandEncoder170.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 44},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 31016 */
+  offset: 4880,
+  bytesPerRow: 256,
+  rowsPerImage: 51,
+  buffer: buffer13,
+}, {width: 6, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.submit([commandBuffer120]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 3, z: 2},
+  aspect: 'depth-only',
+}, new ArrayBuffer(82), /* required buffer size: 82 */
+{offset: 52, rowsPerImage: 21}, {width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter1.label = '\u15c4\u35ae\u03a4\u{1fcfb}\u4d8e\u5f3a\u484b\u95ef\u30dc\u8c64\u7ac5';
+} catch {}
+let texture54 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder51 = commandEncoder168.beginComputePass();
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'depth-only',
+}, new ArrayBuffer(488), /* required buffer size: 488 */
+{offset: 488, rowsPerImage: 2}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let computePassEncoder52 = commandEncoder170.beginComputePass();
+let renderBundle115 = renderBundleEncoder16.finish();
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer6, 'uint32', 1_776, 1_185);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer3, 596);
+} catch {}
+let pipelineLayout31 = device0.createPipelineLayout({label: '\u8957\u7e84\uf908\u2cbe\u{1facb}\ub657\uead2\u0b7c', bindGroupLayouts: [bindGroupLayout14]});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 333});
+let externalTexture20 = device0.importExternalTexture({label: '\u105d\ua542\u0c24', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer7, 'uint16', 186, 45);
+} catch {}
+try {
+device0.queue.submit([commandBuffer125, commandBuffer124]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData13,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 1, y: 4, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder({});
+let computePassEncoder53 = commandEncoder171.beginComputePass({});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer15, 'uint32', 4_856, 547);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 56}
+*/
+{
+  source: video4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 2, y: 26, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({label: '\u0073\u0bf3\ud72d\u7d9c\u045b\u8868'});
+let commandBuffer128 = commandEncoder172.finish({label: '\uf96e\ubdbb\u65af\u28d3\u9c41\u02ee\u6af4\u2fe8\ud556\u1ace'});
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer11, 0);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas2.getContext('webgpu');
+let commandEncoder173 = device0.createCommandEncoder({label: '\u02d6\u01e6\u0367\u{1fca0}\u1249\u7cc7'});
+let renderPassEncoder10 = commandEncoder173.beginRenderPass({
+  label: '\u01e3\u0022\u0599',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 29,
+  clearValue: { r: 815.4, g: -477.9, b: -858.7, a: -783.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.6038816948306078,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 60554,
+  },
+});
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder7.setViewport(3.4656851730718596, 6.191372705762497, 1.9384214280757868, 0.3144047874683304, 0.6569901002210801, 0.9836663987514442);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, buffer18, 1_536);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(47_306), /* required buffer size: 47_306 */
+{offset: 300, bytesPerRow: 88, rowsPerImage: 48}, {width: 7, height: 7, depthOrArrayLayers: 12});
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({label: '\u2db5\ua5e0\u61d8\u05bd\u09a3\u0205\u{1fc90}'});
+let computePassEncoder54 = commandEncoder174.beginComputePass({});
+let renderBundle116 = renderBundleEncoder15.finish({label: '\u{1f6f9}\u0708\u98ad\u{1fd98}\u0a0b\u4962\ue79f\u{1ffe0}\u733e\u{1f609}'});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup5, new Uint32Array(522), 90, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup6);
+} catch {}
+let renderBundle117 = renderBundleEncoder11.finish({label: '\u2f87\u{1fd47}\u{1f674}\u{1f7e7}\ufc98\u79ad'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer14, 1_044);
+} catch {}
+try {
+device0.queue.submit([commandBuffer128]);
+} catch {}
+let imageData20 = new ImageData(8, 28);
+let commandEncoder175 = device0.createCommandEncoder({label: '\u00af\ud56c\u{1fdef}\udd5e\u0bc0\u{1ffef}\u{1fdba}\u70b6\u0145\u{1f66b}'});
+try {
+renderPassEncoder9.setBlendConstant({ r: 619.4, g: 391.6, b: 982.9, a: -805.5, });
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer18, 2_492, 340);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup0, new Uint32Array(832), 539, 0);
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker('\u0153');
+} catch {}
+let texture55 = device0.createTexture({
+  label: '\u{1fe30}\u6b70\u8d00\u{1f7c6}\u2578\u{1fdbc}\u{1fc50}\u{1f7c8}',
+  size: [30, 30, 37],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint'],
+});
+let renderPassEncoder11 = commandEncoder175.beginRenderPass({
+  label: '\u098f\u{1f71d}\u1295\uc2e4\ud82a\u{1f970}\ud10b',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 35,
+  clearValue: { r: 340.5, g: -159.5, b: 83.02, a: 355.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView0, depthLoadOp: 'load', depthStoreOp: 'store', stencilReadOnly: true},
+});
+let renderBundle118 = renderBundleEncoder6.finish({label: '\u41e5\u{1fac7}\ufd0c'});
+let sampler14 = device0.createSampler({
+  label: '\ubefb\ue2cc\u0fce\ufc18\ufc4e\ud5f6',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.45,
+});
+let externalTexture21 = device0.importExternalTexture({label: '\u04c1\u9369\u{1fef2}\ub5f1\u{1ff76}\uf6c0', source: video6, colorSpace: 'display-p3'});
+let commandEncoder176 = device0.createCommandEncoder({label: '\u0714\uac2a\u395c\u{1fe28}\u9a79\u0806\u8f90'});
+let commandBuffer129 = commandEncoder176.finish();
+let externalTexture22 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint16', 436, 675);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(1, buffer14, 3_644, 84);
+} catch {}
+let textureView43 = texture49.createView({label: '\u{1f9ef}\u{1f777}\u0e90\ua6c6', format: 'r8unorm', arrayLayerCount: 1});
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer8, 'uint32', 1_792, 252);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer10, 'uint32', 408, 178);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer16, 628, 1_902);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint32', 396, 333);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer15);
+} catch {}
+try {
+device0.queue.submit([commandBuffer129]);
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let texture56 = device0.createTexture({
+  label: '\u{1f8b2}\u2780\ua875\uda1d\u{1fa1b}\u02f6\u0d5e',
+  size: {width: 30, height: 30, depthOrArrayLayers: 9},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder55 = commandEncoder177.beginComputePass();
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let commandEncoder178 = device0.createCommandEncoder({label: '\u0866\u185c\u{1fa59}\u489f\u{1f960}\u{1f9bc}\uf25b\u6fcf\u14ef'});
+try {
+renderPassEncoder9.setVertexBuffer(4, undefined, 0, 1_783_230_172);
+} catch {}
+let device1 = await adapter2.requestDevice({
+  label: '\u30ff\u025f\u0502\uae67\u0306\u05c0\u5c5e',
+  defaultQueue: {label: '\u{1ff90}\u0503\u0396\u4b3d\u{1fa28}\ud52e\u{1f972}'},
+  requiredFeatures: ['depth-clip-control', 'depth32float-stencil8', 'texture-compression-etc2', 'texture-compression-astc'],
+  requiredLimits: {
+    maxBindGroupsPlusVertexBuffers: 24,
+    maxUniformBufferBindingSize: 35907253,
+    maxStorageBufferBindingSize: 142592348,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<i32>,
+}
+
+@group(1) @binding(43) var tex2: texture_2d_array<u32>;
+@group(0) @binding(92) var et2: texture_external;
+@group(2) @binding(344) var tex3: texture_depth_multisampled_2d;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+}
+
+struct VertexOutput0 {
+  @location(5) @interpolate(flat, centroid) f6: vec3u,
+  @location(4) f7: vec2i,
+  @location(1) @interpolate(perspective, centroid) f8: vec2h,
+  @builtin(position) f9: vec4f,
+  @location(13) @interpolate(flat, sample) f10: u32
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(textureLoad(tex3, vec2i(), 0)) {
+    out.f6 = vec3u(bitcast<u32>(textureLoad(tex3, vec2i(), 0)));
+  }
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) @interpolate(flat) f0: vec4i,
+  @location(0) f1: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(textureLoad(et2, vec2u())[2]) {
+    out.f0 = bitcast<vec4i>(textureDimensions(et2).rgrr);
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandBuffer130 = commandEncoder178.finish();
+try {
+computePassEncoder14.setBindGroup(0, bindGroup4);
+} catch {}
+let textureView44 = texture2.createView({label: '\u67a3\ue43f\ub472', mipLevelCount: 1, baseArrayLayer: 12, arrayLayerCount: 2});
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer18);
+} catch {}
+try {
+device0.queue.submit([commandBuffer123]);
+} catch {}
+try {
+window.someLabel = commandEncoder21.label;
+} catch {}
+let renderBundle119 = renderBundleEncoder0.finish({label: '\uc60b\u0630\uf443\u0be2\u0d6a\u{1f9a3}\u8813\u0a7e\u679f\u7250\u5b20'});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer18, 0, 2_035);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer17, 'uint32', 40, 169);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({});
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(canvas3);
+let promise32 = adapter2.requestAdapterInfo();
+try {
+  await promise32;
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder179 = device1.createCommandEncoder({label: '\ub72b\u8093\u14e8\uae0f\u07a3\u06da'});
+let commandBuffer131 = commandEncoder179.finish({});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+video6.width = 5;
+let img6 = await imageWithData(6, 27, '#10101010', '#20202020');
+let bindGroupLayout26 = device1.createBindGroupLayout({
+  label: '\u866e\u{1f639}\u4825',
+  entries: [
+    {
+      binding: 470,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let querySet25 = device1.createQuerySet({label: '\u9048\u7387\u0b8e\u{1ffae}\udb5f', type: 'occlusion', count: 453});
+try {
+device1.label = '\uc424\ub747\u064e\u0546\u0bf2\u{1f775}\u0019\u{1fbcb}\u{1f958}\uac63\u3a6c';
+} catch {}
+let commandEncoder180 = device1.createCommandEncoder({label: '\u{1fd92}\u099b\u4107\u{1fb97}\u6dc4\u{1f78e}\u0c20\u34b3'});
+try {
+window.someLabel = querySet25.label;
+} catch {}
+let computePassEncoder56 = commandEncoder180.beginComputePass({label: '\u{1fee4}\u07fe\u{1fa06}\u0248\u{1f6f4}\u0778\u0870\u{1f795}\u0242\u7897'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let renderBundle120 = renderBundleEncoder12.finish({label: '\u{1ff85}\u{1f6ef}\u8efd\u8e23\ud012'});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer10, 'uint16', 2_690, 827);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout32 = device1.createPipelineLayout({
+  label: '\u0204\ufaee\u22fa\udf04\u{1ff63}\ud9ad',
+  bindGroupLayouts: [bindGroupLayout26, bindGroupLayout26],
+});
+let pipelineLayout33 = device0.createPipelineLayout({label: '\u019d\u{1fd1e}\u9652\u04b7\u078d\u{1ffb2}', bindGroupLayouts: []});
+let commandEncoder181 = device0.createCommandEncoder({label: '\u1822\u0d2e\udcb8\u{1fb5b}\u2f3a\u0af9\u0f8c\u21e3'});
+let renderPassEncoder12 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{view: textureView27, depthSlice: 44, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView0, depthLoadOp: 'load', depthStoreOp: 'store', depthReadOnly: false},
+  occlusionQuerySet: querySet24,
+});
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer18);
+} catch {}
+try {
+window.someLabel = device1.label;
+} catch {}
+let commandEncoder182 = device1.createCommandEncoder();
+let img7 = await imageWithData(19, 46, '#10101010', '#20202020');
+let commandEncoder183 = device0.createCommandEncoder();
+let computePassEncoder57 = commandEncoder183.beginComputePass({label: '\u0862\u1b0f'});
+let renderBundle121 = renderBundleEncoder3.finish({label: '\u9ebd\u1332\ua6ab'});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup0, new Uint32Array(2409), 863, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(1060), 563, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer3, 'uint16', 2_832, 6_583);
+} catch {}
+let commandEncoder184 = device1.createCommandEncoder();
+try {
+  await promise33;
+} catch {}
+let imageData21 = new ImageData(60, 56);
+let bindGroupLayout27 = device1.createBindGroupLayout({
+  label: '\u568d\ub7e9',
+  entries: [
+    {
+      binding: 89,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 390,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 598,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 3999337, hasDynamicOffset: true },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 254, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 175, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 144,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 784,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 247788, hasDynamicOffset: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 279,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 424,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let computePassEncoder58 = commandEncoder184.beginComputePass({label: '\u013b\u0b05\ubf2f\u0e84\u0346\u06de\u757f'});
+let commandEncoder185 = device0.createCommandEncoder();
+let commandBuffer132 = commandEncoder185.finish({label: '\u{1fa5a}\ud003\uc27e'});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+commandEncoder150.resolveQuerySet(querySet24, 27, 57, buffer1, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 6880, new BigUint64Array(5211), 870, 12);
+} catch {}
+try {
+adapter2.label = '\ua796\uf626\u{1fcff}\u06a1\u{1f86e}\ub88a\u{1f7f5}\u0460\ud798\ud1c0';
+} catch {}
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\u9273\u949b\u6136\u18bd\u05ef\ua39e',
+  entries: [
+    {
+      binding: 241,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let commandEncoder186 = device1.createCommandEncoder({});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder187 = device1.createCommandEncoder();
+let commandBuffer133 = commandEncoder182.finish({label: '\uf79f\u0626\u5a46\u6bb1\uad7e\u0589\u{1fc6c}\u03ca\u06c7'});
+try {
+computePassEncoder58.insertDebugMarker('\u8939');
+} catch {}
+let promise34 = device1.queue.onSubmittedWorkDone();
+let computePassEncoder59 = commandEncoder150.beginComputePass({label: '\ue2df\u7a3a\u{1f7ed}\u7587\uadd9\u08df\u{1faf5}\uc083\u{1fc85}\u0171'});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup4, new Uint32Array(5389), 139, 0);
+} catch {}
+try {
+  await promise34;
+} catch {}
+await gc();
+let imageData22 = new ImageData(100, 24);
+let commandEncoder188 = device0.createCommandEncoder({});
+let computePassEncoder60 = commandEncoder188.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.15,
+  lodMaxClamp: 51.08,
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup0, new Uint32Array(576), 156, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule3 = device1.createShaderModule({
+  code: `
+enable f16;
+enable f16;
+
+struct T0 {
+  f0: array<i32>,
+}
+
+@group(1) @binding(339) var tex5: texture_depth_2d_array;
+@group(0) @binding(339) var tex4: texture_1d<i32>;
+@group(1) @binding(470) var st1: texture_storage_1d<rgba8snorm, write>;
+@group(0) @binding(470) var st0: texture_storage_2d<rgba16uint, write>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f11: vec4f
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4h, @location(13) @interpolate(linear, sample) a1: vec4h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureLoad(tex5, vec2i(), 0, 0);
+  _ = textureLoad(tex4, 0, 0);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(3) @interpolate(flat) f0: vec2f,
+  @location(0) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer18, 1_728);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(3042), 1419, 0);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(99, 67);
+let computePassEncoder61 = commandEncoder187.beginComputePass({label: '\u43bd\u0d84\u472a\u53c1\u37f2\u0ff1\u2961\uedda\uc9fc'});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer131, commandBuffer133]);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer18, 548, 57);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer15, 'uint32', 996, 579);
+} catch {}
+try {
+computePassEncoder44.insertDebugMarker('\u201c');
+} catch {}
+let imageData23 = new ImageData(128, 108);
+let commandEncoder189 = device0.createCommandEncoder({label: '\u0ede\u4eda'});
+let renderBundle122 = renderBundleEncoder13.finish({label: '\u{1fa67}\u6a5e\u{1fbf9}\u639e\u0104\u7819\u{1f76b}\ub5ac'});
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 500.3, g: -189.0, b: 407.3, a: 901.5, });
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer3, 'uint16', 1_924, 6_127);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer8, 0, 326);
+} catch {}
+let arrayBuffer7 = buffer12.getMappedRange(400, 0);
+try {
+commandEncoder189.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1496 */
+  offset: 1496,
+  bytesPerRow: 256,
+  rowsPerImage: 27,
+  buffer: buffer18,
+}, {width: 5, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let texture57 = device1.createTexture({
+  label: '\u0c7f\u{1fad7}\u01ce\ue637\u7afa\u0442\u07b2\u{1fc38}',
+  size: {width: 6, height: 15, depthOrArrayLayers: 42},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u2c07\u2847\u{1ff16}\u9b1a\u074d\u{1fdca}\u{1ff0b}\u08e5\u05eb',
+  colorFormats: ['rgba8unorm'],
+});
+let commandEncoder190 = device1.createCommandEncoder({label: '\u048f\u002d'});
+let texture58 = gpuCanvasContext3.getCurrentTexture();
+let commandBuffer134 = commandEncoder189.finish({label: '\u0443\u0241\u390c\u{1fd27}\u0283\u0dbe\u6734\u55a6\u1e92\ua216\ueb10'});
+try {
+renderPassEncoder10.setIndexBuffer(buffer10, 'uint32', 1_896, 72);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer7, 'uint16', 394, 190);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+document.body.prepend(video0);
+let textureView45 = texture47.createView({});
+let imageData24 = new ImageData(8, 256);
+let commandEncoder191 = device0.createCommandEncoder({label: '\u08a3\u{1fe3c}\uae3b\u38c8\u3c99'});
+let commandBuffer135 = commandEncoder191.finish({label: '\u{1fd15}\u5fbf\u{1fbdd}\u{1fe04}\u{1f858}'});
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setViewport(1.622619127206356, 2.1506074393888452, 1.9700023881485689, 1.6436586743997195, 0.15289405457767613, 0.19318573738175013);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer16, 3_524, 274);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup1, new Uint32Array(685), 2, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer13, 'uint32', 2_564, 3_209);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, undefined, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+computePassEncoder22.pushDebugGroup('\u0e29');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 56}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 2, y: 13 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 917});
+let renderBundle123 = renderBundleEncoder13.finish();
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer17, 'uint16', 2_648, 1_499);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1_087), /* required buffer size: 1_087 */
+{offset: 127, bytesPerRow: 2, rowsPerImage: 16}, {width: 0, height: 1, depthOrArrayLayers: 31});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder192 = device1.createCommandEncoder({label: '\u8418\u{1fda3}\u4af3\ub310\udd40'});
+let commandBuffer136 = commandEncoder190.finish({label: '\ud635\uf09a\u2e8d\u3fe8\u0806\uf920\u752c\uda4f\uacae'});
+let externalTexture23 = device0.importExternalTexture({label: '\u01cd\u1bf9\u6aaf', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 4, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(253), /* required buffer size: 253 */
+{offset: 9, bytesPerRow: 61, rowsPerImage: 54}, {width: 0, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let querySet27 = device1.createQuerySet({label: '\u0a6f\u3f29\u34f1\u06c2\u541d', type: 'occlusion', count: 956});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 15 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer19 = device1.createBuffer({
+  label: '\ua61c\u0ffe\u00d0\u0790\u{1fca9}\u0201\u0c61\u02c1\u7b1b\u4c57',
+  size: 17815,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandBuffer137 = commandEncoder192.finish({label: '\u0214\u0a30\u2655\u0a18\u08fe\ub3ee\uf2a4\u9405\u696a\u7ac9\u41b8'});
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer19, 0);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let querySet28 = device0.createQuerySet({
+  label: '\u{1f744}\u{1f894}\u91a0\u0840\u277d\u{1fc09}\ud811\u6008\ub08e',
+  type: 'occlusion',
+  count: 269,
+});
+let textureView46 = texture9.createView({
+  label: '\u79ca\u{1ff62}\u0e98\u{1fad1}\u2124\u19d6\u{1fe17}\ua549\u03ea\u5793\u944b',
+  dimension: '2d',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+});
+try {
+computePassEncoder59.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer18, 'uint32', 52, 1_167);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout29 = device1.createBindGroupLayout({
+  label: '\u4778\u91a6',
+  entries: [
+    {
+      binding: 81,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 341,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder62 = commandEncoder186.beginComputePass({label: '\u7ea9\u02cd\uf650\u0790'});
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer19, 4_972);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroupLayout30 = device1.createBindGroupLayout({entries: [{binding: 41, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}]});
+let texture59 = device1.createTexture({
+  label: '\u9ddf\ub022\uac61\u9f89\u876b\ucb92',
+  size: [24, 60, 171],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device1.queue.submit([commandBuffer137]);
+} catch {}
+try {
+  await promise35;
+} catch {}
+try {
+adapter1.label = '\u276e\u1cd5\uee8a\uda6c\ud2b7';
+} catch {}
+try {
+texture59.destroy();
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas3.getContext('webgpu');
+let commandEncoder193 = device1.createCommandEncoder({label: '\u2d7d\u{1f624}\u59ac\u018c'});
+let commandBuffer138 = commandEncoder193.finish({});
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(46_652), /* required buffer size: 46_652 */
+{offset: 22, bytesPerRow: 57, rowsPerImage: 204}, {width: 1, height: 3, depthOrArrayLayers: 5});
+} catch {}
+let commandEncoder194 = device1.createCommandEncoder({label: '\u493d\u43f4\u{1fc86}\u{1f7a8}\u{1fd7d}\ufb68'});
+let renderBundle124 = renderBundleEncoder18.finish({label: '\u93a6\udd5e\u08c5\ud6d2\u38b0\u2ef6\u{1f88e}\uae09\u7aef\u6b32'});
+let pipeline2 = device1.createComputePipeline({
+  label: '\u{1fef3}\u8cf4\u03be\u082e\ucb91\u0153',
+  layout: pipelineLayout32,
+  compute: {module: shaderModule3, constants: {}},
+});
+document.body.prepend(canvas1);
+let imageBitmap8 = await createImageBitmap(offscreenCanvas2);
+let commandEncoder195 = device1.createCommandEncoder({label: '\ue502\u319d\u{1fc2c}\u871a\u7731\u0a9a\u6a47'});
+let computePassEncoder63 = commandEncoder195.beginComputePass();
+let renderBundle125 = renderBundleEncoder18.finish({label: '\u0c84\u{1fbdc}\u4d8d'});
+let externalTexture24 = device1.importExternalTexture({label: '\u1068\u5983\u56b7\u5803\ub486\u2072\u0f30\u0dbf', source: videoFrame0});
+try {
+computePassEncoder61.setPipeline(pipeline2);
+} catch {}
+try {
+adapter0.label = '\ufe20\ua49f\u{1fd1a}\u7cd4\u0a9a\u8992\u6c5e';
+} catch {}
+let commandEncoder196 = device0.createCommandEncoder({label: '\u6f64\uee85\u{1fec7}\u{1fcef}\u{1f6d3}'});
+let texture60 = device0.createTexture({
+  label: '\u{1ff72}\u9749',
+  size: {width: 60, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder64 = commandEncoder196.beginComputePass();
+try {
+renderPassEncoder12.setViewport(6.935317125305558, 3.5489272670236893, 0.012333074759875617, 2.260582051079214, 0.7160519191817062, 0.9625288487510189);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer17, 'uint32', 2_288, 131);
+} catch {}
+try {
+renderPassEncoder10.pushDebugGroup('\u{1f85c}');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 12 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 3, y: 6, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView47 = texture34.createView({label: '\u8199\u{1f7d4}\u4620\u0495\u0b85\u{1f616}\u{1fc2f}'});
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer8, 'uint16', 492, 676);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint16', 1_766, 1_196);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer11, 4_660, 110);
+} catch {}
+try {
+computePassEncoder22.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(36), /* required buffer size: 36 */
+{offset: 16}, {width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder197 = device0.createCommandEncoder({label: '\u1d0b\u50f9\u{1fa2b}\u{1fd34}\u0540\u03f5'});
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer6, 'uint32', 6_864, 1_494);
+} catch {}
+let commandEncoder198 = device0.createCommandEncoder();
+let computePassEncoder65 = commandEncoder197.beginComputePass({label: '\ue1c3\u6b65\u02de\uf5f3\ud0b8'});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let promise36 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 9 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 3, y: 3, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+  await promise36;
+} catch {}
+let commandEncoder199 = device1.createCommandEncoder({label: '\u0fcd\u0fdc\u{1f953}\u08bd\u03a9\u094e\u{1fdaf}\ue20f\u0a16'});
+let texture61 = device1.createTexture({
+  label: '\ue2d0\u0d8c\u0c79\ud402\u{1f883}\u6a95',
+  size: {width: 24, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline3 = device1.createRenderPipeline({
+  label: '\u1e68\u{1fcd7}\u{1f893}\ud4e5',
+  layout: pipelineLayout32,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {arrayStride: 224, attributes: []},
+      {arrayStride: 108, stepMode: 'instance', attributes: []},
+      {arrayStride: 124, stepMode: 'vertex', attributes: []},
+      {arrayStride: 156, stepMode: 'instance', attributes: []},
+      {arrayStride: 440, stepMode: 'instance', attributes: []},
+      {arrayStride: 60, attributes: []},
+      {arrayStride: 164, attributes: []},
+      {
+        arrayStride: 124,
+        attributes: [
+          {format: 'float16x4', offset: 24, shaderLocation: 13},
+          {format: 'float32x2', offset: 12, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let commandBuffer139 = commandEncoder198.finish({label: '\u{1fb88}\ua373\ub8fb'});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup6, new Uint32Array(1227), 66, 0);
+} catch {}
+let arrayBuffer8 = buffer12.getMappedRange(352, 4);
+let promise37 = device0.queue.onSubmittedWorkDone();
+try {
+querySet27.destroy();
+} catch {}
+let textureView48 = texture36.createView({
+  label: '\u0f78\u026a\ue4ac\u610f\ucbcf\u7c8f\u{1f668}\uafd1\u3a01\u341b\u9f9d',
+  format: 'depth16unorm',
+  baseMipLevel: 3,
+  baseArrayLayer: 24,
+  arrayLayerCount: 22,
+});
+try {
+renderBundleEncoder17.setIndexBuffer(buffer3, 'uint16', 1_908, 8_935);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise38 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0x2a2afaf9},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 571978593,
+    stencilWriteMask: 220447038,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let buffer20 = device1.createBuffer({
+  label: '\udcbe\u426d\u092d',
+  size: 37790,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+try {
+commandEncoder194.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1460 */
+  offset: 1460,
+  bytesPerRow: 0,
+  rowsPerImage: 58,
+  buffer: buffer19,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 14});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 13448, new DataView(new ArrayBuffer(1627)), 313, 92);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(8);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer8, 'uint16', 840, 4_953);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let textureView49 = texture36.createView({
+  label: '\uc406\u{1fb79}\u0974\u6610\u4775\uef60\u0dee\u5db6\u9bb1',
+  dimension: '2d',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer18);
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({});
+let commandBuffer140 = commandEncoder200.finish({label: '\ubc36\ubb9b\u0d43\u77d5\u03ca\ub786\u8d70\u24c8\u932e'});
+let renderBundle126 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer8, 'uint16', 2_526, 161);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer18, 'uint16', 1_626, 1_487);
+} catch {}
+try {
+device0.queue.submit([commandBuffer130, commandBuffer139]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(335), /* required buffer size: 335 */
+{offset: 335, bytesPerRow: 146}, {width: 30, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer141 = commandEncoder199.finish({label: '\uef9f\u0d7f\u{1f9b8}\u0994\u0494\u{1fee1}\u2b70'});
+let textureView50 = texture57.createView({label: '\u{1f9cb}\u0e69\ubebe\u9304\u4955\u{1fd00}\ucafb\u43ed\u95d2'});
+try {
+computePassEncoder62.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder194.copyBufferToBuffer(buffer19, 792, buffer20, 1784, 1092);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let buffer21 = device0.createBuffer({
+  label: '\ua25f\u02be\ubd93\u{1feed}\u{1ff1d}',
+  size: 6302,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+});
+let commandEncoder201 = device0.createCommandEncoder({label: '\u0c17\u0cc8\u4e96\u5a97\ue22f\u00c0\u011f\u{1f70e}\u1cc5\u{1fbfc}\u8bf0'});
+let texture62 = device0.createTexture({size: [15, 15, 1], mipLevelCount: 2, format: 'r32sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let externalTexture25 = device0.importExternalTexture({label: '\u01d3\ub9d1\u{1f803}\u0dc9\u{1f81c}\u{1fb5e}\u0ae4\ub00c', source: video4});
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer17, 'uint32', 2_364, 924);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer16, 0, 3_732);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 12, y: 8, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder201.clearBuffer(buffer18);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer135, commandBuffer132]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 440, new Int16Array(5687), 1950, 196);
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder();
+let computePassEncoder66 = commandEncoder168.beginComputePass({label: '\u{1f864}\u3ac7\u{1ff34}\uf799\u0ff1\u9c01\u42fc\u0aec\u736b'});
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 464, resource: {buffer: buffer14, offset: 3072, size: 6308}},
+    {binding: 243, resource: {buffer: buffer10, offset: 0, size: 1412}},
+  ],
+});
+let commandEncoder203 = device0.createCommandEncoder({label: '\ue7ae\u882b\u6e6f\u5ff7\u{1fcaf}\u0c13\u6d52\u5e81\ue857\udaef'});
+let renderBundle127 = renderBundleEncoder15.finish({});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: video0,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 4, y: 4, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder204 = device1.createCommandEncoder({label: '\u92da\u00e6\u07a2\u63a0\u4eed\u0b94\u5df7\ub73e'});
+let commandBuffer142 = commandEncoder204.finish();
+try {
+buffer20.destroy();
+} catch {}
+let buffer22 = device0.createBuffer({
+  label: '\u1aa7\udfe3\u{1fcd2}\u{1fedd}\u91dc\ud9e6\u6bc2\u5697',
+  size: 17797,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandBuffer143 = commandEncoder201.finish();
+try {
+computePassEncoder34.setBindGroup(3, bindGroup0, new Uint32Array(1884), 87, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(5.254740871226841, 0.6776955581201551, 1.5147601567767188, 6.238021685052516, 0.10321557733190989, 0.9462233691155664);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer22, 0, 2_761);
+} catch {}
+try {
+querySet18.destroy();
+} catch {}
+try {
+commandEncoder134.copyBufferToBuffer(buffer21, 3528, buffer4, 9052, 404);
+} catch {}
+let imageData25 = new ImageData(4, 36);
+let bindGroup8 = device1.createBindGroup({
+  label: '\uc087\u8589',
+  layout: bindGroupLayout30,
+  entries: [{binding: 41, resource: externalTexture24}],
+});
+let commandBuffer144 = commandEncoder194.finish({});
+let textureView51 = texture57.createView({label: '\u4cd8\u0a66\u3616\u0c97\u{1fa81}\u0098', dimension: '3d', format: 'rgba8unorm'});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], sampleCount: 1});
+let renderBundle128 = renderBundleEncoder18.finish();
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer19, 10_708, 814);
+} catch {}
+let commandEncoder205 = device1.createCommandEncoder({label: '\u4332\u0b98\u8ce9\u1535\u{1fd89}\u0fb0\u0094'});
+let computePassEncoder67 = commandEncoder205.beginComputePass({});
+let renderBundle129 = renderBundleEncoder19.finish({});
+let device2 = await adapter3.requestDevice({
+  defaultQueue: {label: '\u0018\u8db0\u{1fdfa}\u40c3\u7979\u{1ffb7}\u8f68\u0d74'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let commandEncoder206 = device1.createCommandEncoder({label: '\u84e2\u0852\u0d4b'});
+let commandBuffer145 = commandEncoder206.finish({label: '\u050d\u94bd'});
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder207 = device2.createCommandEncoder();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let commandEncoder208 = device0.createCommandEncoder({label: '\u{1f88d}\u6d2a'});
+let computePassEncoder68 = commandEncoder202.beginComputePass({label: '\ub14b\u79bd\u0b13\u0d3f'});
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer14, 0, 1_360);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer10, 'uint16', 742, 365);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 3520, new BigUint64Array(1218), 141, 256);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 15 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData26 = new ImageData(76, 28);
+let commandEncoder209 = device1.createCommandEncoder({label: '\u1ea7\u7716\uecbd\u{1fe3a}\u0231\u16c9\u0486\u{1f9e2}\u0d52\udf3f'});
+let texture63 = device1.createTexture({
+  label: '\u023a\u967c\u{1f951}\u025a\u{1f90e}\u06c1\u8108\u4d04',
+  size: {width: 48, height: 120, depthOrArrayLayers: 22},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder13 = commandEncoder209.beginRenderPass({
+  label: '\ub379\u69b5\u{1fef5}\u0c64\u1dd9\u{1f60e}\u7c59',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 12,
+  clearValue: { r: -512.2, g: -668.5, b: 168.4, a: -797.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 377487073,
+});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: canvas1,
+  origin: { x: 178, y: 9 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 13, y: 15, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandBuffer146 = commandEncoder203.finish({label: '\u{1f913}\u0aaa\u007c\u032c\u{1fc4b}\u301b'});
+let texture64 = device0.createTexture({
+  label: '\ucc38\ucfc0\u28c5\u08ca\u1c69\u7ee1\u{1f6e1}\u85a7\u4c06\ud8cf\u3bfc',
+  size: {width: 7},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup6, new Uint32Array(6028), 825, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer18, 252, 264);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 11, z: 33},
+  aspect: 'all',
+}, new ArrayBuffer(30_088), /* required buffer size: 30_088 */
+{offset: 58, bytesPerRow: 91, rowsPerImage: 22}, {width: 16, height: 0, depthOrArrayLayers: 16});
+} catch {}
+document.body.prepend(video4);
+let commandBuffer147 = commandEncoder207.finish({});
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\ufd8c\u0d0f\u09c5\u9fc3\u8804\u08d8\u{1fcf1}\u0c68\u077d',
+  colorFormats: ['rg32float'],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder20.setVertexBuffer(1, undefined);
+} catch {}
+try {
+device2.queue.submit([commandBuffer147]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video3);
+let commandEncoder210 = device0.createCommandEncoder();
+let commandBuffer148 = commandEncoder208.finish({label: '\u91f7\ue67f\u5493\u56e6\u19ad\u58ec\u1619\u{1ffdf}'});
+let computePassEncoder69 = commandEncoder134.beginComputePass({});
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint16', 1_546, 50);
+} catch {}
+try {
+renderPassEncoder10.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+document.body.prepend(video2);
+let buffer23 = device2.createBuffer({
+  label: '\u00e6\u3d0c\ue1e9',
+  size: 4838,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder211 = device2.createCommandEncoder({label: '\u0fa2\u0eb8\u{1f675}\u7769\u00a5\u6ca9\u{1f909}\u0bea\u4731\u0ad1\u2e8d'});
+let texture65 = device2.createTexture({
+  label: '\u3982\u0587\ue149\ue4e7\u0c83\u080e\u03ed\u0438',
+  size: [649, 1, 21],
+  mipLevelCount: 2,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let bindGroup9 = device0.createBindGroup({
+  label: '\u17fd\u4315\u036d\u{1f722}\ue846\ue212\u{1ffb0}\uee8b\u366a\uf03f\u0e93',
+  layout: bindGroupLayout14,
+  entries: [{binding: 92, resource: externalTexture25}],
+});
+let renderBundle130 = renderBundleEncoder15.finish({label: '\u74c8\u04c9\u25d4\u0809'});
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(3.3488892843398963, 6.348220394442693, 1.9926959071068153, 0.5161348586506029, 0.27569622631086543, 0.6630455578269725);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer3, 'uint32', 1_028, 7_469);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer146]);
+} catch {}
+let renderBundle131 = renderBundleEncoder20.finish({label: '\u{1fe4a}\u0393\ua4fe\u3b56\u8f7c\u2153\u{1f73e}\u5341'});
+try {
+device2.queue.writeBuffer(buffer23, 624, new BigUint64Array(1441), 225, 136);
+} catch {}
+let commandEncoder212 = device1.createCommandEncoder({label: '\u1ed6\u5e83\ud95c\u{1fd57}'});
+let commandBuffer149 = commandEncoder212.finish({label: '\uf635\uddd5\u0509\u5c7a\ubf6e\u0e2f\u9a0d\u{1f72f}'});
+try {
+renderPassEncoder13.setVertexBuffer(2, undefined, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 4, y: 4 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 1, y: 28, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture26 = device2.importExternalTexture({label: '\u{1f7c1}\uab9a\u01b5\u7630\u0067\u7380', source: video2, colorSpace: 'display-p3'});
+try {
+device2.pushErrorScope('validation');
+} catch {}
+let commandEncoder213 = device0.createCommandEncoder({label: '\u09b4\u3ce8\u00f6\u30ee\u{1fd93}\ud087\u714d\u{1fe61}\u4279\u1f71\u{1f923}'});
+let commandBuffer150 = commandEncoder213.finish({label: '\u0565\u3572\ua0c6\u894e\u0892\u8a26\u1bfe'});
+let renderBundle132 = renderBundleEncoder10.finish({});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer6, 'uint16', 1_156, 4_924);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup5);
+} catch {}
+let video7 = await videoWithData();
+let textureView52 = texture65.createView({label: '\u001c\u0826', baseMipLevel: 1, baseArrayLayer: 1, arrayLayerCount: 3});
+canvas2.height = 589;
+let commandEncoder214 = device1.createCommandEncoder();
+let texture66 = device1.createTexture({
+  size: [6],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder70 = commandEncoder214.beginComputePass({label: '\u{1fe61}\u0dce\ub146\u6a3a'});
+let renderBundle133 = renderBundleEncoder18.finish();
+try {
+computePassEncoder61.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup8, new Uint32Array(883), 134, 0);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 2, 0, 4);
+} catch {}
+let renderBundle134 = renderBundleEncoder20.finish({label: '\u6282\u0cb8\u0953\uc61c\u0172\ubbfc\ub876\u0871'});
+try {
+texture65.destroy();
+} catch {}
+let commandEncoder215 = device1.createCommandEncoder();
+let computePassEncoder71 = commandEncoder215.beginComputePass({label: '\u0d1c\u040f\u3644\ue55a\u0365\u320b\u{1f98b}\u{1ff3f}\u0311\ue484\u0a35'});
+try {
+renderPassEncoder13.end();
+} catch {}
+let commandBuffer151 = commandEncoder211.finish({label: '\u91b9\u6d9f\u9b17\u8a03\u{1f92f}'});
+let texture67 = device2.createTexture({
+  label: '\uf704\ucda9\u{1fbb7}\u0760\u{1feb5}\u{1fa3d}\u3725\u1f67\u18c3',
+  size: [186, 18, 1],
+  mipLevelCount: 3,
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle135 = renderBundleEncoder20.finish({label: '\u{1fad9}\u0ffc'});
+let commandEncoder216 = device0.createCommandEncoder();
+let commandBuffer152 = commandEncoder216.finish({label: '\u{1ffe9}\u4518\uecf7\ub475\u{1f61a}\u7d69\u{1fb7b}'});
+let renderBundle136 = renderBundleEncoder1.finish({label: '\u640d\u2c5c\ua340\ue07b\ua1a7\ue8dc\u91b0'});
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer5, 0, 2_669);
+} catch {}
+let renderBundle137 = renderBundleEncoder20.finish({label: '\u418a\u0c7d'});
+let commandBuffer153 = commandEncoder210.finish({label: '\u5d30\ue54a\u8440\u89e9\u{1f991}\u33b1\u0563'});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup3, new Uint32Array(2082), 382, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+video7.height = 65;
+let commandEncoder217 = device2.createCommandEncoder();
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(13), /* required buffer size: 13 */
+{offset: 13, bytesPerRow: 149}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder218 = device1.createCommandEncoder({label: '\u59da\u{1fe89}\u043d\u31f2'});
+let commandBuffer154 = commandEncoder218.finish();
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup8, new Uint32Array(2766), 260, 0);
+} catch {}
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer20, 'uint16', 1_012, 909);
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder({});
+let commandBuffer155 = commandEncoder219.finish({label: '\u935e\u395b\u2a57\u{1fa61}\u0aca'});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup2, new Uint32Array(358), 18, 0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(2.556514528494454, 4.425046867010212, 3.3771154386886564, 2.3172691361287394, 0.5664096665697316, 0.8375533163035478);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 5012, new BigUint64Array(4743), 44, 84);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder220 = device0.createCommandEncoder({label: '\u0c0c\u0626\ud63a'});
+try {
+renderPassEncoder12.setStencilReference(242);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer8, 'uint32', 588, 3_857);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer4, 0);
+} catch {}
+try {
+commandEncoder220.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 19 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2083 */
+  offset: 2083,
+  buffer: buffer13,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder220.clearBuffer(buffer10, 2080, 72);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 15836, new Int16Array(2080), 242, 52);
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  label: '\u09e1\u82b6\u8932\ue683\u0a1e\u0923\u00de',
+  entries: [
+    {binding: 16, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 410, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder221 = device0.createCommandEncoder({label: '\u7c02\u07ec\ufdfd\u0824\uf65f\u0198\u55b0\ucc74\u0771\u018b\u{1fddd}'});
+let commandBuffer156 = commandEncoder221.finish({label: '\u0204\u0279\u7454'});
+try {
+renderBundleEncoder17.setIndexBuffer(buffer22, 'uint32', 168, 878);
+} catch {}
+let pipelineLayout34 = device1.createPipelineLayout({
+  label: '\u4dd6\u04b0\ud9d3\u61b8\ub88a\u0ac4\u{1f61b}\uf950\u797d\u{1fbe7}',
+  bindGroupLayouts: [bindGroupLayout27],
+});
+let querySet29 = device1.createQuerySet({label: '\u7660\u8317\u0f56\uce3c\u536d\u{1fa7c}\u091d\u0be1\u565e', type: 'occlusion', count: 2707});
+let renderPassEncoder14 = commandEncoder187.beginRenderPass({
+  label: '\u{1ffef}\u6821\uab31\u3e9b\ud9fd\u{1fdc5}',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 32,
+  clearValue: { r: 479.5, g: -351.7, b: -199.1, a: 858.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet29,
+});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup8, new Uint32Array(2334), 320, 0);
+} catch {}
+let imageData27 = new ImageData(52, 8);
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(42), /* required buffer size: 42 */
+{offset: 42}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder222 = device1.createCommandEncoder({label: '\u{1f721}\u0b1d\u0b89\u15dc\u0fa3\ub6ba\u0d74\u4d48'});
+let computePassEncoder72 = commandEncoder222.beginComputePass({label: '\udf3e\uaa05\u1a28\u0510\u0fdd'});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup8, new Uint32Array(552), 73, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer20, 'uint16', 1_064, 14_061);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer19, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: img3,
+  origin: { x: 1, y: 16 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 2, y: 8, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture68 = device2.createTexture({
+  label: '\u9b4a\u{1ff10}\u{1f65f}\u75a9\u0a17\u0634\uad9e',
+  size: {width: 649, height: 1, depthOrArrayLayers: 19},
+  mipLevelCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder73 = commandEncoder217.beginComputePass({});
+try {
+buffer23.unmap();
+} catch {}
+let shaderModule4 = device1.createShaderModule({
+  code: `
+enable f16;
+
+struct T0 {
+  f0: vec2h,
+  f1: atomic<i32>,
+}
+
+@group(0) @binding(175) var sam2: sampler;
+@group(0) @binding(94) var<storage, read> buffer28: array<vec2u>;
+@group(0) @binding(133) var sam3: sampler_comparison;
+@group(0) @binding(8) var tex8: texture_2d_array<i32>;
+@group(0) @binding(254) var sam1: sampler_comparison;
+@group(0) @binding(155) var<storage, read> buffer26: array<mat4x2h, 1>;
+@group(0) @binding(424) var tex14: texture_depth_cube;
+@group(0) @binding(598) var<uniform> buffer24: vec3h;
+@group(0) @binding(390) var sam0: sampler;
+@group(0) @binding(279) var<storage, read> buffer27: array<f32>;
+@group(0) @binding(16) var tex7: texture_2d<u32>;
+@group(0) @binding(58) var sam4: sampler;
+@group(0) @binding(0) var tex9: texture_2d_array<u32>;
+@group(0) @binding(50) var tex13: texture_2d_array<i32>;
+@group(0) @binding(176) var st2: texture_storage_2d<r32float, read_write>;
+@group(0) @binding(243) var st3: texture_storage_2d<rgba8uint, read>;
+@group(0) @binding(784) var<uniform> buffer25: array<mat4x2f, 1>;
+@group(0) @binding(116) var tex12: texture_cube_array<i32>;
+@group(0) @binding(9) var tex11: texture_3d<u32>;
+@group(0) @binding(89) var tex6: texture_cube_array<u32>;
+@group(0) @binding(144) var tex10: texture_depth_cube_array;
+struct S1 {
+  @builtin(num_workgroups) f0: vec3u,
+  @builtin(local_invocation_id) f1: vec3u
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32, @builtin(workgroup_id) a1: vec3u, a2: S1) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f12: vec4f
+}
+
+@vertex
+fn vertex0(@location(11) a0: f32, @location(3) @interpolate(perspective, sample) a1: f16, @location(14) @interpolate(flat, centroid) a2: vec3i, @location(10) @interpolate(flat) a3: vec4u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureLoad(tex13, vec2i(), 0, 0);
+  _ = textureGather(0, tex8, sam0, vec2f(), 0i, vec2i());
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) @interpolate(flat) f0: vec2i,
+  @location(0) @interpolate(perspective, center) f1: vec4f,
+  @location(2) f2: vec2i
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder223 = device1.createCommandEncoder({label: '\u1b59\u151b\u0b37\u0c89\u5906\u{1fe0d}'});
+let computePassEncoder74 = commandEncoder223.beginComputePass({label: '\u0af5\uf026'});
+let renderBundle138 = renderBundleEncoder19.finish({label: '\u1615\u092a'});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup8, new Uint32Array(381), 30, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -296.6, g: -265.0, b: 101.4, a: -836.5, });
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer20, 'uint16', 7_788, 2_789);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 9124,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle139 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder69.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer8, 0, 3_010);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(219), /* required buffer size: 219 */
+{offset: 219, bytesPerRow: 79}, {width: 30, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder224 = device1.createCommandEncoder({label: '\u9a34\u0bad\u0c62\ue2d2\uad69\u49e8\ud1cd\u0c78'});
+let commandBuffer157 = commandEncoder224.finish({});
+let renderBundle140 = renderBundleEncoder21.finish({label: '\u3dd0\u0eaf\u{1fb8b}\u{1fc80}\u9312\u0496'});
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer19, 9_292);
+} catch {}
+let buffer30 = device1.createBuffer({
+  label: '\ucae8\uaab1\u9ce6',
+  size: 7295,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder225 = device1.createCommandEncoder({});
+let commandBuffer158 = commandEncoder225.finish();
+try {
+computePassEncoder70.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer19, 460, 1_707);
+} catch {}
+let renderBundle141 = renderBundleEncoder21.finish({});
+try {
+renderPassEncoder14.executeBundles([renderBundle138, renderBundle129, renderBundle141, renderBundle141]);
+} catch {}
+try {
+device1.queue.submit([commandBuffer154, commandBuffer145, commandBuffer142, commandBuffer138, commandBuffer157]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder();
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(0, 3, 1, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer140]);
+} catch {}
+let commandBuffer159 = commandEncoder226.finish({label: '\uabe8\u22e8\u1778\uba3e\u6cee'});
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer156]);
+} catch {}
+let img8 = await imageWithData(92, 300, '#10101010', '#20202020');
+let buffer31 = device1.createBuffer({label: '\u{1f8eb}\u{1f757}', size: 2033, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 5 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 2, y: 31, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u{1f64c}\u{1f72d}\u842a\u0c50\u{1f8c8}',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<array<atomic<i32>, 1>, 1>,
+  f1: array<atomic<u32>>,
+}
+
+@group(0) @binding(130) var sam12: sampler_comparison;
+@group(0) @binding(48) var st4: texture_storage_3d<r32sint, read_write>;
+@group(0) @binding(416) var sam5: sampler;
+@group(0) @binding(90) var tex25: texture_depth_cube;
+@group(0) @binding(127) var tex19: texture_cube_array<i32>;
+@group(0) @binding(21) var et15: texture_external;
+@group(0) @binding(84) var sam10: sampler;
+@group(0) @binding(360) var<storage, read> buffer36: array<f32>;
+@group(0) @binding(167) var et10: texture_external;
+@group(0) @binding(120) var sam16: sampler;
+@group(0) @binding(484) var tex22: texture_multisampled_2d<u32>;
+@group(0) @binding(46) var et14: texture_external;
+@group(0) @binding(226) var sam19: sampler_comparison;
+@group(0) @binding(20) var et13: texture_external;
+@group(0) @binding(532) var tex20: texture_3d<i32>;
+@group(0) @binding(125) var et7: texture_external;
+@group(0) @binding(93) var sam11: sampler_comparison;
+@group(0) @binding(26) var sam7: sampler;
+@group(0) @binding(28) var et18: texture_external;
+@group(0) @binding(5) var st6: texture_storage_3d<rgba8sint, write>;
+@group(0) @binding(242) var et12: texture_external;
+@group(0) @binding(13) var tex15: texture_depth_2d;
+@group(0) @binding(53) var<uniform> buffer39: vec2i;
+@group(0) @binding(221) var<storage, read> buffer37: array<vec3i, 1>;
+@group(0) @binding(279) var tex26: texture_multisampled_2d<u32>;
+@group(0) @binding(196) var tex17: texture_1d<i32>;
+@group(0) @binding(145) var sam18: sampler_comparison;
+@group(0) @binding(199) var<storage, read> buffer38: array<mat4x2h, 1>;
+@group(0) @binding(25) var et17: texture_external;
+@group(0) @binding(27) var<storage, read> buffer34: array<u32>;
+@group(0) @binding(50) var tex29: texture_3d<f32>;
+@group(0) @binding(139) var<uniform> buffer43: mat4x3h;
+@group(0) @binding(236) var<storage, read> buffer41: array<mat4x4f, 1>;
+@group(0) @binding(8) var sam15: sampler;
+@group(0) @binding(109) var sam17: sampler;
+@group(0) @binding(118) var sam9: sampler;
+@group(0) @binding(194) var et9: texture_external;
+@group(0) @binding(271) var<uniform> buffer42: vec3i;
+@group(0) @binding(69) var et11: texture_external;
+@group(0) @binding(182) var et8: texture_external;
+@group(0) @binding(115) var et4: texture_external;
+@group(0) @binding(616) var sam13: sampler;
+@group(0) @binding(63) var tex18: texture_depth_cube;
+@group(0) @binding(453) var tex28: texture_depth_2d_array;
+@group(0) @binding(114) var sam14: sampler_comparison;
+@group(0) @binding(36) var sam8: sampler_comparison;
+@group(0) @binding(185) var tex24: texture_2d_array<i32>;
+@group(0) @binding(291) var<storage, read_write> buffer40: atomic<u32>;
+@group(0) @binding(6) var sam6: sampler;
+@group(0) @binding(302) var st5: texture_storage_2d_array<rgba16sint, write>;
+@group(0) @binding(175) var et16: texture_external;
+@group(0) @binding(387) var tex23: texture_depth_2d;
+@group(0) @binding(105) var sam20: sampler_comparison;
+@group(0) @binding(368) var<storage, read_write> buffer33: array<vec2u>;
+@group(0) @binding(161) var tex27: texture_cube<u32>;
+@group(0) @binding(195) var st7: texture_storage_2d_array<r32uint, read_write>;
+@group(0) @binding(77) var tex21: texture_cube<i32>;
+@group(0) @binding(51) var et5: texture_external;
+@group(0) @binding(110) var<storage, read_write> buffer35: array<atomic<i32>>;
+@group(0) @binding(70) var<uniform> buffer32: mat3x2f;
+@group(0) @binding(1) var tex16: texture_cube<i32>;
+@group(0) @binding(380) var tex30: texture_2d<u32>;
+@group(0) @binding(30) var et3: texture_external;
+@group(0) @binding(60) var et6: texture_external;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  _ = textureDimensions(et18);
+  _ = textureSampleBaseClampToEdge(et12, sam16, vec2f());
+  _ = textureSampleBaseClampToEdge(et16, sam17, vec2f());
+  if bool(textureSampleCompareLevel(tex28, sam8, vec2f(), 0i, 0.)) {
+    atomicStore(&buffer35[12345], -3);
+  }
+}
+
+struct VertexOutput0 {
+  @builtin(position) f13: vec4f
+}
+
+@vertex
+fn vertex0(@location(0) @interpolate(flat, centroid) a0: vec3u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = buffer37;
+  _ = textureSampleBaseClampToEdge(et10, sam13, vec2f());
+  _ = textureSampleLevel(tex29, sam10, vec3f(), 0.0);
+  _ = textureLoad(et8, vec2u());
+  _ = textureSampleLevel(tex15, sam9, vec2f(), 0i, vec2i());
+  _ = textureDimensions(et7);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat, center) f0: vec4i
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureSample(tex18, sam10, vec3f());
+  _ = textureSampleBaseClampToEdge(et5, sam6, vec2f());
+  _ = buffer35;
+  _ = textureLoad(et5, vec2u());
+  _ = textureLoad(tex17, 0, 0);
+  _ = textureSampleLevel(tex29, sam16, vec3f(), 0.0, vec3i());
+  _ = textureSampleBias(tex29, sam6, vec3f(), 0.0);
+  _ = textureSampleBaseClampToEdge(et18, sam13, vec2f());
+  _ = textureSample(tex29, sam6, vec3f());
+  _ = textureSample(tex18, sam15, vec3f());
+  _ = textureDimensions(et3);
+  _ = textureSampleBaseClampToEdge(et5, sam15, vec2f());
+  _ = textureSampleLevel(tex29, sam15, vec3f(), 0.0, vec3i());
+  if bool(textureGather(tex18, sam10, vec3f())[2]) {
+    atomicStore(&buffer40, 16);
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder66.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer10);
+} catch {}
+try {
+commandEncoder220.copyBufferToBuffer(buffer5, 508, buffer22, 2116, 364);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 7256, new BigUint64Array(4718), 1466, 336);
+} catch {}
+let commandEncoder227 = device2.createCommandEncoder();
+let commandBuffer160 = commandEncoder227.finish();
+let renderBundleEncoder22 = device2.createRenderBundleEncoder({
+  label: '\u08d1\ube78\u0f74\u{1fc0e}\u1e8f\u604f\u396e\ueb50',
+  colorFormats: ['rg32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let imageData28 = new ImageData(16, 20);
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder3.setViewport(6.624087612080407, 4.91097261783056, 0.08457879565433983, 1.0394416899547145, 0.10319560129356098, 0.5106124988054379);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer3, 3_368);
+} catch {}
+let pipeline4 = device0.createComputePipeline({
+  label: '\u4b4c\u{1ff90}\u03b8\u024e\u{1f7b8}\u{1f674}\u{1fbbd}\u{1f826}',
+  layout: pipelineLayout28,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let commandEncoder228 = device1.createCommandEncoder({label: '\u02de\uc67c\ua4fe\u{1f714}\u0a5e\u{1f8a5}\ue537\u54bd\u09ef\u0eb8\u{1fe19}'});
+let computePassEncoder75 = commandEncoder228.beginComputePass({});
+let renderBundle142 = renderBundleEncoder18.finish();
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(24);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer141, commandBuffer158]);
+} catch {}
+let textureView53 = texture67.createView({label: '\u{1fe75}\u8f6f\u1dd3\u2f66\ufb90\u1ebc', dimension: '2d-array', baseMipLevel: 2});
+try {
+buffer23.unmap();
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker('\u8ab7');
+} catch {}
+try {
+device2.queue.submit([commandBuffer151]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder229 = device2.createCommandEncoder({label: '\uc1c1\u0a81\u0cac\u0938\u0c79'});
+let commandBuffer161 = commandEncoder229.finish({label: '\uc860\u0f01'});
+let texture69 = device2.createTexture({
+  label: '\ufd00\u{1f83b}\u5b49\u{1fb63}\u0035\u44d7\u406d\uc018',
+  size: {width: 2596, height: 1, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({label: '\u0492\u{1f82b}\uaf7f', colorFormats: ['rg32float'], depthReadOnly: true});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup8, new Uint32Array(3211), 704, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup8, new Uint32Array(2119), 667, 0);
+} catch {}
+try {
+window.someLabel = querySet22.label;
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  label: '\u4d94\u2304\uaab5\u0db3\u63ed\u1ccb\u09ef',
+  entries: [
+    {
+      binding: 90,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder230 = device0.createCommandEncoder({label: '\u0c7e\uf048\uf89d\uf6e5\u03f0\u0b01\u{1f650}\u00c4'});
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(358);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(603);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup5);
+} catch {}
+document.body.prepend(video3);
+let renderBundle143 = renderBundleEncoder14.finish();
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer13, 'uint32', 5_432, 833);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer22, 2_484, 7_707);
+} catch {}
+try {
+texture15.destroy();
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u0f54');
+} catch {}
+let computePassEncoder76 = commandEncoder220.beginComputePass({label: '\u{1f967}\u702c\u0cb8\u3c3f\uf613\u9be1\u{1ffed}\ub157\ucfd4'});
+let renderPassEncoder15 = commandEncoder230.beginRenderPass({
+  label: '\u1343\u4bca\ud361\u{1fd70}\u0db4\u{1f9b8}\u084c',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 11,
+  clearValue: { r: 555.0, g: 961.4, b: 89.37, a: -945.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 37849,
+  },
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 26442002,
+});
+let renderBundle144 = renderBundleEncoder1.finish({label: '\ud83d\ub6c6\u{1fd98}\u8941\u{1f9d6}\u4518\u62cb'});
+let externalTexture27 = device0.importExternalTexture({label: '\u{1f768}\u0981\u2454', source: video5, colorSpace: 'srgb'});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u78f8');
+} catch {}
+try {
+renderBundleEncoder22.pushDebugGroup('\ud4f9');
+} catch {}
+document.body.prepend(img1);
+let renderBundle145 = renderBundleEncoder20.finish();
+try {
+renderBundleEncoder22.insertDebugMarker('\u{1fee8}');
+} catch {}
+let textureView54 = texture7.createView({label: '\u{1fc71}\u2111\u25ab\u06d8\u{1fd14}\u4ed4\u0cce\u021e\u0336\u05f4\u8db2', format: 'r8unorm'});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup0, new Uint32Array(5684), 1841, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, undefined, 0, 756_834_180);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint16', 640, 1_676);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 12, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(160), /* required buffer size: 160 */
+{offset: 160, bytesPerRow: 73}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video2);
+let img9 = await imageWithData(73, 43, '#10101010', '#20202020');
+let renderBundle146 = renderBundleEncoder20.finish({});
+try {
+renderBundleEncoder22.setIndexBuffer(buffer23, 'uint16', 262, 2_189);
+} catch {}
+try {
+renderBundleEncoder22.popDebugGroup();
+} catch {}
+let commandEncoder231 = device1.createCommandEncoder({label: '\ua9f5\ue522\u07ed\u{1fab6}\u051e\u0a6d\u{1ff98}\u9ee4'});
+let renderPassEncoder16 = commandEncoder231.beginRenderPass({
+  label: '\u0331\u7ae0\ufeba\u6c59\u0abc',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 1,
+  clearValue: { r: -683.5, g: -730.3, b: -953.8, a: 531.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet27,
+});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup8, new Uint32Array(448), 133, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup8, new Uint32Array(1075), 4, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer19, 0);
+} catch {}
+let pipeline5 = device1.createComputePipeline({
+  label: '\u{1fb8a}\u3171\u7769\u{1f763}\u2d6f\u{1fa0f}\ueaa5\ua69d\ua86e\u4ca5\ufa39',
+  layout: pipelineLayout32,
+  compute: {module: shaderModule3},
+});
+let bindGroupLayout33 = device2.createBindGroupLayout({
+  label: '\u{1f9e2}\ub17a\u4042\u066b\u{1f906}\u1fff\u79d2',
+  entries: [
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture70 = device2.createTexture({
+  label: '\uabf6\u1c1d\u{1f95d}\u{1fb97}\u{1f7f9}\u0428\u{1fa36}\ubcee',
+  size: {width: 649, height: 1, depthOrArrayLayers: 610},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderBundleEncoder23.setIndexBuffer(buffer23, 'uint16', 346, 2_030);
+} catch {}
+try {
+buffer23.label = '\u371a\u0db9\u046a\u0143\u0242\u04bb\ub057\uc614\u7572\u92a0';
+} catch {}
+let pipelineLayout35 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout33]});
+let commandEncoder232 = device1.createCommandEncoder({label: '\u{1fc6f}\ud7b2'});
+let commandBuffer162 = commandEncoder232.finish({label: '\u40d8\u3970\ucab7\u0bb8\uc6a7\u0c7f\u{1f84e}\u0366\u0823'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer20, 'uint32', 14_520, 197);
+} catch {}
+try {
+device1.queue.submit([commandBuffer149]);
+} catch {}
+let texture71 = device1.createTexture({
+  size: {width: 48, height: 120, depthOrArrayLayers: 342},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer30, 'uint32', 700, 385);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer19, 0);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(0, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(531);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup7, new Uint32Array(2081), 496, 0);
+} catch {}
+offscreenCanvas3.height = 404;
+let externalTexture28 = device0.importExternalTexture({label: '\u9254\u71f9\u{1fa5c}\uf1dc\u{1fd84}\u{1fef3}', source: video3, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer7, 'uint16', 474, 193);
+} catch {}
+try {
+computePassEncoder45.pushDebugGroup('\u{1fac9}');
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\ua621');
+} catch {}
+let promise39 = adapter4.requestAdapterInfo();
+let commandEncoder233 = device0.createCommandEncoder({label: '\u{1fd33}\ud0f4'});
+let renderPassEncoder17 = commandEncoder233.beginRenderPass({
+  label: '\u{1f8f3}\ue4f0',
+  colorAttachments: [{view: textureView27, depthSlice: 6, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 25484,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet19,
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup9, new Uint32Array(1301), 400, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(144);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer4, 3_176);
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+let imageData29 = new ImageData(64, 12);
+let renderBundle147 = renderBundleEncoder18.finish({});
+try {
+  await promise39;
+} catch {}
+let commandEncoder234 = device0.createCommandEncoder({label: '\u2000\u01b5\u0f1e\u5d21\u{1fbbb}\u5be8'});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(0, 0, 2, 1);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(285);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(1, buffer14);
+} catch {}
+try {
+device0.queue.submit([commandBuffer152, commandBuffer148]);
+} catch {}
+let shaderModule6 = device2.createShaderModule({
+  label: '\u{1ff87}\u80e6\u047c\u303f\uc246\u0c42',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<vec3h>,
+}
+
+@group(0) @binding(50) var<storage, read_write> buffer44: array<vec3i>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4f,
+  @location(2) @interpolate(flat) f1: vec2u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle148 = renderBundleEncoder22.finish({});
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder235 = device1.createCommandEncoder({label: '\uae8f\u{1f6a0}\u58d4\ua5b1\uc7d0\u04bd'});
+let externalTexture29 = device1.importExternalTexture({label: '\uc6c3\u878e\u00e9\u0302\u8baf\u412f\u2720\u0d6a\ua656\u{1fdc9}', source: video2});
+let canvas5 = document.createElement('canvas');
+let commandBuffer163 = commandEncoder234.finish({label: '\u8cb1\u{1f967}\u9330\u{1fc30}\u532f\u0cbe\u168a\ufe4b'});
+let texture72 = gpuCanvasContext3.getCurrentTexture();
+let renderBundle149 = renderBundleEncoder14.finish({label: '\ud29a\u5ec2\u0def\u9e30\u8e11\u02d1\ufad1'});
+try {
+computePassEncoder34.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer163, commandBuffer126, commandBuffer143]);
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  label: '\uf95e\uea28\u636c\u0cdb\ud318\u05e7',
+  entries: [
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let pipelineLayout36 = device1.createPipelineLayout({label: '\u0f33\u{1fa8d}\ue230\u82cd', bindGroupLayouts: [bindGroupLayout27]});
+let commandEncoder236 = device1.createCommandEncoder({label: '\uf4cf\u{1f6ec}\ucc61\u0af3'});
+let renderPassEncoder18 = commandEncoder235.beginRenderPass({
+  label: '\u{1f7f3}\u0da6\u74c7\u004d\u0b62\u264a\u24b9\ud777\u0504',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 36,
+  clearValue: { r: -990.0, g: -321.8, b: 757.6, a: -390.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup8, new Uint32Array(302), 42, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle147]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(2.6730330844774977, 12.867475954586114, 0.0880800405807629, 1.9830214043030998, 0.6564756910676497, 0.717966912840276);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer19, 12_292);
+} catch {}
+try {
+commandEncoder236.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 1,
+  origin: {x: 5, y: 4, z: 24},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1456 */
+  offset: 1456,
+  bytesPerRow: 0,
+  rowsPerImage: 54,
+  buffer: buffer20,
+}, {width: 0, height: 37, depthOrArrayLayers: 7});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas5);
+let commandEncoder237 = device2.createCommandEncoder({label: '\ue519\u{1f71e}'});
+let commandBuffer164 = commandEncoder237.finish({});
+let textureView55 = texture67.createView({
+  label: '\u{1fd46}\u0cf3\ue3a1\u4f2a\u529f\u{1fec6}\u0a1d\u2633\uaac3\u0b1a\u9832',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder23.setIndexBuffer(buffer23, 'uint32', 872, 157);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+document.body.prepend(img8);
+let texture73 = device0.createTexture({
+  label: '\u017c\u0584\ue7ee\u6184\u0196\uc0ce\u50b5\ue4f6\u88c0\u0bfb\uc09d',
+  size: {width: 60},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup3, new Uint32Array(2467), 430, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer7);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup7, new Uint32Array(56), 9, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer3, 'uint32', 40, 6_529);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer22);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let commandEncoder238 = device2.createCommandEncoder({label: '\u8588\u2e06\u8432\udbe2\uf40e\u{1ff4d}\u6044\ue821\u05a9\u{1fe71}\u{1fa19}'});
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let commandEncoder239 = device0.createCommandEncoder({label: '\u0a30\u0498\ud52b\u05c7'});
+let querySet30 = device0.createQuerySet({label: '\u1c0c\ufb79\u6d98\ufd74\u7a0d\u0618\u0131\u063c', type: 'occlusion', count: 239});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup4, new Uint32Array(332), 9, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, undefined);
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.WRITE, 0, 8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 56}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 1, y: 6, z: 21},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData30 = new ImageData(12, 12);
+let commandBuffer165 = commandEncoder239.finish();
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(509), 11, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint16', 776, 33);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer14, 0, 5_617);
+} catch {}
+try {
+  await promise40;
+} catch {}
+let commandEncoder240 = device1.createCommandEncoder({});
+let renderPassEncoder19 = commandEncoder236.beginRenderPass({
+  label: '\u{1fd87}\u04ee\ue6dd\u82a5\u5143\u0391\u{1fc4b}\u{1fbf3}\u21c9\u{1f7c2}',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 30,
+  clearValue: { r: 35.04, g: 10.07, b: -533.7, a: -855.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder71.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer19);
+} catch {}
+try {
+commandEncoder240.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 572 */
+  offset: 572,
+  bytesPerRow: 0,
+  rowsPerImage: 30,
+  buffer: buffer30,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 27, depthOrArrayLayers: 27});
+} catch {}
+let commandEncoder241 = device0.createCommandEncoder({label: '\uc4f2\u40a5'});
+let commandBuffer166 = commandEncoder154.finish({label: '\u{1fd6c}\uaaf5\u04ac\u{1fe11}\u{1ffe9}\u0809\u2235\u{1fbfa}\u0666\u{1fc97}'});
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+let commandEncoder242 = device1.createCommandEncoder({label: '\u{1fe2d}\u07ae\udc0e\u{1f609}\u0752\u{1f900}\uacd2'});
+let textureView56 = texture71.createView({label: '\u{1fc06}\uc700', baseMipLevel: 1});
+let computePassEncoder77 = commandEncoder240.beginComputePass({label: '\ubf2f\u097a\ubf2f\uea9d\u9292\u9ac3\u{1fd0f}\u0dc2'});
+let renderBundle150 = renderBundleEncoder21.finish({label: '\uc212\u07e7\u6c1a'});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup8, new Uint32Array(1468), 213, 0);
+} catch {}
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+commandEncoder242.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 8, y: 5, z: 59},
+  aspect: 'all',
+},
+{width: 1, height: 10, depthOrArrayLayers: 3});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture74 = device0.createTexture({
+  label: '\u0248\u0342\u03cd\u{1f959}\ua96a\u{1fdd9}\u563d\u{1fe11}',
+  size: {width: 30, height: 30, depthOrArrayLayers: 190},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder20 = commandEncoder241.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 44,
+  clearValue: { r: 561.4, g: -813.1, b: 988.7, a: -755.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.06843170547140631,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+  },
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 104495998,
+});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+window.someLabel = externalTexture29.label;
+} catch {}
+let commandEncoder243 = device1.createCommandEncoder({});
+let renderPassEncoder21 = commandEncoder243.beginRenderPass({
+  label: '\u0421\ub89b\uc4e7',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 16,
+  clearValue: { r: -499.9, g: 870.1, b: 847.2, a: -470.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 151208678,
+});
+try {
+computePassEncoder72.setPipeline(pipeline5);
+} catch {}
+try {
+device1.queue.submit([commandBuffer162]);
+} catch {}
+let textureView57 = texture36.createView({
+  label: '\u041d\u0144\u0cbc\u{1f64b}\u16bd\u{1f623}\u0a57\u3f29\u09eb',
+  dimension: 'cube',
+  aspect: 'depth-only',
+  baseMipLevel: 3,
+  baseArrayLayer: 26,
+  arrayLayerCount: 6,
+});
+let renderBundle151 = renderBundleEncoder2.finish({label: '\u0a79\u7d88\u0d10\u{1f718}'});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 1028, new DataView(new ArrayBuffer(11938)), 3765, 692);
+} catch {}
+let renderPassEncoder22 = commandEncoder242.beginRenderPass({
+  label: '\uaa52\u{1fef9}\u0e72\ubd82',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 32,
+  clearValue: { r: -896.0, g: -86.61, b: -832.2, a: -722.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet29,
+});
+let renderBundle152 = renderBundleEncoder19.finish({label: '\u{1fbb3}\u7326\u03d7\u1131\u{1f99f}\u804e\u{1ffcc}'});
+try {
+computePassEncoder75.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer20, 'uint16', 9_314, 2_015);
+} catch {}
+let querySet31 = device2.createQuerySet({label: '\uaa57\u53cd\u10ba\u0ba1\u0cfe\u0377\u9426\u02ea', type: 'occlusion', count: 113});
+let renderBundle153 = renderBundleEncoder23.finish();
+try {
+buffer23.unmap();
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer30, 'uint16', 728, 3_912);
+} catch {}
+let commandEncoder244 = device2.createCommandEncoder({label: '\u69c9\ubf98\u{1fdbf}'});
+let renderBundle154 = renderBundleEncoder22.finish();
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder77.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer19, 0);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer22, 0, 15_908);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 60, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({label: '\u0f3b\u9a8d\u{1fac5}\ued2e', entries: []});
+let texture75 = device0.createTexture({
+  size: {width: 15, height: 15, depthOrArrayLayers: 137},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer29, 0, 1_471);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer6, 'uint32', 968, 310);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u{1ff7b}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(5), /* required buffer size: 5 */
+{offset: 5}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder245 = device0.createCommandEncoder({label: '\u{1fef3}\u{1ff0e}\u{1fa10}\u524b\u{1fc0a}\u4aa2\uc750\uceac\u5689'});
+let textureView58 = texture10.createView({label: '\u06de\u0e78\ue434\u2118\u97f3\uddee\u7428\ue26e\uc27e\ub683'});
+let renderBundle155 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup3, []);
+} catch {}
+let commandEncoder246 = device2.createCommandEncoder({label: '\u00e1\u{1fb5c}\u{1f767}\u{1fc92}\u69c9\ud5d2\u9122\u32af\u{1ffd7}\u7f4d'});
+let textureView59 = texture67.createView({label: '\u0df8\u{1fbad}\ua646\u098f\u0024\ua411\u9823', dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder78 = commandEncoder244.beginComputePass({});
+try {
+commandEncoder238.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let texture76 = device0.createTexture({
+  size: {width: 15, height: 15, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm'],
+});
+try {
+renderPassEncoder12.setViewport(1.9801285487485105, 2.7830064938509755, 2.869504530314159, 3.696866136235832, 0.010700962051853335, 0.04549458817579095);
+} catch {}
+try {
+commandEncoder245.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1896 */
+  offset: 1896,
+  buffer: buffer16,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u002b');
+} catch {}
+let commandEncoder247 = device2.createCommandEncoder({label: '\uc506\u0b9a'});
+let renderBundle156 = renderBundleEncoder22.finish({label: '\u9343\u7d47\u{1fbad}\ufeac\u0f7a\u{1f83d}\u{1f797}\u5f5e\u02d8\uf472\uaeb4'});
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 143,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer167 = commandEncoder245.finish({label: '\u{1f87b}\u3751\u85a0\u041e\uad0f\ucb95'});
+let renderBundle157 = renderBundleEncoder11.finish();
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer150, commandBuffer167]);
+} catch {}
+let commandEncoder248 = device1.createCommandEncoder();
+let commandBuffer168 = commandEncoder248.finish({label: '\u04f3\ub2df\u{1fbd3}\u069c\u026b\ueb1b\u00b4\u{1f66f}\uec85\u25bf\u38d7'});
+let renderBundle158 = renderBundleEncoder18.finish({label: '\u{1fdd7}\u09d3\u0c10\u{1f9cc}\ue79c\u{1fdd2}\u1a71\uea43\u0754\u{1f799}\u{1fdc4}'});
+try {
+computePassEncoder63.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer19, 0, 1_162);
+} catch {}
+let promise41 = device1.queue.onSubmittedWorkDone();
+let commandEncoder249 = device0.createCommandEncoder({});
+let commandBuffer169 = commandEncoder249.finish();
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandEncoder250 = device0.createCommandEncoder({});
+let computePassEncoder79 = commandEncoder250.beginComputePass({label: '\u1b38\ud47a\u{1fd67}\u3ca0\u0fd7\ue5eb\u1e64'});
+try {
+computePassEncoder48.setBindGroup(3, bindGroup0);
+} catch {}
+let renderBundle159 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder72.setBindGroup(0, bindGroup8, new Uint32Array(5508), 114, 0);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: -561.4, g: 904.6, b: -352.1, a: 480.3, });
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let renderBundle160 = renderBundleEncoder22.finish({});
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer161, commandBuffer160]);
+} catch {}
+let pipelineLayout37 = device1.createPipelineLayout({
+  label: '\ua348\u0c1a\u{1ffe1}\u0c40\u133b\u{1fb51}\u{1fb61}\u{1fdc5}\u0a9b',
+  bindGroupLayouts: [bindGroupLayout26, bindGroupLayout28],
+});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup8, new Uint32Array(794), 61, 0);
+} catch {}
+try {
+querySet29.destroy();
+} catch {}
+let commandBuffer170 = commandEncoder247.finish({label: '\uf001\u0041\u0bd1\uc36e\ud4eb\u7e70\uf7b1\ued35\uc2b2\u015f\u2224'});
+let computePassEncoder80 = commandEncoder246.beginComputePass({});
+let renderBundle161 = renderBundleEncoder22.finish({label: '\u{1fa2d}\u043b\u756b\u0156\u1369\u16f3\u{1faf4}\u0712\ua035\u{1fe8b}\u5c67'});
+try {
+buffer23.unmap();
+} catch {}
+let commandBuffer171 = commandEncoder238.finish();
+let renderBundle162 = renderBundleEncoder20.finish({label: '\u42d9\u{1f8c3}\u{1f9b8}\u{1f817}\udd63\u1e90'});
+try {
+  await promise41;
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer8);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup4, new Uint32Array(91), 2, 0);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(2, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer19, 1_288);
+} catch {}
+let bindGroupLayout37 = device2.createBindGroupLayout({
+  label: '\u7268\u{1f9c5}\u3521\u0952\u00d1\ueca3\u{1fba8}\u0949\u03fd\u708f\u7a45',
+  entries: [
+    {
+      binding: 417,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let renderBundle163 = renderBundleEncoder20.finish({label: '\u089b\u046a\uceaa\ua316\ufced\u0d13\u0b52\u{1faec}\uc8aa\u0033\u{1f884}'});
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let commandEncoder251 = device1.createCommandEncoder({label: '\udcf5\u4061\u41bf\u0091\u1843\u0709\u{1fb23}\u1a23\u{1fda8}\u{1fe74}\ua4f5'});
+let externalTexture30 = device1.importExternalTexture({source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup8, new Uint32Array(3904), 1258, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer19, 0, 2_414);
+} catch {}
+try {
+commandEncoder251.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1176 */
+  offset: 136,
+  bytesPerRow: 256,
+  buffer: buffer31,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 10, y: 16, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 5, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(46, 144);
+let commandEncoder252 = device1.createCommandEncoder({label: '\uc1ac\u0793\u2eeb\u4edb'});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup8, new Uint32Array(1600), 67, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle124]);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandBuffer172 = commandEncoder252.finish();
+let textureView60 = texture66.createView({label: '\u935c\u{1fa1e}\ud03c\u0a6d\u0062\u{1f917}\u02e3\u01fb\u0dfe\u03e1\u0371'});
+let renderPassEncoder23 = commandEncoder251.beginRenderPass({
+  label: '\u41bd\u5c34\u02f0\u0ca6\u09ec\u{1f6b5}\u2717\u83e5\u1720',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 28,
+  clearValue: { r: 752.9, g: 688.5, b: 238.6, a: -958.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 190105883,
+});
+try {
+renderPassEncoder23.executeBundles([renderBundle129, renderBundle138, renderBundle124, renderBundle142, renderBundle133, renderBundle141, renderBundle128]);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let bindGroup10 = device1.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 41, resource: externalTexture30}]});
+let commandEncoder253 = device1.createCommandEncoder({});
+let textureView61 = texture71.createView({label: '\u559e\u9be4\u693d\ub55c\u585b', baseMipLevel: 1, baseArrayLayer: 0});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup8, new Uint32Array(2848), 89, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle150]);
+} catch {}
+try {
+commandEncoder253.clearBuffer(buffer19, 3928, 4772);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 4, y: 14, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({entries: []});
+let commandEncoder254 = device0.createCommandEncoder({label: '\u2cdd\u0083\u5843\u9a73\ue4c3'});
+let renderPassEncoder24 = commandEncoder254.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 8,
+  clearValue: { r: 591.1, g: -632.7, b: -695.8, a: -519.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.9533829632746098,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+  },
+});
+try {
+computePassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u031f');
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let pipelineLayout38 = device0.createPipelineLayout({
+  label: '\uae9c\u{1ffa7}\u{1f8bd}\u{1fd23}\u36f5\u{1f7bf}\u0a96\u161f',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout25],
+});
+let textureView62 = texture55.createView({
+  label: '\u0bf5\u{1fc1b}\ubac0\u75c8\u0b6c\ub053\u0dc2\u{1fce6}\u{1f808}\u100f\u2d4e',
+  dimension: 'cube-array',
+  baseMipLevel: 0,
+  baseArrayLayer: 5,
+  arrayLayerCount: 6,
+});
+let renderBundle164 = renderBundleEncoder6.finish({label: '\u{1f7ab}\uf99d\u2079\u20c8\u0c25\u{1f9e9}\u6e03\ue2e2'});
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer4);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer159]);
+} catch {}
+let commandEncoder255 = device2.createCommandEncoder({label: '\u4bbe\u{1feeb}'});
+let commandBuffer173 = commandEncoder255.finish({label: '\ude8a\u{1fbfb}\u3cb8\uadd3\u00b9\u53f2\u{1fe0a}'});
+try {
+device2.queue.submit([commandBuffer171]);
+} catch {}
+let shaderModule7 = device2.createShaderModule({
+  label: '\u0e16\u01f4\u03ec',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: mat3x4h,
+}
+
+@group(0) @binding(50) var<storage, read_write> buffer45: array<array<u32, 1>, 1>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+  if bool(a0) {
+    buffer45[0][0] = u32(268);
+  }
+}
+
+struct S2 {
+  @location(7) @interpolate(flat, center) f0: vec4i
+}
+struct VertexOutput0 {
+  @location(3) f14: vec3f,
+  @builtin(position) f15: vec4f
+}
+
+@vertex
+fn vertex0(a0: S2) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec2f {
+  var out: vec2f;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView63 = texture70.createView({label: '\u01e6\u{1f951}\u0129'});
+let computePassEncoder81 = commandEncoder217.beginComputePass({label: '\u07a3\u4cdb\u5546\u79de\u0449\u03b1\u{1ff47}\u07e5\u25fc\u0da4'});
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.submit([commandBuffer155, commandBuffer165]);
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder256 = device0.createCommandEncoder({label: '\u{1f8e6}\ueafa\u07d3\u6f6f\ud319'});
+let commandBuffer174 = commandEncoder256.finish();
+try {
+computePassEncoder79.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer3);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer8, 0, 7_048);
+} catch {}
+try {
+device0.queue.submit([commandBuffer174]);
+} catch {}
+let bindGroupLayout39 = device2.createBindGroupLayout({entries: [{binding: 511, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}]});
+let renderBundle165 = renderBundleEncoder23.finish({label: '\uf423\u3912\uc1c8'});
+try {
+querySet31.destroy();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 600, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(22), /* required buffer size: 22 */
+{offset: 22}, {width: 307, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup11 = device2.createBindGroup({layout: bindGroupLayout39, entries: [{binding: 511, resource: externalTexture26}]});
+let texture77 = device2.createTexture({
+  label: '\ub309\u0859\u0380\u14d7\uf46e',
+  size: [2596],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView64 = texture69.createView({
+  label: '\uba17\u6d9c\u{1fc13}\u0d6b\u6898\ue417\u{1fdad}\u093d\u0bd2\u{1f96b}',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 2,
+});
+let pipeline6 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout35,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilReadMask: 80595733,
+    depthBias: -1184091408,
+    depthBiasSlopeScale: 158.49125062267228,
+    depthBiasClamp: 239.40779704667614,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 176, stepMode: 'instance', attributes: []},
+      {arrayStride: 1356, attributes: []},
+      {arrayStride: 28, stepMode: 'instance', attributes: []},
+      {arrayStride: 96, attributes: []},
+      {arrayStride: 620, attributes: []},
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 0, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup12 = device2.createBindGroup({
+  label: '\u9259\u08a4\u82e0\udfb6\u838d\u072e\u0ad1',
+  layout: bindGroupLayout39,
+  entries: [{binding: 511, resource: externalTexture26}],
+});
+let texture78 = device2.createTexture({
+  label: '\u{1f8f0}\ub4a4\u36be\u0a10',
+  size: [1298],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let commandEncoder257 = device1.createCommandEncoder({label: '\u{1fbc1}\uc4a0\ud973\u0d6c\u{1f9a3}\u{1f97c}\ucdea\u6b28\u0374\u0d96'});
+let externalTexture31 = device1.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+commandEncoder253.copyBufferToBuffer(buffer30, 4552, buffer20, 2468, 336);
+} catch {}
+let imageData31 = new ImageData(48, 4);
+let buffer46 = device1.createBuffer({
+  label: '\u{1f91f}\u0567\ucf5b',
+  size: 12339,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer175 = commandEncoder257.finish({});
+let renderPassEncoder25 = commandEncoder253.beginRenderPass({
+  label: '\uebfa\u0e75\u{1fe0d}\u934f\u{1fed2}\u{1f72d}\u{1f714}\u0175',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 10,
+  clearValue: { r: -238.5, g: 80.20, b: -639.5, a: -613.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+document.body.prepend(img6);
+let textureView65 = texture8.createView({label: '\ua7a7\u6ca0\u2603\ud8fa\u0458\u0bee', dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 1});
+let renderBundle166 = renderBundleEncoder16.finish({label: '\u8ba1\u0566\u2f1c\u3c39'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer3, 0, 1_623);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer8, 'uint16', 2_814, 268);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer14, 496);
+} catch {}
+try {
+device0.queue.submit([commandBuffer153]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 24 */
+{offset: 24, bytesPerRow: 37}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+try {
+renderPassEncoder20.setIndexBuffer(buffer10, 'uint16', 506, 936);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer6, 'uint32', 2_492, 749);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 3636, new BigUint64Array(9163), 125, 356);
+} catch {}
+let commandEncoder258 = device2.createCommandEncoder({});
+let textureView66 = texture77.createView({
+  label: '\u06a3\u6f64\uf7ad\u0a35\u0e46\u{1f9dd}\u4007\u{1f6b7}\u0765\u2347',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+let renderPassEncoder26 = commandEncoder258.beginRenderPass({
+  label: '\u4ebb\u{1f701}\u008c\u11da',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 38,
+  clearValue: { r: 46.96, g: 702.6, b: 916.3, a: 554.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let externalTexture32 = device2.importExternalTexture({label: '\u0bef\u007c\u89f1', source: videoFrame1});
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder259 = device2.createCommandEncoder({label: '\u04bf\uaf1c'});
+let renderBundle167 = renderBundleEncoder20.finish({label: '\u07a7\u{1ff2f}\u{1ff66}\u7974\u0fc4\u0dc9'});
+try {
+renderPassEncoder26.setVertexBuffer(3, undefined, 0);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 292, new BigUint64Array(2886), 478, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter();
+try {
+adapter0.label = '\u0f12\u{1f6c0}\u05c7\u016e\ue2bd\u081c';
+} catch {}
+let commandEncoder260 = device0.createCommandEncoder({label: '\u71e3\ub910\u1428\u2170\u90b3\u678f\u3ccd\ucb6d\u{1fb30}\u99dc\u0e17'});
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer22);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder261 = device2.createCommandEncoder({label: '\u7d34\u7ae1\uc658\u0fe3\u5387'});
+let renderPassEncoder27 = commandEncoder259.beginRenderPass({
+  label: '\u{1fc2c}\uc4c6\u771f\u{1f8b6}\ub48c\u{1f981}\u{1fd34}\udb2a',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 373,
+  clearValue: { r: 241.6, g: -883.6, b: -252.7, a: 292.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet31,
+});
+try {
+renderPassEncoder26.executeBundles([renderBundle131, renderBundle156, renderBundle156]);
+} catch {}
+try {
+commandEncoder261.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 1,
+  origin: {x: 152, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 127, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 88, new BigUint64Array(14766), 1570, 40);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+let texture79 = device0.createTexture({
+  label: '\u04d1\u0e2e\u952e\u0a11\u0fdf\u{1ffec}\uc995\u089b\u{1fa77}\u{1f616}\u0913',
+  size: [7, 7, 30],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder54.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer169]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 2588, new Float32Array(5827), 185, 260);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder262 = device0.createCommandEncoder({label: '\u499b\u7471\u{1fff6}\u091d\u7d9a\u0718\u142d\u{1f638}\u{1fe79}\u{1f662}\u0700'});
+let commandBuffer176 = commandEncoder262.finish({});
+let renderBundle168 = renderBundleEncoder8.finish({label: '\u0932\ua088\u059d\uf4fe\ue208\u050f\u{1f609}\u8927\u84c6\u9917'});
+try {
+computePassEncoder50.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(721);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer22, 'uint32', 4_848, 1_676);
+} catch {}
+try {
+commandEncoder260.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+let commandEncoder263 = device2.createCommandEncoder({});
+let computePassEncoder82 = commandEncoder263.beginComputePass({label: '\u0e5e\u7576\u068a\ue458\u9c0c\u313d\u0bbc'});
+try {
+renderPassEncoder27.setIndexBuffer(buffer23, 'uint32', 528, 577);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas4.getContext('webgpu');
+try {
+  await promise42;
+} catch {}
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setViewport(0.375660023643978, 5.099420442264348, 4.354490315987737, 0.028142744180197556, 0.19627313524994583, 0.8258118921352511);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(1, buffer3, 0);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let imageData32 = new ImageData(24, 48);
+let commandEncoder264 = device2.createCommandEncoder();
+let commandBuffer177 = commandEncoder264.finish({label: '\u0194\ue1fc\u5fba\u1025\u0e27\u{1ff3d}\ua094\u{1f822}\uae3e\u04cf\u8a61'});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, undefined, 0, 228_257_467);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let commandEncoder265 = device0.createCommandEncoder({});
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+let commandEncoder266 = device1.createCommandEncoder({label: '\u0c0c\u{1fc94}'});
+let renderPassEncoder28 = commandEncoder266.beginRenderPass({
+  label: '\u0f12\u{1fa0e}\u0776\u{1f8da}\u{1ffd5}',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 18,
+  clearValue: { r: 893.9, g: -611.1, b: -118.3, a: -343.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer20, 'uint32', 4_964, 18_759);
+} catch {}
+try {
+querySet25.destroy();
+} catch {}
+try {
+device1.queue.submit([commandBuffer172]);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let promise43 = adapter5.requestDevice({
+  defaultQueue: {label: '\u{1fe1e}\ud215\u060d\u{1f7e0}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxVertexBufferArrayStride: 2048,
+    maxUniformBufferBindingSize: 89299449,
+    maxStorageBufferBindingSize: 134962554,
+  },
+});
+let commandEncoder267 = device2.createCommandEncoder({label: '\u3b7c\udda2\u235c\uc5ca\u5755\u{1fe49}\ub564'});
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup12, new Uint32Array(2986), 1, 0);
+} catch {}
+try {
+querySet31.destroy();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(143), /* required buffer size: 143 */
+{offset: 143}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder268 = device1.createCommandEncoder({label: '\u{1fb2f}\u{1f723}\u0424\ucff6\udedd\u{1fc0f}\ue898\u0f30'});
+let renderPassEncoder29 = commandEncoder268.beginRenderPass({
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 36,
+  clearValue: { r: -314.3, g: -39.05, b: 657.8, a: 485.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet29,
+});
+try {
+renderPassEncoder29.beginOcclusionQuery(444);
+} catch {}
+try {
+renderPassEncoder28.setViewport(5.912618562169006, 7.334836245946843, 0.08643710480053861, 6.178166946681742, 0.7170073962355169, 0.7595659646674624);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer19, 0, 3_205);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: imageData26,
+  origin: { x: 28, y: 2 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup10, new Uint32Array(2254), 295, 0);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+device1.queue.submit([commandBuffer136]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(952), /* required buffer size: 952 */
+{offset: 216, bytesPerRow: 23, rowsPerImage: 32}, {width: 0, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: video6,
+  origin: { x: 8, y: 1 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 5, y: 10, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture80 = device1.createTexture({
+  size: {width: 12},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device1.queue.submit([commandBuffer175]);
+} catch {}
+let commandEncoder269 = device1.createCommandEncoder({label: '\u{1f8e1}\u{1f8c9}\u7de7\u4441\u020c\u{1f6aa}\u2df5\u{1fb3f}'});
+let commandBuffer178 = commandEncoder269.finish({});
+let externalTexture33 = device1.importExternalTexture({label: '\uc0e8\u{1fcde}\u2cd9\u{1f778}', source: video5, colorSpace: 'srgb'});
+try {
+computePassEncoder71.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+let pipeline7 = await device1.createComputePipelineAsync({layout: pipelineLayout32, compute: {module: shaderModule3, constants: {}}});
+let imageData33 = new ImageData(16, 44);
+let commandEncoder270 = device1.createCommandEncoder({label: '\ufcbe\u88af\u{1fe67}\u00f6'});
+let computePassEncoder83 = commandEncoder270.beginComputePass({label: '\u27cf\u082c\u0871\u{1fc02}\u{1fe42}\u5561\u40f7\uc06b\u{1f632}\u{1ff96}'});
+try {
+computePassEncoder56.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: -715.9, g: 829.2, b: -95.94, a: 775.3, });
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer19, 4348, new DataView(new ArrayBuffer(10942)), 3323, 1544);
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({label: '\u2ea8\u{1ff1b}\u5fc4\u726a\u043d'});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup2, new Uint32Array(1692), 772, 0);
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer29, 876, 3_833);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+computePassEncoder52.insertDebugMarker('\uf34b');
+} catch {}
+let commandEncoder272 = device0.createCommandEncoder({label: '\u0ecf\uacb8\uf534\u4d04\u0e22\u8395\u078f\uba77\ufad6\u{1fe98}'});
+let commandBuffer179 = commandEncoder265.finish({label: '\u01f1\u{1fddf}\u0550\u0665\u{1f8b7}\u5ba0\u0ecd\u{1fede}'});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup7, new Uint32Array(4461), 463, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(232);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer16, 0);
+} catch {}
+let commandBuffer180 = commandEncoder260.finish({});
+let externalTexture34 = device0.importExternalTexture({label: '\u0df5\u35e8\u71b7\u0c70\u{1fc58}\u503f\u03b4\u0790\u5da0', source: videoFrame3});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(7, buffer10);
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer5, 1228, buffer0, 14172, 2940);
+} catch {}
+try {
+commandEncoder271.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 976 */
+  offset: 916,
+  buffer: buffer22,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: video3,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 24},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder30 = commandEncoder67.beginRenderPass({
+  label: '\u70eb\uca9e\u007d\u0be6\u85b4\u{1f67a}\u{1f626}\u0858\u{1fe9e}',
+  colorAttachments: [{view: textureView27, depthSlice: 5, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: 0.2677002237460697,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 51460,
+  },
+});
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer21, 'uint32', 6_300, 0);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer21, 'uint32', 3_224, 556);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer10, 1_196);
+} catch {}
+try {
+commandEncoder272.insertDebugMarker('\ubff2');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder273 = device1.createCommandEncoder({label: '\uad2e\u1d21\u8f80\u0983\ua059\u0811\u64bf'});
+let commandBuffer181 = commandEncoder273.finish({});
+try {
+computePassEncoder67.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup10, new Uint32Array(78), 19, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle152]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer46);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView67 = texture61.createView({
+  label: '\u001a\u{1f6cf}\u5200\u4c36\u011a\u0ec4\u0ef7\u{1f930}\u{1fc57}\u{1f612}\ucc3d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle169 = renderBundleEncoder19.finish({label: '\ub140\u04b8\u156d\ub9c1'});
+try {
+computePassEncoder74.setPipeline(pipeline5);
+} catch {}
+try {
+device1.queue.submit([commandBuffer178]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(47), /* required buffer size: 47 */
+{offset: 47, bytesPerRow: 29}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule8 = device2.createShaderModule({
+  label: '\u{1f6b9}\uaf63\ue2ca\u0058\u0267\u{1fdb7}\u0a86',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: vec3u,
+}
+
+@group(0) @binding(50) var<storage, read_write> buffer47: mat2x4h;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f16: vec4f,
+  @location(0) @interpolate(flat) f17: vec3u,
+  @location(8) f18: vec4u
+}
+
+@vertex
+fn vertex0(@location(15) @interpolate(perspective) a0: f32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(a0) {
+    var v: vec4f;
+  }
+  out.f16 = vec4f(bitcast<f32>(a0));
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder274 = device2.createCommandEncoder();
+let commandBuffer182 = commandEncoder261.finish();
+let computePassEncoder84 = commandEncoder274.beginComputePass({label: '\u07ed\uf26e\u184d'});
+let renderPassEncoder31 = commandEncoder267.beginRenderPass({
+  label: '\u44e8\ucb15\u0d3b\u066b\udecf\u0961\u{1fd63}',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 166,
+  clearValue: { r: 102.3, g: 472.0, b: -331.5, a: -579.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet31,
+  maxDrawCount: 1783968,
+});
+let renderBundle170 = renderBundleEncoder23.finish({});
+let commandEncoder275 = device1.createCommandEncoder({label: '\uff9e\u2653'});
+let commandBuffer183 = commandEncoder275.finish({});
+let renderBundle171 = renderBundleEncoder18.finish();
+await gc();
+let commandEncoder276 = device1.createCommandEncoder({label: '\u{1fe55}\ue2e0\u0c33\u32f0'});
+let texture81 = gpuCanvasContext2.getCurrentTexture();
+let imageData34 = new ImageData(4, 28);
+let commandBuffer184 = commandEncoder15.finish({label: '\u0b04\u92a1\u0cd4\ua211\u51b8\u332f'});
+let textureView68 = texture44.createView({label: '\u08be\uf96e\u0f78\u0e6a\u{1f777}\u{1ff51}\u09d5\u0298\u{1fedf}', dimension: '2d'});
+try {
+renderPassEncoder24.setIndexBuffer(buffer1, 'uint32', 740, 997);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer3, 2_924);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let renderPassEncoder32 = commandEncoder276.beginRenderPass({
+  label: '\ue358\u6a2a\u977e\ue475\u8299\u{1f879}\u0dd9\uab28\u{1f697}',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 21,
+  clearValue: { r: 31.16, g: 796.6, b: 17.10, a: -137.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder71.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup8, new Uint32Array(2714), 32, 0);
+} catch {}
+let buffer48 = device1.createBuffer({
+  label: '\ucf99\u30d9\u637b\u04ac\uf5b9\u559b\u{1fc48}',
+  size: 5896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let renderBundle172 = renderBundleEncoder21.finish({label: '\u0837\u022f\ub6fa\u{1fe99}'});
+try {
+renderPassEncoder29.beginOcclusionQuery(62);
+} catch {}
+try {
+device1.queue.submit([commandBuffer181, commandBuffer168]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder277 = device1.createCommandEncoder();
+let commandBuffer185 = commandEncoder277.finish({label: '\u{1f761}\u0164'});
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup10, new Uint32Array(171), 13, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer19);
+} catch {}
+document.body.prepend(video6);
+let renderBundle173 = renderBundleEncoder20.finish({label: '\u05d9\u{1fc43}\u045f\u085e\u{1f965}'});
+try {
+renderPassEncoder27.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer23, 'uint32', 2_304, 354);
+} catch {}
+try {
+computePassEncoder81.insertDebugMarker('\u{1fa86}');
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup11, new Uint32Array(217), 58, 0);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let pipelineLayout39 = device0.createPipelineLayout({
+  label: '\u5a3d\u0c9d\u0d20\u777b\u01a6\ucd44\u{1fafe}\u{1fbf5}\u275f\u9c45\ufbab',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout14, bindGroupLayout14, bindGroupLayout15],
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 1, stencilReadOnly: true});
+let externalTexture35 = device0.importExternalTexture({label: '\u082b\u0339\u{1f8d4}\u5377\u381c\u{1fd07}\u{1f60f}', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup7, new Uint32Array(1922), 2, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer15, 'uint32', 560, 1_708);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer29, 1_804);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder278 = device2.createCommandEncoder({});
+let texture82 = device2.createTexture({
+  label: '\u{1fd26}\u970a\u{1fa11}\u5212\ud933\ufc7a\ueb4f\u{1ff72}\ubd0f',
+  size: {width: 324, height: 1, depthOrArrayLayers: 79},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder33 = commandEncoder278.beginRenderPass({
+  label: '\u{1fb0b}\u1da5\u9fdf',
+  colorAttachments: [{view: textureView63, depthSlice: 135, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer173, commandBuffer164]);
+} catch {}
+await gc();
+let commandEncoder279 = device2.createCommandEncoder({label: '\u7c98\ub361\u0b79\u1b36'});
+let commandBuffer186 = commandEncoder279.finish({});
+let externalTexture36 = device2.importExternalTexture({
+  label: '\u0392\u093e\u{1fcbb}\u0666\u8ddc\u0adc\ub1e4\u107a\uf6b4\uec5b',
+  source: video3,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder27.executeBundles([renderBundle163, renderBundle160]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer23, 'uint32', 2_408, 300);
+} catch {}
+let commandEncoder280 = device2.createCommandEncoder({label: '\u{1fc21}\u3a35\u3b4a'});
+let renderPassEncoder34 = commandEncoder280.beginRenderPass({
+  label: '\u0261\u248f\u2e07\ub2cb\u0792\u0bf9\u0846\u2c17\ucd62',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 453,
+  clearValue: { r: 217.0, g: -568.1, b: 359.3, a: -493.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle146]);
+} catch {}
+let pipeline8 = device2.createComputePipeline({
+  label: '\u{1fe0c}\u{1f6a9}\u03a5\u45da',
+  layout: pipelineLayout35,
+  compute: {module: shaderModule6, constants: {}},
+});
+let querySet32 = device2.createQuerySet({type: 'occlusion', count: 3458});
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer23, 'uint16', 350, 11);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\u2035\u3396\uf3f4',
+  entries: [
+    {
+      binding: 393,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup13 = device0.createBindGroup({
+  label: '\u5a0c\ub63a\u0fa6\ud828\u6e94\u0628\u07d7\u83b5\u03e0\ua612\ufd02',
+  layout: bindGroupLayout17,
+  entries: [],
+});
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+let buffer49 = device2.createBuffer({
+  label: '\u1b9c\uee8e\u{1fc50}\u23b0\u2013\u8002\u{1fbb4}\u{1fad0}\u00ca',
+  size: 4180,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let renderBundle174 = renderBundleEncoder15.finish({label: '\u96ee\u6c33\u0694\u039c\ufc87\u010d'});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer0, 'uint32', 12_796, 3_191);
+} catch {}
+video0.width = 12;
+try {
+renderPassEncoder31.label = '\u0c83\u7591\ubf84\u3c0e';
+} catch {}
+let commandEncoder281 = device2.createCommandEncoder({});
+let texture83 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder80.setBindGroup(0, bindGroup11, new Uint32Array(281), 43, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup12, new Uint32Array(4233), 3026, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(1, undefined, 316_759_810, 69_839_319);
+} catch {}
+try {
+commandEncoder281.copyBufferToTexture({
+  /* bytesInLastRow: 400 widthInBlocks: 50 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2072 */
+  offset: 2072,
+  buffer: buffer49,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 50, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder281.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 1,
+  origin: {x: 46, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 384 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2736 */
+  offset: 2736,
+  buffer: buffer23,
+}, {width: 48, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder81.insertDebugMarker('\u{1fce5}');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 75, y: 3 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer50 = device0.createBuffer({size: 22580, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let commandEncoder282 = device0.createCommandEncoder({});
+let externalTexture37 = device0.importExternalTexture({label: '\u{1ffbb}\u{1fda8}\u04ed\ude8f\ub152\u5c6b\uca25\u485e\u6bab\ubed8\u07c6', source: video0});
+try {
+computePassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer29, 0, 72);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer3, 8_668, 8_940);
+} catch {}
+try {
+commandEncoder202.copyBufferToBuffer(buffer1, 2192, buffer6, 3956, 1584);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+try {
+device0.queue.submit([commandBuffer179, commandBuffer176]);
+} catch {}
+let pipelineLayout40 = device0.createPipelineLayout({label: '\u03e4\u0f3a\u00b2', bindGroupLayouts: [bindGroupLayout16]});
+let commandEncoder283 = device0.createCommandEncoder();
+let textureView69 = texture22.createView({mipLevelCount: 1});
+let computePassEncoder85 = commandEncoder188.beginComputePass({label: '\u67ce\uabcd\u6ad9\u774a\u3d2f\u2fd2\u{1fce2}'});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup1, new Uint32Array(1022), 138, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandEncoder284 = device1.createCommandEncoder({label: '\uac09\u1b17\u5dbf\u059c'});
+let renderPassEncoder35 = commandEncoder284.beginRenderPass({
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 33,
+  clearValue: { r: 372.5, g: 158.7, b: 335.8, a: -773.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+let canvas7 = document.createElement('canvas');
+let textureView70 = texture57.createView({});
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder29.setViewport(4.1283056871660895, 6.992795606223524, 1.4302846332054344, 5.636916414773086, 0.7241486858324163, 0.785699863268122);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer20, 'uint16', 4_750, 4_791);
+} catch {}
+let commandEncoder285 = device0.createCommandEncoder({label: '\u0dd3\u{1fd9a}\u0446\u{1f9f3}\u4f12\u0ef8\ua5e5\u88e6\u0da3\ufdda'});
+let textureView71 = texture73.createView({label: '\u3439\u4c9b'});
+let renderBundle175 = renderBundleEncoder15.finish({label: '\u0762\u0b4b\u0b21\u0dac\u03d9\u0abb\u0bd8\u654c\u947b\u0912'});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer17, 'uint16', 474, 1_609);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let commandEncoder286 = device1.createCommandEncoder({label: '\u0725\u01cb\u{1fa68}\u6f30\uae18\u4596\u{1fde4}\u{1fe38}\u811b'});
+let commandBuffer187 = commandEncoder286.finish({});
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer19, 2204, new Int16Array(15214), 2054, 376);
+} catch {}
+let renderBundle176 = renderBundleEncoder21.finish({});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: video3,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let imageData35 = new ImageData(8, 32);
+let renderBundle177 = renderBundleEncoder18.finish({});
+let computePassEncoder86 = commandEncoder281.beginComputePass({label: '\u{1ff02}\u{1ff67}\u{1f80d}\u5182\ub47c\u3028'});
+let renderPassEncoder36 = commandEncoder244.beginRenderPass({
+  label: '\u24f3\uc8dc',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 239,
+  clearValue: { r: 100.7, g: 566.7, b: -685.6, a: -507.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle178 = renderBundleEncoder20.finish({label: '\u0a4a\u0d88\u010e'});
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder287 = device1.createCommandEncoder({label: '\u{1f79c}\u04e6\u0902\u{1f710}\u0a0c\u302c\ubb43\u46e4'});
+let querySet33 = device1.createQuerySet({label: '\u{1f6d1}\u{1fa39}', type: 'occlusion', count: 426});
+let commandBuffer188 = commandEncoder287.finish({label: '\u1469\ud8ac\u9aa5\u077d\u0dfe\u{1f6c5}\u0676\uf9a8\u8587\u53ae'});
+let renderBundle179 = renderBundleEncoder21.finish({label: '\u{1f92d}\u067f\u81be\u080a\udfa4\u0b12\u08e4\ued2b\ud690\u77e2'});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup10, new Uint32Array(3203), 222, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer20, 'uint32', 120, 12_503);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(640, 18);
+let pipelineLayout41 = device2.createPipelineLayout({label: '\u99e3\ub7eb\u08b1\u{1f794}\u0cda', bindGroupLayouts: [bindGroupLayout39]});
+let commandEncoder288 = device2.createCommandEncoder({});
+let commandBuffer189 = commandEncoder288.finish();
+let renderBundle180 = renderBundleEncoder20.finish({label: '\u5cd3\u01c8\u9c5b\u4deb'});
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4_294_967_294, undefined, 0, 1_145_797_259);
+} catch {}
+let gpuCanvasContext10 = canvas6.getContext('webgpu');
+let renderBundle181 = renderBundleEncoder21.finish({label: '\u08c3\u0565\u{1fa9e}\u0c7f\u{1f7fb}\uec1a\u{1f638}'});
+let sampler16 = device1.createSampler({
+  label: '\uebcd\u{1f8a2}\u68b7\u{1f686}\uf5b6\u{1fc52}\ud9ae\ud839\u0b63',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 65.18,
+  lodMaxClamp: 80.13,
+  compare: 'less',
+});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let shaderModule9 = device2.createShaderModule({
+  label: '\u0a45\u0448\u{1f9bb}\u8667',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<vec4i>,
+}
+
+@group(0) @binding(511) var et19: texture_external;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0() {
+}
+
+struct S3 {
+  @location(14) @interpolate(perspective) f0: vec3h,
+  @location(2) f1: vec3f,
+  @location(6) @interpolate(linear, centroid) f2: vec3f
+}
+struct VertexOutput0 {
+  @builtin(position) f19: vec4f,
+  @location(10) @interpolate(flat, sample) f20: vec3i,
+  @location(2) f21: vec4h
+}
+
+@vertex
+fn vertex0(a0: S3, @location(10) a1: vec3h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec4h, @location(10) @interpolate(flat, sample) a1: vec3i, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> @location(200) @interpolate(perspective, center) vec4f {
+  var out: vec4f;
+  if bool(textureDimensions(et19)[0]) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandEncoder289 = device2.createCommandEncoder({label: '\u076b\u277d\u{1f934}\u0d1c\u4cb2'});
+let commandBuffer190 = commandEncoder289.finish({label: '\u7914\u2e7e\u0140\u0527\u0cfc\u1a18\u{1fb9f}\u03e0'});
+let textureView72 = texture83.createView({dimension: '2d-array'});
+try {
+renderPassEncoder27.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+let pipeline9 = await device2.createRenderPipelineAsync({
+  label: '\u2cba\u69ca\u3cb6\ufb01\u06dd\ue8fe\u8cae',
+  layout: pipelineLayout41,
+  multisample: {count: 4, mask: 0xda57e73},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule9,
+    buffers: [
+      {arrayStride: 180, stepMode: 'instance', attributes: []},
+      {arrayStride: 236, attributes: []},
+      {arrayStride: 428, attributes: []},
+      {arrayStride: 892, stepMode: 'instance', attributes: []},
+      {arrayStride: 168, attributes: []},
+      {arrayStride: 76, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 88, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 244,
+        attributes: [
+          {format: 'float16x4', offset: 144, shaderLocation: 2},
+          {format: 'float32x4', offset: 24, shaderLocation: 14},
+          {format: 'float16x4', offset: 8, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back', unclippedDepth: true},
+});
+let textureView73 = texture68.createView({
+  label: '\u09fe\u05e5\u033d\u{1f7c8}\uedae\u3731\u71b4\u30d7\u68a8\u3809\u8b3a',
+  baseArrayLayer: 2,
+  arrayLayerCount: 4,
+});
+try {
+device2.queue.submit([commandBuffer177, commandBuffer170]);
+} catch {}
+let pipeline10 = device2.createRenderPipeline({
+  label: '\u8b78\u{1f950}\u{1fb9e}\ud754\u7229\uf6e8\udaa5\u{1f85a}\ud8c8',
+  layout: pipelineLayout41,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilReadMask: 722799458,
+    depthBiasSlopeScale: 229.51289929846865,
+    depthBiasClamp: 524.9297492599134,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 144, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, attributes: []},
+      {arrayStride: 160, attributes: []},
+      {arrayStride: 0, attributes: [{format: 'unorm10-10-10-2', offset: 188, shaderLocation: 10}]},
+      {arrayStride: 696, attributes: []},
+      {arrayStride: 364, stepMode: 'instance', attributes: []},
+      {arrayStride: 732, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x3', offset: 920, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 284, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 192, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+});
+let renderBundle182 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder29.setStencilReference(437);
+} catch {}
+try {
+renderPassEncoder21.setViewport(2.2611355276595546, 11.490523882074624, 2.115888689977457, 1.9222031758344456, 0.4583740528350321, 0.982931550253539);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 460, new DataView(new ArrayBuffer(2096)));
+} catch {}
+let commandEncoder290 = device1.createCommandEncoder({label: '\u0933\u985f\uf232\u052d\u01a8\u0c76\ue04f\u0985\u0231\u{1fc82}'});
+let querySet34 = device1.createQuerySet({type: 'occlusion', count: 3215});
+let commandBuffer191 = commandEncoder290.finish({label: '\u9f4e\u0fd2\ufa86\ucfb0\u7a37\u{1f75d}\u06ab'});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer20, 'uint32', 6_808, 3_437);
+} catch {}
+try {
+texture80.destroy();
+} catch {}
+try {
+device1.queue.submit([commandBuffer185, commandBuffer188, commandBuffer183]);
+} catch {}
+let textureView74 = texture53.createView({label: '\u{1fca5}\u76ad\u{1fcf1}\u2df0\u11c7\u4b2a\u00b9\u0e02\u073f\ue1c7', arrayLayerCount: 1});
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(4, buffer11, 0, 1_245);
+} catch {}
+let textureView75 = texture68.createView({
+  label: '\uae4b\u{1fb98}\u060f\u03e3\ua262\u{1fde0}\u{1f8be}\u{1fd52}\u0143\u5f67\u95a1',
+  baseArrayLayer: 5,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4_294_967_294, undefined, 439_989_258, 175_058_751);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 162, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 15 },
+  flipY: true,
+}, {
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 49, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let commandEncoder291 = device0.createCommandEncoder({label: '\u4281\u2282\u6c2f'});
+let renderBundle183 = renderBundleEncoder11.finish();
+try {
+renderBundleEncoder24.setIndexBuffer(buffer16, 'uint16', 392, 143);
+} catch {}
+try {
+commandEncoder283.copyBufferToBuffer(buffer50, 18520, buffer14, 856, 68);
+} catch {}
+try {
+commandEncoder272.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2500 */
+  offset: 2500,
+  buffer: buffer18,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture19.label;
+} catch {}
+let bindGroup14 = device0.createBindGroup({label: '\u0a75\u00de', layout: bindGroupLayout35, entries: []});
+let commandEncoder292 = device0.createCommandEncoder({label: '\u05ea\u0528\u0f3c\u2fa1\ue2e0\u29e0'});
+let commandBuffer192 = commandEncoder282.finish({label: '\u05e0\uc762'});
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer18, 0, 2_200);
+} catch {}
+await gc();
+let adapter6 = await navigator.gpu.requestAdapter({});
+let textureView76 = texture61.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle184 = renderBundleEncoder18.finish({label: '\u{1fd55}\u{1fc8b}'});
+try {
+renderPassEncoder23.executeBundles([renderBundle172]);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(5, buffer19, 380);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u879f');
+} catch {}
+let commandEncoder293 = device1.createCommandEncoder({label: '\u02dc\u3abc\u0f0b\uc83c\u{1fa76}'});
+let textureView77 = texture57.createView({label: '\u{1f9f6}\u72b7\u9022\uf76d'});
+let renderPassEncoder37 = commandEncoder293.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  depthSlice: 16,
+  clearValue: { r: -26.33, g: -613.2, b: -278.4, a: -976.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle185 = renderBundleEncoder19.finish({label: '\u9d52\u{1fecc}\u8dce'});
+try {
+computePassEncoder77.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer30, 'uint16', 1_246, 281);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer19, 3952, new Float32Array(4543), 471, 216);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(6_322), /* required buffer size: 6_322 */
+{offset: 232, bytesPerRow: 145, rowsPerImage: 8}, {width: 0, height: 3, depthOrArrayLayers: 6});
+} catch {}
+try {
+offscreenCanvas5.getContext('bitmaprenderer');
+} catch {}
+try {
+computePassEncoder71.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer30, 'uint16', 982, 512);
+} catch {}
+try {
+device1.queue.submit([commandBuffer187]);
+} catch {}
+let pipeline11 = device1.createComputePipeline({layout: pipelineLayout32, compute: {module: shaderModule3, constants: {}}});
+try {
+computePassEncoder62.setPipeline(pipeline5);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData28,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 8, y: 40, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(video7);
+let imageData36 = new ImageData(36, 52);
+try {
+renderPassEncoder35.setIndexBuffer(buffer48, 'uint32', 24, 2_819);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer19, 0, 2_691);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+let pipeline12 = await device1.createComputePipelineAsync({layout: pipelineLayout32, compute: {module: shaderModule3, constants: {}}});
+await gc();
+try {
+canvas7.getContext('webgl');
+} catch {}
+let texture84 = gpuCanvasContext7.getCurrentTexture();
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer23, 'uint16', 226, 764);
+} catch {}
+let pipeline13 = await device2.createRenderPipelineAsync({
+  label: '\ua518\u{1fc2b}\u1368\u046f\uae71\u894f\u{1fe6e}',
+  layout: pipelineLayout41,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 94961996,
+    stencilWriteMask: 3562566355,
+  },
+  vertex: {
+    module: shaderModule9,
+    buffers: [
+      {arrayStride: 728, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 164,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 56, shaderLocation: 6}],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 152, stepMode: 'vertex', attributes: []},
+      {arrayStride: 456, stepMode: 'instance', attributes: []},
+      {arrayStride: 36, attributes: []},
+      {arrayStride: 284, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 196,
+        attributes: [
+          {format: 'unorm16x2', offset: 8, shaderLocation: 2},
+          {format: 'float16x4', offset: 4, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+try {
+adapter2.label = '\uc328\u3e79';
+} catch {}
+let renderBundle186 = renderBundleEncoder23.finish({label: '\uad05\u0b70\u0088'});
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup11, new Uint32Array(1175), 276, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle173]);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandEncoder294 = device2.createCommandEncoder({label: '\u{1f69e}\u492b\u{1ff67}\u03d3\u343e\u2bca\u{1fc90}\u9a46'});
+let renderPassEncoder38 = commandEncoder294.beginRenderPass({
+  label: '\uc26b\u{1f876}\u9f42\uc3d7\ud13c\u{1fa61}\u{1fe39}',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 372,
+  clearValue: { r: 399.7, g: -313.8, b: -689.8, a: 733.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder26.setIndexBuffer(buffer23, 'uint16', 126, 205);
+} catch {}
+let imageData37 = new ImageData(4, 40);
+let querySet35 = device2.createQuerySet({label: '\u10d8\u0cc1\u2c49\u8c30\u3555\u{1fdd0}', type: 'occlusion', count: 538});
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle154, renderBundle148]);
+} catch {}
+let texture85 = gpuCanvasContext8.getCurrentTexture();
+let renderBundle187 = renderBundleEncoder23.finish();
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+let commandEncoder295 = device0.createCommandEncoder({});
+let commandBuffer193 = commandEncoder295.finish();
+let renderPassEncoder39 = commandEncoder291.beginRenderPass({
+  label: '\u0164\u1a88\u6109\u{1faf3}\u3a41\u1a0f\u0f24',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 25,
+  clearValue: { r: -240.1, g: 162.9, b: 989.6, a: 281.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView0,
+    depthClearValue: -2.4271812256812098,
+    depthReadOnly: true,
+    stencilClearValue: 14517,
+  },
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup4, new Uint32Array(680), 20, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer10, 'uint32', 1_060, 1_236);
+} catch {}
+try {
+commandEncoder197.insertDebugMarker('\u576c');
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle135, renderBundle178]);
+} catch {}
+try {
+renderPassEncoder26.pushDebugGroup('\u{1f990}');
+} catch {}
+await gc();
+try {
+window.someLabel = renderPassEncoder13.label;
+} catch {}
+let pipelineLayout42 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout30]});
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup10, new Uint32Array(552), 102, 0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer19);
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker('\uda93');
+} catch {}
+let pipeline14 = device1.createRenderPipeline({
+  label: '\u6b3d\ueea5\u479c\ufac6\u{1ffe6}\u3bfb\u6359\ubd29\ub570\u043b',
+  layout: pipelineLayout32,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 1297758199,
+    stencilWriteMask: 887895062,
+    depthBias: -2071103022,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 560, stepMode: 'instance', attributes: []},
+      {arrayStride: 176, stepMode: 'instance', attributes: []},
+      {arrayStride: 548, stepMode: 'instance', attributes: []},
+      {arrayStride: 344, stepMode: 'instance', attributes: []},
+      {arrayStride: 636, stepMode: 'instance', attributes: []},
+      {arrayStride: 172, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x2', offset: 16, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 760, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let querySet36 = device0.createQuerySet({label: '\u71f7\u{1ff5d}\udd8a', type: 'occlusion', count: 851});
+let renderBundle188 = renderBundleEncoder7.finish({label: '\ubb29\u3257\u0c39\u05ad\u{1fb12}\u{1fa5d}\u{1fdb7}'});
+try {
+renderPassEncoder9.setStencilReference(1349);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer7, 'uint16', 374, 498);
+} catch {}
+try {
+commandEncoder285.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1280 */
+  offset: 1280,
+  buffer: buffer10,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'depth-only',
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder202.resolveQuerySet(querySet4, 171, 4, buffer18, 768);
+} catch {}
+try {
+device0.queue.submit([commandBuffer193, commandBuffer192]);
+} catch {}
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({label: '\u5b18\u0773', colorFormats: ['rgba8unorm'], sampleCount: 1});
+try {
+computePassEncoder75.setBindGroup(3, bindGroup10, new Uint32Array(539), 83, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(131);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer19, 0);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 1, y: 104, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(1_717), /* required buffer size: 1_717 */
+{offset: 201, bytesPerRow: 46, rowsPerImage: 17}, {width: 11, height: 16, depthOrArrayLayers: 2});
+} catch {}
+let texture86 = device1.createTexture({
+  label: '\ue681\u53cf\u{1fabb}\u2096',
+  size: {width: 12},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(0, buffer46, 916, 1_527);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker('\u0836');
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer14, 0);
+} catch {}
+try {
+commandEncoder283.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'depth-only',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet37 = device0.createQuerySet({label: '\u7625\u8cbf\u{1f9d6}\udf13\u484f\u{1fbfe}\u1d1c', type: 'occlusion', count: 780});
+let textureView78 = texture43.createView({baseMipLevel: 0});
+let externalTexture38 = device0.importExternalTexture({
+  label: '\u0743\u0738\u0e96\u{1fdea}\udbc0\u2f96\u192d\u{1f828}\u055c',
+  source: videoFrame5,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 10, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(288), /* required buffer size: 288 */
+{offset: 288}, {width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer48, 'uint32', 404, 2_331);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer19, 2940, new Int16Array(10483), 79, 1420);
+} catch {}
+let externalTexture39 = device0.importExternalTexture({label: '\u{1fa81}\u1780\u4435', source: video2});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup2, new Uint32Array(503), 14, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer29);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 68, new Float32Array(58771), 16891, 352);
+} catch {}
+let commandEncoder296 = device0.createCommandEncoder();
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 601.1, g: -420.3, b: 487.8, a: 42.95, });
+} catch {}
+try {
+commandEncoder272.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3518 */
+  offset: 1968,
+  bytesPerRow: 256,
+  buffer: buffer14,
+}, {width: 7, height: 7, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder272.clearBuffer(buffer13, 13496, 6816);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandBuffer194 = commandEncoder271.finish({label: '\u{1f7cf}\u872e\ua40a\u0e67\u07c0\u65f4\u{1fee5}\u{1fe79}\u0e40'});
+let texture87 = device0.createTexture({
+  label: '\u{1f75f}\u3e71\u25e0\udeb4\u04e8\u22d8\uaeae\ub6d1',
+  size: [7, 7, 47],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder87 = commandEncoder285.beginComputePass({label: '\u{1fa6e}\u{1f64f}\uce94\u050f\u{1fabc}'});
+let renderBundle189 = renderBundleEncoder11.finish();
+let sampler17 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.32,
+  lodMaxClamp: 58.43,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder7.setViewport(1.3186272012813487, 1.8867567434910115, 4.882403419680842, 1.054635942590354, 0.8691204981176427, 0.9872451551757871);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder283.copyBufferToBuffer(buffer7, 184, buffer4, 4676, 868);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView79 = texture69.createView({label: '\u{1fad8}\u{1fdc7}', baseMipLevel: 1, arrayLayerCount: 3});
+try {
+computePassEncoder81.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+let pipeline15 = device2.createRenderPipeline({
+  layout: pipelineLayout35,
+  multisample: {mask: 0xa5c6f78},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule7,
+    buffers: [
+      {arrayStride: 456, attributes: []},
+      {arrayStride: 20, stepMode: 'instance', attributes: []},
+      {arrayStride: 120, attributes: []},
+      {arrayStride: 168, stepMode: 'instance', attributes: []},
+      {arrayStride: 448, attributes: []},
+      {arrayStride: 1060, attributes: []},
+      {arrayStride: 188, stepMode: 'instance', attributes: []},
+      {arrayStride: 628, attributes: [{format: 'sint16x2', offset: 64, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let commandBuffer195 = commandEncoder272.finish({label: '\u0356\u1979\ue313'});
+let textureView80 = texture73.createView({
+  label: '\u{1f655}\ufe64\u{1fe57}\u05ed\u0503\u{1f760}\u0026\u70e5\u00f7\u9438\u9c9c',
+  format: 'r8sint',
+});
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer8, 2_608);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer6, 'uint32', 3_260, 4_467);
+} catch {}
+try {
+querySet10.destroy();
+} catch {}
+try {
+computePassEncoder45.popDebugGroup();
+} catch {}
+try {
+computePassEncoder69.insertDebugMarker('\u0453');
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let commandEncoder297 = device2.createCommandEncoder({label: '\u07ae\ua8bc\u5d6a\u34f6\u09aa'});
+let commandBuffer196 = commandEncoder297.finish({label: '\u17b1\u703b\uba99\u2e98\u0686\u5517\ub09e\u5def\ub18a\u887d\u3e4a'});
+let renderBundle190 = renderBundleEncoder20.finish({label: '\u0a9e\u8e97\u{1f7bf}\u0dd5\u0991\u{1ffb6}\u00ea\u4952'});
+let sampler18 = device2.createSampler({
+  label: '\u9f31\u{1f9f7}\u92a4\u7570\u050f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.155,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder84.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 464, new BigUint64Array(9899), 997, 24);
+} catch {}
+let commandEncoder298 = device2.createCommandEncoder({});
+let commandBuffer197 = commandEncoder298.finish({});
+let textureView81 = texture83.createView({label: '\u0da4\ud7a2\u05d4'});
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup11, new Uint32Array(151), 14, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder38.setScissorRect(161, 0, 135, 0);
+} catch {}
+let videoFrame6 = new VideoFrame(videoFrame4, {timestamp: 0});
+let texture88 = device1.createTexture({
+  label: '\u{1f66b}\u0669\u5684\uac03',
+  size: {width: 24},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView82 = texture66.createView({label: '\uf911\ub2df\ubf70\u1625\u41e5'});
+let renderBundle191 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(1, buffer46, 0, 1_405);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let pipelineLayout43 = device2.createPipelineLayout({
+  label: '\u4291\u24ca\u{1f951}\u9413',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout39, bindGroupLayout37],
+});
+let querySet38 = device2.createQuerySet({label: '\u1a73\u0c48', type: 'occlusion', count: 354});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup12, new Uint32Array(2270), 642, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.popDebugGroup();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 20 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 4, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let pipeline16 = await device2.createRenderPipelineAsync({
+  label: '\u00ef\u02f3\ua192\u6ca5\u08a5',
+  layout: pipelineLayout41,
+  multisample: {count: 4, mask: 0x4166ff7},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule9,
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 32, stepMode: 'instance', attributes: []},
+      {arrayStride: 288, attributes: [{format: 'unorm8x4', offset: 36, shaderLocation: 14}]},
+      {arrayStride: 40, stepMode: 'instance', attributes: []},
+      {arrayStride: 100, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 96, attributes: []},
+      {
+        arrayStride: 288,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 6},
+          {format: 'float16x2', offset: 24, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let renderBundle192 = renderBundleEncoder12.finish();
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup4, new Uint32Array(38), 5, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer1, 'uint16', 126, 1_938);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer22, 4_696);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer16, 'uint32', 532, 177);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer46, 1_308, 775);
+} catch {}
+await gc();
+let commandEncoder299 = device1.createCommandEncoder({label: '\u{1fa6e}\u071f\ua8b0\u{1fb4b}'});
+let querySet39 = device1.createQuerySet({label: '\ucee9\u028c\u4228\u004f\ueb37\uff46\ue3c0\u{1fc69}\u062b', type: 'occlusion', count: 238});
+try {
+renderBundleEncoder25.setIndexBuffer(buffer30, 'uint16', 3_040, 1_636);
+} catch {}
+try {
+commandEncoder299.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3004 */
+  offset: 3004,
+  bytesPerRow: 0,
+  rowsPerImage: 5,
+  buffer: buffer30,
+}, {
+  texture: texture59,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 15},
+  aspect: 'all',
+}, {width: 0, height: 3, depthOrArrayLayers: 8});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(66), /* required buffer size: 66 */
+{offset: 66}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video4.width = 300;
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let bindGroup15 = device0.createBindGroup({label: '\u581a\u2055\u0f81\u{1fbbb}\u8b72\ucd9f\u0eae\u016e', layout: bindGroupLayout35, entries: []});
+let commandEncoder300 = device0.createCommandEncoder({label: '\uc0f1\ud8a7\u0dde\u0f46\u0ca4\ub606\u75d3\u21e0\ub27f\u{1f89a}\ube04'});
+let commandBuffer198 = commandEncoder197.finish({label: '\ub5ce\u6f00\u5f39\u5704\ue59f\u{1f75a}\u7e3e'});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer21, 'uint16', 988, 409);
+} catch {}
+try {
+device0.queue.submit([commandBuffer198, commandBuffer180]);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle178, renderBundle156]);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline15);
+} catch {}
+try {
+computePassEncoder82.insertDebugMarker('\u0f7e');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 63, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(152), /* required buffer size: 152 */
+{offset: 152, bytesPerRow: 3118}, {width: 378, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder301 = device2.createCommandEncoder({});
+let renderPassEncoder40 = commandEncoder301.beginRenderPass({
+  label: '\u0514\u{1fd8c}\u6f50\u3184\ucfcc',
+  colorAttachments: [{
+  view: textureView63,
+  depthSlice: 36,
+  clearValue: { r: 307.9, g: 567.9, b: -107.6, a: 652.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet35,
+});
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup12, new Uint32Array(1956), 1218, 0);
+} catch {}
+try {
+renderPassEncoder36.setBlendConstant({ r: -384.9, g: -70.27, b: 13.65, a: 691.0, });
+} catch {}
+document.body.prepend(video2);
+let querySet40 = device1.createQuerySet({label: '\u61e9\ua41b\u{1ffea}\u25cb\u04ce\u853c', type: 'occlusion', count: 345});
+let renderPassEncoder41 = commandEncoder299.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -404.4, g: 542.5, b: 475.8, a: -999.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: -52.43, g: -481.2, b: 994.5, a: -964.0, });
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer48, 'uint32', 384, 4_783);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(6, buffer46);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(7, buffer46, 0, 120);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let commandBuffer199 = commandEncoder292.finish({});
+try {
+renderPassEncoder12.setViewport(6.858882551046555, 2.41601670459832, 0.05836497429117151, 1.9838309232162554, 0.6241201615128331, 0.8896779673045649);
+} catch {}
+try {
+device0.queue.submit([commandBuffer184]);
+} catch {}
+let commandEncoder302 = device2.createCommandEncoder({label: '\u0b4c\u0d6d\u{1fbcb}\u0a93\u36a4\u0f14\uc87c\u8a7a\u02a2'});
+let commandBuffer200 = commandEncoder302.finish({label: '\u70f9\u{1f9a9}\u{1ffab}\ue1cc\ua8df\u0a22\u{1fa52}\u{1ff34}\ucc46\u{1ff84}'});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup12, new Uint32Array(4571), 1537, 0);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint16', 704, 1_049);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+texture77.destroy();
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+renderPassEncoder27.insertDebugMarker('\u023a');
+} catch {}
+try {
+device2.queue.submit([commandBuffer186]);
+} catch {}
+let promise44 = device2.queue.onSubmittedWorkDone();
+try {
+computePassEncoder63.setBindGroup(2, bindGroup8, new Uint32Array(298), 43, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup8);
+} catch {}
+let commandEncoder303 = device1.createCommandEncoder({label: '\u06ca\ua41d\u{1f8b6}\u732f\u0d4b\u0c11\u4a49\ue33d\u048f'});
+let renderBundle193 = renderBundleEncoder21.finish({label: '\u04f2\u{1f95c}\uadb8\u0244'});
+try {
+computePassEncoder71.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer30, 'uint16', 1_554, 825);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer46, 0);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer48, 'uint16', 552, 110);
+} catch {}
+try {
+device1.queue.submit([commandBuffer191]);
+} catch {}
+let commandEncoder304 = device1.createCommandEncoder({});
+let renderPassEncoder42 = commandEncoder304.beginRenderPass({
+  label: '\uac40\u063b\u0369\u{1f81e}\ud445\u0f29\uf61c\u{1fbe6}\uefc7\u2722\u0314',
+  colorAttachments: [{view: textureView76, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 77562334,
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder42.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle169]);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer30, 'uint16', 938, 264);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  label: '\u58f9\u036a\ua6fe\u39fa\u67a2\u523f\u{1f7c4}\u7ba0',
+  entries: [
+    {
+      binding: 316,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 481,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView83 = texture43.createView({dimension: '2d-array'});
+let computePassEncoder88 = commandEncoder202.beginComputePass({label: '\u0b89\u{1f9ee}\u070b\uf5e2\u3982\u{1fd5e}\u{1f830}\u25d3'});
+let renderBundle194 = renderBundleEncoder12.finish();
+try {
+computePassEncoder55.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer15, 'uint32', 616, 383);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder43 = commandEncoder303.beginRenderPass({
+  label: '\u0db2\u0572\u5753\u{1fc03}',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 15,
+  clearValue: { r: 53.09, g: -398.9, b: 539.1, a: 474.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet40,
+});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer19, 3072, new Int16Array(12735), 1630, 3244);
+} catch {}
+let commandEncoder305 = device2.createCommandEncoder({label: '\u015e\u2718\ue391\u0f0a\u02d2'});
+let commandBuffer201 = commandEncoder305.finish({});
+try {
+computePassEncoder84.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle131, renderBundle148]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 328, new Float32Array(11477), 957, 16);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 60, new DataView(new ArrayBuffer(10006)), 125, 1444);
+} catch {}
+let texture89 = device1.createTexture({
+  size: [6, 15, 1],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer46);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(263), /* required buffer size: 263 */
+{offset: 263}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img5);
+let video9 = await videoWithData();
+let commandEncoder306 = device2.createCommandEncoder();
+let renderBundleEncoder26 = device2.createRenderBundleEncoder({label: '\ua1ad\u0dc3', colorFormats: ['rg32float']});
+let renderBundle195 = renderBundleEncoder26.finish({label: '\u57e8\uf7cc\u0b8e\u06e8\u{1ff82}\u4014'});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(1, bindGroup12, new Uint32Array(2556), 673, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle156, renderBundle145, renderBundle187, renderBundle135]);
+} catch {}
+let promise45 = device2.queue.onSubmittedWorkDone();
+let commandBuffer202 = commandEncoder296.finish({label: '\u962e\u078b\u{1f660}\u00bc\uf55c\u0fd3\u4b58\u3285\ud359\u8fac'});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let querySet41 = device2.createQuerySet({label: '\ud27e\u5169\u028b\u0ce3', type: 'occlusion', count: 2315});
+try {
+renderPassEncoder26.setScissorRect(84, 0, 25, 0);
+} catch {}
+try {
+commandEncoder306.copyBufferToBuffer(buffer49, 272, buffer23, 348, 1292);
+} catch {}
+try {
+  await promise45;
+} catch {}
+let computePassEncoder89 = commandEncoder306.beginComputePass({});
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup11, new Uint32Array(2056), 214, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, undefined, 0, 994_743_036);
+} catch {}
+try {
+renderPassEncoder40.insertDebugMarker('\u05a2');
+} catch {}
+let img10 = await imageWithData(26, 19, '#10101010', '#20202020');
+let commandEncoder307 = device2.createCommandEncoder({label: '\u{1fca7}\u84a0\u0a7f'});
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+let commandEncoder308 = device2.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder307.beginComputePass({});
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline15);
+} catch {}
+let promise46 = adapter2.requestAdapterInfo();
+let buffer51 = device0.createBuffer({
+  label: '\uefe2\u588e\u0ce4\u6718',
+  size: 27599,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer3, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer16, 'uint32', 1_620, 220);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer16, 484, 1_064);
+} catch {}
+try {
+commandEncoder283.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 37855 */
+  offset: 733,
+  bytesPerRow: 256,
+  rowsPerImage: 29,
+  buffer: buffer0,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 3},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 6});
+} catch {}
+let texture90 = gpuCanvasContext10.getCurrentTexture();
+let computePassEncoder91 = commandEncoder217.beginComputePass({label: '\u{1f6e6}\ua265\u0754\u{1fe18}\u0fdb\u927b\u019b\ufe4b'});
+let renderBundle196 = renderBundleEncoder23.finish({label: '\u0b37\uf636'});
+try {
+renderPassEncoder31.beginOcclusionQuery(36);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.submit([commandBuffer196]);
+} catch {}
+let commandBuffer203 = commandEncoder300.finish({label: '\u7afe\udd38'});
+let texture91 = device0.createTexture({
+  label: '\u3223\u7098\u0a45\ue7d6\u0468\u0b74',
+  size: [7, 7, 98],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle197 = renderBundleEncoder15.finish({label: '\u0f75\u8e2e\ue048\u6da4\u5fe2\u{1f7a9}'});
+try {
+computePassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer10, 'uint16', 1_158, 187);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer8, 1_364, 2_708);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder283.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 18, y: 7, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder309 = device1.createCommandEncoder({label: '\ua046\u{1fbf7}\ua7c5\u01cf'});
+let commandBuffer204 = commandEncoder309.finish({label: '\u0316\ubf7d\u8729\u5001\u097b\u0c0b\u{1f652}\u0bb2\uc713\u0da4\u6870'});
+let texture92 = device1.createTexture({
+  size: [6],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture40 = device1.importExternalTexture({label: '\u0d12\u0f3b\u7919\u3a57\uf5c6\u{1fc78}\u0e45', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder71.end();
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer30, 'uint16', 1_420, 607);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4, buffer19, 3_276, 218);
+} catch {}
+try {
+commandEncoder215.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 5, y: 7, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder310 = device1.createCommandEncoder({label: '\ucce6\u0d86\u00e2\u{1fff6}'});
+let commandBuffer205 = commandEncoder215.finish({label: '\u9dac\u{1f691}\u{1ff0d}\ub561\u7ee9\u5961'});
+try {
+computePassEncoder83.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer19, 7_328, 401);
+} catch {}
+try {
+renderPassEncoder37.pushDebugGroup('\u0ed8');
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device1, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let commandEncoder311 = device1.createCommandEncoder({});
+let commandBuffer206 = commandEncoder311.finish({label: '\u8282\ud1ee\u0c7b\u01ea\u03fa\u0492'});
+let texture93 = device1.createTexture({
+  label: '\u{1f86c}\u{1fe36}',
+  size: {width: 6, height: 15, depthOrArrayLayers: 42},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise47 = adapter6.requestAdapterInfo();
+let commandEncoder312 = device1.createCommandEncoder({label: '\u6b1a\uf647'});
+let renderBundle198 = renderBundleEncoder25.finish({label: '\u{1fa64}\u8b88\u0806\u12b5\u07b7'});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer48, 'uint16', 296, 2_824);
+} catch {}
+try {
+commandEncoder312.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 13, y: 9, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 70, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder310.resolveQuerySet(querySet40, 112, 79, buffer30, 2560);
+} catch {}
+video4.height = 86;
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandBuffer207 = commandEncoder308.finish({label: '\ua1d5\u{1f66e}\u919f\ufb18'});
+let renderBundle199 = renderBundleEncoder22.finish({label: '\u0320\ua9cf\u1734\udf19\uca68\u0385\u4ef9\u{1f874}'});
+try {
+renderPassEncoder27.setViewport(7.6332456794743, 0.20070548382235553, 275.68288975219644, 0.3983569086975649, 0.9524972295500272, 0.9811704822384748);
+} catch {}
+try {
+device2.queue.submit([commandBuffer207, commandBuffer189]);
+} catch {}
+let promise48 = device2.queue.onSubmittedWorkDone();
+let sampler19 = device2.createSampler({
+  label: '\u{1f883}\u533d\u4a8b\u{1fad1}\u478e\u6825\u8cda\u{1fc6c}\u048b\ua122\u19c4',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.691,
+  lodMaxClamp: 60.67,
+});
+try {
+renderPassEncoder34.executeBundles([renderBundle170]);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise44;
+} catch {}
+let imageBitmap9 = await createImageBitmap(offscreenCanvas5);
+let shaderModule10 = device1.createShaderModule({
+  label: '\uee89\u026b\uad7b\u042a\u{1fd6a}\uc911\u5255\u9698\u041b',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<i32>,
+}
+
+@group(0) @binding(16) var tex32: texture_cube<f32>;
+@group(0) @binding(0) var tex34: texture_depth_2d;
+@group(0) @binding(598) var<uniform> buffer52: vec2u;
+@group(0) @binding(116) var tex37: texture_2d<f32>;
+@group(0) @binding(243) var st9: texture_storage_2d<rg32sint, read>;
+@group(0) @binding(784) var<uniform> buffer53: vec3i;
+@group(0) @binding(89) var tex31: texture_depth_cube_array;
+@group(0) @binding(254) var sam22: sampler_comparison;
+@group(0) @binding(390) var sam21: sampler;
+@group(0) @binding(8) var tex33: texture_2d_array<i32>;
+@group(0) @binding(58) var sam25: sampler;
+@group(0) @binding(50) var tex38: texture_1d<f32>;
+@group(0) @binding(175) var sam23: sampler;
+@group(0) @binding(279) var<storage, read> buffer55: array<vec3h>;
+@group(0) @binding(155) var<storage, read> buffer54: array<mat3x4f>;
+@group(0) @binding(133) var sam24: sampler_comparison;
+@group(0) @binding(9) var tex36: texture_1d<f32>;
+@group(0) @binding(176) var st8: texture_storage_2d<r32uint, read_write>;
+@group(0) @binding(94) var<storage, read> buffer56: vec4h;
+@group(0) @binding(424) var tex39: texture_1d<i32>;
+@group(0) @binding(144) var tex35: texture_2d_array<i32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32, @builtin(local_invocation_id) a1: vec3u) {
+  _ = buffer53;
+}
+
+struct VertexOutput0 {
+  @location(1) f22: vec2f,
+  @builtin(position) f23: vec4f
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3f) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = textureLoad(tex35, vec2i(), 0, 0);
+  _ = textureSampleLevel(tex34, sam21, vec2f(), 0i, vec2i());
+  return out;
+}
+
+@fragment
+fn fragment0(@location(1) @interpolate(perspective, center) a0: vec2f, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> @location(200) vec4f {
+  var out: vec4f;
+  _ = a1;
+  _ = textureGather(3, tex37, sam25, vec2f());
+  _ = textureSampleBaseClampToEdge(tex37, sam25, vec2f());
+  if bool(textureSampleBaseClampToEdge(tex37, sam25, vec2f())[2]) {
+    discard;
+  }
+  return out;
+}
+`,
+});
+let commandEncoder313 = device1.createCommandEncoder({label: '\u{1fe19}\ub8fd\u368f\u232a\u0391\u02bc\uf08e\u04c1\ufde3\u0fd1\u{1f618}'});
+let texture94 = device1.createTexture({
+  label: '\u9829\ucd3e\ud9d4\uac48\u0bd7\u5f4a\u0d83\ub865',
+  size: {width: 6, height: 15, depthOrArrayLayers: 21},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder67.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup10, new Uint32Array(452), 22, 0);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setViewport(2.1872452236077042, 10.206172255414083, 1.187550175993233, 0.9765861746593649, 0.6752728767939291, 0.8520371833835868);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline17 = await device1.createComputePipelineAsync({layout: pipelineLayout36, compute: {module: shaderModule4, constants: {}}});
+let computePassEncoder92 = commandEncoder313.beginComputePass({label: '\u{1fa99}\udfc3\u4e83'});
+let renderPassEncoder44 = commandEncoder312.beginRenderPass({
+  label: '\ub5dd\u052e\ucdf0\u9b32\ua29c\ud35a\u076a',
+  colorAttachments: [{
+  view: textureView76,
+  clearValue: { r: -261.7, g: 36.30, b: -292.4, a: 355.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle200 = renderBundleEncoder21.finish();
+let sampler20 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 69.51,
+  lodMaxClamp: 79.31,
+});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(0, 2, 1, 1);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: imageData26,
+  origin: { x: 14, y: 3 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule11 = device1.createShaderModule({
+  label: '\uc6e9\u0d2e\u3273',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<i32>,
+}
+struct T1 {
+  f0: atomic<i32>,
+}
+
+@group(0) @binding(784) var<uniform> buffer58: mat3x4f;
+@group(0) @binding(89) var tex40: texture_cube<u32>;
+@group(0) @binding(254) var sam27: sampler_comparison;
+@group(0) @binding(8) var tex42: texture_cube<u32>;
+@group(0) @binding(94) var<storage, read> buffer61: array<mat2x3h, 1>;
+@group(0) @binding(243) var st11: texture_storage_1d<rgba8sint, read>;
+@group(0) @binding(144) var tex44: texture_cube_array<i32>;
+@group(0) @binding(176) var st10: texture_storage_2d<r32float, read_write>;
+@group(0) @binding(58) var sam30: sampler;
+@group(0) @binding(175) var sam28: sampler;
+@group(0) @binding(598) var<uniform> buffer57: vec4u;
+@group(0) @binding(424) var tex48: texture_cube_array<i32>;
+@group(0) @binding(16) var tex41: texture_2d_array<u32>;
+@group(0) @binding(0) var tex43: texture_2d_array<u32>;
+@group(0) @binding(50) var tex47: texture_cube_array<f32>;
+@group(0) @binding(390) var sam26: sampler;
+@group(0) @binding(116) var tex46: texture_3d<u32>;
+@group(0) @binding(9) var tex45: texture_3d<u32>;
+@group(0) @binding(155) var<storage, read> buffer59: u32;
+@group(0) @binding(279) var<storage, read> buffer60: vec3i;
+@group(0) @binding(133) var sam29: sampler_comparison;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0() {
+  _ = textureGather(2, tex48, sam28, vec3f(), 0);
+}
+
+struct VertexOutput0 {
+  @builtin(position) f24: vec4f
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = buffer60;
+  _ = textureLoad(tex46, vec3i(), 0);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(textureLoad(st10, vec2i())[3]) {
+    discard;
+  }
+  return out;
+}
+`,
+  hints: {},
+});
+let bindGroupLayout42 = device1.createBindGroupLayout({
+  label: '\u4a44\u9188\u249b\uc774\u{1f693}\u035a',
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 120,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 541,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 156, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 194,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 236,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 153,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 292,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 214,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 55, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 31,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 14,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 198,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 658,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 92, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 179,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 523, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 225,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 89, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer48, 'uint32', 304, 305);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 96, 760);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise47;
+} catch {}
+let img11 = await imageWithData(7, 116, '#10101010', '#20202020');
+let bindGroup16 = device1.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 41, resource: externalTexture24}]});
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup8);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let renderBundle201 = renderBundleEncoder22.finish({label: '\u030f\ub97d\u0d28\u110a\u0dd9\u919a\u{1f748}\uf620\u94e1'});
+try {
+renderPassEncoder31.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 39, y: 2 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise46;
+} catch {}
+try {
+computePassEncoder59.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 68, new BigUint64Array(217), 47, 4);
+} catch {}
+let renderBundleEncoder27 = device2.createRenderBundleEncoder({
+  label: '\uf2bb\u09e8\u0a57\u5a08\u1d9a\u7104\u{1fc91}\u8ad6\ub663',
+  colorFormats: ['rgba16sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle202 = renderBundleEncoder23.finish();
+try {
+renderPassEncoder38.setPipeline(pipeline15);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer200, commandBuffer190]);
+} catch {}
+let promise49 = device2.queue.onSubmittedWorkDone();
+let gpuCanvasContext11 = canvas8.getContext('webgpu');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+document.body.prepend(video1);
+let commandEncoder314 = device1.createCommandEncoder();
+let commandBuffer208 = commandEncoder314.finish();
+let renderPassEncoder45 = commandEncoder310.beginRenderPass({
+  label: '\u9617\u8eb2\u{1ff92}\u6cdc\u5d28\ue774\u{1fa8a}\u03de\u6cd1\u04a2',
+  colorAttachments: [{view: textureView51, depthSlice: 4, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet34,
+});
+let renderBundle203 = renderBundleEncoder21.finish({label: '\u401c\u2012\u17ec\u70a6\u0e7f\ufb33\u40b5\u{1fce0}\u01a5\u00dd\u0dda'});
+let externalTexture41 = device1.importExternalTexture({label: '\u70d3\u2e38\u0a63\u{1ff39}', source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer48, 'uint32', 1_612, 197);
+} catch {}
+try {
+renderPassEncoder37.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(31_646), /* required buffer size: 31_646 */
+{offset: 166, bytesPerRow: 56, rowsPerImage: 64}, {width: 2, height: 51, depthOrArrayLayers: 9});
+} catch {}
+try {
+  await promise48;
+} catch {}
+let commandEncoder315 = device2.createCommandEncoder();
+let commandBuffer209 = commandEncoder315.finish({label: '\ud316\u{1fe60}\u{1fd40}\uc42b\u33d8\u05a6'});
+try {
+renderPassEncoder31.setIndexBuffer(buffer23, 'uint32', 24, 811);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 968, 909);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+  await promise49;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandBuffer210 = commandEncoder283.finish({label: '\u536b\u0db9\u1376\u{1f8df}\u0176'});
+let texture95 = device0.createTexture({
+  label: '\u9d4c\u{1fa9f}\u4b4c\u{1f8c4}\u{1ffbc}\u1d87\u3a3a\u585d\u508f\u{1f60f}\u11af',
+  size: {width: 15, height: 15, depthOrArrayLayers: 2},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder93 = commandEncoder82.beginComputePass({label: '\u{1f680}\u0c7e\ue2f1\u3a1c\u8eee\u0d45\u{1fc8d}\ub431\u5b12\u{1fb0d}'});
+let renderBundle204 = renderBundleEncoder0.finish({label: '\u{1fe39}\u002d\u{1fa14}\uee90\u074f\u{1f6c0}\u{1faa8}\u5357\u{1f6fd}\u{1f80d}\ue878'});
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer195, commandBuffer202]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 60, depthOrArrayLayers: 56}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 8, y: 9, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder316 = device2.createCommandEncoder({});
+let commandBuffer211 = commandEncoder316.finish({label: '\u{1fdac}\u{1f9f3}\u0142\u0f91\u00e8\u02a0'});
+let renderBundle205 = renderBundleEncoder26.finish({});
+try {
+renderPassEncoder38.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 324, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 28},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer23, 'uint32', 396, 373);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4_294_967_294, undefined, 1_269_206_080);
+} catch {}
+let commandEncoder317 = device1.createCommandEncoder({label: '\u0e56\u{1fce3}\u0f6b\u0429\u1b18\u0dda\u0c38\u8564\u{1f81f}\ub782'});
+let commandBuffer212 = commandEncoder317.finish({label: '\u0fc7\u010d\u{1f68d}\u79f8\u{1fd56}\ubc72'});
+let renderBundle206 = renderBundleEncoder21.finish({label: '\ud9e3\u{1fd75}\u0f78\u{1f725}\u1083'});
+try {
+renderPassEncoder42.beginOcclusionQuery(22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(52), /* required buffer size: 52 */
+{offset: 52, rowsPerImage: 15}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder28 = device2.createRenderBundleEncoder({
+  label: '\u08ed\u070c\u1e11\u157a\u{1fd3d}',
+  colorFormats: ['rgba16sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle207 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer23, 'uint32', 380, 163);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup12, new Uint32Array(253), 8, 0);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 1_294, 1_652);
+} catch {}
+try {
+device2.queue.submit([commandBuffer211, commandBuffer201, commandBuffer197, commandBuffer209]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder318 = device0.createCommandEncoder({label: '\u{1ff71}\ue560\u01e5'});
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+renderPassEncoder3.setViewport(1.3922694684704315, 0.8976628083913454, 1.097512186731258, 2.8802875097372587, 0.5889913618510203, 0.8717481857068489);
+} catch {}
+let commandBuffer213 = commandEncoder318.finish({label: '\ud234\u0116\ufddd\ue192\ua2a0\udf6f\u7bc8'});
+let texture96 = device0.createTexture({
+  label: '\u{1ff14}\uf0e3\uee37\u{1ff82}\u829f\u4bfe\u1d8f\uef96\ub339\u17e8\u3f71',
+  size: [15, 15, 4],
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder17.setBlendConstant({ r: 829.1, g: -157.7, b: -389.5, a: -765.7, });
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 3_828, 849);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup7, new Uint32Array(1253), 35, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer4, 0, 392);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 214, y: 4 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let pipelineLayout44 = device1.createPipelineLayout({
+  label: '\u0732\uc0fd\u99c5\u0f10\u95d8\u19ca\u{1feac}\u0347\ub68c',
+  bindGroupLayouts: [bindGroupLayout28, bindGroupLayout27, bindGroupLayout26, bindGroupLayout28],
+});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup10, new Uint32Array(864), 212, 0);
+} catch {}
+let buffer62 = device1.createBuffer({
+  label: '\u{1fc85}\u2dd1\u94f8\u0758\u{1fe64}\u0b94\u09e8\u6bf8\u07e2\u26b2\u9c13',
+  size: 10300,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture97 = device1.createTexture({
+  label: '\u6624\u81ba\u818e\uac98\u{1fbbd}\u2c0a\u0dc6\u{1f790}\u03f2\u0e6b\u0d46',
+  size: {width: 48},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle208 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer48, 'uint32', 1_572, 3_448);
+} catch {}
+try {
+device1.queue.submit([commandBuffer212]);
+} catch {}
+await gc();
+let texture98 = device0.createTexture({
+  size: {width: 60},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup14, new Uint32Array(1739), 21, 0);
+} catch {}
+try {
+renderPassEncoder24.setViewport(6.255993626760976, 5.554291379494193, 0.037680868437266, 0.5292518432219514, 0.8260715940004831, 0.8777160383113313);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+commandEncoder188.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1076 */
+  offset: 1076,
+  bytesPerRow: 256,
+  buffer: buffer8,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 27, y: 383, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 253, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer213]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData21,
+  origin: { x: 40, y: 1 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder319 = device2.createCommandEncoder({label: '\u0265\u5bf6\u031d\u07c8\u784f\u7240\u850b\u2c2a\udd58'});
+let computePassEncoder94 = commandEncoder319.beginComputePass({label: '\u20f3\ud553\u2778\u0f1b\u4331\u0bfd\u{1fc24}\uafa0\u{1fa9f}\u{1fd7c}'});
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u88f7');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 116, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(83), /* required buffer size: 83 */
+{offset: 83}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle209 = renderBundleEncoder18.finish();
+try {
+computePassEncoder63.setBindGroup(3, bindGroup8, new Uint32Array(3522), 913, 0);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer20, 'uint32', 12_188, 4_489);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle171]);
+} catch {}
+try {
+device1.queue.submit([commandBuffer208]);
+} catch {}
+let commandEncoder320 = device2.createCommandEncoder({label: '\u{1fff8}\u0a5b\u0d80\u5131'});
+let commandBuffer214 = commandEncoder320.finish({});
+let textureView84 = texture68.createView({
+  label: '\ufc2a\uf76f\uf1f4\u{1f6b9}\u68c7\u0d94\udc3b\u07d0\u08b6',
+  baseArrayLayer: 0,
+  arrayLayerCount: 3,
+});
+let sampler21 = device2.createSampler({
+  label: '\u0708\u8b30\u28d4\u0d15\u82b1\u0eab\u81b3\u05a9\u23db\u7082',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.78,
+  lodMaxClamp: 99.48,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4_294_967_294, undefined, 795_064_249);
+} catch {}
+let buffer63 = device1.createBuffer({
+  label: '\u18fc\u39da\u0582\u0f04\u8d17\u{1f612}\u{1f6f2}\u7693\u0d22',
+  size: 17426,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder42.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle182]);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer46, 0, 1_029);
+} catch {}
+let commandEncoder321 = device0.createCommandEncoder({label: '\u0e74\u0efc\u08f0\u0e70\u2da6\u00ab\u{1feeb}\u{1fcb2}\u9e3e'});
+let commandBuffer215 = commandEncoder321.finish();
+try {
+computePassEncoder87.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer16, 'uint16', 266, 941);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+bindGroupLayout26.label = '\u{1f7b1}\u{1fc65}\ub748\u{1f793}\u12f6\u08fb\u015e\u0ddf\uebc0';
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup8, new Uint32Array(401), 82, 0);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(10), /* required buffer size: 10 */
+{offset: 10}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder322 = device2.createCommandEncoder({label: '\u{1ffde}\u{1fe36}\ud647\u078a\u{1f89d}\ube6c\u0022\u{1fc84}\u{1f8cc}\u{1f793}\ucf48'});
+let computePassEncoder95 = commandEncoder322.beginComputePass();
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer23, 'uint32', 500, 673);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup12, new Uint32Array(496), 165, 0);
+} catch {}
+try {
+renderPassEncoder38.insertDebugMarker('\u{1fc24}');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 392, new Float32Array(22902), 2881, 632);
+} catch {}
+let querySet42 = device2.createQuerySet({type: 'occlusion', count: 810});
+try {
+renderPassEncoder27.setBlendConstant({ r: -403.4, g: 936.3, b: -937.7, a: -892.6, });
+} catch {}
+await gc();
+let commandEncoder323 = device0.createCommandEncoder({label: '\u{1f968}\u{1f8e4}\u{1fe80}\u5470\u{1fb78}\u02cb\u0e4e'});
+let commandBuffer216 = commandEncoder188.finish();
+let computePassEncoder96 = commandEncoder323.beginComputePass({label: '\u7cbf\u{1ff0f}\ufbab'});
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer13, 'uint32', 12_908, 1_442);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer18);
+} catch {}
+let texture99 = device2.createTexture({
+  size: [1298, 1, 97],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler22 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 38.27,
+  lodMaxClamp: 87.54,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup11, new Uint32Array(845), 80, 0);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 212.6, g: -31.31, b: 244.0, a: -199.1, });
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(6, undefined);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder324 = device2.createCommandEncoder({label: '\u0020\u{1fe5d}\u1920\u0f86'});
+let texture100 = device2.createTexture({
+  label: '\u72e6\u002e\u{1f9df}\u0653\u9c24\ue8f2\u{1faf2}',
+  size: {width: 1298, height: 1, depthOrArrayLayers: 541},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle210 = renderBundleEncoder23.finish({label: '\u0596\u{1fee7}\u0d8e\u4b6c'});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4_294_967_295, undefined, 0, 859_435_384);
+} catch {}
+let imageData38 = new ImageData(132, 8);
+let commandEncoder325 = device1.createCommandEncoder({label: '\u379e\u5668\uaa02\u0426\u05ec\u0035\ua73b'});
+try {
+texture89.destroy();
+} catch {}
+try {
+device1.queue.submit([commandBuffer206]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 2488, new Float32Array(194));
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(61), /* required buffer size: 61 */
+{offset: 61}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise50 = device1.queue.onSubmittedWorkDone();
+let bindGroupLayout43 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 118,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder326 = device2.createCommandEncoder({label: '\u0470\u0eba'});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+commandEncoder326.copyTextureToBuffer({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 592 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 856 */
+  offset: 856,
+  buffer: buffer23,
+}, {width: 74, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup14, new Uint32Array(603), 322, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer215]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: 450.9, g: 509.4, b: 430.7, a: -970.0, });
+} catch {}
+let commandBuffer217 = commandEncoder326.finish({label: '\u3b65\u{1f931}\u85e5\ue2e4\u00d9\u017a'});
+let renderPassEncoder46 = commandEncoder324.beginRenderPass({
+  label: '\u0ddb\uae6a\u{1fdb0}\u9d5d\u0dfb\u049f\u{1fc95}\u0f99\ud44b\u1e3e\u{1f7e2}',
+  colorAttachments: [{
+  view: textureView75,
+  clearValue: { r: -949.3, g: -686.6, b: 169.6, a: -744.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle211 = renderBundleEncoder26.finish({});
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(4_294_967_295, undefined, 421_534_065);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+texture68.destroy();
+} catch {}
+let commandEncoder327 = device0.createCommandEncoder({});
+let renderBundle212 = renderBundleEncoder10.finish({label: '\u{1f880}\uab62\ub941\u{1f678}\u09fb\u0b55\u{1fa11}\ud668\u0b95\u00d6\u0387'});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer0, 'uint32', 3_996, 771);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer15, 2_492, 319);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 2, y: 8 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder97 = commandEncoder327.beginComputePass({label: '\u{1fa32}\u{1f93b}\u{1fd1c}\u8894\ua54d'});
+let renderBundle213 = renderBundleEncoder1.finish({label: '\uabb8\u0d3f\u02da\u{1f9fe}\u1fe1\u{1fcbc}\u2efc\u2915\u0871\u06ea'});
+try {
+computePassEncoder97.end();
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup3, new Uint32Array(142), 37, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer10, 3_204, 445);
+} catch {}
+try {
+commandEncoder327.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 578 */
+  offset: 578,
+  bytesPerRow: 0,
+  rowsPerImage: 34,
+  buffer: buffer15,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 6},
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 8});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 3, y: 13 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 28},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup11, new Uint32Array(1019), 63, 0);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4_294_967_295, undefined, 0, 571_559_840);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+window.someLabel = sampler18.label;
+} catch {}
+try {
+computePassEncoder80.setBindGroup(3, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer23, 'uint32', 1_564, 191);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 1_540, 742);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 720, new DataView(new ArrayBuffer(2603)), 478, 96);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 128, y: 0, z: 18},
+  aspect: 'all',
+}, new ArrayBuffer(152), /* required buffer size: 152 */
+{offset: 152, bytesPerRow: 3302, rowsPerImage: 0}, {width: 409, height: 0, depthOrArrayLayers: 2});
+} catch {}
+await gc();
+let commandEncoder328 = device2.createCommandEncoder({label: '\u{1fe55}\u1667\u5074\u{1f72f}\u0ee5\u609c\u0818\u91df\ua0b7\ub1b4'});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup12, new Uint32Array(1895), 402, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle146, renderBundle162]);
+} catch {}
+try {
+renderPassEncoder40.setViewport(58.751319092233395, 0.3688252098153467, 429.0710269088789, 0.5986835755264776, 0.27445550717493816, 0.2836213132532751);
+} catch {}
+try {
+commandEncoder328.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 141, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder328.insertDebugMarker('\u0838');
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout44 = device2.createBindGroupLayout({
+  label: '\uc1c0\ud72f\u344f',
+  entries: [
+    {
+      binding: 289,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 234,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 435,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 110,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 89, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 190, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 184, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 69,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 10169700, hasDynamicOffset: false },
+    },
+    {binding: 114, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 28, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 186,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 201,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 14, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 37,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 443,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 279, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 142,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 195,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 152, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 440,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 995, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {binding: 47, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false }},
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 222,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 71, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 221,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {binding: 419, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 135,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 310, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 211, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 13,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 95, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 122,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 646,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 120, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 83, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 365, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderBundle214 = renderBundleEncoder23.finish({label: '\u2b7e\ubdf3\u23b9\u{1fa72}\u0536\u0440\u{1f8a8}\u04c0\u{1fefb}\u{1fdc6}'});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint32', 368, 514);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+commandEncoder328.copyTextureToBuffer({
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 199, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1472 widthInBlocks: 184 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4376 */
+  offset: 4376,
+  rowsPerImage: 58,
+  buffer: buffer23,
+}, {width: 184, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder328.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 491, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 862, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 536, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandBuffer218 = commandEncoder328.finish({label: '\u1a0f\uac22\u78a0\u{1fde3}\ua6aa\u4fe2\u{1f7a3}\u{1ff20}\u212d\u{1fbf9}'});
+let renderBundleEncoder29 = device2.createRenderBundleEncoder({colorFormats: ['rgba16sint'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup12, new Uint32Array(724), 138, 0);
+} catch {}
+try {
+renderPassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer23, 'uint32', 384, 329);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise50;
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup16, new Uint32Array(1306), 11, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer46, 0);
+} catch {}
+let renderBundle215 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup6, new Uint32Array(207), 7, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData31,
+  origin: { x: 28, y: 0 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 0, y: 9, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet43 = device2.createQuerySet({type: 'occlusion', count: 802});
+let textureView85 = texture82.createView({label: '\u091b\u{1ff9a}\u02e9\u47fe\u6507\u072b', mipLevelCount: 1});
+let sampler23 = device2.createSampler({
+  label: '\u6149\u9edf\u2d61\u5fe8\u{1fc18}\uc6e4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(26_735), /* required buffer size: 26_735 */
+{offset: 85, bytesPerRow: 533, rowsPerImage: 5}, {width: 49, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let renderBundle216 = renderBundleEncoder22.finish();
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup11, new Uint32Array(3432), 40, 0);
+} catch {}
+let commandEncoder329 = device1.createCommandEncoder({label: '\u4045\u84b4\u0b52'});
+let commandBuffer219 = commandEncoder325.finish({label: '\u7d0b\ua60a\u5bde\u03bd\u4251\u277a\u5cb8\u0625\u06db'});
+let texture101 = device1.createTexture({
+  label: '\u{1fafc}\u{1fd13}\u{1fc7a}\u{1fbc0}\u15fe\u4649\u{1fc13}',
+  size: {width: 6, height: 15, depthOrArrayLayers: 42},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer30, 'uint32', 1_920, 29);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 6 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle217 = renderBundleEncoder20.finish({});
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 200, new BigUint64Array(1759), 167, 100);
+} catch {}
+await gc();
+try {
+computePassEncoder15.setBindGroup(0, bindGroup5, new Uint32Array(878), 216, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer8, 'uint16', 1_638, 1_811);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer4, 748, 1_497);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+commandBuffer164.label = '\udfc0\u04bc\u0003\u{1fdcd}\u{1f889}\u0eff\ub20a\u{1fdf1}\uc5b1\u{1feaf}\u{1f64c}';
+} catch {}
+let bindGroupLayout45 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let renderBundle218 = renderBundleEncoder22.finish({label: '\ua6c0\u0750\uc64c'});
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle153]);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.submit([commandBuffer218]);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup11, []);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData31,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder330 = device1.createCommandEncoder();
+let renderPassEncoder47 = commandEncoder330.beginRenderPass({
+  label: '\ub54a\uf60f\ubc19\u41ed',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 6,
+  clearValue: { r: 145.1, g: 247.4, b: -344.9, a: -206.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+commandEncoder329.copyBufferToBuffer(buffer31, 0, buffer20, 14248, 804);
+} catch {}
+try {
+renderPassEncoder42.insertDebugMarker('\ua842');
+} catch {}
+let pipelineLayout45 = device1.createPipelineLayout({
+  label: '\u0fc7\u0772\u95c6\u028c\ubbed\u{1f96b}\u0f67\u158c',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout26, bindGroupLayout29, bindGroupLayout26],
+});
+let computePassEncoder98 = commandEncoder329.beginComputePass({label: '\ua9ab\u{1fea4}'});
+let promise51 = device1.queue.onSubmittedWorkDone();
+let shaderModule12 = device1.createShaderModule({
+  label: '\u0ee8\u0a19\ub164\u04d6\u1344\u7a6e\u0237\u3072\ud84e\u0bc7',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<array<mat2x3h, 1>>,
+}
+
+@group(1) @binding(241) var tex50: texture_multisampled_2d<f32>;
+@group(0) @binding(470) var st12: texture_storage_1d<rg32uint, write>;
+@group(0) @binding(339) var tex49: texture_cube<i32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  textureStore(st12, 0, vec4u(231, 45, 72, 258));
+}
+
+struct VertexOutput0 {
+  @builtin(position) f25: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(linear, center) f0: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder29.executeBundles([renderBundle140, renderBundle124]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer48, 'uint32', 228, 170);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer205]);
+} catch {}
+let pipelineLayout46 = device0.createPipelineLayout({
+  label: '\ud09c\u47ce\u7277\u5cec\u09f0\ucb3c\u2042\uff72\u3163\u050a\u0852',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout41, bindGroupLayout7],
+});
+let commandEncoder331 = device0.createCommandEncoder({label: '\u0fb7\u96e0\u{1fd9a}\u128a\u081a\u{1f9d2}\u5998\u88f2\u3aff\u{1fcc3}\uc055'});
+let texture102 = device0.createTexture({
+  label: '\u{1ff7a}\uc7ee\u1747',
+  size: [30, 30, 1],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder99 = commandEncoder327.beginComputePass();
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({label: '\u{1f9cc}\u009f\u0148\u0251\u0359\ue70a', colorFormats: ['r32sint']});
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+commandEncoder331.copyBufferToTexture({
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1345 */
+  offset: 1345,
+  rowsPerImage: 25,
+  buffer: buffer10,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let computePassEncoder100 = commandEncoder331.beginComputePass({label: '\u805c\u{1fde8}\u{1fcfb}\u844a\u04c8'});
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer16, 1_076, 198);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer22, 'uint32', 528, 940);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(7, buffer3, 0, 5_777);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer203]);
+} catch {}
+document.body.prepend(video0);
+try {
+device1.queue.label = '\u79e2\u0986\u0fac\u0bc0\ua675\u08d8\u80c1\udcca\u{1fa61}\u0b04';
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData19,
+  origin: { x: 25, y: 3 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(0, bindGroup11, new Uint32Array(3520), 353, 0);
+} catch {}
+await gc();
+let pipelineLayout47 = device0.createPipelineLayout({
+  label: '\u{1f7e7}\uafbb\uce0d\u14ba\u6edb\u039c\u{1f78a}\uc70f\u1572\uf6ea\u40df',
+  bindGroupLayouts: [bindGroupLayout25],
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup7, new Uint32Array(660), 116, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer18, 752, 595);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let renderBundle219 = renderBundleEncoder19.finish({label: '\u8103\u1210\u4418\u0594\u0207\u8497\ub5a8'});
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup8, new Uint32Array(96), 8, 0);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(871);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 5, y: 6, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1_915), /* required buffer size: 1_915 */
+{offset: 13, bytesPerRow: 13, rowsPerImage: 140}, {width: 1, height: 7, depthOrArrayLayers: 2});
+} catch {}
+let promise52 = device1.queue.onSubmittedWorkDone();
+let texture103 = gpuCanvasContext10.getCurrentTexture();
+try {
+computePassEncoder67.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle208]);
+} catch {}
+let pipelineLayout48 = device2.createPipelineLayout({bindGroupLayouts: []});
+let texture104 = device2.createTexture({
+  label: '\u2234\u2ee0\uc9b9',
+  size: {width: 324, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder38.end();
+} catch {}
+let bindGroupLayout46 = device0.createBindGroupLayout({
+  label: '\u1ce8\u0647',
+  entries: [{binding: 47, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }}],
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u{1ff78}\u{1fd5e}\ubdb7\ufb98\u0578\u33d5\u9464\u25a6\u0b8e',
+  colorFormats: ['r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture42 = device0.importExternalTexture({label: '\u06da\u190a\u5cb0\u0eb3\u{1faee}\u5a90', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup1, new Uint32Array(717), 30, 0);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer15, 'uint16', 2_526, 1_834);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(1, buffer15);
+} catch {}
+try {
+  await promise51;
+} catch {}
+let pipelineLayout49 = device1.createPipelineLayout({label: '\u011a\u59bf', bindGroupLayouts: [bindGroupLayout34]});
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({colorFormats: ['rg8uint'], depthReadOnly: true});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup16, new Uint32Array(3360), 73, 0);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer20, 'uint16', 4_430, 4_352);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(0, buffer19, 0, 6_393);
+} catch {}
+let renderBundle220 = renderBundleEncoder24.finish({label: '\ue0b7\ucb9c\udc1a\u01c5\u0ee8'});
+try {
+renderPassEncoder12.setIndexBuffer(buffer13, 'uint16', 6_546, 2_477);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle205, renderBundle161, renderBundle170, renderBundle154]);
+} catch {}
+try {
+renderPassEncoder46.setViewport(260.0839626981029, 0.4758519863286389, 11.243742411780461, 0.4758540920405036, 0.8102500050896771, 0.8846592710418298);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 142, 625);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+renderBundleEncoder29.insertDebugMarker('\u{1fd26}');
+} catch {}
+let renderBundle221 = renderBundleEncoder28.finish({label: '\u382f\u6626\u781a\u07c9\u06fb\u0013\u9260'});
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4_294_967_294, undefined, 197_046_394);
+} catch {}
+try {
+  await promise52;
+} catch {}
+document.body.prepend(img1);
+let querySet44 = device1.createQuerySet({
+  label: '\u08ae\u{1f917}\ua044\u{1f91b}\u5111\u106a\uec92\u0f0e\u{1f81c}\u02e3',
+  type: 'occlusion',
+  count: 1939,
+});
+let renderBundle222 = renderBundleEncoder19.finish({label: '\ub6c7\u0224\u97ef\uc423\ub4f4\u8f4e\uf9d4'});
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(1294);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle133, renderBundle179]);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer46);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder332 = device1.createCommandEncoder({label: '\u96c0\u9797\u52c1\u{1fae8}\ue4a7\u047a\u0606\u535e'});
+let commandBuffer220 = commandEncoder332.finish({label: '\u358f\ub38f\ua2e1'});
+try {
+buffer63.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer204]);
+} catch {}
+let bindGroupLayout47 = device1.createBindGroupLayout({
+  label: '\u{1faed}\u{1ff8c}\u02ee\u0609\uf092\u{1f628}\u{1f632}\u{1f66b}\u34b3\u3551\u9d53',
+  entries: [
+    {
+      binding: 313,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 304,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 123,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 232, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 29,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 476,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 25, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 382,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 406,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 285, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 107,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 229, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 643,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 321,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 116306, hasDynamicOffset: false },
+    },
+    {
+      binding: 81,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 510,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 182,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 145,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 342,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 205,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 194,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 38, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 230,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 120, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 281,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 385,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 521,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 5080922, hasDynamicOffset: false },
+    },
+    {binding: 347, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 163,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 214,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 86,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 27, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 74,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 368,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 200, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+  ],
+});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer62, 0);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup16, new Uint32Array(138), 8, 0);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer48, 'uint16', 620, 504);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(6, buffer62);
+} catch {}
+try {
+texture25.label = '\u{1ff50}\ud1bc\u0755\ubf55\u89cc\u035d\u8199\ue9f7';
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup0);
+} catch {}
+offscreenCanvas3.height = 666;
+let pipelineLayout50 = device2.createPipelineLayout({label: '\u1c89\u0348\ud841\u0749\u0bd6\u0482\ub5b2\u7153\u0008', bindGroupLayouts: []});
+let commandEncoder333 = device2.createCommandEncoder({label: '\u098a\u6cb4\u1714\u{1fd72}\u{1fca1}\u96b7'});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup11, new Uint32Array(904), 209, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder334 = device2.createCommandEncoder();
+let commandBuffer221 = commandEncoder334.finish({label: '\u6420\uffa5\ub655\ua1a7\u3e51\u0c0f\u6c1a\u097c\ub3fd\uc525\u{1f970}'});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(107_602), /* required buffer size: 107_602 */
+{offset: 19, bytesPerRow: 2289, rowsPerImage: 47}, {width: 274, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let commandBuffer222 = commandEncoder333.finish({label: '\uc10d\u3db9\ub943\u{1fafd}\u0fb3\u931d\u{1fc56}\ue71d'});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint32', 508, 599);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder46.setStencilReference(534);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer23, 'uint16', 1_510, 392);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup12, new Uint32Array(877), 32, 0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer23, 'uint16', 1_272, 545);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer23, 'uint32', 112, 198);
+} catch {}
+let promise53 = device2.queue.onSubmittedWorkDone();
+let imageBitmap10 = await createImageBitmap(videoFrame5);
+let commandEncoder335 = device2.createCommandEncoder({label: '\u9c9b\u63ea\uaceb\u845b\u308d\u03a7\u{1f6df}\ue4e3'});
+try {
+computePassEncoder91.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer23, 'uint16', 734, 1_507);
+} catch {}
+try {
+commandEncoder335.copyTextureToBuffer({
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16 */
+  offset: 16,
+  buffer: buffer23,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder48 = commandEncoder335.beginRenderPass({
+  label: '\u{1f75b}\uc77c\u{1f6fd}\u0d60\u{1fc26}',
+  colorAttachments: [{view: textureView63, depthSlice: 58, loadOp: 'load', storeOp: 'discard'}],
+});
+let renderBundle223 = renderBundleEncoder29.finish({label: '\ud35f\uf739\u046c\udbdd\ubee0'});
+try {
+computePassEncoder84.setPipeline(pipeline8);
+} catch {}
+try {
+device2.queue.submit([commandBuffer221]);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+  await promise53;
+} catch {}
+let bindGroupLayout48 = device2.createBindGroupLayout({
+  label: '\u9a6a\u1193\u75c9',
+  entries: [
+    {
+      binding: 214,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder336 = device2.createCommandEncoder();
+let computePassEncoder101 = commandEncoder336.beginComputePass({label: '\u{1fd54}\uee9f\u0811\u0e68\u0df9\u0e5b\ua2a7\u0618\u066d\u{1f926}\u1e74'});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer23, 'uint32', 3_576, 30);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(1, undefined, 0, 1_156_395_281);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 52, new Int16Array(5201), 123, 52);
+} catch {}
+let promise54 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let textureView86 = texture55.createView({
+  label: '\u{1f7f2}\u577f\ua3c4\ua6ec\u0e3d\u{1f86a}\u671d\u990c\udd60',
+  format: 'r8sint',
+  baseArrayLayer: 9,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(2, buffer14, 3_840, 3_915);
+} catch {}
+try {
+texture73.destroy();
+} catch {}
+try {
+  await promise54;
+} catch {}
+let commandEncoder337 = device1.createCommandEncoder({label: '\u075c\ue0af\u09ed\u034b\u546e\u0d7a\u66ad\u9287'});
+try {
+computePassEncoder77.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle185, renderBundle158]);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(4, buffer62, 2_856);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(4, buffer46, 512, 387);
+} catch {}
+let commandEncoder338 = device1.createCommandEncoder({label: '\u23cb\uf3d2\uba62\u47a9'});
+let textureView87 = texture101.createView({});
+let computePassEncoder102 = commandEncoder338.beginComputePass({label: '\u6c0e\ucee5\ud3ae\ud103\u07e7\ufd3e\u047f\uda71\u0c53\u0eba'});
+let renderPassEncoder49 = commandEncoder337.beginRenderPass({
+  label: '\u8f2c\u4075\u0cca\uaa59',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 17,
+  clearValue: { r: 431.1, g: -964.9, b: 801.1, a: 23.01, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 81893256,
+});
+try {
+computePassEncoder63.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer62, 4_592, 158);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup8, new Uint32Array(1290), 23, 0);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1680, new Int16Array(571), 33);
+} catch {}
+let promise55 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise55;
+} catch {}
+let pipelineLayout51 = device2.createPipelineLayout({label: '\ud7f2\u05c7', bindGroupLayouts: [bindGroupLayout43, bindGroupLayout39, bindGroupLayout45]});
+let commandEncoder339 = device2.createCommandEncoder({label: '\u0e4a\u9fb8\ue688\u74aa\ufb57'});
+let computePassEncoder103 = commandEncoder339.beginComputePass();
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+device2.queue.submit([commandBuffer222]);
+} catch {}
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroup17 = device2.createBindGroup({
+  label: '\u79fa\u372e\ufb1d\u049d\u7ddb\u47db\ua7f6\u22f4',
+  layout: bindGroupLayout39,
+  entries: [{binding: 511, resource: externalTexture26}],
+});
+try {
+renderPassEncoder46.executeBundles([renderBundle148]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 272, 1_005);
+} catch {}
+let imageData39 = new ImageData(12, 36);
+let commandEncoder340 = device0.createCommandEncoder({label: '\u00d9\u3a70\u44c6\u{1fecd}\ud380\u9855\u{1fc9f}\u76b2\ud401'});
+let textureView88 = texture1.createView({});
+try {
+renderPassEncoder8.setViewport(2.819437949606537, 5.367174835764112, 1.9909728161474103, 1.2179194012020953, 0.4597298653131743, 0.878161229887763);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer51, 0, 8_729);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(0, buffer7, 1_312, 566);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder340.clearBuffer(buffer6, 76, 4532);
+} catch {}
+let commandEncoder341 = device1.createCommandEncoder({label: '\u0030\uea13\u52bd\u{1f78b}\u{1ff27}\u{1fe04}\u04c6\u776d\u{1f687}'});
+let renderPassEncoder50 = commandEncoder341.beginRenderPass({
+  label: '\u5133\u{1f939}\ua675\uc9a9\u03cd\u1cdf\u{1f90a}\ud795\u0e34\ubbae',
+  colorAttachments: [{
+  view: textureView76,
+  clearValue: { r: -163.9, g: 847.8, b: 158.9, a: 566.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 147090583,
+});
+let renderBundle224 = renderBundleEncoder32.finish();
+try {
+computePassEncoder75.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder47.setViewport(2.151134170691952, 0.7997842019382917, 2.571691891655531, 2.9098302191599523, 0.9452419634938427, 0.9969026151323661);
+} catch {}
+let commandEncoder342 = device1.createCommandEncoder({label: '\u0128\uf709\ubc41\u0308'});
+let renderPassEncoder51 = commandEncoder223.beginRenderPass({
+  label: '\u{1f774}\u04ec\u0728\u06e8\u{1f8b3}\u2aad\u0390\u21bb\u897d\u{1ff1b}',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 31,
+  clearValue: { r: -748.0, g: 165.8, b: 427.3, a: 603.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+let arrayBuffer9 = buffer31.getMappedRange(96, 240);
+let commandEncoder343 = device2.createCommandEncoder({label: '\u6c97\u2101\u6454\udb10\u04ee'});
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, undefined, 717_411_875);
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+let texture105 = device0.createTexture({
+  label: '\u3ee2\ud622\u051c\u5700\uc85c\u805a\u25fe',
+  size: [60, 60, 1],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup0, new Uint32Array(390), 7, 0);
+} catch {}
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer0, 'uint32', 1_760, 1_465);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer14, 1_572);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer8, 0, 2_161);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder344 = device2.createCommandEncoder({});
+let commandBuffer223 = commandEncoder344.finish({});
+try {
+computePassEncoder91.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u07ba');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 93, y: 0, z: 57},
+  aspect: 'all',
+}, new ArrayBuffer(897_062), /* required buffer size: 897_062 */
+{offset: 230, bytesPerRow: 692, rowsPerImage: 162}, {width: 75, height: 0, depthOrArrayLayers: 9});
+} catch {}
+document.body.prepend(canvas5);
+let querySet45 = device0.createQuerySet({
+  label: '\u9bd1\u{1f947}\ua03d\u{1ffde}\u0c3f\u{1f9d6}\u8044\u021b\u7b50\u0009\u78a7',
+  type: 'occlusion',
+  count: 753,
+});
+let computePassEncoder104 = commandEncoder340.beginComputePass({});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer11, 680);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup2);
+} catch {}
+let commandEncoder345 = device0.createCommandEncoder({label: '\u{1f7ed}\u0ca9\uf900\u4f5b\ub728\ub28a'});
+let commandEncoder346 = device1.createCommandEncoder({label: '\u0cbe\u0594'});
+let commandBuffer224 = commandEncoder346.finish({label: '\u487d\u0bb8\ue6d5\u08c9\uf30c\u851a\u0e78\u{1f8ca}\u236c'});
+let renderPassEncoder52 = commandEncoder342.beginRenderPass({
+  label: '\u2ee7\uce6d\ua79b\u0b2b\u080a\u{1fef6}',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 14,
+  clearValue: { r: -945.2, g: 112.7, b: 787.4, a: 965.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 74491665,
+});
+let sampler24 = device1.createSampler({
+  label: '\u7b1e\u58e8\ufec9\u04a9\u12a5\u04cf\u2705',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 39.97,
+});
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup8, new Uint32Array(3977), 344, 0);
+} catch {}
+let renderBundle225 = renderBundleEncoder4.finish({label: '\u0a13\udae3'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.45,
+  lodMaxClamp: 74.67,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup1, new Uint32Array(752), 23, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup4, new Uint32Array(1087), 213, 0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer18, 92, 728);
+} catch {}
+try {
+commandEncoder345.resolveQuerySet(querySet12, 78, 50, buffer17, 1792);
+} catch {}
+try {
+renderBundleEncoder31.insertDebugMarker('\u0895');
+} catch {}
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({colorFormats: ['rg8uint']});
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle124, renderBundle176, renderBundle222, renderBundle169, renderBundle159]);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer20, 'uint16', 7_936, 15_620);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+commandEncoder205.copyTextureToBuffer({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 6},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1776 */
+  offset: 1776,
+  bytesPerRow: 0,
+  rowsPerImage: 184,
+  buffer: buffer20,
+}, {width: 0, height: 8, depthOrArrayLayers: 4});
+} catch {}
+video4.width = 162;
+await gc();
+let commandBuffer225 = commandEncoder205.finish();
+let commandEncoder347 = device0.createCommandEncoder({label: '\u{1f808}\u{1fe28}\u{1fa15}\uc2d6\u057b\u512a'});
+let commandBuffer226 = commandEncoder347.finish();
+let computePassEncoder105 = commandEncoder345.beginComputePass({label: '\u514d\u{1f9c9}\u2095\u066c\ud756\u30aa\u063a\u0fc7'});
+let renderBundle226 = renderBundleEncoder1.finish({label: '\u08bc\u643d\uac27\u{1f7cf}\u9222\u3787\u004d\uce09'});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup9, new Uint32Array(26), 2, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup15, new Uint32Array(868), 132, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer3, 'uint32', 2_128, 4_018);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer1, 'uint32', 4_564, 181);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let querySet46 = device0.createQuerySet({label: '\ua7ba\u{1f65f}\u1a33', type: 'occlusion', count: 77});
+try {
+computePassEncoder53.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(0, 2, 0, 0);
+} catch {}
+let externalTexture43 = device1.importExternalTexture({label: '\u{1f71c}\u02ba\u{1f6f8}\u0a1c\uc1ed\u0f5d\u092f\ubb5a\u2984\ue615', source: videoFrame2});
+try {
+renderBundleEncoder33.setIndexBuffer(buffer30, 'uint32', 844, 1_195);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer46, 0, 585);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer62, 276, new Float32Array(23837), 249, 308);
+} catch {}
+let promise56 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: imageData39,
+  origin: { x: 2, y: 3 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder348 = device2.createCommandEncoder({label: '\u0099\u0522\u{1fdbd}\u21aa\u{1fc63}\u{1fffb}'});
+let commandBuffer227 = commandEncoder343.finish({label: '\u0335\u{1f9b2}\u0e9c\u089a\u0879\u3ffd\u8565\u1ebf\u0364\uefee\u3984'});
+let computePassEncoder106 = commandEncoder348.beginComputePass({label: '\u{1fbc1}\u{1f8b7}\u0de5\u03e2\uec49\u60b5\u5cf8\u53a8\u0a63'});
+let renderBundle227 = renderBundleEncoder23.finish();
+try {
+computePassEncoder103.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline15);
+} catch {}
+try {
+device2.queue.submit([commandBuffer223]);
+} catch {}
+let pipelineLayout52 = device0.createPipelineLayout({
+  label: '\u{1f677}\u4641\ufc9d\u001f\u474d\uec71\u6a8b\u0e9b',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout23, bindGroupLayout35],
+});
+let commandEncoder349 = device0.createCommandEncoder({label: '\u0f89\ucec6\u7f02\uc5d1\u8893'});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\u6ef5\u{1fcd3}\u01c1\u75cd\uaff4\u73aa\u476f\u{1faee}\u{1f6c8}',
+  colorFormats: ['r32sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer16, 800);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer21, 'uint32', 40, 1_119);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(296), /* required buffer size: 296 */
+{offset: 296, bytesPerRow: 4, rowsPerImage: 43}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video10 = await videoWithData();
+let commandBuffer228 = commandEncoder349.finish();
+try {
+renderBundleEncoder34.setVertexBuffer(6, buffer5, 4_300);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 2264, new BigUint64Array(33767), 2301, 80);
+} catch {}
+let commandEncoder350 = device2.createCommandEncoder();
+let textureView89 = texture82.createView({label: '\u{1ff06}\uabd1\ubf20\u{1fb8a}\u{1fbf8}\u{1fabc}\ubab4\ub009', baseMipLevel: 1});
+let renderBundle228 = renderBundleEncoder26.finish({label: '\u0eb2\u02e9\u5886'});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, undefined, 882_092_491, 475_887_803);
+} catch {}
+try {
+commandEncoder350.copyBufferToBuffer(buffer49, 88, buffer23, 1032, 708);
+} catch {}
+let pipeline18 = device2.createComputePipeline({
+  label: '\ub251\u3c70\u{1fe3b}',
+  layout: pipelineLayout35,
+  compute: {module: shaderModule7, constants: {}},
+});
+let promise57 = adapter6.requestAdapterInfo();
+let commandEncoder351 = device1.createCommandEncoder({label: '\ubcd7\u2dc7\uf6ce\u4f99\u{1fd1d}'});
+let commandBuffer229 = commandEncoder351.finish({label: '\ua638\ucc3d\u065d\u6c81\u5fed\u3dbc\u2dba\u9a6b\u6cd1\u7b07'});
+try {
+renderPassEncoder18.executeBundles([renderBundle159]);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer48, 'uint32', 508, 344);
+} catch {}
+try {
+device1.queue.submit([commandBuffer219]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer62, 4348, new DataView(new ArrayBuffer(11199)), 881, 864);
+} catch {}
+let renderBundle229 = renderBundleEncoder12.finish();
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer7, 'uint16', 12, 491);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(162), /* required buffer size: 162 */
+{offset: 162, bytesPerRow: 99, rowsPerImage: 197}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+canvas6.width = 694;
+let imageBitmap11 = await createImageBitmap(img1);
+try {
+computePassEncoder70.setBindGroup(2, bindGroup8, new Uint32Array(2953), 219, 0);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer19, 0, 5_665);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer30, 'uint16', 1_338, 1_201);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+window.someLabel = texture5.label;
+} catch {}
+let commandEncoder352 = device0.createCommandEncoder();
+let texture106 = gpuCanvasContext7.getCurrentTexture();
+let textureView90 = texture34.createView({
+  label: '\u420e\ua408\u8cd5\u{1f6ba}\u0211\u4f26\u0c1c\u902f\ud693\u010f',
+  dimension: '1d',
+  baseMipLevel: 0,
+});
+let externalTexture44 = device0.importExternalTexture({label: '\u9b33\u2d56\u9797\u{1f8cc}\u8578\u7212', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder87.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer10, 'uint16', 1_694, 1_309);
+} catch {}
+try {
+commandEncoder352.copyBufferToBuffer(buffer29, 216, buffer22, 1308, 1264);
+} catch {}
+try {
+device0.queue.submit([commandBuffer199, commandBuffer226]);
+} catch {}
+let promise58 = device0.queue.onSubmittedWorkDone();
+let commandBuffer230 = commandEncoder352.finish();
+let texture107 = device0.createTexture({
+  label: '\u426b\u7abc\u03e5\u0525\u01a2\u{1fcae}\u0d9d',
+  size: [7, 7, 47],
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder105.setBindGroup(2, bindGroup4, new Uint32Array(2426), 34, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer17, 'uint16', 3_114, 1_097);
+} catch {}
+let arrayBuffer10 = buffer50.getMappedRange(2104);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: video8,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 29},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder353 = device1.createCommandEncoder({label: '\u{1f9bb}\ua0a5\u0edb\u7a87\u0627\u07f6\u0330\u0f7c\u4385\u0047'});
+let commandBuffer231 = commandEncoder353.finish();
+try {
+computePassEncoder72.setBindGroup(0, bindGroup16, new Uint32Array(538), 2, 0);
+} catch {}
+try {
+renderPassEncoder37.setViewport(2.201958773896611, 4.663308283188498, 1.3268321709411783, 1.6505187031107014, 0.7967739147811053, 0.8344474395236301);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer48, 'uint32', 1_792, 118);
+} catch {}
+let commandEncoder354 = device1.createCommandEncoder();
+let commandBuffer232 = commandEncoder354.finish({label: '\u{1fbc6}\u058b\uce20\u9890\u2fed\u{1fe26}\u04e0\u506a\u53f6'});
+try {
+computePassEncoder83.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(32);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.submit([commandBuffer224, commandBuffer229]);
+} catch {}
+let commandEncoder355 = device1.createCommandEncoder({label: '\u0fd3\u7a2e\u0492\uda38\u0961'});
+let commandBuffer233 = commandEncoder355.finish({label: '\u{1f9e7}\u04d8\ub4d1\ubeae\u{1f70b}\u02c9\u{1f8cd}\u4f5f\u22e4\u5725\u73fd'});
+let sampler26 = device1.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.63,
+  lodMaxClamp: 99.95,
+});
+let externalTexture45 = device1.importExternalTexture({
+  label: '\u3fc1\ub0df\ueaf8\u7934\ubde4\ue6ab\u2e5a\ua35b\u{1fb39}',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder50.setViewport(1.735464933347116, 4.184830323846268, 2.1843840296941117, 15.893844454918888, 0.6155567732200233, 0.8894262241000653);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer20, 'uint32', 10_364, 532);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup8, new Uint32Array(1062), 14, 0);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(338), /* required buffer size: 338 */
+{offset: 338}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let pipelineLayout53 = device2.createPipelineLayout({label: '\uf44d\u08fa\u06ad\u07f3', bindGroupLayouts: [bindGroupLayout48]});
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 906, 972);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let buffer64 = device1.createBuffer({size: 1271, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder356 = device1.createCommandEncoder();
+let commandBuffer234 = commandEncoder356.finish({label: '\u07fb\u09fc\u0ae4\ubc19\u2acb\u0e04\u8277\u62ac\u0195\u0def\u8386'});
+try {
+renderBundleEncoder33.setVertexBuffer(3, buffer46);
+} catch {}
+try {
+  await buffer64.mapAsync(GPUMapMode.WRITE, 128, 440);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 3, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture39.label = '\u983d\u0eac\ubf8a\u6b37\udeef\u{1fe39}';
+} catch {}
+let buffer65 = device0.createBuffer({
+  label: '\u00d3\u{1f9de}',
+  size: 23831,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder357 = device0.createCommandEncoder({});
+let renderBundle230 = renderBundleEncoder12.finish({label: '\u07d9\u009e\u7cb2\u1411\u09bf\u052c\u6362'});
+try {
+renderPassEncoder6.setBlendConstant({ r: 285.4, g: 853.5, b: 718.2, a: 345.6, });
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer16, 'uint32', 1_760, 3_040);
+} catch {}
+try {
+commandEncoder357.copyBufferToBuffer(buffer4, 5068, buffer13, 4856, 4660);
+} catch {}
+try {
+adapter0.label = '\u0e56\u04e8\u72ff\u0fed\u0c7c\u48a3';
+} catch {}
+let commandBuffer235 = commandEncoder357.finish({label: '\u4a9e\u1c2b\u{1f607}'});
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup14, new Uint32Array(2203), 80, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer22, 'uint16', 1_528, 589);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u{1f730}\u27cb\u9d20\u{1fcae}\ud90a\u0798\u{1feda}',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<u32>,
+}
+struct T1 {
+  f0: array<atomic<u32>, 1>,
+}
+struct T2 {
+  f0: array<array<atomic<u32>, 1>>,
+}
+
+@group(1) @binding(66) var st13: texture_storage_3d<r32sint, read_write>;
+@group(1) @binding(98) var tex52: texture_2d<u32>;
+@group(0) @binding(344) var tex51: texture_multisampled_2d<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f26: vec4f
+}
+
+@vertex
+fn vertex0(@location(0) a0: u32, @location(14) @interpolate(perspective) a1: vec2h, @location(2) @interpolate(flat) a2: vec4f, @location(6) @interpolate(flat, centroid) a3: i32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(0) @interpolate(flat, center) f1: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(textureLoad(tex51, vec2i(), 0)[1]) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, undefined, 0, 329_305_806);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup7, new Uint32Array(3400), 228, 0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer22);
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 181 */
+  offset: 181,
+  bytesPerRow: 0,
+  buffer: buffer22,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder34.insertDebugMarker('\u05e0');
+} catch {}
+let bindGroupLayout49 = device1.createBindGroupLayout({label: '\u{1f763}\u2003', entries: []});
+let commandEncoder358 = device1.createCommandEncoder();
+try {
+computePassEncoder75.setBindGroup(0, bindGroup8, new Uint32Array(546), 83, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle177, renderBundle176]);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer20, 'uint16', 2_124, 2_445);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(203), /* required buffer size: 203 */
+{offset: 203}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise58;
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  label: '\u7911\u{1ff32}\u{1fae3}\u0080',
+  layout: bindGroupLayout32,
+  entries: [{binding: 90, resource: textureView44}],
+});
+let commandEncoder359 = device0.createCommandEncoder({label: '\ua57f\u5a59\ud203\u5132'});
+let commandBuffer236 = commandEncoder83.finish({label: '\u03dc\u2770\ubf32'});
+try {
+computePassEncoder100.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer22, 'uint16', 6_234, 680);
+} catch {}
+try {
+commandEncoder359.resolveQuerySet(querySet10, 72, 67, buffer1, 0);
+} catch {}
+try {
+  await promise56;
+} catch {}
+let commandEncoder360 = device1.createCommandEncoder({label: '\u278d\u3849\u0884\u09ba'});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle222]);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer62, 0, 325);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+video8.width = 12;
+let computePassEncoder107 = commandEncoder360.beginComputePass({label: '\u1ebe\u{1fd25}\u{1fa71}\ufc48\u{1fff0}\u0bb6'});
+let renderBundle231 = renderBundleEncoder19.finish({label: '\u443a\u0d04\u98fd\ucecc\uf6bf\u0330\u0550\u00ae\u1a2e'});
+try {
+computePassEncoder63.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer63, 'uint16', 6_074, 1_656);
+} catch {}
+try {
+device1.queue.submit([commandBuffer231, commandBuffer220, commandBuffer234]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let shaderModule14 = device1.createShaderModule({
+  label: '\u9371\u78c2\ub593\ue3d5\uae93\u{1f87b}\uc3a8\u8440',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<u32>,
+}
+
+@group(1) @binding(241) var tex54: texture_multisampled_2d<u32>;
+@group(0) @binding(470) var st14: texture_storage_1d<rgba8unorm, write>;
+@group(0) @binding(339) var tex53: texture_cube_array<i32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(12) @interpolate(flat, centroid) f27: vec3f,
+  @location(13) f28: vec2u,
+  @location(14) @interpolate(perspective) f29: vec2f,
+  @location(6) @interpolate(flat, centroid) f30: u32,
+  @location(11) @interpolate(flat, centroid) f31: i32,
+  @location(3) f32: f16,
+  @builtin(position) f33: vec4f,
+  @location(9) f34: vec4h,
+  @location(4) f35: f32,
+  @location(10) @interpolate(flat) f36: vec2i,
+  @location(5) @interpolate(flat, sample) f37: vec2u,
+  @location(15) @interpolate(flat, sample) f38: vec2u,
+  @location(1) f39: vec3f,
+  @location(8) f40: vec2u
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2h, @location(10) @interpolate(flat, center) a1: vec2i, @location(12) a2: f16, @location(11) @interpolate(flat, centroid) a3: u32, @location(15) a4: vec4h, @location(8) a5: f32, @location(3) a6: vec3i, @location(9) a7: vec2i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = a4;
+  out.f30 = u32(a1[1]);
+  out.f27 = bitcast<vec3f>(a6);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2i,
+  @location(0) @interpolate(perspective) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer237 = commandEncoder358.finish({label: '\ub523\u3157\uc7f5\u1d4f\u{1f68e}'});
+try {
+renderPassEncoder43.setBlendConstant({ r: -106.5, g: -917.9, b: -211.5, a: 754.6, });
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(4_294_967_294, undefined, 82_963_333);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup10, []);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 15, depthOrArrayLayers: 42}
+*/
+{
+  source: imageData35,
+  origin: { x: 0, y: 14 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder361 = device2.createCommandEncoder({});
+let commandBuffer238 = commandEncoder350.finish();
+let renderBundle232 = renderBundleEncoder26.finish({});
+let externalTexture46 = device2.importExternalTexture({label: '\u00d2\u3cd3\u97ba\u2833', source: video5, colorSpace: 'display-p3'});
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer227]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 104, new Float32Array(21577), 68, 204);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer19);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(7, buffer62, 3_804, 477);
+} catch {}
+let commandEncoder362 = device1.createCommandEncoder({label: '\u23f5\u2510\u0ceb\u{1fb31}'});
+let commandBuffer239 = commandEncoder362.finish({label: '\u44c9\u{1fffc}\u81e4\u7639\u834c\u773a\u77c2\u{1f940}\u3139\uea48'});
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(0, 1, 1, 1);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer30, 'uint32', 20, 1_063);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(6, buffer46, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer237]);
+} catch {}
+let bindGroupLayout50 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 325,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder363 = device2.createCommandEncoder({});
+let textureView91 = texture70.createView({label: '\u0b27\u{1fa43}\u{1f960}'});
+let renderPassEncoder53 = commandEncoder363.beginRenderPass({
+  label: '\u7bc9\u5344\u8b3a\ua0ef',
+  colorAttachments: [{view: textureView91, depthSlice: 353, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 204224100,
+});
+let renderBundle233 = renderBundleEncoder23.finish({label: '\u1785\u67a2\u0680\u2a1e\ua498\uf0d4\u0602\u06aa\u{1f8f7}\u{1f74c}'});
+try {
+computePassEncoder89.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder48.setViewport(154.78406630325824, 0.4982988700186123, 19.52490865290967, 0.21614831440116788, 0.4408988576487146, 0.46283932945762923);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 194, 8);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(81), /* required buffer size: 81 */
+{offset: 81, bytesPerRow: 358}, {width: 44, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder364 = device1.createCommandEncoder();
+let querySet47 = device1.createQuerySet({label: '\u{1f88b}\u{1fbf0}\u7cea\u6bbe\u0430\u{1f66c}', type: 'occlusion', count: 2303});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup8, new Uint32Array(3291), 480, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle129, renderBundle124]);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(0, 5, 0, 1);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup10, new Uint32Array(2810), 166, 0);
+} catch {}
+let computePassEncoder108 = commandEncoder361.beginComputePass();
+let renderBundle234 = renderBundleEncoder26.finish({label: '\u{1f89e}\ue172\u{1fd72}\uff53\u6139'});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup17, new Uint32Array(1133), 388, 0);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(53);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer23, 'uint32', 2_776, 767);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+computePassEncoder106.pushDebugGroup('\u8bf2');
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 80, 381);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4_294_967_294, undefined, 0, 106_655_733);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let promise59 = navigator.gpu.requestAdapter({});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer5);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup15, new Uint32Array(2967), 718, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer17, 'uint32', 1_036, 751);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 8, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(20), /* required buffer size: 20 */
+{offset: 20, bytesPerRow: 70}, {width: 2, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData33,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+video4.height = 64;
+let commandBuffer240 = commandEncoder359.finish({label: '\u0a75\u{1fb57}\u039d\ub60f\u{1f7b9}\uc361\u066c\u03f7'});
+try {
+renderPassEncoder8.setIndexBuffer(buffer15, 'uint16', 480, 3_172);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(1, buffer4, 8_924, 13_557);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer7, 'uint32', 436, 784);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(6, buffer65, 0, 2_675);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(125_846), /* required buffer size: 125_846 */
+{offset: 58, bytesPerRow: 41, rowsPerImage: 118}, {width: 0, height: 0, depthOrArrayLayers: 27});
+} catch {}
+let commandBuffer241 = commandEncoder364.finish({label: '\u34a0\u0ed7'});
+let sampler27 = device1.createSampler({
+  label: '\uaeda\u4679\u0434',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  lodMinClamp: 97.07,
+  lodMaxClamp: 99.64,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(0, bindGroup16, new Uint32Array(425), 111, 0);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder51.setScissorRect(0, 1, 0, 1);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer48, 'uint32', 108, 119);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup9, []);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 4},
+  aspect: 'depth-only',
+}, new ArrayBuffer(13_459), /* required buffer size: 13_459 */
+{offset: 37, bytesPerRow: 124, rowsPerImage: 6}, {width: 15, height: 1, depthOrArrayLayers: 19});
+} catch {}
+try {
+computePassEncoder106.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint32', 2_676, 614);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let querySet48 = device2.createQuerySet({type: 'occlusion', count: 1379});
+let renderBundleEncoder35 = device2.createRenderBundleEncoder({colorFormats: ['rgba16sint'], sampleCount: 4, stencilReadOnly: true});
+let sampler28 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.13,
+  lodMaxClamp: 98.50,
+  compare: 'always',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer23, 'uint32', 660, 211);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let renderBundle235 = renderBundleEncoder34.finish({label: '\u0f59\ud99c\u467c\u0ed4\u7a90\u{1fff0}\u409d\u{1fd14}\u{1fc88}'});
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer228]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 3704, new Float32Array(1873), 882, 24);
+} catch {}
+canvas7.width = 2654;
+let imageData40 = new ImageData(48, 208);
+let bindGroupLayout51 = device1.createBindGroupLayout({
+  label: '\u3308\u0786\u0aa9\u5402\udc0b',
+  entries: [
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder365 = device1.createCommandEncoder({label: '\u0584\u{1f7ba}\u0f66\uf625\u09fe\u0055\ucb63\u0b45'});
+let commandBuffer242 = commandEncoder365.finish({label: '\u1a7f\u0c22\u1af3\u34cd\u06f2\u470e\u0075\ue98b\ucf34'});
+try {
+computePassEncoder72.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle128, renderBundle191]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer48, 'uint32', 2_908, 754);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer46, 692, 611);
+} catch {}
+let buffer66 = device0.createBuffer({
+  size: 26292,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer4, 6_596, 1_298);
+} catch {}
+try {
+device0.queue.submit([commandBuffer194]);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder366 = device0.createCommandEncoder();
+let commandBuffer243 = commandEncoder366.finish({label: '\u{1fcf4}\u0ae0\u0f6c\u07be\u6244\u576b\u0a93\u1e53\u{1f6e4}\u6d30'});
+let renderBundle236 = renderBundleEncoder15.finish({label: '\u99b6\u651c\u77c1\u0016\u0f2a\u419e\u88a3'});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(3, bindGroup13, new Uint32Array(4353), 278, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer13, 'uint16', 2_312, 287);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer21, 'uint32', 1_128, 644);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(0, buffer3, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer236, commandBuffer216]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(60), /* required buffer size: 60 */
+{offset: 60, rowsPerImage: 26}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise60 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let texture108 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 3_110, 40);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer16, 0, 129);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer5);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture109 = gpuCanvasContext7.getCurrentTexture();
+try {
+computePassEncoder91.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(7);
+} catch {}
+await gc();
+let pipelineLayout54 = device0.createPipelineLayout({
+  label: '\uc82f\uada0\uad57\u574a\u84e5\u0b4e\u0a70\u0b9f\u8b93',
+  bindGroupLayouts: [bindGroupLayout16],
+});
+let querySet49 = device0.createQuerySet({label: '\u6db7\u0968\u8f2c\u0575\u{1fc6f}\u1453', type: 'occlusion', count: 114});
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup5, new Uint32Array(480), 117, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 3464, new Float32Array(3884), 2, 96);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 15, depthOrArrayLayers: 56}
+*/
+{
+  source: imageData8,
+  origin: { x: 3, y: 10 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView92 = texture104.createView({
+  label: '\u3831\u38b8\u5159\u0840',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup12, []);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer23, 'uint16', 2_820, 1_058);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise61 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise60;
+} catch {}
+let commandEncoder367 = device1.createCommandEncoder({});
+let renderBundle237 = renderBundleEncoder19.finish({label: '\u{1f625}\u853e\u415a\u0b1a\u7a81\u{1fa16}\u4ab5'});
+try {
+computePassEncoder70.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup10, new Uint32Array(0), 0, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer19, 0, 14_294);
+} catch {}
+try {
+commandEncoder367.copyTextureToBuffer({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3368 */
+  offset: 3368,
+  bytesPerRow: 0,
+  buffer: buffer62,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder367.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(img11);
+let commandEncoder368 = device1.createCommandEncoder();
+let renderPassEncoder54 = commandEncoder367.beginRenderPass({
+  label: '\u4c8a\u{1f643}\u7c04\ubd38',
+  colorAttachments: [{
+  view: textureView70,
+  depthSlice: 0,
+  clearValue: { r: 53.46, g: 392.7, b: -232.4, a: 905.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet39,
+});
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer46, 36);
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u0cc7');
+} catch {}
+try {
+device1.queue.submit([commandBuffer232]);
+} catch {}
+let texture110 = device1.createTexture({
+  size: [12, 30, 1],
+  sampleCount: 4,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView93 = texture92.createView({label: '\u0417\u03e8\u86ed\u1030\u0b25\ue5b5', baseMipLevel: 0});
+let renderBundle238 = renderBundleEncoder32.finish();
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+device1.queue.submit([commandBuffer233]);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+  await promise61;
+} catch {}
+await gc();
+let textureView94 = texture97.createView({label: '\u772b\u78f3\u02b2\u0a30\ub682\u0bfa\uc063'});
+try {
+computePassEncoder77.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(5, buffer46, 188);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4_294_967_294, undefined, 0);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+let canvas9 = document.createElement('canvas');
+let bindGroupLayout52 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder369 = device1.createCommandEncoder({});
+try {
+renderPassEncoder41.setIndexBuffer(buffer20, 'uint32', 4_416, 3_337);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup10);
+} catch {}
+let arrayBuffer11 = buffer31.getMappedRange(336, 96);
+let querySet50 = device0.createQuerySet({label: '\ue0a4\u748e\u0834\u5393\u{1fbd1}\u761c', type: 'occlusion', count: 147});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup7, new Uint32Array(3159), 491, 0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer22);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData0,
+  origin: { x: 6, y: 39 },
+  flipY: false,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 5, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder370 = device1.createCommandEncoder({label: '\u{1fd98}\u9abb\u0a19\u01c1'});
+let computePassEncoder109 = commandEncoder370.beginComputePass({label: '\u{1fd5e}\u0c3a\u030f\uafd9\u092e\u9575\u{1fcf4}\u097e'});
+try {
+renderBundleEncoder33.setIndexBuffer(buffer48, 'uint16', 750, 842);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5, buffer46, 3_416);
+} catch {}
+try {
+device1.queue.submit([commandBuffer239]);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer30, 'uint32', 6_836, 22);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer63, 'uint16', 1_200, 4_235);
+} catch {}
+try {
+commandEncoder369.resolveQuerySet(querySet40, 26, 96, buffer30, 1280);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 1308, new BigUint64Array(11646), 5201, 92);
+} catch {}
+video7.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let texture111 = device0.createTexture({
+  label: '\ucb54\u{1f6ed}',
+  size: {width: 15, height: 15, depthOrArrayLayers: 41},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView95 = texture14.createView({label: '\u{1f98e}\u559c\ue9af', baseMipLevel: 0});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u764f\u{1f850}\u1f7a\u3163',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup14, new Uint32Array(1814), 213, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(1, buffer14);
+} catch {}
+let imageData41 = new ImageData(28, 4);
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint32', 344, 426);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(4_294_967_294, undefined, 1_140_729_521, 335_822_830);
+} catch {}
+let computePassEncoder110 = commandEncoder368.beginComputePass({label: '\ua45c\u6c55\u{1f749}\uc57b\u500c\ufe19\u2a3a'});
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer46, 1_540, 2_848);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+  await promise57;
+} catch {}
+let commandEncoder371 = device1.createCommandEncoder({label: '\u{1fe64}\u210c\u742b'});
+let commandBuffer244 = commandEncoder369.finish({label: '\u6004\u0e51\u04a7\u23c3\u0b80\u0025\u0bca\u0d75\uf1f8'});
+try {
+computePassEncoder107.setPipeline(pipeline5);
+} catch {}
+let texture112 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder95.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, undefined, 0, 333_660_733);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device2, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 24},
+  aspect: 'all',
+}, new ArrayBuffer(7_095), /* required buffer size: 7_095 */
+{offset: 103, bytesPerRow: 184, rowsPerImage: 19}, {width: 23, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder372 = device2.createCommandEncoder();
+let commandBuffer245 = commandEncoder372.finish({label: '\u0ea8\u1654\ua604\u{1fae1}\u02b4\udde5\u474c'});
+let sampler29 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.94,
+  lodMaxClamp: 86.32,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder91.setPipeline(pipeline18);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1), /* required buffer size: 1 */
+{offset: 1, rowsPerImage: 61}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder224.label;
+} catch {}
+let renderPassEncoder55 = commandEncoder371.beginRenderPass({
+  label: '\u{1fa01}\u4fbf\u1db8\u071e\u{1fe25}\uf9fa\ua263\u{1fc02}\ucdf2\u03ff\ud290',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 34,
+  clearValue: { r: -911.5, g: 648.5, b: 766.6, a: -537.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet47,
+  maxDrawCount: 403735881,
+});
+try {
+renderPassEncoder18.executeBundles([renderBundle128, renderBundle150]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(277), /* required buffer size: 277 */
+{offset: 277, bytesPerRow: 86}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+renderPassEncoder3.setViewport(1.546445007462468, 5.758739855998049, 5.325043771715056, 0.11603212177238328, 0.985126567223277, 0.9868371639289497);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer230]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(488), /* required buffer size: 488 */
+{offset: 484}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView96 = texture97.createView({label: '\u{1f9c7}\u{1fcf2}\u9aba\u{1fbac}\u57c8'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData5,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 20, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let bindGroupLayout53 = device2.createBindGroupLayout({
+  label: '\u{1fd79}\u57f9\u{1f99e}\u073f\uab7d\u4ce3\u6b04\u0b11',
+  entries: [
+    {
+      binding: 124,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout55 = device2.createPipelineLayout({label: '\u0001\u5af9\u0a38\u4f5b\u{1f679}\uc7b7\u0e4e', bindGroupLayouts: []});
+let querySet51 = device2.createQuerySet({label: '\ub250\u8423\u5e30\u074d\u92cd\u033f\u{1f8f4}', type: 'occlusion', count: 1963});
+let texture113 = device2.createTexture({
+  label: '\u8c53\ud16c\u00af\uce13\u3ef2\u02bf\udd8e\u{1ff42}\u{1fe53}\uc87b\u4335',
+  size: [649, 1, 106],
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder53.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup11, new Uint32Array(718), 410, 0);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 612, new Int16Array(877), 127, 60);
+} catch {}
+let promise62 = device2.queue.onSubmittedWorkDone();
+let gpuCanvasContext12 = canvas9.getContext('webgpu');
+await gc();
+try {
+computePassEncoder44.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup4, new Uint32Array(782), 151, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(3.9788274473139076, 3.094150518128086, 0.023768129689777266, 1.041654070501329, 0.06390655610467644, 0.7984122380892993);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+await gc();
+try {
+computePassEncoder86.setBindGroup(2, bindGroup12, new Uint32Array(651), 48, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup17, new Uint32Array(140), 14, 0);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline15);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+renderPassEncoder54.end();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle198, renderBundle124, renderBundle198, renderBundle140]);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer63, 'uint32', 5_176, 339);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(2, buffer46);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer20, 'uint16', 10_914, 1_412);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer46);
+} catch {}
+try {
+buffer64.destroy();
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+let imageData42 = new ImageData(4, 80);
+let texture114 = device2.createTexture({
+  label: '\u{1f66a}\uecac\u5e38\u{1fbd6}\u{1f991}\u556e\u0a69\u8f2d\ua368',
+  size: [1298, 1, 44],
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(2, undefined, 87_415_922, 1_932_251_970);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder373 = device0.createCommandEncoder({label: '\u{1fabc}\u{1fc11}\uf5ec'});
+let commandBuffer246 = commandEncoder373.finish({label: '\u03d7\u374e\ubadc\u{1fd6f}\u{1febf}\u911e\u2bf3\u2ed4\u0b71\u0f8a\uf326'});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup18, new Uint32Array(7266), 444, 0);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer10, 'uint32', 2_108, 1_496);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer11, 0);
+} catch {}
+let commandEncoder374 = device1.createCommandEncoder({label: '\u{1f684}\uf3d3\u07f5\ua3fb\u05fe\u0fed\u7db9\u3943\u{1fe51}\u{1fc32}\ubc47'});
+let commandBuffer247 = commandEncoder374.finish({label: '\u0a63\u{1fe32}\u088e\u1340\ue4b8\u0df2'});
+let renderBundle239 = renderBundleEncoder21.finish();
+try {
+computePassEncoder75.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+device1.queue.submit([commandBuffer241]);
+} catch {}
+try {
+  await promise62;
+} catch {}
+let bindGroupLayout54 = device0.createBindGroupLayout({
+  label: '\u{1fb07}\u8010\u0045\u{1f8e3}\u{1fa45}\u0b54\u46da',
+  entries: [
+    {
+      binding: 951,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let pipelineLayout56 = device0.createPipelineLayout({
+  label: '\ufea9\u47a3\u{1f8ee}\u0be1\ub9a6\uc82f\u798e\u{1f75a}\ud202',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout16, bindGroupLayout22],
+});
+let renderBundle240 = renderBundleEncoder8.finish({label: '\u0956\u{1f6d4}\uae44\u{1f6c1}\u0a7c\ua78e'});
+try {
+computePassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer22, 'uint16', 1_260, 7_986);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData9,
+  origin: { x: 5, y: 24 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder69.setBindGroup(1, bindGroup4, new Uint32Array(135), 7, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+let arrayBuffer12 = buffer50.getMappedRange(480, 200);
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 1764, new Int16Array(6769), 293, 1116);
+} catch {}
+let renderBundle241 = renderBundleEncoder19.finish({label: '\udd3d\ub1db\ue7c5\uaac3\ubb4a\u0892\uc704\u092d\ud313\uc587'});
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer46);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4_294_967_295, undefined, 0, 417_538_550);
+} catch {}
+try {
+device1.queue.submit([commandBuffer242]);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup16, new Uint32Array(942), 147, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer247]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(22), /* required buffer size: 22 */
+{offset: 22}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup19 = device1.createBindGroup({
+  label: '\u{1f971}\u0c4d',
+  layout: bindGroupLayout30,
+  entries: [{binding: 41, resource: externalTexture40}],
+});
+let buffer67 = device1.createBuffer({
+  label: '\u0429\u08f6\u0b95\ub3e1\u{1f7d6}\u{1f72b}\u{1f96c}\u{1fbed}\u63e7\u5f3c',
+  size: 8186,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder375 = device1.createCommandEncoder({label: '\u6d23\ucd81'});
+try {
+computePassEncoder102.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer19, 1_620, 944);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer63, 'uint32', 428, 955);
+} catch {}
+try {
+commandEncoder375.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 1,
+  origin: {x: 1, y: 24, z: 25},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder106.popDebugGroup();
+} catch {}
+let bindGroup20 = device0.createBindGroup({label: '\u0399\u0363', layout: bindGroupLayout0, entries: []});
+let commandEncoder376 = device0.createCommandEncoder();
+let commandBuffer248 = commandEncoder376.finish();
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup2, new Uint32Array(2333), 14, 0);
+} catch {}
+try {
+renderPassEncoder30.setViewport(5.438370857046995, 1.4760885208720071, 0.09088905176221644, 1.8264239439653314, 0.9265138545790904, 0.9778217637631161);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(1, buffer14, 0, 4_702);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1), /* required buffer size: 1 */
+{offset: 1}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup11, new Uint32Array(274), 9, 0);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 486, 1_331);
+} catch {}
+let texture115 = device1.createTexture({
+  label: '\u0a5f\u2323\u0ed6\u0d30\uda17\u7a63\u9f1a\u5415\u0560\ue743\u{1febe}',
+  size: [6],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder111 = commandEncoder375.beginComputePass({label: '\u37fd\u0534\u052b\u0a9d\u08c4\u0234\u{1fced}'});
+let renderBundle242 = renderBundleEncoder18.finish({label: '\u305d\u{1fe83}'});
+try {
+computePassEncoder111.setBindGroup(3, bindGroup8, new Uint32Array(2795), 736, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5, buffer19, 0);
+} catch {}
+try {
+window.someLabel = externalTexture25.label;
+} catch {}
+let commandEncoder377 = device0.createCommandEncoder();
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup3, new Uint32Array(2131), 96, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer0, 'uint32', 64, 6_928);
+} catch {}
+try {
+device0.queue.submit([commandBuffer243]);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let commandEncoder378 = device1.createCommandEncoder({});
+let querySet52 = device1.createQuerySet({label: '\ueefd\ub58b\u0af2\u0d27\u{1f7e9}', type: 'occlusion', count: 118});
+let renderPassEncoder56 = commandEncoder378.beginRenderPass({
+  colorAttachments: [{view: textureView77, depthSlice: 10, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 952661620,
+});
+let sampler30 = device1.createSampler({
+  label: '\u{1f6c7}\u{1fc29}\u05af\u7513\ua6df\u6115\u{1fc03}\u023d',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.26,
+});
+try {
+renderPassEncoder50.setVertexBuffer(6, buffer46, 724, 1_595);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 680, new Int16Array(12451), 529, 92);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder377.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1312 */
+  offset: 1312,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let pipelineLayout57 = device1.createPipelineLayout({
+  label: '\u7363\u0197\u34e3\u3124\uf4ca\u998f\u9073\u{1f7fb}\u848a\u6566',
+  bindGroupLayouts: [bindGroupLayout28, bindGroupLayout51, bindGroupLayout28],
+});
+try {
+computePassEncoder63.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup10, new Uint32Array(69), 30, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer46, 0, 581);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let commandEncoder379 = device2.createCommandEncoder({label: '\u{1ffcc}\u4574\u099b\ufe5e\uf02d\u09e4\u0a47\ubae5'});
+let renderPassEncoder57 = commandEncoder379.beginRenderPass({
+  label: '\uf73f\uf77f\u0759\u7a4e\u0dea',
+  colorAttachments: [{
+  view: textureView75,
+  clearValue: { r: 452.2, g: 370.9, b: -661.8, a: -428.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder27.setScissorRect(125, 0, 33, 0);
+} catch {}
+try {
+renderPassEncoder48.setViewport(114.54612928387559, 0.11843284735879123, 307.3062203110875, 0.8581234850242522, 0.9840701667116489, 0.9841678710073031);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 728, 577);
+} catch {}
+try {
+device2.queue.submit([commandBuffer238, commandBuffer214]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 1048, new DataView(new ArrayBuffer(14793)), 5514, 572);
+} catch {}
+let pipeline19 = device2.createComputePipeline({layout: pipelineLayout35, compute: {module: shaderModule7, constants: {}}});
+let renderBundle243 = renderBundleEncoder11.finish({label: '\u4940\ud01e\u5bca\ue9a5\ue520\u6a89\u0b55'});
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer16, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(3, buffer65, 0, 2_403);
+} catch {}
+try {
+commandEncoder377.clearBuffer(buffer0, 5360);
+} catch {}
+try {
+commandEncoder377.resolveQuerySet(querySet49, 11, 34, buffer3, 3840);
+} catch {}
+try {
+device0.queue.submit([commandBuffer246]);
+} catch {}
+try {
+externalTexture32.label = '\u0e1d\u1caf\u7697\ub910\u{1f70e}\u5269\u{1ff96}\u{1f8c0}';
+} catch {}
+let renderBundle244 = renderBundleEncoder26.finish();
+let externalTexture47 = device2.importExternalTexture({label: '\ueabc\u18ed', source: video6, colorSpace: 'srgb'});
+try {
+computePassEncoder80.end();
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint16', 292, 788);
+} catch {}
+try {
+commandEncoder246.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 524 */
+  offset: 524,
+  bytesPerRow: 256,
+  buffer: buffer49,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 1, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 8, y: 1 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({});
+try {
+adapter4.label = '\ubc23\u41d7\u{1f88d}\u6a65\uaab9\u1708\u796d\u581a\u9dcd\u3d94\u2a7e';
+} catch {}
+let commandBuffer249 = commandEncoder246.finish({label: '\u4ae3\ud197\u6009\u{1f819}\uee28'});
+let renderBundle245 = renderBundleEncoder23.finish({label: '\u590f\ub1d7\u24d1\u0739\u03e5\u663d\u7f88\u232e\u0d92\u{1fce0}'});
+try {
+computePassEncoder86.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer23, 'uint32', 348, 45);
+} catch {}
+let renderBundle246 = renderBundleEncoder29.finish({label: '\u0d03\u42bc\u044e\u{1ff80}\u05ac\u0f09\uda69\u{1f853}\u09fc\u0ac8'});
+try {
+computePassEncoder108.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder94.insertDebugMarker('\u0053');
+} catch {}
+await gc();
+let commandEncoder380 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup15, []);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer13, 'uint32', 17_944, 9_625);
+} catch {}
+try {
+querySet5.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData18,
+  origin: { x: 6, y: 4 },
+  flipY: false,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let canvas10 = document.createElement('canvas');
+let commandEncoder381 = device2.createCommandEncoder({label: '\ua5fc\u91a2\u61ed\uee53\u3f5a\u2a05\u{1fe76}\u{1f7ce}\u8da4\u0417'});
+let computePassEncoder112 = commandEncoder381.beginComputePass({});
+try {
+renderPassEncoder57.executeBundles([renderBundle148, renderBundle162, renderBundle173, renderBundle186]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u4a56');
+} catch {}
+let gpuCanvasContext13 = canvas10.getContext('webgpu');
+try {
+adapter4.label = '\uc051\ud603\u{1f7ad}\ue942\u053c\u03d6\u8d3e\u0107';
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint16', 632, 671);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device2, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(2, buffer62, 0, 1_591);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer48, 'uint32', 124, 929);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer62, 0, 622);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandEncoder382 = device1.createCommandEncoder({label: '\u{1ffc8}\u6625\u0ffc\u0c1d\uf77b\u9a62\u6ae6\u0dd3\u0e9b\u7cbb\u0e54'});
+let textureView97 = texture71.createView({label: '\uab21\u5a19', baseMipLevel: 0, mipLevelCount: 1});
+let sampler31 = device1.createSampler({
+  label: '\u0008\u05ce',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 92.47,
+  lodMaxClamp: 92.49,
+});
+try {
+computePassEncoder110.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder50.setBlendConstant({ r: 935.5, g: 923.0, b: -421.9, a: -286.8, });
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup10, new Uint32Array(194), 37, 0);
+} catch {}
+let bindGroupLayout55 = device2.createBindGroupLayout({
+  label: '\u6f29\u9805\u0dc0',
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup12, new Uint32Array(2612), 431, 0);
+} catch {}
+let commandEncoder383 = device2.createCommandEncoder({});
+let computePassEncoder113 = commandEncoder383.beginComputePass({label: '\u{1f7e5}\u{1f75a}\uc67b\u0af0\u0452\u{1fdfa}'});
+try {
+renderPassEncoder53.end();
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(4_294_967_295, undefined, 0, 904_220_155);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 1180, new Int16Array(6671), 46, 176);
+} catch {}
+let commandBuffer250 = commandEncoder382.finish({label: '\u099c\ud293\ud724\u0745\ufde7\udf97\u0c27\u0c04\u{1fbbb}\u{1f8f4}'});
+try {
+computePassEncoder98.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(1, buffer46, 524, 2_272);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer63, 'uint16', 1_580, 4_313);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+let pipeline20 = device1.createComputePipeline({
+  label: '\ucf00\u{1fe32}\u00f0\u6898\u031a\u{1fce2}',
+  layout: pipelineLayout37,
+  compute: {module: shaderModule14, constants: {}},
+});
+let renderBundle247 = renderBundleEncoder32.finish({label: '\udf00\u0b42\u0098\u1261\ucb0b\u{1fd7e}\u{1fc17}\u{1fbea}\u{1faf6}'});
+let externalTexture48 = device1.importExternalTexture({label: '\u02b6\u{1f6a6}\u0883\u3afa\uaa78', source: videoFrame6});
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder43.setStencilReference(247);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer63, 'uint32', 672, 1_172);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer46, 0, 416);
+} catch {}
+try {
+device2.queue.label = '\u0a4f\u920c\ua534\u{1fe2b}\u2506';
+} catch {}
+try {
+computePassEncoder82.end();
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle148, renderBundle156, renderBundle196, renderBundle148]);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer23, 'uint16', 542, 352);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(5, undefined, 0, 720_939_689);
+} catch {}
+let commandBuffer251 = commandEncoder380.finish({label: '\u{1ff25}\u2288'});
+let textureView98 = texture87.createView({label: '\u8589\u{1fea6}\u0e13\ue85f\u0172\u009f', baseMipLevel: 1});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer3, 'uint16', 12_950, 496);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer8, 'uint32', 400, 1_577);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: imageData33,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 2, y: 9, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder114 = commandEncoder377.beginComputePass({});
+try {
+renderBundleEncoder36.setIndexBuffer(buffer0, 'uint32', 2_396, 4_253);
+} catch {}
+let commandEncoder384 = device2.createCommandEncoder();
+let renderPassEncoder58 = commandEncoder384.beginRenderPass({
+  label: '\ue60b\ud94f\u40cc\u0b4d\ua43c\ufd6a\u318e\u1d34\u081e',
+  colorAttachments: [{view: textureView92, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet32,
+});
+try {
+renderPassEncoder27.beginOcclusionQuery(57);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(4, undefined);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+commandEncoder263.copyBufferToBuffer(buffer49, 124, buffer23, 1272, 2036);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 2596, new Float32Array(34492), 20308, 132);
+} catch {}
+video9.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let imageData43 = new ImageData(72, 48);
+let pipelineLayout58 = device0.createPipelineLayout({label: '\uefe0\u{1f8dc}\u0106', bindGroupLayouts: [bindGroupLayout25]});
+let querySet53 = device0.createQuerySet({label: '\u{1f99f}\u{1fd01}\u{1fac5}\ub1f8\u{1fb2b}\ud6be', type: 'occlusion', count: 112});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer18);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder385 = device1.createCommandEncoder({label: '\u058e\u11dc\u04dc\u98ca\u9180\u87c7\u00ec'});
+let texture116 = device1.createTexture({
+  label: '\u5fbd\u005b',
+  size: [24, 60, 75],
+  sampleCount: 1,
+  format: 'eac-rg11unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder115 = commandEncoder385.beginComputePass({label: '\ud636\u0360\ud235\u03da\uf9a6\u550d'});
+try {
+computePassEncoder115.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer30, 'uint32', 624, 865);
+} catch {}
+let commandBuffer252 = commandEncoder55.finish({label: '\ub23f\u63d9\u00f7\u{1fe93}\u0d1f'});
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(34);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(0, 1, 1, 2);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer18, 0, 559);
+} catch {}
+let commandEncoder386 = device1.createCommandEncoder({label: '\u4ef3\uebd0\u0509\u0caa\u{1ff03}\u{1f6f5}\u8bff\u0fe1\u0a56'});
+let textureView99 = texture88.createView({});
+let renderBundle248 = renderBundleEncoder32.finish({label: '\u{1fe78}\u2d9a\u342e\u0df8\ud206\u699d\u{1f92d}\u{1f8c0}\u4104'});
+try {
+computePassEncoder77.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder386.resolveQuerySet(querySet25, 31, 24, buffer30, 2816);
+} catch {}
+let commandEncoder387 = device1.createCommandEncoder({label: '\u{1f91b}\u03ea\u3cd4'});
+let textureView100 = texture57.createView({label: '\u0a98\ub53f\u0955\ud6f9\u09fe\u1acf\uba96\u{1f71b}', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer46);
+} catch {}
+try {
+commandEncoder386.copyTextureToTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder75.insertDebugMarker('\ud342');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let promise63 = device1.queue.onSubmittedWorkDone();
+let renderBundle249 = renderBundleEncoder2.finish({label: '\u65db\u78ea'});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup18, new Uint32Array(116), 19, 0);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup20, new Uint32Array(2276), 493, 0);
+} catch {}
+try {
+texture48.destroy();
+} catch {}
+let commandBuffer253 = commandEncoder387.finish({label: '\u{1f846}\u{1f8f8}\u799a\u{1f964}'});
+try {
+renderPassEncoder47.setIndexBuffer(buffer48, 'uint16', 304, 106);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer46);
+} catch {}
+let promise64 = device1.queue.onSubmittedWorkDone();
+let textureView101 = texture63.createView({
+  label: '\u0caa\u0c5f\u{1fd52}',
+  format: 'rgba8unorm',
+  baseMipLevel: 0,
+  baseArrayLayer: 1,
+  arrayLayerCount: 7,
+});
+let renderPassEncoder59 = commandEncoder386.beginRenderPass({colorAttachments: [{view: textureView51, depthSlice: 35, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder83.setBindGroup(1, bindGroup10, new Uint32Array(13), 3, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup10, new Uint32Array(3064), 101, 0);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let renderBundle250 = renderBundleEncoder3.finish({label: '\u067a\u8d4a\u07c7\u{1fbeb}\ud4be\u{1f6a1}\uc2a1\u05c4'});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup4, new Uint32Array(2610), 169, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer18, 'uint32', 4_632, 140);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer8, 1_900, 317);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer3, 'uint16', 13_628, 956);
+} catch {}
+try {
+device0.queue.submit([commandBuffer248]);
+} catch {}
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let commandEncoder388 = device1.createCommandEncoder({label: '\u04b6\u0890\u0ed9\u7862\u36b2\u02de\u090f\udb7b\ua63d'});
+let computePassEncoder116 = commandEncoder388.beginComputePass();
+let sampler32 = device1.createSampler({
+  label: '\u0ff5\ubc1b\u{1f8aa}\uf443\ued91\ue28c\u158b\u575f\u00e0\u9562\ud3a4',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.069,
+  lodMaxClamp: 14.31,
+});
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+let commandBuffer254 = commandEncoder263.finish({});
+let renderBundle251 = renderBundleEncoder20.finish({label: '\u{1ffe4}\u0a2c\u{1fd73}\u05ed'});
+try {
+computePassEncoder112.setBindGroup(2, bindGroup12, new Uint32Array(1438), 4, 0);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+let device3 = await adapter4.requestDevice({
+  label: '\u84e2\u{1fa3c}',
+  defaultQueue: {label: '\ub777\ua95d\uadd6\uebbc\u51d8'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 11901163, maxStorageBufferBindingSize: 162788157},
+});
+let commandEncoder389 = device2.createCommandEncoder({label: '\u0828\uefd5\ue4a5\u{1f710}\u4abe'});
+try {
+renderPassEncoder58.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer23, 'uint32', 56, 1_026);
+} catch {}
+let renderBundle252 = renderBundleEncoder7.finish({label: '\uf54d\u09f3\uf53f\u{1fce8}\u0c34\ub504\u4452\u{1f7ff}\u914b\ud807'});
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint16', 298, 9);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer51, 0, 9_166);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup3, new Uint32Array(203), 10, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer8);
+} catch {}
+let querySet54 = device0.createQuerySet({label: '\u0e7a\u0e8a\u02c5', type: 'occlusion', count: 198});
+let renderBundle253 = renderBundleEncoder5.finish({label: '\u5bc0\u0afd\u02ab\u2848'});
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(2.290442648557492, 6.82360564564316, 3.28115954198124, 0.16856972785462115, 0.35830922617957084, 0.7953746793720633);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(3, bindGroup11, new Uint32Array(377), 37, 0);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+commandEncoder389.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 256, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 9},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let img12 = await imageWithData(1, 115, '#10101010', '#20202020');
+let renderBundle254 = renderBundleEncoder11.finish({label: '\u{1f6a3}\u022d'});
+try {
+computePassEncoder66.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer17, 'uint32', 2_036, 3_012);
+} catch {}
+document.body.prepend(canvas9);
+let commandEncoder390 = device3.createCommandEncoder({label: '\u{1fb23}\u{1f61b}\u39e7\u059b\u448f'});
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let shaderModule15 = device1.createShaderModule({
+  label: '\u02c7\uc09f\u71b8\u{1f6ea}\u2806\u4d94\ub902\ua573\ua49a',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: u32,
+  f1: array<mat2x3h>,
+}
+
+@group(0) @binding(470) var st15: texture_storage_1d<rgba8sint, write>;
+@group(0) @binding(339) var tex55: texture_cube_array<i32>;
+@group(1) @binding(470) var st16: texture_storage_2d_array<rgba8snorm, write>;
+@group(1) @binding(339) var tex56: texture_depth_cube;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0() {
+  textureStore(st16, vec2i(), 0, vec4f(0.05394, 0.03764, 0.2305, 0.2812));
+}
+
+struct VertexOutput0 {
+  @location(2) f41: vec4u,
+  @location(12) @interpolate(flat, centroid) f42: vec4f,
+  @location(3) f43: vec3h,
+  @builtin(position) f44: vec4f
+}
+
+@vertex
+fn vertex0(@location(0) @interpolate(flat, sample) a0: f16, @location(10) @interpolate(flat, center) a1: vec3u, @location(1) a2: vec3i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = a2;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat) f0: vec3u,
+  @location(5) f1: vec4u,
+  @location(4) f2: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture117 = device1.createTexture({
+  label: '\u0e77\ub416\ua68a',
+  size: {width: 6},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder42.beginOcclusionQuery(35);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle181, renderBundle129, renderBundle159]);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup10, new Uint32Array(2014), 470, 0);
+} catch {}
+try {
+renderPassEncoder42.pushDebugGroup('\u76be');
+} catch {}
+let commandEncoder391 = device0.createCommandEncoder({label: '\u0013\u0886\u16ec'});
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, buffer16, 12);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder391.copyBufferToBuffer(buffer21, 28, buffer66, 1284, 460);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.submit([commandBuffer235, commandBuffer252]);
+} catch {}
+let commandBuffer255 = commandEncoder389.finish({label: '\u{1f898}\u{1fa5f}\u0aab\ud34b\u0540\u02d9\u11fd'});
+try {
+computePassEncoder89.setBindGroup(2, bindGroup12, new Uint32Array(4048), 433, 0);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder58.beginOcclusionQuery(147);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+  await promise64;
+} catch {}
+let promise65 = device3.queue.onSubmittedWorkDone();
+let video11 = await videoWithData();
+try {
+renderPassEncoder1.setIndexBuffer(buffer8, 'uint32', 672, 90);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: img3,
+  origin: { x: 7, y: 6 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise63;
+} catch {}
+offscreenCanvas4.width = 188;
+let imageBitmap12 = await createImageBitmap(imageData18);
+let imageData44 = new ImageData(100, 104);
+let commandEncoder392 = device3.createCommandEncoder({label: '\u0719\ud202\u684e\u{1fe07}\u{1fc5e}\u{1fda1}\u091a\u2ee1\u8440\u9045\u0b56'});
+let commandBuffer256 = commandEncoder392.finish({label: '\u2518\u4312\u0000\ucc4d\u{1f791}\u{1fa78}\u{1fef3}\u27dc\u{1faf6}\u09bf'});
+let renderBundleEncoder37 = device3.createRenderBundleEncoder({
+  label: '\u0d6d\u0ab7\u{1f8bc}\u7582\u{1f965}\u{1fdc8}\u9ada\uec6e\uf091',
+  colorFormats: ['rg32uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder37.setVertexBuffer(1, undefined);
+} catch {}
+let renderBundle255 = renderBundleEncoder22.finish({label: '\u30f1\u0e0b\u{1f82a}\u4c06\u0d63\ue61f\ua825\u4e64\u3be7'});
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 428, new Int16Array(17006), 2118, 468);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 162, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: imageData44,
+  origin: { x: 7, y: 15 },
+  flipY: false,
+}, {
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData45 = new ImageData(60, 4);
+try {
+computePassEncoder35.setBindGroup(0, bindGroup15, new Uint32Array(4843), 2114, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+  await promise65;
+} catch {}
+let commandEncoder393 = device0.createCommandEncoder({label: '\u{1fe04}\u{1fd13}\u0f13\u{1fc95}\u{1fee2}\u1daa\u9558\u{1fe6b}\u{1fb7d}'});
+let commandBuffer257 = commandEncoder393.finish({});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer7, 0, 303);
+} catch {}
+try {
+commandEncoder391.copyBufferToBuffer(buffer5, 2696, buffer21, 1840, 96);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 56 */
+{offset: 56}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle227, renderBundle137]);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup12, new Uint32Array(3829), 125, 0);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(4_294_967_295, undefined, 0, 319_469_797);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer51);
+} catch {}
+try {
+commandEncoder391.resolveQuerySet(querySet16, 0, 0, buffer1, 768);
+} catch {}
+try {
+device0.queue.submit([commandBuffer257]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let textureView102 = texture90.createView({label: '\u0b55\ub90d\u0c6f\u3dd6\u9ef5\u0607\u4f44\u044b'});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint32', 80, 21);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+await gc();
+let commandBuffer258 = commandEncoder391.finish({});
+let renderBundle256 = renderBundleEncoder17.finish();
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setViewport(4.583781838665461, 4.099477830615391, 2.321085661408105, 0.6854710024105274, 0.15049918985604227, 0.6696238018829839);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup2, new Uint32Array(1448), 524, 0);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\ue49a');
+} catch {}
+try {
+computePassEncoder91.setBindGroup(0, bindGroup11, new Uint32Array(1595), 613, 0);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder58.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer23, 'uint16', 110, 263);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer23, 'uint32', 520, 380);
+} catch {}
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({colorFormats: ['rg8uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle257 = renderBundleEncoder18.finish({label: '\ud477\u07e5\u0556\u8beb\u0412\u0391\u{1fa20}\u5e8d\u0e4b\u012a'});
+try {
+computePassEncoder110.end();
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(10, 1, 0, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer62, 0, 282);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.prepend(video0);
+let texture118 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder117 = commandEncoder390.beginComputePass({label: '\u8236\u0a7f\u{1fa54}\u{1ffd4}\ue658\u{1f8aa}\u{1f6a9}\u{1ff19}'});
+try {
+renderBundleEncoder37.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+let commandEncoder394 = device1.createCommandEncoder({});
+try {
+computePassEncoder107.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer48, 'uint16', 1_014, 731);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup19, new Uint32Array(2250), 391, 0);
+} catch {}
+try {
+commandEncoder394.copyTextureToBuffer({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1840 */
+  offset: 1840,
+  buffer: buffer19,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder394.clearBuffer(buffer20, 16780, 2236);
+} catch {}
+try {
+commandEncoder368.resolveQuerySet(querySet33, 141, 91, buffer30, 512);
+} catch {}
+try {
+externalTexture14.label = '\u0b27\u649e\u{1ffca}\u{1fee0}\uf150\u9c66\uf168\u02b5';
+} catch {}
+let commandEncoder395 = device0.createCommandEncoder({label: '\ue1f5\ufc90\ud0e4\u0412'});
+let commandBuffer259 = commandEncoder395.finish({label: '\u03dc\u0cce\u2c15\u0c39\u430c\ua91e\u01a3'});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup0, new Uint32Array(480), 10, 0);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+await gc();
+try {
+renderPassEncoder3.setBlendConstant({ r: 578.7, g: -325.7, b: -81.55, a: -805.7, });
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer7, 'uint32', 396, 188);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(1, buffer7, 1_120);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: img3,
+  origin: { x: 10, y: 7 },
+  flipY: false,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle258 = renderBundleEncoder7.finish({label: '\ue599\u5cc7\u{1fd87}\ub5c1\u63b7\u081d\u0346'});
+try {
+computePassEncoder66.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup2, new Uint32Array(406), 266, 0);
+} catch {}
+let arrayBuffer13 = buffer50.getMappedRange(0, 56);
+try {
+computePassEncoder112.setBindGroup(2, bindGroup12, new Uint32Array(1948), 86, 0);
+} catch {}
+try {
+computePassEncoder113.end();
+} catch {}
+try {
+renderPassEncoder58.setViewport(37.88090998477396, 0.38840970362948124, 20.421148012956266, 0.403918624940831, 0.17146804011622052, 0.34627826025462094);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer23, 1276, new Float32Array(5273), 305, 36);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.prepend(canvas6);
+let querySet55 = device0.createQuerySet({label: '\u0d5e\u{1f98f}\u6d21\u79f2\u{1fb01}\u60f1', type: 'occlusion', count: 109});
+let renderBundle259 = renderBundleEncoder11.finish({label: '\u8fe6\ue4a2\u{1ff86}'});
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer7);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(3, buffer8, 0);
+} catch {}
+try {
+commandEncoder106.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 19},
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder60 = commandEncoder383.beginRenderPass({
+  label: '\u0625\ufcde\u{1fbbd}\ua317\u870b\u0a80\u8f0c\ua43a',
+  colorAttachments: [{
+  view: textureView91,
+  depthSlice: 400,
+  clearValue: { r: -265.3, g: 47.28, b: 389.4, a: -165.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet43,
+});
+let externalTexture49 = device2.importExternalTexture({label: '\u2e70\u{1fe2c}\u{1fb2e}\u08f7\uf26f\u4df6\u{1faa1}', source: videoFrame0});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer23, 'uint32', 492, 1_011);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+let texture119 = device0.createTexture({
+  size: {width: 15, height: 15, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let texture120 = gpuCanvasContext8.getCurrentTexture();
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup2, new Uint32Array(1625), 68, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer22, 'uint32', 348, 4_549);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer29);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+video5.height = 3;
+let imageData46 = new ImageData(36, 24);
+try {
+  await buffer67.mapAsync(GPUMapMode.WRITE, 0, 264);
+} catch {}
+try {
+computePassEncoder62.pushDebugGroup('\u0699');
+} catch {}
+document.body.prepend(img7);
+let canvas11 = document.createElement('canvas');
+let renderBundle260 = renderBundleEncoder37.finish({label: '\u007c\u291b\u45e4\u{1fe11}\uaff6\u{1fb91}'});
+let canvas12 = document.createElement('canvas');
+try {
+canvas11.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder396 = device0.createCommandEncoder({label: '\u5660\ud816\u0a81\uc33a\ua75c\u1850\ue2c3\u1e0c\u01a6'});
+let commandBuffer260 = commandEncoder396.finish({label: '\u2d91\u0b22\u{1f7e8}\u042c\ub02e\u{1fd22}'});
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer14, 0);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer21, 'uint32', 536, 106);
+} catch {}
+let querySet56 = device2.createQuerySet({label: '\u{1f9a3}\u{1fdfe}\u{1fa11}\u05f6\u{1fecb}\u029e', type: 'occlusion', count: 724});
+try {
+renderPassEncoder58.setScissorRect(33, 0, 27, 0);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline15);
+} catch {}
+let gpuCanvasContext14 = canvas12.getContext('webgpu');
+let commandBuffer261 = commandEncoder106.finish({});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\uc28e\u2039\u0f6d\u01b3\u0317\u070b',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle261 = renderBundleEncoder16.finish({label: '\u{1ff0c}\u840b'});
+let externalTexture50 = device0.importExternalTexture({label: '\u07b1\u473b\u{1fb05}\ud6f1\uc308\u0115\u0511', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup1);
+} catch {}
+let textureView103 = texture53.createView({label: '\u0ea1\u8883\u0275\ubc6a\u708e\u02cd\u031c\u{1fc3e}\u{1f827}\u9f9c', arrayLayerCount: 1});
+try {
+computePassEncoder64.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer13, 'uint32', 11_988, 4_720);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(0, bindGroup15, new Uint32Array(755), 65, 0);
+} catch {}
+try {
+renderPassEncoder30.insertDebugMarker('\u00ed');
+} catch {}
+let commandEncoder397 = device2.createCommandEncoder({label: '\u633d\uf7c6\u94f9\u0cc4\ua646\u6f3f\u4514'});
+let commandBuffer262 = commandEncoder397.finish({label: '\ud45e\u1a23\u{1f7ab}\u{1ffd9}\u{1fdd8}\ucc16\u917a\u{1f6e0}\u{1fe34}'});
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup12, new Uint32Array(351), 32, 0);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer262, commandBuffer245]);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let imageData47 = new ImageData(16, 24);
+let commandEncoder398 = device3.createCommandEncoder({});
+let renderBundle262 = renderBundleEncoder37.finish({label: '\u2cb7\uc0c4\u3790\u0ca0\u6645'});
+document.body.prepend(img3);
+let commandEncoder399 = device3.createCommandEncoder({label: '\u1bcc\u7f4c\u{1fc91}\ue118\ubf1f\u{1fbe6}\u75db\u01b9\u{1feda}\u9254'});
+let commandBuffer263 = commandEncoder398.finish({label: '\u{1fc29}\u0d6c'});
+try {
+gpuCanvasContext5.configure({device: device3, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+await gc();
+let promise66 = adapter6.requestAdapterInfo();
+let commandEncoder400 = device0.createCommandEncoder({label: '\u{1fb93}\u068b\u{1f858}'});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer15, 'uint32', 96, 2_111);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer4, 0, 716);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(43), /* required buffer size: 43 */
+{offset: 43, bytesPerRow: 20}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise67 = device0.queue.onSubmittedWorkDone();
+await gc();
+let renderPassEncoder61 = commandEncoder394.beginRenderPass({
+  label: '\u6f04\u0ee2\u{1fa79}\u0c08\u{1f9e1}\u2a35\ua181',
+  colorAttachments: [{
+  view: textureView76,
+  clearValue: { r: -136.8, g: 822.6, b: -916.6, a: -678.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 33532002,
+});
+let renderBundleEncoder40 = device1.createRenderBundleEncoder({colorFormats: ['rgba8unorm'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let externalTexture51 = device1.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder77.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer46);
+} catch {}
+try {
+device1.queue.submit([commandBuffer250]);
+} catch {}
+let commandEncoder401 = device1.createCommandEncoder();
+let texture121 = gpuCanvasContext10.getCurrentTexture();
+try {
+computePassEncoder111.setBindGroup(2, bindGroup16, new Uint32Array(632), 94, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer30, 'uint32', 144, 274);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer46, 0, 3_384);
+} catch {}
+try {
+renderPassEncoder42.popDebugGroup();
+} catch {}
+try {
+  await promise67;
+} catch {}
+let commandEncoder402 = device2.createCommandEncoder({label: '\u0456\u06cc\u6b3c\u0996\u716b'});
+let renderPassEncoder62 = commandEncoder402.beginRenderPass({
+  label: '\u{1fb41}\u{1fa73}',
+  colorAttachments: [{
+  view: textureView89,
+  depthSlice: 13,
+  clearValue: { r: -67.55, g: -932.2, b: -640.9, a: 76.35, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle263 = renderBundleEncoder29.finish({label: '\u0c9d\u7102\uec73\u0a19\u1e95\u3b55\u0e0d\u0b35\u0334'});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup17, new Uint32Array(2533), 180, 0);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle180, renderBundle232, renderBundle196]);
+} catch {}
+try {
+renderPassEncoder58.setScissorRect(25, 0, 73, 0);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer23, 'uint16', 164, 131);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder403 = device0.createCommandEncoder({label: '\u057e\u0215\ubf3e\u4c34\u{1fd06}\u4e2f'});
+let renderBundle264 = renderBundleEncoder8.finish({label: '\u05e2\u{1f980}\u{1ff66}\u0842\u8c08\u0d61\ue786\u65d5'});
+let externalTexture52 = device0.importExternalTexture({
+  label: '\u7d82\u0c85\ub103\u8127\u8615\u0133\ude90\u213a\u54b1\u0de8',
+  source: video11,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup5, new Uint32Array(155), 10, 0);
+} catch {}
+try {
+commandEncoder400.copyBufferToBuffer(buffer50, 212, buffer16, 72, 1476);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1856, new BigUint64Array(2421), 416, 44);
+} catch {}
+document.body.prepend(canvas12);
+try {
+computePassEncoder83.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer48, 'uint16', 996, 22);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(6, buffer46);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(4, buffer19, 1_736, 751);
+} catch {}
+try {
+commandEncoder368.copyTextureToBuffer({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6420 */
+  offset: 6420,
+  buffer: buffer19,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise68 = device1.queue.onSubmittedWorkDone();
+let commandBuffer264 = commandEncoder403.finish({label: '\udbf2\u0922'});
+let renderPassEncoder63 = commandEncoder400.beginRenderPass({
+  label: '\u811d\u7058\u1523\ub01b\u7dd9\uc447\u{1fce2}',
+  colorAttachments: [{
+  view: textureView27,
+  depthSlice: 15,
+  clearValue: { r: -576.2, g: 332.0, b: 568.1, a: 497.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView0, depthReadOnly: true},
+  occlusionQuerySet: querySet54,
+});
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup18, new Uint32Array(2462), 292, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData16,
+  origin: { x: 25, y: 7 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 10, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise66;
+} catch {}
+let bindGroupLayout56 = device0.createBindGroupLayout({
+  label: '\u{1f64b}\u49e1',
+  entries: [
+    {
+      binding: 89,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 25, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 132,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {binding: 77, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 123, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 277,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 20, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 370, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 291, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 192, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 80,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 469,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 181,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 292,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 133, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 296,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 747,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {binding: 558, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 78,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 394,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 405,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 66, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 458,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 610,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 74,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 574, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 174,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 340,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 201,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 16852972, hasDynamicOffset: false },
+    },
+    {
+      binding: 223,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder404 = device0.createCommandEncoder({label: '\u3d7f\u01b7\u24e1\u{1fe5d}\u3f03\u0a04\u2c04'});
+let texture122 = gpuCanvasContext8.getCurrentTexture();
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer14, 1_668);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup15, []);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer14 = buffer50.getMappedRange(688, 476);
+try {
+device0.queue.submit([commandBuffer260]);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(2, bindGroup4, new Uint32Array(1476), 553, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(5, buffer8);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer65);
+} catch {}
+let videoFrame7 = new VideoFrame(videoFrame0, {timestamp: 0});
+try {
+window.someLabel = device3.label;
+} catch {}
+let externalTexture53 = device3.importExternalTexture({
+  label: '\ubae2\u78c4\u{1f74d}\u{1fcc5}\u{1fdd8}\u{1ffc1}\uf198',
+  source: videoFrame4,
+  colorSpace: 'srgb',
+});
+let adapter8 = await promise59;
+let commandEncoder405 = device1.createCommandEncoder({label: '\u0dd0\ubfcc\u99a3'});
+let commandBuffer265 = commandEncoder368.finish();
+let renderPassEncoder64 = commandEncoder405.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  depthSlice: 2,
+  clearValue: { r: 713.6, g: -911.0, b: -416.1, a: 289.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 266087540,
+});
+try {
+renderPassEncoder21.setIndexBuffer(buffer63, 'uint32', 4_376, 3_902);
+} catch {}
+try {
+commandEncoder401.copyBufferToBuffer(buffer63, 920, buffer20, 5580, 2576);
+} catch {}
+try {
+  await promise68;
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(543, 335);
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+let commandEncoder406 = device1.createCommandEncoder({});
+let commandBuffer266 = commandEncoder406.finish({label: '\ua6e7\u00eb\u909b\u1d01\u{1f681}\u05cb'});
+let renderPassEncoder65 = commandEncoder401.beginRenderPass({
+  label: '\ude38\u{1f751}\u7fd4\u{1f9c0}\u01fd\u85ed\ub10b\uaebc\u0497',
+  colorAttachments: [{view: textureView50, depthSlice: 0, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet29,
+});
+let renderBundle265 = renderBundleEncoder33.finish({label: '\u{1f8f1}\u1e04\ud061\ue2ca\u0d84\u{1fe20}\u2b88\u0739\u4c04\u{1f71b}'});
+try {
+computePassEncoder109.setBindGroup(0, bindGroup10, new Uint32Array(5521), 1150, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 8, y: 32, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let imageData48 = new ImageData(8, 88);
+let commandEncoder407 = device2.createCommandEncoder({label: '\u{1ff94}\u6901\u0332\ub9e4\u{1f626}\u0945\u4004\u9c6c\u19e7\u039d'});
+let renderBundle266 = renderBundleEncoder27.finish({});
+try {
+computePassEncoder91.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint16', 92, 134);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 1, y: 6 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 28, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+canvas2.height = 247;
+let commandEncoder408 = device0.createCommandEncoder({label: '\ua993\u{1fe6d}\u2dd6\u{1f92d}\u{1f912}\u0974\u0e5a'});
+let commandBuffer267 = commandEncoder404.finish({label: '\u{1f60c}\u01c5\ub3b9'});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u{1f935}\u{1fa91}\u0795\u{1fc0d}',
+  colorFormats: ['r32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer5, 0, 4_647);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup4, new Uint32Array(939), 72, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(1, buffer11, 0, 54);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder408.copyBufferToBuffer(buffer50, 4828, buffer13, 796, 1868);
+} catch {}
+try {
+commandEncoder408.copyBufferToTexture({
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1125 */
+  offset: 1125,
+  bytesPerRow: 256,
+  buffer: buffer8,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 24 */
+{offset: 24}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder409 = device0.createCommandEncoder({label: '\uf354\u{1f638}\ue477\u0a8f\ub90c\u02b7\u{1f693}\u{1ffba}\u1b21\u03c3\u7498'});
+let renderBundle267 = renderBundleEncoder14.finish({label: '\u4e74\u{1fe16}\u{1f757}\u76de\u082f\u{1f614}\u9dec'});
+try {
+computePassEncoder64.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData39,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let img13 = await imageWithData(133, 4, '#10101010', '#20202020');
+let commandEncoder410 = device0.createCommandEncoder({label: '\u0b34\u0211'});
+let texture123 = device0.createTexture({
+  label: '\u007d\u6aa3\u5bb3\ub62b\u{1faa8}\u2a97\u157b\ud09a\u63c5',
+  size: {width: 60, height: 60, depthOrArrayLayers: 380},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup15, new Uint32Array(4029), 680, 0);
+} catch {}
+try {
+renderPassEncoder39.setStencilReference(168);
+} catch {}
+let arrayBuffer15 = buffer50.getMappedRange(680, 0);
+try {
+device0.queue.writeBuffer(buffer66, 1304, new Int16Array(88));
+} catch {}
+let bindGroupLayout57 = device1.createBindGroupLayout({
+  label: '\u03e5\u03f7\u0486\ubdc3\u54ff\u23d6\ud714\u5182\u04fd\u0892',
+  entries: [{binding: 180, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }}],
+});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer30, 'uint32', 2_572, 200);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer46, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let renderBundle268 = renderBundleEncoder17.finish({label: '\ud26d\u5646\u0af0\u5e90\u010f\u0da7\u2648\u4099\u1fde'});
+let sampler33 = device0.createSampler({
+  label: '\u8bb7\ua3b4\u09e4\u0377\uc398\u0be8\u6ed9\uf3a0\ud9f2',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.28,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer8, 'uint16', 1_074, 3_531);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(1, bindGroup18);
+} catch {}
+let commandEncoder411 = device1.createCommandEncoder({label: '\u07ec\u699e\u{1f651}\u3c31\ubaee\u{1fd38}'});
+let commandBuffer268 = commandEncoder180.finish({label: '\ueab0\u{1f6b0}\u{1fad1}\u0b6c\udbd7\u{1faae}\u{1f85e}\u{1fe97}\u{1f6e5}\u{1ffa3}\u596d'});
+let renderPassEncoder66 = commandEncoder411.beginRenderPass({
+  label: '\u0acf\u27d1\u037d\u01b1',
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 32,
+  clearValue: { r: -546.2, g: -537.5, b: 797.3, a: 311.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderBundleEncoder38.setBindGroup(1, bindGroup16);
+} catch {}
+let commandEncoder412 = device3.createCommandEncoder({label: '\u{1f666}\u0f83\u61fe\u08e2\u0b1f\u3172\u0751\u{1f6ee}\u03ca\u0d19'});
+let commandBuffer269 = commandEncoder399.finish({label: '\u7f1a\u2ca6\u0f8a\u081c'});
+let texture124 = device3.createTexture({
+  label: '\u02da\ueed3\u0d28',
+  size: {width: 788, height: 12, depthOrArrayLayers: 226},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler34 = device3.createSampler({
+  label: '\u7942\ue313\u2851\u{1fdde}\u39a6\u3e25\u8886\u0915\u99ba\ub549\u0527',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 83.70,
+});
+try {
+computePassEncoder117.end();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let computePassEncoder118 = commandEncoder148.beginComputePass({});
+let externalTexture54 = device0.importExternalTexture({label: '\u0dd2\u08ef\uce3a', source: videoFrame5});
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer51, 0, 595);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer22, 0, 949);
+} catch {}
+video9.height = 190;
+let textureView104 = texture124.createView({baseMipLevel: 1, arrayLayerCount: 1});
+try {
+commandEncoder412.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 1,
+  origin: {x: 67, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 44, height: 2, depthOrArrayLayers: 11});
+} catch {}
+video9.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let querySet57 = device3.createQuerySet({label: '\u{1fafb}\u1d92\u0ef4\u{1fe88}\u{1fe58}\u7264\u0a03', type: 'occlusion', count: 4});
+let texture125 = device3.createTexture({
+  size: [112],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder119 = commandEncoder412.beginComputePass();
+let commandEncoder413 = device2.createCommandEncoder({label: '\ucfde\u{1fd44}\ud735\u04ed\u6350\u8810\ubc94\ud24f\u441c'});
+let querySet58 = device2.createQuerySet({label: '\u890c\u0c30\u00d0', type: 'occlusion', count: 1064});
+let commandBuffer270 = commandEncoder413.finish();
+let renderBundle269 = renderBundleEncoder35.finish();
+try {
+computePassEncoder108.setPipeline(pipeline18);
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+offscreenCanvas0.width = 38;
+let shaderModule16 = device2.createShaderModule({
+  label: '\u{1f8b6}\u06e3\u87a3\u{1fb87}\u00db\u{1fe31}\u008c\u95cc',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: mat4x4h,
+}
+
+@group(0) @binding(214) var st17: texture_storage_3d<r32float, read_write>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(0) @interpolate(flat, sample) f45: vec2i,
+  @location(2) @interpolate(flat, sample) f46: vec4u,
+  @builtin(position) f47: vec4f
+}
+
+@vertex
+fn vertex0(@location(0) @interpolate(flat) a0: vec4i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3f,
+  @location(3) f1: vec4u,
+  @location(0) f2: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder414 = device2.createCommandEncoder({label: '\u{1fccb}\u0dfe\u02a6\u755b\u0e95\u14d3\u0469\u31ca\ua049\u0430\uc0d7'});
+let commandBuffer271 = commandEncoder407.finish({label: '\u453a\u0f51\u0727\u99fd\uf9d5\u409f\u3dda\u{1fc1d}\u8146\u0555'});
+try {
+computePassEncoder90.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(4_294_967_294, undefined, 0, 1_148_688_403);
+} catch {}
+try {
+commandEncoder414.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 256 */
+  offset: 256,
+  buffer: buffer49,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder414.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 5, y: 41, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 944 */
+  offset: 944,
+  bytesPerRow: 0,
+  buffer: buffer23,
+}, {width: 0, height: 65, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 324, height: 1, depthOrArrayLayers: 79}
+*/
+{
+  source: imageData48,
+  origin: { x: 0, y: 44 },
+  flipY: false,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder415 = device2.createCommandEncoder({label: '\uac09\u24d3\u7e55\u{1f8fa}\u7ad6'});
+let commandBuffer272 = commandEncoder415.finish({label: '\u{1f8bc}\uea4d\u2048\u009d\u5a46\u0c75\ua5b5\u5cc8\u0705\uce7b'});
+try {
+commandEncoder414.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 12, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 152 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1064 */
+  offset: 1064,
+  bytesPerRow: 256,
+  buffer: buffer23,
+}, {width: 19, height: 13, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.submit([commandBuffer272, commandBuffer249]);
+} catch {}
+let promise69 = adapter6.requestDevice({
+  label: '\u4be3\u79ea\ub62c\u56db\u42a3\u{1f979}\u099c\uc1b8\u3ef0\u02ce\u0607',
+  requiredLimits: {
+    maxStorageTexturesPerShaderStage: 4,
+    maxStorageBuffersPerShaderStage: 8,
+    maxUniformBufferBindingSize: 18266503,
+    maxStorageBufferBindingSize: 157790973,
+  },
+});
+let commandBuffer273 = commandEncoder414.finish({label: '\udeba\u9482\u3465\u5ce6\ud9dd\u0e4b\ufa9b\ub0d4\u{1ff75}\u{1f69e}\u2293'});
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup12, new Uint32Array(4754), 907, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer23, 'uint16', 240, 39);
+} catch {}
+let textureView105 = texture46.createView({dimension: '2d', aspect: 'all'});
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(80);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(1, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 132, new DataView(new ArrayBuffer(8191)), 1497, 3420);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder49.setViewport(4.87587602304683, 7.20931189505399, 0.6260083602806636, 1.609369988985773, 0.11692687610638941, 0.27325874343125983);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(7, buffer62, 708, 154);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup8, new Uint32Array(235), 64, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 120, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData38,
+  origin: { x: 48, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 19, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.destroy();
+} catch {}
+document.body.prepend(canvas11);
+try {
+window.someLabel = externalTexture21.label;
+} catch {}
+let commandEncoder416 = device0.createCommandEncoder({label: '\u{1ff2b}\ua0ea\u04b5\u0b11'});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({label: '\u9868\u6089\u{1fe94}', colorFormats: ['r8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder114.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup4, new Uint32Array(869), 457, 0);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(0, 2, 0, 1);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(0, bindGroup0);
+} catch {}
+let commandEncoder417 = device3.createCommandEncoder();
+let commandBuffer274 = commandEncoder417.finish({label: '\ua9ed\u{1fcd1}\u8ade\u4f95\u47c9\uf82e\u5c4f\u95df\u42a2\u037a\uefae'});
+let renderBundle270 = renderBundleEncoder37.finish({label: '\u0c78\u01c4\u{1fbc0}\u3897\u7054\u4d80\u0dea\uc95c\ue2ac'});
+try {
+gpuCanvasContext1.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img14 = await imageWithData(36, 44, '#10101010', '#20202020');
+let computePassEncoder120 = commandEncoder409.beginComputePass();
+let renderBundle271 = renderBundleEncoder39.finish({label: '\u4644\u3d4a\uc89a\u7e0f\u{1f700}\u8caf\u{1f82c}\ub1ae\u0a5e\u{1fc3d}\ue0ec'});
+let sampler35 = device0.createSampler({
+  label: '\u{1ff73}\ua960\u1b77\ue899\ud49d\ud68b\ua073\u3187',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 66.90,
+  lodMaxClamp: 80.90,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup13, new Uint32Array(998), 257, 0);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder63.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(823);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup2, new Uint32Array(4306), 98, 0);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(5, buffer7, 316, 501);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer251, commandBuffer264]);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let videoFrame8 = videoFrame2.clone();
+let renderBundle272 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup15, new Uint32Array(55), 31, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer18, 'uint32', 1_192, 457);
+} catch {}
+try {
+commandEncoder408.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1005 */
+  offset: 1005,
+  buffer: buffer1,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 812, new BigUint64Array(11171), 2071, 24);
+} catch {}
+let imageBitmap13 = await createImageBitmap(imageData46);
+let imageData49 = new ImageData(32, 28);
+try {
+renderBundleEncoder36.setIndexBuffer(buffer0, 'uint16', 3_026, 1_351);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'depth-only',
+}, new ArrayBuffer(57), /* required buffer size: 57 */
+{offset: 57}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData26,
+  origin: { x: 11, y: 7 },
+  flipY: true,
+}, {
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 62, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet59 = device3.createQuerySet({label: '\u{1f7b7}\u1cac\u05ed\ua862\u51ad\ue123\u{1f6ee}\u410f\ua5c6', type: 'occlusion', count: 363});
+let texture126 = device3.createTexture({
+  label: '\ucd9d\ue698\u03d7\u12d7\u8ba7\uf767\uf50b\u08cc',
+  size: {width: 3152},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder67 = commandEncoder390.beginRenderPass({
+  label: '\u2e75\u18a0\u10ca\u07c5\ua758\uf472\u{1fb1a}',
+  colorAttachments: [{
+  view: textureView104,
+  depthSlice: 17,
+  clearValue: { r: 338.4, g: -467.3, b: -461.4, a: -447.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 62055478,
+});
+await gc();
+try {
+computePassEncoder87.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setViewport(2.9237375702359554, 3.085702228029163, 0.6050840782520407, 2.5795986701318543, 0.6025489013949258, 0.8547748635850396);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(0, buffer7);
+} catch {}
+try {
+commandEncoder408.copyBufferToBuffer(buffer4, 2040, buffer22, 1620, 1784);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 5296, new DataView(new ArrayBuffer(8322)), 1043, 504);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 8, y: 25 },
+  flipY: false,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder418 = device3.createCommandEncoder();
+let renderPassEncoder68 = commandEncoder418.beginRenderPass({
+  label: '\ucb6c\u87d4',
+  colorAttachments: [{
+  view: textureView104,
+  depthSlice: 14,
+  clearValue: { r: -551.4, g: -893.9, b: 769.6, a: -702.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 615227397,
+});
+let renderBundle273 = renderBundleEncoder37.finish({label: '\u95e9\ua16b\u38d7\u03fe\u{1fa41}\u7f18'});
+try {
+renderPassEncoder67.setBlendConstant({ r: -984.4, g: 82.06, b: 111.1, a: -370.6, });
+} catch {}
+try {
+device3.queue.submit([commandBuffer269, commandBuffer263]);
+} catch {}
+let commandEncoder419 = device2.createCommandEncoder({label: '\u{1fa24}\u{1f962}\ue4db\u55fe\u2385\ufc0f\u{1ffe4}\u08ee'});
+let commandBuffer275 = commandEncoder419.finish({label: '\u{1f741}\ua0ba\u4c7f\u544a\u58c6\u0c4e\u0834'});
+let textureView106 = texture69.createView({
+  label: '\u{1f6a8}\u8043\u0206\u0f58\u42bd\u05ed\u{1f840}\u{1fc06}\uf7ac\u68c6\u3016',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 2,
+});
+try {
+renderPassEncoder57.executeBundles([renderBundle201, renderBundle162]);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder67.end();
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle273, renderBundle262, renderBundle270]);
+} catch {}
+let buffer68 = device0.createBuffer({
+  label: '\u5454\uc142\u5c46\u5839\u8193\ua058\u09dd\u0334\u{1f635}',
+  size: 7005,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup3, new Uint32Array(784), 39, 0);
+} catch {}
+try {
+commandEncoder416.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 15020 */
+  offset: 1190,
+  bytesPerRow: 256,
+  rowsPerImage: 6,
+  buffer: buffer5,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 66},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 10});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer4);
+} catch {}
+let commandEncoder420 = device3.createCommandEncoder({label: '\u03a3\u71c4\u08a1\ud436\u834d\ue73f\u14c1\u9ca8'});
+let commandBuffer276 = commandEncoder420.finish();
+try {
+renderPassEncoder68.setVertexBuffer(1, undefined);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer274]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 1,
+  origin: {x: 123, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(236_049), /* required buffer size: 236_049 */
+{offset: 67, bytesPerRow: 65, rowsPerImage: 117}, {width: 4, height: 4, depthOrArrayLayers: 32});
+} catch {}
+let bindGroup21 = device2.createBindGroup({
+  label: '\u{1ff39}\u0cc5\u0233\u45b0\ude21',
+  layout: bindGroupLayout53,
+  entries: [{binding: 124, resource: textureView59}],
+});
+let buffer69 = device2.createBuffer({
+  label: '\u{1fcd6}\u{1ff9d}\u0885\u{1fefd}\ua9ce\u087b\u986e\u{1f76c}\u7f4c\u0117\u0e59',
+  size: 12216,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder421 = device2.createCommandEncoder({label: '\u03eb\u{1f82b}\u13f5\ue55d\u041b\u40dc\u{1febb}\u4281'});
+let querySet60 = device2.createQuerySet({
+  label: '\u099d\u2adc\u8aa8\u0a21\u6cd8\u072c\u{1fed0}\ub7ff\u{1fbda}\u012c\u3f8b',
+  type: 'occlusion',
+  count: 173,
+});
+let commandBuffer277 = commandEncoder421.finish({label: '\u{1fc20}\u{1fa8f}\u79fd\u{1f841}\u{1f77c}\u{1fa2f}\u{1fd79}\u{1ffe9}\u0d3c\u46a7'});
+let renderBundleEncoder43 = device2.createRenderBundleEncoder({
+  label: '\u06cf\u0a07\uef29\ue7e1\u8e60\u0227',
+  colorFormats: ['rgba16sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder103.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer69, 'uint16', 374, 642);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+querySet43.destroy();
+} catch {}
+let commandEncoder422 = device3.createCommandEncoder({});
+let commandBuffer278 = commandEncoder422.finish({label: '\u{1fa15}\u{1fb71}\u056e\ufd2b\ua419\uf2fc\u53d0\u091f\u{1f990}\uaf90'});
+let sampler36 = device3.createSampler({
+  label: '\u0198\ubf5a\u3dd1\u0939\u6a04',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 17.66,
+});
+try {
+gpuCanvasContext7.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder423 = device3.createCommandEncoder({label: '\u47cd\u{1fcfe}\u{1f6be}\u{1fddb}\u1122'});
+let renderPassEncoder69 = commandEncoder423.beginRenderPass({
+  label: '\u{1fb63}\u{1f8c2}\u0fe9',
+  colorAttachments: [{view: textureView104, depthSlice: 101, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet57,
+});
+try {
+renderPassEncoder68.executeBundles([renderBundle262, renderBundle273, renderBundle262]);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+let imageData50 = new ImageData(24, 28);
+let commandEncoder424 = device3.createCommandEncoder({label: '\u6f32\u0dd2\ud33e\u481e\u9510'});
+let computePassEncoder121 = commandEncoder424.beginComputePass();
+let renderBundle274 = renderBundleEncoder37.finish({label: '\u1829\u423f\ud6c3\u{1fe1d}\u{1fed3}\u{1fb07}\u{1fac7}\u{1fcb9}\u0fe6\u1400'});
+try {
+device3.queue.submit([commandBuffer256]);
+} catch {}
+let img15 = await imageWithData(42, 57, '#10101010', '#20202020');
+try {
+gpuCanvasContext3.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+video4.width = 5;
+let imageData51 = new ImageData(28, 16);
+try {
+device3.queue.submit([commandBuffer276]);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle148, renderBundle146]);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer23, 'uint32', 192, 1_102);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(730_695), /* required buffer size: 730_695 */
+{offset: 7, bytesPerRow: 1864, rowsPerImage: 14}, {width: 230, height: 0, depthOrArrayLayers: 29});
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(59);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer11);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 2232, new BigUint64Array(31527), 12560, 80);
+} catch {}
+try {
+renderPassEncoder69.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder69.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+let commandEncoder425 = device0.createCommandEncoder({label: '\u{1ffee}\u189f\u5875\u{1fbf5}\ua5c8\ua66f\u0db8\u010b\u{1fa9f}\u0d29'});
+try {
+renderPassEncoder3.beginOcclusionQuery(8);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer8, 'uint16', 1_300, 128);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+commandEncoder416.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 296 */
+  offset: 296,
+  bytesPerRow: 0,
+  buffer: buffer14,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer267]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder426 = device2.createCommandEncoder();
+let commandBuffer279 = commandEncoder426.finish({label: '\ub03f\u{1fb76}'});
+let texture127 = device2.createTexture({
+  label: '\u6ba1\ua15e\u927b\u084a',
+  size: {width: 649, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(6, undefined, 714_877_237, 38_946_908);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer69, 'uint32', 952, 1_351);
+} catch {}
+try {
+device2.queue.submit([commandBuffer271, commandBuffer275, commandBuffer277]);
+} catch {}
+let imageData52 = new ImageData(48, 28);
+let promise70 = adapter5.requestAdapterInfo();
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder427 = device2.createCommandEncoder();
+let textureView107 = texture113.createView({label: '\ua407\u281a', dimension: '3d', mipLevelCount: 1});
+try {
+renderPassEncoder57.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4_294_967_294, undefined, 1_221_886_746, 802_403_908);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData41,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder428 = device0.createCommandEncoder({label: '\ua579\u{1f861}'});
+let querySet61 = device0.createQuerySet({label: '\u3d3b\u0ff9\u0edc\u88f1\u5752\u0a52\u04c3\u{1f993}\ue799', type: 'occlusion', count: 1440});
+let commandBuffer280 = commandEncoder425.finish({label: '\ua963\u{1f8f8}\ud23b'});
+let texture128 = device0.createTexture({
+  size: [60, 60, 1],
+  mipLevelCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder63.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(1, buffer5, 0, 9_720);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(169, 131);
+let renderBundle275 = renderBundleEncoder37.finish();
+try {
+renderPassEncoder68.executeBundles([]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderBundle276 = renderBundleEncoder11.finish();
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup6, new Uint32Array(885), 13, 0);
+} catch {}
+try {
+commandEncoder416.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9362 */
+  offset: 1140,
+  bytesPerRow: 256,
+  rowsPerImage: 18,
+  buffer: buffer6,
+}, {width: 15, height: 15, depthOrArrayLayers: 2});
+} catch {}
+try {
+computePassEncoder93.insertDebugMarker('\u794f');
+} catch {}
+let imageData53 = new ImageData(28, 16);
+try {
+device3.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 115, y: 1, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(37_741), /* required buffer size: 37_741 */
+{offset: 39, bytesPerRow: 67, rowsPerImage: 33}, {width: 6, height: 2, depthOrArrayLayers: 18});
+} catch {}
+try {
+  await promise70;
+} catch {}
+let commandEncoder429 = device3.createCommandEncoder({label: '\u{1fa3c}\u8272\u40d2\ub96d\u{1f681}\u{1feab}\u612d\u34d6'});
+try {
+window.someLabel = device2.queue.label;
+} catch {}
+let commandBuffer281 = commandEncoder427.finish();
+let renderBundle277 = renderBundleEncoder43.finish({label: '\u15c3\u{1f8ab}\uc3c2\ue8ce\u{1fce3}\u735c'});
+try {
+computePassEncoder94.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle137, renderBundle211, renderBundle180]);
+} catch {}
+try {
+renderPassEncoder58.setStencilReference(1135);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint16', 1_444, 1_504);
+} catch {}
+let commandEncoder430 = device0.createCommandEncoder({});
+let computePassEncoder122 = commandEncoder410.beginComputePass({label: '\u4e43\u0052\u0880\u07f1\ued66\u8d59\uf246'});
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer18);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer22, 'uint32', 1_656, 2_128);
+} catch {}
+try {
+commandEncoder416.copyBufferToBuffer(buffer0, 1960, buffer4, 1256, 9192);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 9}
+*/
+{
+  source: video8,
+  origin: { x: 5, y: 2 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData54 = new ImageData(8, 20);
+let commandEncoder431 = device2.createCommandEncoder({label: '\uabd7\u05fe\u8200'});
+let querySet62 = device2.createQuerySet({type: 'occlusion', count: 581});
+let commandBuffer282 = commandEncoder431.finish({label: '\u886e\u8a10\u0baf\ue37b'});
+let texture129 = device2.createTexture({
+  label: '\u{1fa62}\u2fb1\u2be6\u3365\u{1f81d}\u8c55\u{1fd22}',
+  size: {width: 2596},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle278 = renderBundleEncoder12.finish({label: '\u{1fa0b}\u8e59\u0604\u077b\u292b\ue4ac\u{1f9df}\u0868\u4268'});
+try {
+renderPassEncoder3.setIndexBuffer(buffer22, 'uint16', 1_236, 15);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer4, 4_340, 2_190);
+} catch {}
+try {
+device0.queue.submit([commandBuffer259]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(262), /* required buffer size: 262 */
+{offset: 262, rowsPerImage: 48}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 30, depthOrArrayLayers: 190}
+*/
+{
+  source: imageData20,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 3, y: 11, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas7.getContext('webgpu');
+let imageBitmap14 = await createImageBitmap(imageData5);
+let bindGroupLayout58 = device2.createBindGroupLayout({
+  label: '\ua16d\ue6dc\u0653\u2fe8\uf4c8\u8ccf\u61cd\u0e96\u8601\u2c7c',
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 259, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 104, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 167, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 144, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 46,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 19945823, hasDynamicOffset: false },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 417,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 337,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {binding: 52, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {binding: 95, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 283,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 335, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 114,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 382,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 200,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 106, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 279, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 39, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 156,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 302,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 165, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 297,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 291,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 236,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 484,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 657, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 245,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 356,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 244,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 58, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 315,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 360,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 26214244, hasDynamicOffset: false },
+    },
+    {
+      binding: 350,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 105,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 90,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 13, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 273, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 204, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 303, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 152, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 256,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 99, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 40, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let externalTexture55 = device2.importExternalTexture({label: '\u0c09\u0611\u{1ff89}\u0bb4\u{1fb81}\u{1ffda}\u55b1', source: video11});
+let commandEncoder432 = device0.createCommandEncoder({label: '\u0a41\uaf91\u{1ff1c}\u9c37\u04ac\u0a32\u087b\u68d5\ua1de'});
+let computePassEncoder123 = commandEncoder416.beginComputePass({});
+try {
+computePassEncoder118.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer29, 0);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer18, 'uint16', 1_436, 853);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer51, 0, 15_139);
+} catch {}
+try {
+commandEncoder428.copyBufferToBuffer(buffer7, 68, buffer65, 5552, 68);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 150, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 11, y: 23, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder57.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder48.insertDebugMarker('\u01cf');
+} catch {}
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let commandEncoder433 = device2.createCommandEncoder({});
+let commandBuffer283 = commandEncoder432.finish({label: '\u6417\u{1ffd7}\u1a94\u{1f80b}\u0002\u{1fe0d}\ucf22'});
+try {
+renderBundleEncoder31.setVertexBuffer(1, buffer4, 0, 1_670);
+} catch {}
+try {
+commandEncoder428.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 840 */
+  offset: 840,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 7, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let buffer70 = device2.createBuffer({
+  label: '\u0cef\u8e31\u04cc\u8fad\u7689\ube44\uf042\ue15e\u0b50',
+  size: 35748,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder434 = device2.createCommandEncoder();
+let commandBuffer284 = commandEncoder434.finish({label: '\u{1f698}\u45d3\u344a\u3cde'});
+let renderBundle279 = renderBundleEncoder20.finish({label: '\u0d1a\u596f\u3951\u{1fe39}\u0eb0'});
+try {
+computePassEncoder103.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer23, 'uint16', 894, 837);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder435 = device3.createCommandEncoder();
+let commandBuffer285 = commandEncoder435.finish({});
+let renderPassEncoder70 = commandEncoder429.beginRenderPass({
+  label: '\u0821\udc2a\u{1f914}\u0db1\u8c6f\u{1f889}',
+  colorAttachments: [{view: textureView104, depthSlice: 20, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 175597686,
+});
+try {
+gpuCanvasContext8.configure({device: device3, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame8.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -937,18 +937,12 @@ void RenderPassEncoder::endPass()
     auto endEncoder = ^{
         m_parentEncoder->endEncoding(m_renderCommandEncoder);
     };
-    auto issuedDraw = issuedDrawCall();
     bool useDiscardTextures = m_attachmentsToClear.count || m_clearDepthAttachment || m_clearStencilAttachment;
     bool hasTexturesToClear = m_allColorAttachments.count || m_attachmentsToClear.count || (m_depthStencilAttachmentToClear && (m_clearDepthAttachment || m_clearStencilAttachment));
 
-    if ((!issuedDraw || useDiscardTextures) && hasTexturesToClear) {
-        if (m_depthStencilView && m_depthStencilAttachmentToClear && !issuedDraw && !useDiscardTextures) {
-            m_clearDepthAttachment = Texture::containsDepthAspect(m_depthStencilView->format());
-            m_clearStencilAttachment = Texture::containsStencilAspect(m_depthStencilView->format());
-        }
-        if (useDiscardTextures)
-            endEncoder();
-        m_parentEncoder->runClearEncoder(useDiscardTextures ? m_attachmentsToClear : m_allColorAttachments, m_depthStencilAttachmentToClear, m_clearDepthAttachment, m_clearStencilAttachment, m_depthClearValue, m_stencilClearValue, useDiscardTextures ? nil : m_renderCommandEncoder);
+    if (useDiscardTextures && hasTexturesToClear) {
+        endEncoder();
+        m_parentEncoder->runClearEncoder(m_attachmentsToClear, m_depthStencilAttachmentToClear, m_clearDepthAttachment, m_clearStencilAttachment, m_depthClearValue, m_stencilClearValue, nil);
     } else
         endEncoder();
 


### PR DESCRIPTION
#### 7d9bcc5f209d78b255bd211e56b2969e246c5be1
<pre>
[WebGPU] Validation error inside runClearEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=277864">https://bugs.webkit.org/show_bug.cgi?id=277864</a>
radar://133539340

Reviewed by Dan Glastonbury.

Metal bug impacting clears of 16xN or Nx16 textures is fixed in iOS 18
and macOS 15, so we can remove the workaround which clears them when
a draw call is not issued.

The logic is simplified assuming &apos;issuedDraw==true&apos;

* LayoutTests/fast/webgpu/nocrash/fuzz-277864-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277864.html: Added.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::endPass):

Canonical link: <a href="https://commits.webkit.org/282130@main">https://commits.webkit.org/282130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8a0ddb82a78fa7b51787c733cf292285c0c4ba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14487 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65875 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49867 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8602 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57247 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57488 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4788 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37049 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->