### PR TITLE
[TZone] WebKit/Platform: Convert FastMalloc to TZone

### DIFF
--- a/Source/WebKit/Platform/CoroutineUtilities.h
+++ b/Source/WebKit/Platform/CoroutineUtilities.h
@@ -27,6 +27,7 @@
 
 #include <concepts>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if __has_include(<coroutine>)
 #include <coroutine>
@@ -140,7 +141,7 @@ struct Task {
 };
 
 class CoroutineCaller {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CoroutineCaller);
 public:
     CoroutineCaller() = default;
     void setCoroutine(Function<Task()>&& coroutine)

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -31,6 +31,7 @@
 #include "MessageFlags.h"
 #include <stdio.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace IPC {
 
@@ -46,6 +47,8 @@ static uint8_t* copyBuffer(std::span<const uint8_t> buffer)
     memcpy(bufferCopy, buffer.data(), bufferSize);
     return bufferCopy;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Decoder);
 
 std::unique_ptr<Decoder> Decoder::create(std::span<const uint8_t> buffer, Vector<Attachment>&& attachments)
 {

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -34,6 +34,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(MAC)
@@ -65,7 +66,7 @@ template<typename T, typename = IsObjCObject<T>> Class getClass()
 #endif
 
 class Decoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Decoder);
 public:
     static std::unique_ptr<Decoder> create(std::span<const uint8_t> buffer, Vector<Attachment>&&);
     using BufferDeallocator = Function<void(std::span<const uint8_t>)>;

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -30,6 +30,7 @@
 #include "MessageFlags.h"
 #include <algorithm>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 
 #if OS(DARWIN)
@@ -61,6 +62,8 @@ static inline void freeBuffer(void* addr, size_t size)
     fastFree(addr);
 #endif
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Encoder);
 
 Encoder::Encoder(MessageName messageName, uint64_t destinationID)
     : m_messageName(messageName)

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace IPC {
@@ -42,7 +43,7 @@ enum class ShouldDispatchWhenWaitingForSyncReply : uint8_t;
 template<typename, typename> struct ArgumentCoder;
 
 class Encoder final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Encoder);
 public:
     Encoder(MessageName, uint64_t destinationID);
     ~Encoder();

--- a/Source/WebKit/Platform/IPC/IPCEvent.h
+++ b/Source/WebKit/Platform/IPC/IPCEvent.h
@@ -28,6 +28,7 @@
 #include "Decoder.h"
 #include "Encoder.h"
 #include "IPCSemaphore.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace IPC {
 
@@ -41,7 +42,7 @@ std::optional<EventSignalPair> createEventSignalPair();
 // killed).
 // FIXME: Write proper interruptible implementations for non-COCOA platforms.
 class Signal {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Signal);
     WTF_MAKE_NONCOPYABLE(Signal);
 public:
     Signal(Signal&& other) = default;
@@ -83,7 +84,7 @@ private:
 };
 
 class Event {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Event);
     WTF_MAKE_NONCOPYABLE(Event);
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Platform/IPC/IPCSemaphore.h
+++ b/Source/WebKit/Platform/IPC/IPCSemaphore.h
@@ -29,6 +29,7 @@
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include <mach/semaphore.h>
@@ -54,7 +55,7 @@ std::optional<EventSignalPair> createEventSignalPair();
 // It is generally preferred to start using IPC::Event/Signal instead
 // to avoid this.
 class Semaphore {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Semaphore);
     WTF_MAKE_NONCOPYABLE(Semaphore);
 public:
     Semaphore();

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -28,11 +28,12 @@
 #include "Connection.h"
 #include "MessageReceiveQueue.h"
 #include "WorkQueueMessageReceiver.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace IPC {
 
 class FunctionDispatcherQueue final : public MessageReceiveQueue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FunctionDispatcherQueue);
 public:
     FunctionDispatcherQueue(FunctionDispatcher& dispatcher, MessageReceiver& receiver)
         : m_dispatcher(dispatcher)
@@ -53,7 +54,7 @@ private:
 };
 
 class WorkQueueMessageReceiverQueue final : public MessageReceiveQueue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WorkQueueMessageReceiverQueue);
 public:
     WorkQueueMessageReceiverQueue(WorkQueue& queue, WorkQueueMessageReceiver& receiver)
         : m_queue(queue)

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "StreamClientConnection.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace IPC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StreamClientConnection);
 
 // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -35,6 +35,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
 namespace WebKit {
@@ -56,7 +57,7 @@ namespace IPC {
 //
 // The StreamClientConnection trusts the StreamServerConnection.
 class StreamClientConnection final : public ThreadSafeRefCounted<StreamClientConnection> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StreamClientConnection);
     WTF_MAKE_NONCOPYABLE(StreamClientConnection);
 public:
     struct StreamConnectionPair {

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -39,6 +39,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniStdExtras.h>
 
 #if USE(GLIB)
@@ -67,7 +68,7 @@ static const size_t messageMaxSize = 4096;
 static const size_t attachmentMaxAmount = 254;
 
 class AttachmentInfo {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AttachmentInfo);
 public:
     AttachmentInfo()
     {

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -30,6 +30,7 @@
 #include "Attachment.h"
 #include "Encoder.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace IPC {
@@ -78,7 +79,7 @@ private:
 };
 
 class UnixMessage {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(UnixMessage);
 public:
     UnixMessage(Encoder& encoder)
         : m_attachments(encoder.releaseAttachments())

--- a/Source/WebKit/Platform/Module.cpp
+++ b/Source/WebKit/Platform/Module.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "Module.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Module);
 
 Module::Module(const String& path)
     : m_path(path)

--- a/Source/WebKit/Platform/Module.h
+++ b/Source/WebKit/Platform/Module.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 #if USE(CF)
@@ -44,7 +45,7 @@ typedef struct _GModule GModule;
 namespace WebKit {
 
 class Module {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Module);
     WTF_MAKE_NONCOPYABLE(Module);
 public:
     explicit Module(const String& path);

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -29,6 +29,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS CAContext;
@@ -64,7 +65,8 @@ struct LayerHostingContextOptions {
 };
 
 class LayerHostingContext {
-    WTF_MAKE_NONCOPYABLE(LayerHostingContext); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LayerHostingContext);
+    WTF_MAKE_NONCOPYABLE(LayerHostingContext);
 public:
     static std::unique_ptr<LayerHostingContext> createForPort(const WTF::MachSendRight& serverPort);
     

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -31,6 +31,7 @@
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/MachSendRight.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #if USE(EXTENSIONKIT)
 #import "ExtensionKitSPI.h"
@@ -45,6 +46,8 @@ SOFT_LINK_CLASS_OPTIONAL(BrowserEngineKit, BELayerHierarchyHostingTransactionCoo
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerHostingContext);
 
 std::unique_ptr<LayerHostingContext> LayerHostingContext::createForPort(const MachSendRight& serverPort)
 {

--- a/Source/WebKit/Platform/cocoa/NetworkIssueReporter.h
+++ b/Source/WebKit/Platform/cocoa/NetworkIssueReporter.h
@@ -28,13 +28,14 @@
 #if ENABLE(NETWORK_ISSUE_REPORTING)
 
 #import <wtf/Forward.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSURLSessionTaskMetrics;
 
 namespace WebKit {
 
 class NetworkIssueReporter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkIssueReporter);
     WTF_MAKE_NONCOPYABLE(NetworkIssueReporter);
 public:
     NetworkIssueReporter();

--- a/Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm
+++ b/Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm
@@ -30,6 +30,7 @@
 
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/TZoneMallocInlines.h>
 
 SOFT_LINK_SYSTEM_LIBRARY(libsystem_networkextension)
 SOFT_LINK_OPTIONAL(libsystem_networkextension, ne_tracker_create_xcode_issue, void, __cdecl, (const char*, const void*, size_t))
@@ -37,6 +38,8 @@ SOFT_LINK_OPTIONAL(libsystem_networkextension, ne_tracker_copy_current_stacktrac
 SOFT_LINK_OPTIONAL(libsystem_networkextension, ne_tracker_should_save_stacktrace, bool, __cdecl, (void))
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkIssueReporter);
 
 bool NetworkIssueReporter::isEnabled()
 {

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -29,9 +29,9 @@
 
 #include "CocoaWindow.h"
 #include <WebCore/ApplePaySessionPaymentRequest.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS UIViewController;
@@ -63,7 +63,7 @@ struct ApplePayShippingMethodUpdate;
 namespace WebKit {
 
 class PaymentAuthorizationPresenter : public CanMakeWeakPtr<PaymentAuthorizationPresenter> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PaymentAuthorizationPresenter);
     WTF_MAKE_NONCOPYABLE(PaymentAuthorizationPresenter);
 public:
     struct Client {

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -44,6 +44,7 @@
 #import <WebCore/ApplePayShippingMethodUpdate.h>
 #import <WebCore/PaymentMerchantSession.h>
 #import <WebCore/PaymentSummaryItems.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #import <pal/cocoa/PassKitSoftLink.h>
@@ -265,6 +266,8 @@ static RetainPtr<NSArray> toNSErrors(const Vector<Ref<WebCore::ApplePayError>>& 
         return toNSError(error);
     });
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PaymentAuthorizationPresenter);
 
 void PaymentAuthorizationPresenter::completeMerchantValidation(const WebCore::PaymentMerchantSession& merchantSession)
 {

--- a/Source/WebKit/Platform/generic/LayerHostingContext.h
+++ b/Source/WebKit/Platform/generic/LayerHostingContext.h
@@ -27,13 +27,15 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using LayerHostingContextID = uint32_t;
 
 class LayerHostingContext {
-    WTF_MAKE_NONCOPYABLE(LayerHostingContext); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(LayerHostingContext);
+    WTF_MAKE_NONCOPYABLE(LayerHostingContext);
 public:
 };
 

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -30,13 +30,14 @@
 #include <WebCore/NowPlayingMetadataObserver.h>
 #include <WebCore/PlaybackSessionInterfaceIOS.h>
 #include <wtf/Observer.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKLinearMediaPlayerDelegate;
 
 namespace WebKit {
 
 class PlaybackSessionInterfaceLMK final : public WebCore::PlaybackSessionInterfaceIOS {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PlaybackSessionInterfaceLMK);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceLMK);
 public:
     static Ref<PlaybackSessionInterfaceLMK> create(WebCore::PlaybackSessionModel&);

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -36,6 +36,7 @@
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/TimeRanges.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakPtr.h>
 
 #import "WebKitSwiftSoftLink.h"
@@ -216,6 +217,8 @@
 @end
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionInterfaceLMK);
 
 Ref<PlaybackSessionInterfaceLMK> PlaybackSessionInterfaceLMK::create(WebCore::PlaybackSessionModel& model)
 {

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -28,6 +28,7 @@
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 
 #include <WebCore/VideoPresentationInterfaceIOS.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS LMPlayableViewController;
 OBJC_CLASS WKCaptionLayerLayoutManager;
@@ -40,7 +41,7 @@ class PlaybackSessionInterfaceIOS;
 namespace WebKit {
 
 class VideoPresentationInterfaceLMK final : public WebCore::VideoPresentationInterfaceIOS {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VideoPresentationInterfaceLMK);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceLMK);
 public:
     static Ref<VideoPresentationInterfaceLMK> create(WebCore::PlaybackSessionInterfaceIOS&);


### PR DESCRIPTION
#### 93561ebbb777901cacdbd3b32f297ddfd7bcefa6
<pre>
[TZone] WebKit/Platform: Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=277868">https://bugs.webkit.org/show_bug.cgi?id=277868</a>
<a href="https://rdar.apple.com/133555093">rdar://133555093</a>

Reviewed by Michael Saboff.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebKit/Platform/CoroutineUtilities.h:
* Source/WebKit/Platform/IPC/Decoder.cpp:
* Source/WebKit/Platform/IPC/Decoder.h:
* Source/WebKit/Platform/IPC/Encoder.cpp:
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/IPCEvent.h:
* Source/WebKit/Platform/IPC/IPCSemaphore.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
* Source/WebKit/Platform/Module.cpp:
* Source/WebKit/Platform/Module.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
* Source/WebKit/Platform/cocoa/NetworkIssueReporter.h:
* Source/WebKit/Platform/cocoa/NetworkIssueReporter.mm:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
* Source/WebKit/Platform/generic/LayerHostingContext.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:

Canonical link: <a href="https://commits.webkit.org/282182@main">https://commits.webkit.org/282182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/219a8b218f048aa0e886ea3684edfe15d577fa10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12611 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49980 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8705 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35086 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11542 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57358 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57607 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4923 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37220 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->