### PR TITLE
[Writing Tools] macOS: Selection should be hidden when the pondering animation begins, stay hidden until all animations complete

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -686,9 +686,9 @@ public:
 
     virtual void addInitialTextAnimation(const WritingTools::SessionID&) { }
 
-    virtual void addSourceTextAnimation(const WritingTools::SessionID&, const CharacterRange&, const String, WTF::CompletionHandler<void(TextAnimationRunMode)>&&) { }
+    virtual void addSourceTextAnimation(const WritingTools::SessionID&, const CharacterRange&, const String&, CompletionHandler<void(TextAnimationRunMode)>&&) { }
 
-    virtual void addDestinationTextAnimation(const WritingTools::SessionID&, const CharacterRange&, const String) { }
+    virtual void addDestinationTextAnimation(const WritingTools::SessionID&, const std::optional<CharacterRange>&, const String&) { }
 
     virtual void clearAnimationsForSessionID(const WritingTools::SessionID&) { };
 #endif

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4964,6 +4964,11 @@ std::optional<SimpleRange> Page::contextRangeForSessionWithID(const WritingTools
     return m_writingToolsController->contextRangeForSessionWithID(sessionID);
 }
 
+void Page::showSelectionForWritingToolsSessionWithID(const WritingTools::Session::ID& sessionID) const
+{
+    return m_writingToolsController->showSelectionForWritingToolsSessionWithID(sessionID);
+}
+
 void Page::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WritingTools::Action action)
 {
     m_writingToolsController->writingToolsSessionDidReceiveAction(session, action);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1185,6 +1185,7 @@ public:
     void respondToReappliedWritingToolsEditing(EditCommandComposition*);
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::SessionID&) const;
+    WEBCORE_EXPORT void showSelectionForWritingToolsSessionWithID(const WritingTools::SessionID&) const;
 #endif
 
     bool hasActiveNowPlayingSession() const { return m_hasActiveNowPlayingSession; }

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -76,8 +76,9 @@ public:
     void respondToReappliedEditing(EditCommandComposition*);
 
     // FIXME: Refactor `TextAnimationController` in such a way so as to not explicitly depend on `WritingToolsController`,
-    // and then remove this method after doing so.
+    // and then remove these methods after doing so.
     std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::Session::ID&) const;
+    void showSelectionForWritingToolsSessionWithID(const WritingTools::Session::ID&) const;
 
 private:
     struct CompositionState : CanMakeCheckedPtr<CompositionState> {
@@ -93,6 +94,7 @@ private:
         // These two vectors should never have the same command in both of them.
         Vector<Ref<WritingToolsCompositionCommand>> unappliedCommands;
         Vector<Ref<WritingToolsCompositionCommand>> reappliedCommands;
+        std::optional<SimpleRange> currentRange;
     };
 
     struct ProofreadingState : CanMakeCheckedPtr<ProofreadingState> {
@@ -146,6 +148,9 @@ private:
 
     void replaceContentsOfRangeInSession(ProofreadingState&, const SimpleRange&, const String&);
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, const AttributedString&, WritingToolsCompositionCommand::State);
+
+    void compositionSessionDidFinishReplacement(const WritingTools::Session&);
+    void compositionSessionDidFinishReplacement(const WritingTools::Session&, const CharacterRange&, const String&);
 
     void compositionSessionDidReceiveTextWithReplacementRangeAsync(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1831,28 +1831,40 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
 }
 
 #if ENABLE(WRITING_TOOLS_UI)
+
 - (void)_addTextAnimationForAnimationID:(NSUUID *)nsUUID withData:(const WebCore::TextAnimationData&)data
 {
 #if PLATFORM(IOS_FAMILY)
     [_contentView addTextAnimationForAnimationID:nsUUID withStyleType:toWKTextAnimationType(data.style)];
-#elif PLATFORM(MAC)
+#else
     auto uuid = WTF::UUID::fromNSUUID(nsUUID);
     if (!uuid)
         return;
+
     _impl->addTextAnimationForAnimationID(*uuid, data);
 #endif
 }
+
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)nsUUID
 {
 #if PLATFORM(IOS_FAMILY)
     [_contentView removeTextAnimationForAnimationID:nsUUID];
-#elif PLATFORM(MAC)
+#else
     auto uuid = WTF::UUID::fromNSUUID(nsUUID);
     if (!uuid)
         return;
+
     _impl->removeTextAnimationForAnimationID(*uuid);
 #endif
 }
+
+- (void)_didEndPartialIntelligenceTextPonderingAnimation
+{
+#if PLATFORM(MAC)
+    _impl->didEndPartialIntelligenceTextPonderingAnimation();
+#endif
+}
+
 #endif
 
 - (WKPageRef)_pageForTesting
@@ -2256,6 +2268,10 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
         return;
     }
 
+#if PLATFORM(MAC)
+    _impl->writingToolsCompositionSessionDidReceiveReplacements(webSession->identifier, finished);
+#endif
+
     _page->compositionSessionDidReceiveTextWithReplacementRange(*webSession, WebCore::AttributedString::fromNSAttributedString(attributedText), { range }, *webContext, finished);
 }
 
@@ -2267,9 +2283,18 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
         return;
     }
 
-    _page->writingToolsSessionDidReceiveAction(*webSession, WebKit::convertToWebAction(action));
-}
+    auto webAction = WebKit::convertToWebAction(action);
 
+#if PLATFORM(MAC)
+    if (webAction == WebCore::WritingTools::Action::Restart && webSession->compositionType != WebCore::WritingTools::Session::CompositionType::SmartReply) {
+        // This must be done in the UI process to avoid any race conditions that may result from IPC
+        // to/from the web process with the UI process animations.
+        _impl->writingToolsCompositionSessionDidReceiveRestartAction();
+    }
+#endif
+
+    _page->writingToolsSessionDidReceiveAction(*webSession, webAction);
+}
 
 #pragma mark - WTTextViewDelegate invoking methods
 
@@ -3124,10 +3149,12 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 {
     return [self _enableSourceTextAnimationAfterElementWithID:elementID];
 }
+
 - (NSUUID *)_enableTextIndicatorStylingForElementWithID:(NSString *)elementID
 {
     return [self _enableFinalTextAnimationForElementWithID:elementID];
 }
+
 - (void)_disableTextIndicatorStylingWithUUID:(NSUUID *)nsUUID
 {
     return [self _disableTextAnimationWithUUID:nsUUID];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -426,6 +426,7 @@ struct PerWebProcessState {
 #if ENABLE(WRITING_TOOLS_UI)
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;
+- (void)_didEndPartialIntelligenceTextPonderingAnimation;
 #endif
 
 - (void)_internalDoAfterNextPresentationUpdate:(void (^)(void))updateBlock withoutWaitingForPainting:(BOOL)withoutWaitingForPainting withoutWaitingForAnimatedResize:(BOOL)withoutWaitingForAnimatedResize;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -102,6 +102,7 @@ public:
 #if ENABLE(WRITING_TOOLS_UI)
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) final;
     void removeTextAnimationForAnimationID(const WTF::UUID&) final;
+    void didEndPartialIntelligenceTextPonderingAnimation() final;
 #endif
 
     void microphoneCaptureWillChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -167,6 +167,11 @@ void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uui
 {
     [m_webView _removeTextAnimationForAnimationID:uuid];
 }
+
+void PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation()
+{
+    [m_webView _didEndPartialIntelligenceTextPonderingAnimation];
+}
 #endif
 
 void PageClientImplCocoa::pageClosed()

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1228,7 +1228,7 @@ void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& ele
     if (!hasRunningProcess())
         return;
 
-    legacyMainFrameProcess().send(Messages::WebPage::enableSourceTextAnimationAfterElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().send(Messages::WebPage::EnableSourceTextAnimationAfterElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID& uuid)
@@ -1275,7 +1275,7 @@ void WebPageProxy::getTextIndicatorForID(const WTF::UUID& uuid, CompletionHandle
     }
 
     // FIXME: This shouldn't be reached/called anymore. Verify and remove.
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::createTextIndicatorForTextAnimationID(uuid), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::CreateTextIndicatorForTextAnimationID(uuid), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
@@ -1285,7 +1285,28 @@ void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::U
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::updateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::UpdateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID& animationID)
+{
+    if (!hasRunningProcess())
+        return;
+
+    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForWritingToolsSessionAssociatedWithAnimationID(animationID), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::showSelectionForWritingToolsSessionWithID(const WebCore::WritingTools::Session::ID& sessionID)
+{
+    if (!hasRunningProcess())
+        return;
+
+    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForWritingToolsSessionWithID(sessionID), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&)
+{
+    protectedPageClient()->didEndPartialIntelligenceTextPonderingAnimation();
 }
 
 void WebPageProxy::removeTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -725,10 +725,13 @@ public:
 #if ENABLE(APP_HIGHLIGHTS)
     virtual void storeAppHighlight(const WebCore::AppHighlight&) = 0;
 #endif
+
 #if ENABLE(WRITING_TOOLS_UI)
     virtual void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) = 0;
     virtual void removeTextAnimationForAnimationID(const WTF::UUID&) = 0;
+    virtual void didEndPartialIntelligenceTextPonderingAnimation() = 0;
 #endif
+
     virtual void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) { }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2438,6 +2438,10 @@ public:
     void callCompletionHandlerForAnimationID(const WTF::UUID&, WebCore::TextAnimationRunMode);
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
+
+    void showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID&);
+    void showSelectionForWritingToolsSessionWithID(const WebCore::WritingTools::SessionID&);
+    void didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&);
 #endif
 
     void resetVisibilityAdjustmentsForTargetedElements(const Vector<Ref<API::TargetedElementInfo>>&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -517,6 +517,7 @@ messages -> WebPageProxy {
 #if ENABLE(WRITING_TOOLS_UI)
     AddTextAnimationForAnimationID(WTF::UUID uuid, struct WebCore::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData) -> (enum:uint8_t WebCore::TextAnimationRunMode runMode)
     RemoveTextAnimationForAnimationID(WTF::UUID uuid)
+    DidEndPartialIntelligenceTextPonderingAnimation()
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -743,6 +743,15 @@ public:
 #if ENABLE(WRITING_TOOLS_UI)
     void addTextAnimationForAnimationID(WTF::UUID, const WebCore::TextAnimationData&);
     void removeTextAnimationForAnimationID(WTF::UUID);
+
+    void writingToolsCompositionSessionDidReceiveRestartAction();
+    void writingToolsCompositionSessionDidReceiveReplacements(const WTF::UUID&, bool finished);
+
+    bool isWritingToolsTextReplacementsFinished() const;
+    bool isIntelligenceTextPonderingAnimationFinished() const;
+
+    void willBeginPartialIntelligenceTextPonderingAnimation();
+    void didEndPartialIntelligenceTextPonderingAnimation();
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)
@@ -982,8 +991,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     NSInteger m_initialNumberOfValidItemsForDrop { 0 };
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    RetainPtr<WKTextAnimationManager> m_TextAnimationTypeManager;
+#if ENABLE(WRITING_TOOLS_UI)
+    RetainPtr<WKTextAnimationManager> m_textAnimationTypeManager;
+
+    unsigned m_partialIntelligenceTextPonderingAnimationCount { 0 };
+    bool m_writingToolsTextReplacementsFinished { false };
 #endif
 
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)

--- a/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
@@ -67,7 +67,7 @@ extension TextAnimationManager: UITextEffectViewSource {
             return UITargetedPreview(view: UIView(frame: .zero))
         }
         
-        let defaultPreview = UITargetedPreview(view: UIView(frame: .zero), parameters:UIPreviewParameters(), target:UIPreviewTarget(container:delegate.containingViewForTextAnimationType(), center:delegate.containingViewForTextAnimationType().center))
+        let defaultPreview = UITargetedPreview(view: UIView(frame: .zero), parameters: UIPreviewParameters(), target: UIPreviewTarget(container: delegate.containingViewForTextAnimationType(), center: delegate.containingViewForTextAnimationType().center))
         guard let uuidChunk = chunk as? TextEffectChunk else {
             Self.logger.debug("Can't get text preview. Incorrect UITextEffectTextChunk subclass")
             return defaultPreview

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1903,12 +1903,12 @@ void WebChromeClient::addInitialTextAnimation(const WritingTools::Session::ID& s
     protectedPage()->addInitialTextAnimation(sessionID);
 }
 
-void WebChromeClient::addSourceTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range, const String string, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+void WebChromeClient::addSourceTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
     protectedPage()->addSourceTextAnimation(sessionID, range, string, WTFMove(completionHandler));
 }
 
-void WebChromeClient::addDestinationTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range, const String string)
+void WebChromeClient::addDestinationTextAnimation(const WritingTools::Session::ID& sessionID, const std::optional<CharacterRange>& range, const String& string)
 {
     protectedPage()->addDestinationTextAnimation(sessionID, range, string);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -528,9 +528,9 @@ private:
 
     void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&) final;
 
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&&) final;
+    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&) final;
 
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String) final;
+    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const std::optional<WebCore::CharacterRange>&, const String&) final;
 
     void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&) final;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -80,12 +80,14 @@ public:
 
     void removeInitialTextAnimation(const WTF::UUID& sessionUUID);
     void addInitialTextAnimation(const WTF::UUID& sessionUUID);
-    void addSourceTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange&, const String, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange&, const String);
+    void addSourceTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
+    void addDestinationTextAnimation(const WTF::UUID& sessionUUID, const std::optional<WebCore::CharacterRange>&, const String&);
 
     void clearAnimationsForSessionID(const WTF::UUID& sessionUUID);
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool visible, CompletionHandler<void()>&&);
+
+    void showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID&);
 
     std::optional<WebCore::TextIndicatorData> createTextIndicatorForRange(const WebCore::SimpleRange&);
     void createTextIndicatorForTextAnimationID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -314,6 +314,47 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 }
 
 #if ENABLE(WRITING_TOOLS_UI)
+
+void WebPage::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::WebPageProxy::AddTextAnimationForAnimationID(uuid, styleData, indicatorData), WTFMove(completionHandler));
+}
+
+void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
+{
+    send(Messages::WebPageProxy::RemoveTextAnimationForAnimationID(uuid));
+}
+
+void WebPage::removeTransparentMarkersForSessionID(const WTF::UUID& uuid)
+{
+    m_textAnimationController->removeTransparentMarkersForSessionID(uuid);
+}
+
+void WebPage::removeInitialTextAnimation(const WTF::UUID& uuid)
+{
+    m_textAnimationController->removeInitialTextAnimation(uuid);
+}
+
+void WebPage::addInitialTextAnimation(const WTF::UUID& uuid)
+{
+    m_textAnimationController->addInitialTextAnimation(uuid);
+}
+
+void WebPage::addSourceTextAnimation(const WTF::UUID& uuid, const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+{
+    m_textAnimationController->addSourceTextAnimation(uuid, range, string, WTFMove(completionHandler));
+}
+
+void WebPage::addDestinationTextAnimation(const WTF::UUID& uuid, const std::optional<CharacterRange>& range, const String& string)
+{
+    m_textAnimationController->addDestinationTextAnimation(uuid, range, string);
+}
+
+void WebPage::clearAnimationsForSessionID(const WTF::UUID& uuid)
+{
+    m_textAnimationController->clearAnimationsForSessionID(uuid);
+}
+
 void WebPage::createTextIndicatorForTextAnimationID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
 {
     m_textAnimationController->createTextIndicatorForTextAnimationID(uuid, WTFMove(completionHandler));
@@ -332,6 +373,21 @@ void WebPage::enableSourceTextAnimationAfterElementWithID(const String& elementI
 void WebPage::enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID& uuid)
 {
     m_textAnimationController->enableTextAnimationTypeForElementWithID(elementID, uuid);
+}
+
+void WebPage::showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID& animationID)
+{
+    m_textAnimationController->showSelectionForWritingToolsSessionAssociatedWithAnimationID(animationID);
+}
+
+void WebPage::showSelectionForWritingToolsSessionWithID(const WritingTools::Session::ID& sessionID)
+{
+    corePage()->showSelectionForWritingToolsSessionWithID(sessionID);
+}
+
+void WebPage::didEndPartialIntelligenceTextPonderingAnimation()
+{
+    send(Messages::WebPageProxy::DidEndPartialIntelligenceTextPonderingAnimation());
 }
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9229,51 +9229,6 @@ void WebPage::lastNavigationWasAppInitiated(CompletionHandler<void(bool)>&& comp
     return completionHandler(mainFrame->document()->loader()->lastNavigationWasAppInitiated());
 }
 
-#if ENABLE(WRITING_TOOLS_UI)
-
-void WebPage::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
-{
-    sendWithAsyncReply(Messages::WebPageProxy::AddTextAnimationForAnimationID(uuid, styleData, indicatorData), WTFMove(completionHandler));
-}
-
-void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
-{
-    send(Messages::WebPageProxy::RemoveTextAnimationForAnimationID(uuid));
-}
-
-void WebPage::removeTransparentMarkersForSessionID(const WTF::UUID& uuid)
-{
-    m_textAnimationController->removeTransparentMarkersForSessionID(uuid);
-}
-
-void WebPage::removeInitialTextAnimation(const WTF::UUID& uuid)
-{
-    m_textAnimationController->removeInitialTextAnimation(uuid);
-}
-
-void WebPage::addInitialTextAnimation(const WTF::UUID& uuid)
-{
-    m_textAnimationController->addInitialTextAnimation(uuid);
-}
-
-
-void WebPage::addSourceTextAnimation(const WTF::UUID& uuid, const CharacterRange& range, const String string, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
-{
-    m_textAnimationController->addSourceTextAnimation(uuid, range, string, WTFMove(completionHandler));
-}
-
-void WebPage::addDestinationTextAnimation(const WTF::UUID& uuid, const CharacterRange& range, const String string)
-{
-    m_textAnimationController->addDestinationTextAnimation(uuid, range, string);
-}
-
-void WebPage::clearAnimationsForSessionID(const WTF::UUID& uuid)
-{
-    m_textAnimationController->clearAnimationsForSessionID(uuid);
-}
-
-#endif
-
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
 
 void WebPage::handleContextMenuTranslation(const TranslationContextMenuInfo& info)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1785,12 +1785,14 @@ public:
 
     void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&);
     void addInitialTextAnimation(const WebCore::WritingTools::SessionID&);
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String);
+    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
+    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const std::optional<WebCore::CharacterRange>&, const String&);
     void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&);
 
     std::optional<WebCore::TextIndicatorData> createTextIndicatorForRange(const WebCore::SimpleRange&);
     void createTextIndicatorForTextAnimationID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+
+    void didEndPartialIntelligenceTextPonderingAnimation();
 #endif
 
     void startObservingNowPlayingMetadata();
@@ -2313,6 +2315,9 @@ private:
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
+
+    void showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID&);
+    void showSelectionForWritingToolsSessionWithID(const WebCore::WritingTools::SessionID&);
 #endif
 
     void remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -379,8 +379,14 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
     
 #if ENABLE(WRITING_TOOLS_UI)
-    createTextIndicatorForTextAnimationID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
-    updateUnderlyingTextVisibilityForTextAnimationID(WTF::UUID uuid, bool visible) -> ()
+    CreateTextIndicatorForTextAnimationID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
+    UpdateUnderlyingTextVisibilityForTextAnimationID(WTF::UUID uuid, bool visible) -> ()
+
+    EnableSourceTextAnimationAfterElementWithID(String elementID, WTF::UUID uuid);
+    EnableTextAnimationTypeForElementWithID(String elementID, WTF::UUID uuid);
+
+    ShowSelectionForWritingToolsSessionAssociatedWithAnimationID(WTF::UUID animationID);
+    ShowSelectionForWritingToolsSessionWithID(WebCore::WritingTools::Session::ID sessionID);
 #endif
 
     # Popup menu.
@@ -793,12 +799,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     CompositionSessionDidReceiveTextWithReplacementRange(struct WebCore::WritingTools::Session session, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebCore::WritingTools::Context context, bool finished);
 
     WritingToolsSessionDidReceiveAction(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::Action action);
-#endif
-
-#if ENABLE(WRITING_TOOLS_UI)
-    enableSourceTextAnimationAfterElementWithID(String elementID, WTF::UUID uuid);
-    
-    EnableTextAnimationTypeForElementWithID(String elementID, WTF::UUID uuid);
 #endif
 
     TakeSnapshotForTargetedElement(WebCore::ElementIdentifier elementID, WebCore::ScriptExecutionContextIdentifier documentID) -> (std::optional<WebCore::ShareableBitmapHandle> image)


### PR DESCRIPTION
#### a42d8d1b580267a1428d6056c315e7cf3853ee50
<pre>
[Writing Tools] macOS: Selection should be hidden when the pondering animation begins, stay hidden until all animations complete
<a href="https://bugs.webkit.org/show_bug.cgi?id=277873">https://bugs.webkit.org/show_bug.cgi?id=277873</a>
<a href="https://rdar.apple.com/130995812">rdar://130995812</a>

Reviewed by Wenson Hsieh.

Clear the selection when a session begins, and reveal it when the session replacement animation is completely done.

To facilitate the latter, the UI process now maintains a counter of ongoing intelligence text animations. There are
several distinct sequence of events that should cause the selection to be revealed, assuming a replacement is done
in multiple pieces;

1) The sequence

a. `didReceive` [finished=false]
b. animation 1 starts
c. animation 1 ends
d. `didReceive` [finished=false]
e. animation 2 starts
f. animation 2 ends
g. `didReceive` [finished=true].

In this case, all animations are complete before `finished` is true. Therefore, by (g), the counter will be 0, and
the call from `didReceive` with `finished = true` can reveal the selection.

2) The sequence

a. `didReceive` [finished=false]
b. `didReceive` [finished=false]
c. `didReceive` [finished=true].
d. animation 1 starts
e. animation 1 ends
f. animation 2 starts
g. animation 2 ends

In this case, the call from `didReceive` where `finished = true` happens prior to all the animations finishing. In this
case, the UI process notes that the replacement is finished. Then, in the text animation manager, when the last animation
finishes (which is known via maintaining the counter of animations), then `finished` will be true, and the selection will
be revealed.

Drive-by fix: Fix and improve some formatting across various files.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::addSourceTextAnimation):
(WebCore::ChromeClient::addDestinationTextAnimation):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::showSelectionForWritingToolsSessionWithID const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::showSelectionForWritingToolsSessionWithID const):
(WebCore::WritingToolsController::compositionSessionDidFinishReplacement):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _addTextAnimationForAnimationID:withData:]):
(-[WKWebView _removeTextAnimationForAnimationID:]):
(-[WKWebView _deferIntelligenceTextAnimation]):
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::deferIntelligenceTextAnimation):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::enableSourceTextAnimationAfterElementWithID):
(WebKit::WebPageProxy::getTextIndicatorForID):
(WebKit::WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::WebPageProxy::showSelectionForWritingToolsSessionAssociatedWithAnimationID):
(WebKit::WebPageProxy::showSelectionForWritingToolsSessionWithID):
(WebKit::WebPageProxy::deferIntelligenceTextAnimation):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::hasContentRelativeChildViews const):
(WebKit::WebViewImpl::suppressContentRelativeChildViews):
(WebKit::WebViewImpl::restoreContentRelativeChildViews):
(WebKit::WebViewImpl::addTextAnimationForAnimationID):
(WebKit::WebViewImpl::removeTextAnimationForAnimationID):
(WebKit::WebViewImpl::writingToolsSessionWillBegin):
(WebKit::WebViewImpl::writingToolsCompositionSessionDidReceiveReplacements):
(WebKit::WebViewImpl::isWritingToolsTextReplacementsFinished const):
(WebKit::WebViewImpl::isIntelligenceTextPonderingAnimationFinished const):
(WebKit::WebViewImpl::willBeginPartialIntelligenceTextPonderingAnimation):
(WebKit::WebViewImpl::didEndPartialIntelligenceTextPonderingAnimation):
* Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift:
(TextAnimationManager.targetedPreview(for:)):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::addSourceTextAnimation):
(WebKit::WebChromeClient::addDestinationTextAnimation):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::remainingCharacterRange):
(WebKit::TextAnimationController::addSourceTextAnimation):
(WebKit::TextAnimationController::addDestinationTextAnimation):
(WebKit::TextAnimationController::showSelectionForWritingToolsSessionAssociatedWithAnimationID):
(WebKit::TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::addTextAnimationForAnimationID):
(WebKit::WebPage::removeTextAnimationForAnimationID):
(WebKit::WebPage::removeTransparentMarkersForSessionID):
(WebKit::WebPage::removeInitialTextAnimation):
(WebKit::WebPage::addInitialTextAnimation):
(WebKit::WebPage::addSourceTextAnimation):
(WebKit::WebPage::addDestinationTextAnimation):
(WebKit::WebPage::clearAnimationsForSessionID):
(WebKit::WebPage::showSelectionForWritingToolsSessionAssociatedWithAnimationID):
(WebKit::WebPage::showSelectionForWritingToolsSessionWithID):
(WebKit::WebPage::deferIntelligenceTextAnimation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addTextAnimationForAnimationID): Deleted.
(WebKit::WebPage::removeTextAnimationForAnimationID): Deleted.
(WebKit::WebPage::removeTransparentMarkersForSessionID): Deleted.
(WebKit::WebPage::removeInitialTextAnimation): Deleted.
(WebKit::WebPage::addInitialTextAnimation): Deleted.
(WebKit::WebPage::addSourceTextAnimation): Deleted.
(WebKit::WebPage::addDestinationTextAnimation): Deleted.
(WebKit::WebPage::clearAnimationsForSessionID): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/282125@main">https://commits.webkit.org/282125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39edb8342b73bc1bde447285f273621be866010c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50008 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8733 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11011 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6037 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11079 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57635 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4949 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9354 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37248 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->