### PR TITLE
[TZone] WebKit/UIProcess: Convert FastMalloc to TZone

### DIFF
--- a/Source/WebKit/UIProcess/API/APIAutomationClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationClient.h
@@ -27,6 +27,7 @@
 #define APIAutomationClient_h
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebProcessPool;
@@ -35,7 +36,7 @@ class WebProcessPool;
 namespace API {
 
 class AutomationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AutomationClient);
 public:
     virtual ~AutomationClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
@@ -27,6 +27,7 @@
 #define APIAutomationSessionClient_h
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -41,7 +42,7 @@ enum AutomationSessionBrowsingContextOptions : uint16_t {
 };
 
 class AutomationSessionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AutomationSessionClient);
 public:
     enum class JavaScriptDialogType {
         Alert,

--- a/Source/WebKit/UIProcess/API/APIContextMenuClient.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuClient.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS NSMenu;
 
@@ -49,7 +50,7 @@ class WebPageProxy;
 namespace API {
 
 class ContextMenuClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ContextMenuClient);
 public:
     virtual ~ContextMenuClient() { }
 

--- a/Source/WebKit/UIProcess/API/APICustomProtocolManagerClient.h
+++ b/Source/WebKit/UIProcess/API/APICustomProtocolManagerClient.h
@@ -27,6 +27,7 @@
 
 #include "LegacyCustomProtocolID.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class LegacyCustomProtocolManagerProxy;
@@ -39,7 +40,7 @@ class ResourceRequest;
 namespace API {
 
 class CustomProtocolManagerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CustomProtocolManagerClient);
 public:
     virtual ~CustomProtocolManagerClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIDataTaskClient.h
+++ b/Source/WebKit/UIProcess/API/APIDataTaskClient.h
@@ -28,6 +28,7 @@
 #include "AuthenticationChallengeDisposition.h"
 #include "AuthenticationChallengeProxy.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class Credential;
@@ -41,7 +42,7 @@ namespace API {
 class Data;
 
 class DataTaskClient : public RefCounted<DataTaskClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DataTaskClient);
 public:
     static Ref<DataTaskClient> create() { return adoptRef(*new DataTaskClient); }
     virtual ~DataTaskClient() { }

--- a/Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 enum DiagnosticLoggingResultType : uint8_t;
@@ -41,7 +42,7 @@ namespace API {
 class Dictionary;
 
 class DiagnosticLoggingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DiagnosticLoggingClient);
 public:
     virtual ~DiagnosticLoggingClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIDownloadClient.h
+++ b/Source/WebKit/UIProcess/API/APIDownloadClient.h
@@ -30,6 +30,7 @@
 #include "AuthenticationDecisionListener.h"
 #include "DownloadID.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -52,7 +53,7 @@ namespace API {
 class Data;
 
 class DownloadClient : public RefCounted<DownloadClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DownloadClient);
 public:
     virtual ~DownloadClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFindClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindClient.h
@@ -27,6 +27,7 @@
 #define APIFindClient_h
 
 #include <WebCore/PlatformLayer.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS CALayer;
@@ -42,7 +43,7 @@ class WebPageProxy;
 namespace API {
 
 class FindClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FindClient);
 public:
     virtual ~FindClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFindMatchesClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindMatchesClient.h
@@ -27,6 +27,7 @@
 #define APIFindMatchesClient_h
 
 #include <WebCore/IntRect.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,7 +39,7 @@ class WebPageProxy;
 namespace API {
 
 class FindMatchesClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FindMatchesClient);
 public:
     virtual ~FindMatchesClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFormClient.h
+++ b/Source/WebKit/UIProcess/API/APIFormClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebFrameProxy;
@@ -36,7 +37,7 @@ namespace API {
 class Object;
 
 class FormClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FormClient);
 public:
     virtual ~FormClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFullscreenClient.h
+++ b/Source/WebKit/UIProcess/API/APIFullscreenClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS NSError;
 OBJC_CLASS UIViewController;
@@ -37,7 +38,7 @@ class WebPageProxy;
 namespace API {
 
 class FullscreenClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FullscreenClient);
 public:
     enum Type {
         APIType,

--- a/Source/WebKit/UIProcess/API/APIGeolocationProvider.h
+++ b/Source/WebKit/UIProcess/API/APIGeolocationProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebGeolocationManagerProxy;
@@ -34,7 +35,7 @@ class WebGeolocationManagerProxy;
 namespace API {
 
 class GeolocationProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(GeolocationProvider);
 public:
     virtual ~GeolocationProvider() { }
 

--- a/Source/WebKit/UIProcess/API/APIHistoryClient.h
+++ b/Source/WebKit/UIProcess/API/APIHistoryClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebPageProxy;
@@ -35,7 +36,7 @@ struct WebNavigationDataStore;
 namespace API {
 
 class HistoryClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(HistoryClient);
 public:
     virtual ~HistoryClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIIconDatabaseClient.h
+++ b/Source/WebKit/UIProcess/API/APIIconDatabaseClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebIconDatabase;
@@ -34,7 +35,7 @@ class WebIconDatabase;
 namespace API {
 
 class IconDatabaseClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(IconDatabaseClient);
 public:
     virtual ~IconDatabaseClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIIconLoadingClient.h
+++ b/Source/WebKit/UIProcess/API/APIIconLoadingClient.h
@@ -28,13 +28,14 @@
 #include <WebCore/LinkIcon.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace API {
 
 class Data;
 
 class IconLoadingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(IconLoadingClient);
 public:
     virtual ~IconLoadingClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
@@ -29,6 +29,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebProcessPool;
@@ -37,7 +38,7 @@ class WebProcessPool;
 namespace API {
 
 class InjectedBundleClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InjectedBundleClient);
 public:
     virtual ~InjectedBundleClient() = default;
 

--- a/Source/WebKit/UIProcess/API/APIInspectorClient.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebInspectorUIProxy;
@@ -34,7 +35,7 @@ class WebInspectorUIProxy;
 namespace API {
 
 class InspectorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorClient);
 public:
     virtual ~InspectorClient() = default;
 

--- a/Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h
@@ -28,11 +28,12 @@
 #include "InspectorExtensionTypes.h"
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace API {
 
 class InspectorExtensionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorExtensionClient);
 public:
     virtual ~InspectorExtensionClient() = default;
 

--- a/Source/WebKit/UIProcess/API/APILegacyContextHistoryClient.h
+++ b/Source/WebKit/UIProcess/API/APILegacyContextHistoryClient.h
@@ -27,6 +27,7 @@
 #define APILegacyContextHistoryClient_h
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebFrameProxy;
@@ -38,7 +39,7 @@ struct WebNavigationDataStore;
 namespace API {
 
 class LegacyContextHistoryClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(LegacyContextHistoryClient);
 public:
     virtual ~LegacyContextHistoryClient() { }
 

--- a/Source/WebKit/UIProcess/API/APILoaderClient.h
+++ b/Source/WebKit/UIProcess/API/APILoaderClient.h
@@ -29,6 +29,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class ResourceError;
@@ -50,7 +51,7 @@ class Navigation;
 class Object;
 
 class LoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(LoaderClient);
 public:
     virtual ~LoaderClient() { }
     virtual void didStartProvisionalLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) { }

--- a/Source/WebKit/UIProcess/API/APINavigationClient.h
+++ b/Source/WebKit/UIProcess/API/APINavigationClient.h
@@ -37,6 +37,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if HAVE(APP_SSO)
 #include "SOAuthorizationLoadPolicy.h"
@@ -73,7 +74,7 @@ class NavigationResponse;
 class Object;
 
 class NavigationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(NavigationClient);
 public:
     virtual ~NavigationClient() { }
 

--- a/Source/WebKit/UIProcess/API/APINotificationProvider.h
+++ b/Source/WebKit/UIProcess/API/APINotificationProvider.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebKit {
@@ -45,7 +46,7 @@ class NotificationResources;
 namespace API {
 
 class NotificationProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(NotificationProvider);
 public:
     virtual ~NotificationProvider() = default;
 

--- a/Source/WebKit/UIProcess/API/APIPolicyClient.h
+++ b/Source/WebKit/UIProcess/API/APIPolicyClient.h
@@ -28,6 +28,7 @@
 #include "WebFramePolicyListenerProxy.h"
 #include <WebCore/FrameLoaderTypes.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class ResourceError;
@@ -46,7 +47,7 @@ namespace API {
 class Object;
 
 class PolicyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PolicyClient);
 public:
     virtual ~PolicyClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -36,6 +36,7 @@
 #include <WebCore/PermissionState.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/PlatformViewController.h>
@@ -95,7 +96,7 @@ class SecurityOrigin;
 class WebAuthenticationPanel;
 
 class UIClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(UIClient);
 public:
     virtual ~UIClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
@@ -31,6 +31,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/spi/cocoa/SecuritySPI.h>
 #include <wtf/text/WTFString.h>
 
@@ -43,7 +44,7 @@ class AuthenticatorAssertionResponse;
 namespace API {
 
 class WebAuthenticationPanelClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebAuthenticationPanelClient);
 public:
     virtual ~WebAuthenticationPanelClient() = default;
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -103,6 +103,7 @@
 #include <WebCore/SerializedCryptoKeyWrap.h>
 #include <WebCore/WindowFeatures.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #ifdef __BLOCKS__
 #include <Block.h>
@@ -2427,7 +2428,7 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
 }
 
 class StateClient final : public API::Client<WKPageStateClientBase>, public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(StateClient);
 public:
     explicit StateClient(const WKPageStateClientBase* client)
     {

--- a/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
@@ -24,12 +24,13 @@
  */
 
 #import "PageLoadState.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
 
 class PageLoadStateObserver : public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageLoadStateObserver);
 public:
     PageLoadStateObserver(id object, NSString *activeURLKey = @"activeURL")
         : m_object(object)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -34,6 +34,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -46,7 +47,7 @@ static NSArray<NSHTTPCookie *> *coreCookiesToNSCookies(const Vector<WebCore::Coo
 }
 
 class WKHTTPCookieStoreObserver : public API::HTTPCookieStoreObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WKHTTPCookieStoreObserver);
 public:
     explicit WKHTTPCookieStoreObserver(id<WKHTTPCookieStoreObserver> observer)
         : m_observer(observer)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -48,6 +48,7 @@
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/SerializedScriptValue.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/TZoneMallocInlines.h>
 
 @implementation WKUserContentController
 
@@ -127,7 +128,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 }
 
 class ScriptMessageHandlerDelegate final : public WebKit::WebScriptMessageHandler::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ScriptMessageHandlerDelegate);
 public:
     ScriptMessageHandlerDelegate(WKUserContentController *controller, id <WKScriptMessageHandler> handler, NSString *name)
         : m_controller(controller)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -169,6 +169,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SystemTracing.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/UUID.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SpanCocoa.h>
@@ -4294,7 +4295,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
     _inputDelegate = inputDelegate;
 
     class FormClient : public API::FormClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(FormClient);
     public:
         explicit FormClient(WKWebView *webView)
             : m_webView(webView)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -52,6 +52,7 @@
 #import <WebCore/ScrollingNodeID.h>
 #import <WebCore/ValidationBubble.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
 
 #if PLATFORM(MAC)
@@ -676,7 +677,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     class WKMediaSessionCoordinatorForTesting
         : public WebKit::MediaSessionCoordinatorProxyPrivate
         , public WebCore::MediaSessionCoordinatorClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(WKMediaSessionCoordinatorForTesting);
     public:
 
         static Ref<WKMediaSessionCoordinatorForTesting> create(id <_WKMediaSessionCoordinator> privateCoordinator)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -35,6 +35,7 @@
 #import "WKWebViewInternal.h"
 #import "_WKInspectorConfigurationInternal.h"
 #import "_WKInspectorDebuggableInfoInternal.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 #import "APIInspectorExtension.h"
@@ -53,7 +54,7 @@
 namespace WebKit {
 
 class _WKRemoteWebInspectorUIProxyClient final : public RemoteWebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(_WKRemoteWebInspectorUIProxyClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(_WKRemoteWebInspectorUIProxyClient);
 public:
     _WKRemoteWebInspectorUIProxyClient(_WKRemoteWebInspectorViewController *controller)

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -28,6 +28,7 @@
 #include "WebKitWebViewPrivate.h"
 #include "WebKitWebsiteDataManagerPrivate.h"
 #include <glib/gi18n-lib.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -77,7 +78,7 @@ static guint signals[LAST_SIGNAL] = { 0, };
 WEBKIT_DEFINE_FINAL_TYPE(WebKitAutomationSession, webkit_automation_session, G_TYPE_OBJECT, GObject)
 
 class AutomationSessionClient final : public API::AutomationSessionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AutomationSessionClient);
 public:
     explicit AutomationSessionClient(WebKitAutomationSession* session)
         : m_session(session)

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/HTTPCookieAcceptPolicy.h>
 #include <glib/gi18n-lib.h>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
@@ -57,7 +58,7 @@ enum {
 };
 
 class CookieStoreObserver : public API::HTTPCookieStoreObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CookieStoreObserver);
 public:
     CookieStoreObserver(Function<void()>&& callback)
         : m_callback(WTFMove(callback)) { }

--- a/Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp
@@ -22,12 +22,13 @@
 
 #include "APIIconLoadingClient.h"
 #include "WebKitWebViewPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GWeakPtr.h>
 
 using namespace WebKit;
 
 class IconLoadingClient : public API::IconLoadingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(IconLoadingClient);
 public:
     explicit IconLoadingClient(WebKitWebView* webView)
         : m_webView(webView)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp
@@ -36,6 +36,7 @@
 #include "WebKitWebViewPrivate.h"
 #include "WebNotificationManagerProxy.h"
 #include "WebPageProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 
 using namespace WebKit;
@@ -72,6 +73,8 @@ private:
 
     WebKitNotificationProvider& m_provider;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebKitNotificationProvider);
 
 WebKitNotificationProvider::WebKitNotificationProvider(WebNotificationManagerProxy* notificationManager, WebKitWebContext* webContext)
     : m_webContext(webContext)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.h
@@ -24,6 +24,7 @@
 #include "WebKitWebContext.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/StringHash.h>
 
@@ -37,7 +38,7 @@ class WebNotification;
 class WebPageProxy;
 
 class WebKitNotificationProvider final : public NotificationService::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebKitNotificationProvider);
 public:
     WebKitNotificationProvider(WebNotificationManagerProxy*, WebKitWebContext*);
     ~WebKitNotificationProvider();

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -40,6 +40,7 @@
 #include <epoxy/gl.h>
 #include <fcntl.h>
 #include <gio/gio.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/glib/GRefPtr.h>
@@ -87,6 +88,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebKitProtocolHandler);
 
 WebKitProtocolHandler::WebKitProtocolHandler(WebKitWebContext* context)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.h
@@ -21,11 +21,12 @@
 
 #include "WebKitURISchemeRequest.h"
 #include "WebKitWebContext.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebKitProtocolHandler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebKitProtocolHandler);
 public:
     explicit WebKitProtocolHandler(WebKitWebContext*);
     ~WebKitProtocolHandler() = default;

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -28,6 +28,7 @@
 #include "WebKitWebContextPrivate.h"
 #include "WebScriptMessageHandler.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -394,7 +395,7 @@ webkit_script_message_reply_return_error_message(WebKitScriptMessageReply* messa
 }
 
 class ScriptMessageClientGtk final : public WebScriptMessageHandler::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ScriptMessageClientGtk);
 public:
     ScriptMessageClientGtk(WebKitUserContentManager* manager, const char* handlerName, bool supportsAsyncReply)
         : m_handlerName(g_quark_from_string(handlerName))

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -68,6 +68,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URLParser.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -208,7 +209,7 @@ typedef HashMap<String, RefPtr<WebKitURISchemeHandler> > URISchemeHandlerMap;
 
 #if ENABLE(REMOTE_INSPECTOR)
 class WebKitAutomationClient final : Inspector::RemoteInspector::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitAutomationClient);
 public:
     explicit WebKitAutomationClient(WebKitWebContext* context)
         : m_webContext(context)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.cpp
@@ -23,9 +23,12 @@
 #include "WebFrameProxy.h"
 #include "WebKitWebResourcePrivate.h"
 #include "WebKitWebViewPrivate.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebKitWebResourceLoadManager);
 
 WebKitWebResourceLoadManager::WebKitWebResourceLoadManager(WebKitWebView* webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.h
@@ -24,6 +24,7 @@
 #include <WebCore/GlobalFrameIdentifier.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 
 namespace WebCore {
@@ -35,7 +36,7 @@ class ResourceResponse;
 namespace WebKit {
 
 class WebKitWebResourceLoadManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebKitWebResourceLoadManager);
 public:
     explicit WebKitWebResourceLoadManager(WebKitWebView*);
     ~WebKitWebResourceLoadManager();

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -81,6 +81,7 @@
 #include <jsc/JSCContextPrivate.h>
 #include <libsoup/soup.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
@@ -243,7 +244,7 @@ enum {
 static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
 
 class PageLoadStateObserver final : public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageLoadStateObserver);
 public:
     PageLoadStateObserver(WebKitWebView* webView)
         : m_webView(webView)

--- a/Source/WebKit/UIProcess/API/gtk/DragSource.h
+++ b/Source/WebKit/UIProcess/API/gtk/DragSource.h
@@ -31,6 +31,7 @@
 #include <WebCore/SelectionData.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GtkWidget GtkWidget;
@@ -48,7 +49,8 @@ class ShareableBitmap;
 namespace WebKit {
 
 class DragSource {
-    WTF_MAKE_NONCOPYABLE(DragSource); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DragSource);
+    WTF_MAKE_NONCOPYABLE(DragSource);
 public:
 
     explicit DragSource(GtkWidget*);

--- a/Source/WebKit/UIProcess/API/gtk/DropTarget.h
+++ b/Source/WebKit/UIProcess/API/gtk/DropTarget.h
@@ -33,6 +33,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GtkWidget GtkWidget;
@@ -49,7 +50,8 @@ using PlatformDropContext = GdkDragContext;
 namespace WebKit {
 
 class DropTarget {
-    WTF_MAKE_NONCOPYABLE(DropTarget); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DropTarget);
+    WTF_MAKE_NONCOPYABLE(DropTarget);
 public:
     explicit DropTarget(GtkWidget*);
     ~DropTarget();

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -57,6 +57,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/ValidationBubble.h>
 #include <wtf/Compiler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GWeakPtr.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
@@ -68,6 +69,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageClientImpl);
 
 PageClientImpl::PageClientImpl(GtkWidget* viewWidget)
     : m_viewWidget(viewWidget)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -35,6 +35,7 @@
 #include <WebCore/IntSize.h>
 #include <gtk/gtk.h>
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum class DOMPasteAccessPolicy : uint8_t;
@@ -52,7 +53,7 @@ class PageClientImpl : public PageClient
     , public WebFullScreenManagerProxyClient
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageClientImpl);
 public:
     explicit PageClientImpl(GtkWidget*);
 

--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp
@@ -29,6 +29,7 @@
 #include "WebKitWebViewBasePrivate.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -42,6 +43,8 @@ static void toplevelWindowDestroyedCallback(gpointer, GObject* window)
 {
     toplevelWindows().remove(reinterpret_cast<GtkWindow*>(window));
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ToplevelWindow);
 
 ToplevelWindow* ToplevelWindow::forGtkWindow(GtkWindow* window)
 {

--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
@@ -26,16 +26,17 @@
 #pragma once
 
 #include <gtk/gtk.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 typedef struct _WebKitWebViewBase WebKitWebViewBase;
 
 namespace WebKit {
 
 class ToplevelWindow {
-    WTF_MAKE_NONCOPYABLE(ToplevelWindow); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ToplevelWindow);
+    WTF_MAKE_NONCOPYABLE(ToplevelWindow);
 public:
     static ToplevelWindow* forGtkWindow(GtkWindow*);
     explicit ToplevelWindow(GtkWindow*);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
@@ -30,6 +30,7 @@
 #include "WebKitWebContextPrivate.h"
 #include "WebPageProxy.h"
 #include "WebScriptMessageHandler.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -38,7 +39,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class ScriptMessageClient final : public WebScriptMessageHandler::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ScriptMessageClient);
 public:
     ScriptMessageClient(RemoteInspectorProtocolHandler& inspectorProtocolHandler)
         : m_inspectorProtocolHandler(inspectorProtocolHandler)
@@ -70,6 +71,8 @@ public:
 private:
     RemoteInspectorProtocolHandler& m_inspectorProtocolHandler;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteInspectorProtocolHandler);
 
 RemoteInspectorProtocolHandler::RemoteInspectorProtocolHandler(WebKitWebContext* context)
 {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.h
@@ -27,12 +27,13 @@
 #include "WebKitWebView.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebKit {
 
 class RemoteInspectorProtocolHandler final : public RemoteInspectorObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteInspectorProtocolHandler);
 public:
     explicit RemoteInspectorProtocolHandler(WebKitWebContext* context);
     ~RemoteInspectorProtocolHandler();

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
@@ -24,6 +24,7 @@
 #include "WebInspectorUIProxyClient.h"
 #include "WebKitWebInspectorPrivate.h"
 #include <glib/gi18n-lib.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
@@ -282,7 +283,7 @@ static void webkit_web_inspector_class_init(WebKitWebInspectorClass* findClass)
 }
 
 class WebKitInspectorClient final : public WebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitInspectorClient);
 public:
     explicit WebKitInspectorClient(WebKitWebInspector* inspector)
         : m_inspector(inspector)

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
@@ -29,6 +29,7 @@
 #if USE(LIBWPE) && ENABLE(TOUCH_EVENTS)
 
 #include <WebCore/Scrollbar.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -39,6 +40,8 @@ static constexpr uint32_t axisLockMovementThreshold { 8 };
 static constexpr uint32_t axisLockActivationThreshold { 15 };
 static constexpr uint32_t axisLockReleaseThreshold { 30 };
 static constexpr uint32_t contextMenuThreshold { 500 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TouchGestureController);
 
 TouchGestureController::EventVariant TouchGestureController::handleEvent(const struct wpe_input_touch_event_raw* touchPoint)
 {

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
@@ -30,11 +30,12 @@
 #include "WebWheelEvent.h"
 #include <variant>
 #include <wpe/wpe.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class TouchGestureController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TouchGestureController);
 public:
     TouchGestureController() = default;
 

--- a/Source/WebKit/UIProcess/API/playstation/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/playstation/APIViewClient.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
 class Cursor;
 class IntRect;
@@ -38,7 +40,7 @@ class PlayStationWebView;
 namespace API {
 
 class ViewClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ViewClient);
 public:
     virtual ~ViewClient() = default;
 

--- a/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
@@ -27,6 +27,7 @@
 
 #include "UserMessage.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 typedef struct OpaqueJSContext* JSGlobalContextRef;
 
@@ -42,7 +43,7 @@ class View;
 namespace API {
 
 class ViewClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ViewClient);
 public:
     virtual ~ViewClient() = default;
 

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
@@ -21,6 +21,7 @@
 
 #include "APIViewClient.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 typedef struct _WebKitWebView WebKitWebView;
 
@@ -40,7 +41,7 @@ struct UserMessage;
 }
 
 class WebKitWebViewClient final : public API::ViewClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitWebViewClient);
 public:
     explicit WebKitWebViewClient(WebKitWebView*);
 

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/Forward.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -56,7 +57,7 @@ enum class ApplicationType : uint8_t {
 };
 
 class ApplicationStateTracker : public CanMakeWeakPtr<ApplicationStateTracker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ApplicationStateTracker);
 public:
     ApplicationStateTracker(UIView *, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector);
     ~ApplicationStateTracker();

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -36,6 +36,7 @@
 #import <WebCore/UIViewControllerUtilities.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/ObjCRuntimeExtras.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
@@ -155,6 +156,8 @@ ApplicationType applicationType(UIWindow *window)
 
     return ApplicationType::Application;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ApplicationStateTracker);
 
 ApplicationStateTracker::ApplicationStateTracker(UIView *view, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector)
     : m_view(view)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -37,6 +37,7 @@
 #include "WebProcessProxy.h"
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "CoreIPCSecureCoding.h"
@@ -73,6 +74,8 @@ static Seconds adjustedTimeoutForThermalState(Seconds timeout)
     return timeout;
 #endif
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AuxiliaryProcessProxy);
 
 AuxiliaryProcessProxy::AuxiliaryProcessProxy(ShouldTakeUIBackgroundAssertion shouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority alwaysRunsAtBackgroundPriority, Seconds responsivenessTimeout)
     : m_responsivenessTimer(*this, adjustedTimeoutForThermalState(responsivenessTimeout))

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -38,6 +38,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/Seconds.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueRef.h>
 
@@ -68,7 +69,7 @@ class AuxiliaryProcessProxy
     , public IPC::Connection::Client
     , public CanMakeThreadSafeCheckedPtr<AuxiliaryProcessProxy> {
     WTF_MAKE_NONCOPYABLE(AuxiliaryProcessProxy);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AuxiliaryProcessProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AuxiliaryProcessProxy);
 protected:
     AuxiliaryProcessProxy(ShouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority = AlwaysRunsAtBackgroundPriority::No, Seconds responsivenessTimeout = ResponsivenessTimer::defaultResponsivenessTimeout);

--- a/Source/WebKit/UIProcess/BackingStore.h
+++ b/Source/WebKit/UIProcess/BackingStore.h
@@ -31,6 +31,7 @@
 #include <WebCore/PlatformImage.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(CAIRO) || PLATFORM(GTK)
 #include <WebCore/RefPtrCairo.h>
@@ -56,7 +57,7 @@ using PlatformPaintContextPtr = SkCanvas*;
 #endif
 
 class BackingStore {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(BackingStore);
     WTF_MAKE_NONCOPYABLE(BackingStore);
 public:
     BackingStore(const WebCore::IntSize&, float deviceScaleFactor);

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
@@ -29,6 +29,7 @@
 
 #import "APIAutomationClient.h"
 #import <JavaScriptCore/RemoteInspector.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKProcessPool;
@@ -38,7 +39,7 @@
 namespace WebKit {
 
 class AutomationClient final : public API::AutomationClient, Inspector::RemoteInspector::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AutomationClient);
 public:
     explicit AutomationClient(WKProcessPool *, id <_WKAutomationDelegate>);
     virtual ~AutomationClient();

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -33,12 +33,15 @@
 #import "_WKAutomationSessionConfiguration.h"
 #import <JavaScriptCore/RemoteInspector.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
 #import <wtf/text/WTFString.h>
 
 using namespace Inspector;
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AutomationClient);
 
 AutomationClient::AutomationClient(WKProcessPool *processPool, id <_WKAutomationDelegate> delegate)
     : m_processPool(processPool)

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
@@ -29,6 +29,7 @@
 #import "WKFoundation.h"
 
 #import "APIAutomationSessionClient.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @protocol _WKAutomationSessionDelegate;
@@ -36,7 +37,7 @@
 namespace WebKit {
 
 class AutomationSessionClient final : public API::AutomationSessionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AutomationSessionClient);
 public:
     explicit AutomationSessionClient(id <_WKAutomationSessionDelegate>);
 

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -33,8 +33,11 @@
 #import "_WKAutomationSessionDelegate.h"
 #import "_WKAutomationSessionInternal.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AutomationSessionClient);
 
 AutomationSessionClient::AutomationSessionClient(id <_WKAutomationSessionDelegate> delegate)
     : m_delegate(delegate)

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
@@ -27,6 +27,7 @@
 
 #import "APIDiagnosticLoggingClient.h"
 #import "WKFoundation.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -35,7 +36,7 @@
 namespace WebKit {
 
 class DiagnosticLoggingClient final : public API::DiagnosticLoggingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DiagnosticLoggingClient);
 public:
     explicit DiagnosticLoggingClient(WKWebView *);
 

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
@@ -30,8 +30,11 @@
 #import "WKSharedAPICast.h"
 #import "_WKDiagnosticLoggingDelegate.h"
 #import <WebCore/DiagnosticLoggingDomain.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DiagnosticLoggingClient);
 
 DiagnosticLoggingClient::DiagnosticLoggingClient(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
@@ -31,6 +31,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -62,7 +63,7 @@ struct ExtensionCapabilityGranterClient : public CanMakeWeakPtr<ExtensionCapabil
 };
 
 class ExtensionCapabilityGranter : public CanMakeWeakPtr<ExtensionCapabilityGranter> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ExtensionCapabilityGranter);
     WTF_MAKE_NONCOPYABLE(ExtensionCapabilityGranter);
 public:
     static UniqueRef<ExtensionCapabilityGranter> create(ExtensionCapabilityGranterClient&);

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -38,6 +38,7 @@
 #import <wtf/CrossThreadCopier.h>
 #import <wtf/NativePromise.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #define GRANTER_RELEASE_LOG(envID, fmt, ...) RELEASE_LOG(ProcessCapabilities, "%{public}s[envID=%{public}s] " fmt, __FUNCTION__, envID.utf8().data(), ##__VA_ARGS__)
 #define GRANTER_RELEASE_LOG_ERROR(envID, fmt, ...) RELEASE_LOG_ERROR(ProcessCapabilities, "%{public}s[envID=%{public}s] " fmt, __FUNCTION__, envID.utf8().data(), ##__VA_ARGS__)
@@ -141,6 +142,8 @@ static bool finalizeGrant(ExtensionCapabilityGranter& granter, const String& env
     existingGrants.remove(iterator);
     return false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExtensionCapabilityGranter);
 
 UniqueRef<ExtensionCapabilityGranter> ExtensionCapabilityGranter::create(ExtensionCapabilityGranterClient& client)
 {

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.h
@@ -29,6 +29,7 @@
 #import "WKFoundation.h"
 
 #import "APIFindClient.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -37,7 +38,7 @@
 namespace WebKit {
 
 class FindClient final : public API::FindClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FindClient);
 public:
     explicit FindClient(WKWebView *);
     

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.mm
@@ -27,8 +27,11 @@
 #import "FindClient.h"
 
 #import "_WKFindDelegate.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FindClient);
 
 FindClient::FindClient(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
@@ -30,6 +30,7 @@
 #include "GroupActivitiesSession.h"
 #include "MediaSessionCoordinatorProxyPrivate.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVDelegatingPlaybackCoordinator;
 OBJC_CLASS AVDelegatingPlaybackCoordinatorPlayCommand;
@@ -42,7 +43,7 @@ OBJC_CLASS WKGroupActivitiesCoordinatorDelegate;
 namespace WebKit {
 
 class GroupActivitiesCoordinator final : public MediaSessionCoordinatorProxyPrivate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GroupActivitiesCoordinator);
 public:
     static Ref<GroupActivitiesCoordinator> create(GroupActivitiesSession&);
     ~GroupActivitiesCoordinator();

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -31,6 +31,7 @@
 #import "WKGroupSession.h"
 #import <WebCore/NotImplemented.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 #import <pal/cf/CoreMediaSoftLink.h>
@@ -103,6 +104,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GroupActivitiesCoordinator);
 
 Ref<GroupActivitiesCoordinator> GroupActivitiesCoordinator::create(GroupActivitiesSession& session)
 {

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
@@ -31,6 +31,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakHashSet.h>
 
@@ -39,7 +40,7 @@ OBJC_CLASS WKGroupSession;
 namespace WebKit {
 
 class GroupActivitiesSession : public RefCounted<GroupActivitiesSession> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GroupActivitiesSession);
 public:
     static Ref<GroupActivitiesSession> create(RetainPtr<WKGroupSession>&&);
     ~GroupActivitiesSession();

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.mm
@@ -25,12 +25,15 @@
 
 #import "config.h"
 #import "GroupActivitiesSession.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR) && HAVE(GROUP_ACTIVITIES)
 
 #import "WKGroupSession.h"
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GroupActivitiesSession);
 
 Ref<GroupActivitiesSession> GroupActivitiesSession::create(RetainPtr<WKGroupSession>&& session)
 {

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
@@ -29,6 +29,7 @@
 
 #include "GroupActivitiesSession.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
 
@@ -48,7 +49,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class GroupActivitiesSessionNotifier : public CanMakeWeakPtr<GroupActivitiesSessionNotifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GroupActivitiesSessionNotifier);
 public:
     static GroupActivitiesSessionNotifier& sharedNotifier();
 

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
@@ -32,6 +32,7 @@
 #import "WKGroupSession.h"
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
+#import <wtf/TZoneMallocInlines.h>
 
 #import "WebKitSwiftSoftLink.h"
 
@@ -39,6 +40,8 @@ namespace WebKit {
 
 using namespace PAL;
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GroupActivitiesSessionNotifier);
 
 GroupActivitiesSessionNotifier& GroupActivitiesSessionNotifier::sharedNotifier()
 {

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
@@ -29,6 +29,7 @@
 
 #import "APIIconLoadingClient.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -37,7 +38,7 @@
 namespace WebKit {
 
 class IconLoadingDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IconLoadingDelegate);
 public:
     explicit IconLoadingDelegate(WKWebView *);
     ~IconLoadingDelegate();
@@ -49,7 +50,7 @@ public:
 
 private:
     class IconLoadingClient : public API::IconLoadingClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(IconLoadingClient);
     public:
         explicit IconLoadingClient(IconLoadingDelegate&);
         ~IconLoadingClient();

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
@@ -31,8 +31,11 @@
 #import "_WKLinkIconParametersInternal.h"
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IconLoadingDelegate);
 
 IconLoadingDelegate::IconLoadingDelegate(WKWebView *webView)
     : m_webView(webView)
@@ -70,6 +73,8 @@ IconLoadingDelegate::IconLoadingClient::~IconLoadingClient()
 }
 
 typedef void (^IconLoadCompletionHandler)(NSData*);
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(IconLoadingDelegateIconLoadingClient, IconLoadingDelegate::IconLoadingClient);
 
 void IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon(const WebCore::LinkIcon& linkIcon, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h
@@ -27,6 +27,7 @@
 
 #import "APIDownloadClient.h"
 #import "WKFoundation.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @protocol _WKDownloadDelegate;
@@ -39,7 +40,7 @@ class ResourceResponse;
 namespace WebKit {
 
 class LegacyDownloadClient final : public API::DownloadClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyDownloadClient);
 public:
     explicit LegacyDownloadClient(id <_WKDownloadDelegate>);
     

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -44,10 +44,13 @@
 #import <WebCore/ResourceResponse.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/FileSystem.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyDownloadClient);
 
 LegacyDownloadClient::LegacyDownloadClient(id <_WKDownloadDelegate> delegate)
     : m_delegate(delegate)

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -34,6 +34,7 @@
 #import "ProcessThrottler.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/UniqueRef.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
@@ -64,7 +65,7 @@ namespace WebKit {
 struct WebNavigationDataStore;
 
 class NavigationState final : public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NavigationState);
 public:
     explicit NavigationState(WKWebView *);
     ~NavigationState();

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -79,6 +79,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/Scope.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WeakHashMap.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -118,6 +119,8 @@ static WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>& navigationStates()
 
     return navigationStates;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationState);
 
 NavigationState::NavigationState(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -40,6 +40,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
@@ -52,7 +53,7 @@ class PlaybackSessionModelContext final
     : public RefCounted<PlaybackSessionModelContext>
     , public WebCore::PlaybackSessionModel
     , public CanMakeCheckedPtr<PlaybackSessionModelContext> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PlaybackSessionModelContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionModelContext);
 public:
     static Ref<PlaybackSessionModelContext> create(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -41,11 +41,14 @@
 #import <WebCore/PlaybackSessionInterfaceAVKit.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <wtf/LoggerHelper.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 #pragma mark - PlaybackSessionModelContext
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionModelContext);
 
 PlaybackSessionModelContext::PlaybackSessionModelContext(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)
     : m_manager(manager)

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h
@@ -27,6 +27,7 @@
 
 #import "APIResourceLoadClient.h"
 #import "WKFoundation.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -40,7 +41,7 @@ class ResourceLoadClient;
 namespace WebKit {
 
 class ResourceLoadDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ResourceLoadDelegate);
 public:
     explicit ResourceLoadDelegate(WKWebView *);
     ~ResourceLoadDelegate();
@@ -52,7 +53,7 @@ public:
 
 private:
     class ResourceLoadClient : public API::ResourceLoadClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(ResourceLoadClient);
     public:
         explicit ResourceLoadClient(ResourceLoadDelegate&);
         ~ResourceLoadClient();

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
@@ -31,8 +31,11 @@
 #import "WKNSURLAuthenticationChallenge.h"
 #import "_WKResourceLoadDelegate.h"
 #import "_WKResourceLoadInfoInternal.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ResourceLoadDelegate);
 
 ResourceLoadDelegate::ResourceLoadDelegate(WKWebView *webView)
     : m_webView(webView)
@@ -66,6 +69,8 @@ void ResourceLoadDelegate::setDelegate(id <_WKResourceLoadDelegate> delegate)
     m_delegateMethods.didReceiveResponse = [delegate respondsToSelector:@selector(webView:resourceLoad:didReceiveResponse:)];
     m_delegateMethods.didCompleteWithError = [delegate respondsToSelector:@selector(webView:resourceLoad:didCompleteWithError:response:)];
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(ResourceLoadDelegateResourceLoadClient, ResourceLoadDelegate::ResourceLoadClient);
 
 ResourceLoadDelegate::ResourceLoadClient::ResourceLoadClient(ResourceLoadDelegate& delegate)
     : m_resourceLoadDelegate(delegate)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS SOAuthorization;
 OBJC_CLASS WKSOAuthorizationDelegate;
@@ -47,7 +48,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SOAuthorizationCoordinator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SOAuthorizationCoordinator);
     WTF_MAKE_NONCOPYABLE(SOAuthorizationCoordinator);
 public:
     SOAuthorizationCoordinator();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -37,15 +37,18 @@
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
 #import <WebCore/ResourceRequest.h>
-#import <pal/cocoa/AppSSOSoftLink.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/spi/cocoa/AuthKitSPI.h>
 #import <wtf/Function.h>
+#import <wtf/TZoneMallocInlines.h>
+#import <pal/cocoa/AppSSOSoftLink.h>
 
 #define AUTHORIZATIONCOORDINATOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - SOAuthorizationCoordinator::" fmt, this, ##__VA_ARGS__)
 #define AUTHORIZATIONCOORDINATOR_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(AppSSO, "%p - SOAuthorizationCoordinator::" fmt, this, ##__VA_ARGS__)
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SOAuthorizationCoordinator);
 
 SOAuthorizationCoordinator::SOAuthorizationCoordinator()
 {

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.h
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.h
@@ -30,6 +30,7 @@
 #import "EditingRange.h"
 #import <WebCore/FloatRect.h>
 #import <wtf/CompletionHandler.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSAttributedString;
 
@@ -38,7 +39,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class TextCheckingController final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextCheckingController);
     WTF_MAKE_NONCOPYABLE(TextCheckingController);
 public:
     explicit TextCheckingController(WebPageProxy&);

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
@@ -33,8 +33,11 @@
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
 #import <WebCore/AttributedString.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCheckingController);
 
 TextCheckingController::TextCheckingController(WebPageProxy& webPageProxy)
     : m_page(webPageProxy)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -31,6 +31,7 @@
 #import "APIUIClient.h"
 #import <WebCore/PlatformViewController.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -62,7 +63,7 @@ namespace WebKit {
 enum class TapHandlingResult : uint8_t;
 
 class UIDelegate : public CanMakeWeakPtr<UIDelegate> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UIDelegate);
 public:
     explicit UIDelegate(WKWebView *);
     ~UIDelegate();

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -70,6 +70,7 @@
 #import <WebCore/FontAttributes.h>
 #import <WebCore/SecurityOrigin.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -82,6 +83,8 @@
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UIDelegate);
 
 UIDelegate::UIDelegate(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/VideoFrameCV.h>
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/NativePromise.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/cocoa/Entitlements.h>
@@ -70,7 +71,7 @@ class UserMediaCaptureManagerProxySourceProxy final
     , private RealtimeMediaSource::AudioSampleObserver
     , private RealtimeMediaSource::VideoFrameObserver
     , public CanMakeCheckedPtr<UserMediaCaptureManagerProxySourceProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(UserMediaCaptureManagerProxySourceProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(UserMediaCaptureManagerProxySourceProxy);
 public:
     UserMediaCaptureManagerProxySourceProxy(RealtimeMediaSourceIdentifier id, Ref<IPC::Connection>&& connection, ProcessIdentity&& resourceOwner, Ref<RealtimeMediaSource>&& source, RefPtr<RemoteVideoFrameObjectHeap>&& videoFrameObjectHeap)
@@ -434,6 +435,8 @@ private:
     std::optional<MediaConstraints> m_videoConstraints;
     Ref<GenericPromise> m_pendingAction { GenericPromise::createAndResolve() };
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaCaptureManagerProxy);
 
 UserMediaCaptureManagerProxy::UserMediaCaptureManagerProxy(UniqueRef<ConnectionProxy>&& connectionProxy)
     : m_connectionProxy(WTFMove(connectionProxy))

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -38,6 +38,7 @@
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <pal/spi/cocoa/TCCSPI.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -61,7 +62,7 @@ class WebProcessProxy;
 class UserMediaCaptureManagerProxySourceProxy;
 
 class UserMediaCaptureManagerProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserMediaCaptureManagerProxy);
 public:
     class ConnectionProxy {
     public:

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LockdownModeObserver.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS WKWebpagePreferences;
@@ -37,7 +38,7 @@ class WebsitePolicies;
 namespace WebKit {
 
 class WebPagePreferencesLockdownModeObserver final : public LockdownModeObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPagePreferencesLockdownModeObserver);
 public:
     explicit WebPagePreferencesLockdownModeObserver(API::WebsitePolicies&);
     ~WebPagePreferencesLockdownModeObserver();

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
@@ -31,8 +31,11 @@
 #include "APIWebsitePolicies.h"
 #include "WKWebpagePreferencesInternal.h"
 #include "WebProcessPool.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPagePreferencesLockdownModeObserver);
 
 WebPagePreferencesLockdownModeObserver::WebPagePreferencesLockdownModeObserver(API::WebsitePolicies& policies)
     : m_policies(policies)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -39,6 +39,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/Region.h>
 #include <optional>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(GTK)
 #include <gtk/gtk.h>
@@ -299,6 +300,8 @@ void DrawingAreaProxyCoordinatedGraphics::discardBackingStore()
     send(Messages::DrawingArea::DidDiscardBackingStore());
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(DrawingAreaProxyCoordinatedGraphicsDrawingMonitor, DrawingAreaProxyCoordinatedGraphics::DrawingMonitor);
 
 DrawingAreaProxyCoordinatedGraphics::DrawingMonitor::DrawingMonitor(WebPageProxy& webPage)
     : m_timer(RunLoop::main(), this, &DrawingMonitor::stop)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -30,6 +30,7 @@
 #include "DrawingAreaProxy.h"
 #include "LayerTreeContext.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 #if !PLATFORM(WPE)
 #include "BackingStore.h"
@@ -103,7 +104,8 @@ private:
 #endif
 
     class DrawingMonitor {
-        WTF_MAKE_NONCOPYABLE(DrawingMonitor); WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(DrawingMonitor);
+        WTF_MAKE_NONCOPYABLE(DrawingMonitor);
     public:
         DrawingMonitor(WebPageProxy&);
         ~DrawingMonitor();

--- a/Source/WebKit/UIProcess/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/DisplayLink.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/AnimationFrameRate.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebKit {
@@ -39,6 +40,9 @@ namespace WebKit {
 using namespace WebCore;
 
 constexpr unsigned maxFireCountWithoutObservers { 20 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DisplayLink);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(DisplayLinkClient, DisplayLink::Client);
 
 DisplayLink::DisplayLink(PlatformDisplayID displayID)
     : m_displayID(displayID)

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -32,9 +32,9 @@
 #include <WebCore/DisplayUpdate.h>
 #include <WebCore/PlatformScreen.h>
 #include <wtf/CheckedPtr.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(MAC)
 #include <CoreVideo/CVDisplayLink.h>
@@ -51,10 +51,10 @@ struct wpe_playstation_display;
 namespace WebKit {
 
 class DisplayLink {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DisplayLink);
 public:
     class Client : public CanMakeThreadSafeCheckedPtr<Client> {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Client);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
     friend class DisplayLink;
     public:

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp
@@ -30,8 +30,11 @@
 
 #include "EventDispatcherMessages.h"
 #include "WebProcessMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DisplayLinkProcessProxyClient);
 
 void DisplayLinkProcessProxyClient::setConnection(RefPtr<IPC::Connection>&& connection)
 {

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
@@ -30,6 +30,7 @@
 #if HAVE(DISPLAY_LINK)
 
 #include "Connection.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ class WebProcessProxy;
 
 class DisplayLinkProcessProxyClient final : public DisplayLink::Client {
 public:
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DisplayLinkProcessProxyClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DisplayLinkProcessProxyClient);
 public:
     DisplayLinkProcessProxyClient() = default;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
@@ -37,12 +37,15 @@
 #include "ProcessAssertion.h"
 #include "WebProcessPool.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/Entitlements.h>
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DownloadProxyMap);
 
 DownloadProxyMap::DownloadProxyMap(NetworkProcessProxy& process)
     : m_process(process)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -62,7 +63,7 @@ class WebsiteDataStore;
 struct FrameInfoData;
 
 class DownloadProxyMap : public CanMakeWeakPtr<DownloadProxyMap> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DownloadProxyMap);
     WTF_MAKE_NONCOPYABLE(DownloadProxyMap);
 
 public:

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/ScrollView.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "MessageSenderInlines.h"
@@ -39,6 +40,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DrawingAreaProxy);
 
 DrawingAreaProxy::DrawingAreaProxy(DrawingAreaType type, WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : m_type(type)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -38,6 +38,7 @@
 #include <wtf/Identified.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakRef.h>
 
@@ -74,7 +75,7 @@ struct UpdateInfo;
 #endif
 
 class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<DrawingAreaIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DrawingAreaProxy);
     WTF_MAKE_NONCOPYABLE(DrawingAreaProxy);
 
 public:

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.h
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 
 OBJC_CLASS NSSet;
@@ -54,7 +55,7 @@ public:
 };
 
 class EndowmentStateTracker {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EndowmentStateTracker);
 public:
     static EndowmentStateTracker& singleton();
 

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.mm
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.mm
@@ -32,6 +32,7 @@
 #import "RunningBoardServicesSPI.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -72,6 +73,8 @@ static NSSet<NSString *> *endowmentsForHandle(RBSProcessHandle *processHandle)
 
     return [state endowmentNamespaces];
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EndowmentStateTracker);
 
 inline auto EndowmentStateTracker::stateFromEndowments(NSSet *endowments) -> State
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -85,6 +85,7 @@
 #import <wtf/CallbackAggregator.h>
 #import <wtf/EnumTraits.h>
 #import <wtf/FileSystem.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URLParser.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/MakeString.h>
@@ -3861,7 +3862,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         return;
 
     class InspectorExtensionClient : public API::InspectorExtensionClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorExtensionClient);
 
     public:
         explicit InspectorExtensionClient(API::InspectorExtension& inspectorExtension, WebExtensionContext& extensionContext)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -47,6 +47,7 @@
 #import "_WKFrameHandle.h"
 #import "_WKFrameTreeNode.h"
 #import <wtf/CallbackAggregator.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -102,7 +103,7 @@ SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParamet
 
 class InjectionResultHolder : public RefCounted<InjectionResultHolder> {
     WTF_MAKE_NONCOPYABLE(InjectionResultHolder);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InjectionResultHolder);
 
 public:
     template<typename... Args>
@@ -213,6 +214,8 @@ WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resul
 
     return parameters;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionRegisteredScript);
 
 void WebExtensionRegisteredScript::updateParameters(const WebExtensionRegisteredScriptParameters& parameters)
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -48,8 +48,11 @@
 #import "WebExtensionWindowIdentifier.h"
 #import "WebPageProxy.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionTab);
 
 WebExtensionTab::WebExtensionTab(const WebExtensionContext& context, WKWebExtensionTab *delegate)
     : m_extensionContext(context)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -40,8 +40,11 @@
 #import "WebExtensionTabQueryParameters.h"
 #import "WebExtensionUtilities.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionWindow);
 
 WebExtensionWindow::WebExtensionWindow(const WebExtensionContext& context, WKWebExtensionWindow* delegate)
     : m_extensionContext(context)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "WebExtensionAlarm.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -33,6 +34,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionAlarm);
 
 void WebExtensionAlarm::schedule()
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
@@ -33,6 +33,7 @@
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -40,7 +41,7 @@ class WebExtensionContext;
 
 class WebExtensionAlarm : public RefCounted<WebExtensionAlarm> {
     WTF_MAKE_NONCOPYABLE(WebExtensionAlarm);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionAlarm);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -45,6 +45,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakHashSet.h>
 
@@ -220,7 +221,7 @@ private:
     void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
     class HTTPCookieStoreObserver : public API::HTTPCookieStoreObserver {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(HTTPCookieStoreObserver);
 
     public:
         explicit HTTPCookieStoreObserver(WebExtensionController& extensionController)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.cpp
@@ -29,8 +29,11 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionDataRecordHolder);
 
 WebExtensionDataRecord::WebExtensionDataRecord(const String& displayName, const String& uniqueIdentifier)
     : m_displayName(displayName)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -31,6 +31,7 @@
 #include "WebExtensionDataType.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS NSArray;
@@ -82,7 +83,7 @@ private:
 
 class WebExtensionDataRecordHolder : public RefCounted<WebExtensionDataRecordHolder> {
     WTF_MAKE_NONCOPYABLE(WebExtensionDataRecordHolder);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionDataRecordHolder);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -36,6 +36,7 @@
 #include "WebExtensionScriptInjectionResultParameters.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKWebView;
 OBJC_CLASS WKFrameInfo;
@@ -61,7 +62,7 @@ using UserStyleSheetVector = Vector<Ref<API::UserStyleSheet>>;
 
 class WebExtensionRegisteredScript : public RefCounted<WebExtensionRegisteredScript> {
     WTF_MAKE_NONCOPYABLE(WebExtensionRegisteredScript);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionRegisteredScript);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
@@ -33,8 +33,11 @@
 #import "WebExtensionMatchPattern.h"
 #import "WebExtensionMenuItemContextParameters.h"
 #import "WebExtensionMenuItemParameters.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionMenuItem);
 
 bool WebExtensionMenuItem::operator==(const WebExtensionMenuItem& other) const
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -33,6 +33,7 @@
 #include "WebExtensionMenuItemContextType.h"
 #include "WebExtensionMenuItemType.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -67,7 +68,7 @@ struct WebExtensionMenuItemParameters;
 
 class WebExtensionMenuItem : public RefCounted<WebExtensionMenuItem>, public CanMakeWeakPtr<WebExtensionMenuItem> {
     WTF_MAKE_NONCOPYABLE(WebExtensionMenuItem);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionMenuItem);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -34,6 +34,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSArray;
@@ -57,7 +58,7 @@ enum class WebExtensionTabImageFormat : uint8_t {
 
 class WebExtensionTab : public RefCounted<WebExtensionTab>, public CanMakeWeakPtr<WebExtensionTab>, public Identified<WebExtensionTabIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebExtensionTab);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionTab);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -32,6 +32,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_PROTOCOL(WKWebExtensionWindow);
@@ -62,7 +63,7 @@ static constexpr OptionSet<WebExtensionWindowTypeFilter> allWebExtensionWindowTy
 
 class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow>, public Identified<WebExtensionWindowIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionWindow);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -54,6 +54,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/LogInitialization.h>
 #include <wtf/MachSendRight.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TranslatedProcess.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -108,6 +109,8 @@ static RefPtr<GPUProcessProxy>& keptAliveGPUProcessProxy()
     static MainThreadNeverDestroyed<RefPtr<GPUProcessProxy>> keptAliveGPUProcessProxy;
     return keptAliveGPUProcessProxy.get();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GPUProcessProxy);
 
 void GPUProcessProxy::keepProcessAliveTemporarily()
 {

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -37,6 +37,7 @@
 #include <WebCore/ShareableBitmap.h>
 #include <memory>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 #include "LayerHostingContext.h"
@@ -67,7 +68,7 @@ struct GPUProcessCreationParameters;
 struct SharedPreferencesForWebProcess;
 
 class GPUProcessProxy final : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GPUProcessProxy);
     WTF_MAKE_NONCOPYABLE(GPUProcessProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GPUProcessProxy);
     friend LazyNeverDestroyed<GPUProcessProxy>;

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
@@ -30,9 +30,12 @@
 
 #include "GamepadData.h"
 #include <WebCore/PlatformGamepad.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UIGamepad);
 
 UIGamepad::UIGamepad(WebCore::PlatformGamepad& platformGamepad)
     : m_index(platformGamepad.index())

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
@@ -30,6 +30,7 @@
 #include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,7 +43,7 @@ namespace WebKit {
 class GamepadData;
 
 class UIGamepad {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UIGamepad);
 public:
     UIGamepad(WebCore::PlatformGamepad&);
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
@@ -34,11 +34,14 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorBrowserAgent);
 
 InspectorBrowserAgent::InspectorBrowserAgent(WebPageAgentContext& context)
     : InspectorAgentBase("Browser"_s, context)

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -37,7 +38,7 @@ class WebPageProxy;
 
 class InspectorBrowserAgent final : public InspectorAgentBase, public Inspector::BrowserBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorBrowserAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorBrowserAgent);
 public:
     InspectorBrowserAgent(WebPageAgentContext&);
     ~InspectorBrowserAgent();

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
@@ -30,6 +30,7 @@
 #import "APIInspectorExtensionClient.h"
 #import "WKFoundation.h"
 #import <WebCore/FrameIdentifier.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class _WKInspectorExtension;
@@ -38,7 +39,7 @@
 namespace WebKit {
 
 class InspectorExtensionDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorExtensionDelegate);
 public:
     InspectorExtensionDelegate(_WKInspectorExtension *, id <_WKInspectorExtensionDelegate>);
     ~InspectorExtensionDelegate();
@@ -48,7 +49,7 @@ public:
 
 private:
     class InspectorExtensionClient final : public API::InspectorExtensionClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(InspectorExtensionClient);
     public:
         explicit InspectorExtensionClient(InspectorExtensionDelegate&);
         ~InspectorExtensionClient();

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -33,9 +33,12 @@
 #import "_WKFrameHandleInternal.h"
 #import "_WKInspectorExtensionDelegate.h"
 #import "_WKInspectorExtensionInternal.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/UniqueRef.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorExtensionDelegate);
 
 InspectorExtensionDelegate::InspectorExtensionDelegate(_WKInspectorExtension *inspectorExtension, id <_WKInspectorExtensionDelegate> delegate)
     : m_inspectorExtension(inspectorExtension)
@@ -55,6 +58,8 @@ RetainPtr<id <_WKInspectorExtensionDelegate>> InspectorExtensionDelegate::delega
 {
     return m_delegate.get();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(InspectorExtensionDelegateInspectorExtensionClient, InspectorExtensionDelegate::InspectorExtensionClient);
 
 InspectorExtensionDelegate::InspectorExtensionClient::InspectorExtensionClient(InspectorExtensionDelegate& delegate)
     : m_inspectorExtensionDelegate(delegate)

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -33,10 +33,13 @@
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorTargetProxy);
 
 std::unique_ptr<InspectorTargetProxy> InspectorTargetProxy::create(WebPageProxy& page, const String& targetId, Inspector::InspectorTargetType type)
 {

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/InspectorTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ class WebPageProxy;
 // any target -> frontend messages will be routed to the WebPageProxy with a targetId.
 
 class InspectorTargetProxy final : public Inspector::InspectorTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorTargetProxy);
     WTF_MAKE_NONCOPYABLE(InspectorTargetProxy);
 public:
     static std::unique_ptr<InspectorTargetProxy> create(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -36,6 +36,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/NotImplemented.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 #include "WebInspectorUIExtensionControllerProxy.h"
@@ -43,6 +44,9 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteWebInspectorUIProxyClient);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteWebInspectorUIProxy);
 
 RemoteWebInspectorUIProxy::RemoteWebInspectorUIProxy()
     : m_debuggableInfo(API::DebuggableInfo::create(DebuggableInfoData::empty()))

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -30,10 +30,10 @@
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/InspectorFrontendClient.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -66,7 +66,7 @@ class WebInspectorUIExtensionControllerProxy;
 #endif
 
 class RemoteWebInspectorUIProxyClient : public CanMakeWeakPtr<RemoteWebInspectorUIProxyClient>, public CanMakeCheckedPtr<RemoteWebInspectorUIProxyClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteWebInspectorUIProxyClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteWebInspectorUIProxyClient);
 public:
     virtual ~RemoteWebInspectorUIProxyClient() { }
@@ -76,6 +76,7 @@ public:
 };
 
 class RemoteWebInspectorUIProxy : public RefCounted<RemoteWebInspectorUIProxy>, public IPC::MessageReceiver {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteWebInspectorUIProxy);
 public:
     static Ref<RemoteWebInspectorUIProxy> create()
     {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -36,8 +36,11 @@
 #include "WebInspectorUIExtensionControllerProxyMessages.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorUIExtensionControllerProxy);
 
 WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage)
     : m_inspectorPage(inspectorPage)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -46,7 +47,7 @@ class WebPageProxy;
 class WebInspectorUIExtensionControllerProxy final
     : public RefCounted<WebInspectorUIExtensionControllerProxy>
     , public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebInspectorUIExtensionControllerProxy);
     WTF_MAKE_NONCOPYABLE(WebInspectorUIExtensionControllerProxy);
 public:
     static Ref<WebInspectorUIExtensionControllerProxy> create(WebPageProxy& inspectorPage);

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -31,10 +31,13 @@
 #include "WebFrameProxy.h"
 #include "WebPageInspectorController.h"
 #include "WebPageProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageDebuggable);
 
 WebPageDebuggable::WebPageDebuggable(WebPageProxy& page)
     : m_page(page)

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -29,13 +29,14 @@
 
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
 class WebPageDebuggable final : public Inspector::RemoteInspectionTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageDebuggable);
     WTF_MAKE_NONCOPYABLE(WebPageDebuggable);
 public:
     WebPageDebuggable(WebPageProxy&);

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <JavaScriptCore/InspectorTargetAgent.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -48,6 +49,8 @@ static String getTargetID(const ProvisionalPageProxy& provisionalPage)
 {
     return WebPageInspectorTarget::toTargetID(provisionalPage.webPageID());
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInspectorController);
 
 WebPageInspectorController::WebPageInspectorController(WebPageProxy& inspectedPage)
     : m_frontendRouter(FrontendRouter::create())

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -46,8 +47,8 @@ class InspectorBrowserAgent;
 struct WebPageAgentContext;
 
 class WebPageInspectorController {
+    WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorController);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorController);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     WebPageInspectorController(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/InspectorDebuggableType.h>
 #include <gio/gio.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
@@ -43,7 +44,7 @@
 namespace WebKit {
 
 class RemoteInspectorProxy final : public RemoteWebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteInspectorProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorProxy);
 public:
     RemoteInspectorProxy(RemoteInspectorClient& inspectorClient, uint64_t connectionID, uint64_t targetID)
@@ -117,6 +118,8 @@ private:
     uint64_t m_connectionID;
     uint64_t m_targetID;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteInspectorClient);
 
 const SocketConnection::MessageHandlers& RemoteInspectorClient::messageHandlers()
 {

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
@@ -28,6 +28,7 @@
 #if ENABLE(REMOTE_INSPECTOR)
 
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/SocketConnection.h>
@@ -49,7 +50,7 @@ public:
 };
 
 class RemoteInspectorClient {
-    WTF_MAKE_FAST_ALLOCATED();
+    WTF_MAKE_TZONE_ALLOCATED(RemoteInspectorClient);
 public:
     RemoteInspectorClient(String&& hostAndPort, RemoteInspectorObserver&);
     ~RemoteInspectorClient();

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -33,13 +33,16 @@
 #include "RemoteWebInspectorUIProxy.h"
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteInspectorProxy);
+
 class RemoteInspectorProxy final : public RemoteWebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteInspectorProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorProxy);
 public:
     RemoteInspectorProxy(RemoteInspectorClient& inspectorClient, ConnectionID connectionID, TargetID targetID, Inspector::DebuggableType debuggableType)

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/RemoteInspectorConnectionClient.h>
 #include <WebCore/InspectorDebuggableType.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -51,7 +52,7 @@ using ConnectionID = Inspector::ConnectionID;
 using TargetID = Inspector::TargetID;
 
 class RemoteInspectorClient final : public Inspector::RemoteInspectorConnectionClient {
-    WTF_MAKE_FAST_ALLOCATED();
+    WTF_MAKE_TZONE_ALLOCATED(RemoteInspectorClient);
 public:
     RemoteInspectorClient(URL, RemoteInspectorObserver&);
     ~RemoteInspectorClient();

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/JSDOMExceptionHandling.h>
 #include <WebCore/RunJavaScriptParameters.h>
 #include <WebCore/SerializedScriptValue.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -50,7 +51,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class ScriptMessageClient final : public WebScriptMessageHandler::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(X);
 public:
     ScriptMessageClient(RemoteInspectorProtocolHandler& inspectorProtocolHandler)
         : m_inspectorProtocolHandler(inspectorProtocolHandler) { }
@@ -97,7 +98,7 @@ private:
 };
 
 class LoaderClient final : public API::LoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(LoaderClient);
 public:
     LoaderClient(Function<void()>&& loadedCallback)
         : m_loadedCallback { WTFMove(loadedCallback) } { }

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
@@ -30,6 +30,7 @@
 #include "BubblewrapLauncher.h"
 #include <WebCore/PlatformDisplay.h>
 #include <gio/gunixinputstream.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniStdExtras.h>
 #include <wtf/glib/Application.h>
 #include <wtf/glib/GRefPtr.h>
@@ -38,6 +39,8 @@
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XDGDBusProxy);
 
 CString XDGDBusProxy::makeProxy(const char* baseDirectory, const char* proxyTemplate)
 {

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #if ENABLE(BUBBLEWRAP_SANDBOX)
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 #include <wtf/unix/UnixFileDescriptor.h>
@@ -35,7 +35,8 @@
 namespace WebKit {
 
 class XDGDBusProxy {
-    WTF_MAKE_NONCOPYABLE(XDGDBusProxy); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(XDGDBusProxy);
+    WTF_MAKE_NONCOPYABLE(XDGDBusProxy);
 public:
     XDGDBusProxy() = default;
     ~XDGDBusProxy() = default;

--- a/Source/WebKit/UIProcess/LegacyGlobalSettings.cpp
+++ b/Source/WebKit/UIProcess/LegacyGlobalSettings.cpp
@@ -28,8 +28,11 @@
 
 #include "WebProcessPool.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyGlobalSettings);
 
 LegacyGlobalSettings::LegacyGlobalSettings() = default;
 

--- a/Source/WebKit/UIProcess/LegacyGlobalSettings.h
+++ b/Source/WebKit/UIProcess/LegacyGlobalSettings.h
@@ -28,12 +28,13 @@
 #include "CacheModel.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class LegacyGlobalSettings {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyGlobalSettings);
 public:
     static LegacyGlobalSettings& singleton();
 

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
@@ -28,12 +28,15 @@
 #include "Logging.h"
 #include "WebProcessProxy.h"
 #include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(ROUTING_ARBITRATION)
 
 #include "AudioSessionRoutingArbitratorProxyMessages.h"
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioSessionRoutingArbitratorProxy);
 
 #if !HAVE(AVAUDIO_ROUTING_ARBITER)
 

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/AudioSession.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakPtr.h>
 
@@ -52,7 +53,7 @@ class WebProcessProxy;
 
 class AudioSessionRoutingArbitratorProxy
     : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AudioSessionRoutingArbitratorProxy);
 public:
     AudioSessionRoutingArbitratorProxy(WebProcessProxy&);
     virtual ~AudioSessionRoutingArbitratorProxy();

--- a/Source/WebKit/UIProcess/Media/MediaUsageManager.cpp
+++ b/Source/WebKit/UIProcess/Media/MediaUsageManager.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "MediaUsageManager.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_USAGE)
 
@@ -39,7 +40,9 @@ std::unique_ptr<MediaUsageManager> MediaUsageManager::create()
 }
 #endif
 
-void MediaUsageManager:: reset()
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaUsageManager);
+
+void MediaUsageManager::reset()
 {
     notImplemented();
 }

--- a/Source/WebKit/UIProcess/Media/MediaUsageManager.h
+++ b/Source/WebKit/UIProcess/Media/MediaUsageManager.h
@@ -27,11 +27,12 @@
 
 #include <WebCore/MediaUsageInfo.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class MediaUsageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MediaUsageManager);
 public:
     static std::unique_ptr<MediaUsageManager> create();
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -39,6 +39,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 extern WTFLogChannel LogMedia;
@@ -46,6 +47,8 @@ extern WTFLogChannel LogMedia;
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionCoordinatorProxy);
 
 Ref<RemoteMediaSessionCoordinatorProxy> RemoteMediaSessionCoordinatorProxy::create(WebPageProxy& webPageProxy, Ref<MediaSessionCoordinatorProxyPrivate>&& privateCoordinator)
 {

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct ExceptionData;
@@ -45,7 +46,7 @@ class RemoteMediaSessionCoordinatorProxy
     : private IPC::MessageReceiver
     , public RefCounted<RemoteMediaSessionCoordinatorProxy>
     , public WebCore::MediaSessionCoordinatorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionCoordinatorProxy);
 public:
     static Ref<RemoteMediaSessionCoordinatorProxy> create(WebPageProxy&, Ref<MediaSessionCoordinatorProxyPrivate>&&);
     ~RemoteMediaSessionCoordinatorProxy();

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h
@@ -28,13 +28,14 @@
 #if ENABLE(MEDIA_USAGE)
 
 #include "MediaUsageManager.h"
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS USVideoUsage;
 
 namespace WebKit {
 
 class MediaUsageManagerCocoa : public MediaUsageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(MediaUsageManagerCocoa);
 public:
     MediaUsageManagerCocoa() = default;
     virtual ~MediaUsageManagerCocoa();

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/MediaKeySystemRequest.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -55,6 +56,8 @@ static WTFLogChannel& logChannel()
 {
     return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, EME);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManagerProxy);
 
 const Logger& MediaKeySystemPermissionRequestManagerProxy::logger() const
 {

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -51,7 +52,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class MediaKeySystemPermissionRequestManagerProxy : public CanMakeWeakPtr<MediaKeySystemPermissionRequestManagerProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MediaKeySystemPermissionRequestManagerProxy);
 public:
     explicit MediaKeySystemPermissionRequestManagerProxy(WebPageProxy&);
     ~MediaKeySystemPermissionRequestManagerProxy();

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -48,6 +48,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/LogInitialization.h>
 #include <wtf/MachSendRight.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, this->connection())
 
@@ -59,6 +60,8 @@ static WeakPtr<ModelProcessProxy>& singleton()
     static NeverDestroyed<WeakPtr<ModelProcessProxy>> singleton;
     return singleton;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessProxy);
 
 Ref<ModelProcessProxy> ModelProcessProxy::getOrCreate()
 {

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -35,6 +35,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <memory>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 #include "LayerHostingContext.h"
@@ -48,7 +49,7 @@ struct ModelProcessConnectionParameters;
 struct ModelProcessCreationParameters;
 
 class ModelProcessProxy final : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ModelProcessProxy);
     WTF_MAKE_NONCOPYABLE(ModelProcessProxy);
     friend LazyNeverDestroyed<ModelProcessProxy>;
 public:

--- a/Source/WebKit/UIProcess/ModelElementController.cpp
+++ b/Source/WebKit/UIProcess/ModelElementController.cpp
@@ -29,8 +29,11 @@
 #if ENABLE(ARKIT_INLINE_PREVIEW)
 
 #include "WebPageProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelElementController);
 
 ModelElementController::ModelElementController(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/ModelElementController.h
+++ b/Source/WebKit/UIProcess/ModelElementController.h
@@ -34,6 +34,7 @@
 #include <WebCore/ResourceError.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -57,7 +58,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class ModelElementController : public CanMakeWeakPtr<ModelElementController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ModelElementController);
 public:
     explicit ModelElementController(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -78,6 +78,7 @@
 #include <WebCore/ResourceError.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/MakeString.h>
 
@@ -121,6 +122,8 @@ static WeakHashSet<NetworkProcessProxy>& networkProcessesSet()
     static NeverDestroyed<WeakHashSet<NetworkProcessProxy>> set;
     return set;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkProcessProxy);
 
 Vector<Ref<NetworkProcessProxy>> NetworkProcessProxy::allNetworkProcesses()
 {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -42,6 +42,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <memory>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
@@ -109,7 +110,7 @@ struct WebsiteData;
 struct WebsiteDataStoreParameters;
 
 class NetworkProcessProxy final : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkProcessProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkProcessProxy);
 public:
     using RegistrableDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
@@ -34,8 +34,11 @@
 #include "WebNotification.h"
 #include "WebNotificationManagerProxy.h"
 #include "WebPageProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebNotificationProvider);
 
 WebNotificationProvider::WebNotificationProvider(const WKNotificationProviderBase* provider)
 {

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
@@ -30,6 +30,7 @@
 #include "APINotificationProvider.h"
 #include "WKNotificationProvider.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKNotificationProviderBase> {
@@ -44,7 +45,7 @@ class WebNotificationManagerProxy;
 class WebPageProxy;
 
 class WebNotificationProvider : public API::NotificationProvider, public API::Client<WKNotificationProviderBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebNotificationProvider);
 public:
     explicit WebNotificationProvider(const WKNotificationProviderBase*);
 

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
@@ -39,6 +39,7 @@
 #include <wtf/SafeStrerror.h>
 #include <wtf/Seconds.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/glib/Application.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -112,7 +113,7 @@ private:
 #endif
 
 class IconCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(IconCache);
 public:
     IconCache()
         : m_timer(RunLoop::main(), this, &IconCache::timerFired)
@@ -294,6 +295,8 @@ static IconCache& iconCache()
     static std::unique_ptr<IconCache> cache = makeUnique<IconCache>();
     return *cache;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NotificationService);
 
 NotificationService& NotificationService::singleton()
 {

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.h
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -45,7 +46,7 @@ class WebNotification;
 
 class NotificationService {
     WTF_MAKE_NONCOPYABLE(NotificationService);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NotificationService);
     friend LazyNeverDestroyed<NotificationService>;
 public:
     static NotificationService& singleton();

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -53,6 +53,7 @@
 #include <variant>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -242,7 +243,7 @@ class WebKitWebResourceLoadManager;
 #endif
 
 class PageClient : public CanMakeWeakPtr<PageClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageClient);
 public:
     virtual ~PageClient() { }
 

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -32,11 +32,14 @@
 #include "WebProcessProxy.h"
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 static const Seconds loggingInterval { 60_min };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerActivityStateCPUUsageSampler);
 
 PerActivityStateCPUUsageSampler::PerActivityStateCPUUsageSampler(WebProcessPool& processPool)
     : m_processPool(processPool)

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -28,6 +28,7 @@
 #include <WebCore/Page.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -35,7 +36,7 @@ class WebPageProxy;
 class WebProcessPool;
 
 class PerActivityStateCPUUsageSampler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerActivityStateCPUUsageSampler);
 public:
     explicit PerActivityStateCPUUsageSampler(WebProcessPool&);
     ~PerActivityStateCPUUsageSampler();

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -29,6 +29,7 @@
 #include "AuxiliaryProcessProxy.h"
 #include "WKBase.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -54,6 +55,8 @@ ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
     }
     return "unknown"_s;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessAssertion);
 
 void ProcessAssertion::aquireAssertion(Mode mode, CompletionHandler<void()>&& acquisisionHandler)
 {

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -28,6 +28,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/ProcessID.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -75,7 +76,7 @@ ASCIILiteral processAssertionTypeDescription(ProcessAssertionType);
 class AuxiliaryProcessProxy;
 
 class ProcessAssertion : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ProcessAssertion> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProcessAssertion);
 public:
     enum class Mode : bool { Sync, Async };
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
@@ -49,7 +50,7 @@ static constexpr Seconds removeAllAssertionsTimeout { 8_min };
 static constexpr Seconds processAssertionCacheLifetime { 1_s };
 
 class ProcessThrottler::ProcessAssertionCache final : public CanMakeCheckedPtr<ProcessThrottler::ProcessAssertionCache> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProcessThrottler::ProcessAssertionCache);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProcessAssertionCache);
 public:
     void add(Ref<ProcessAssertion>&& assertion)
@@ -84,7 +85,7 @@ public:
 
 private:
     class CachedAssertion {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(CachedAssertion);
     public:
         CachedAssertion(ProcessAssertionCache& cache, Ref<ProcessAssertion>&& assertion)
             : m_cache(cache)
@@ -112,6 +113,9 @@ private:
     HashMap<ProcessAssertionType, UniqueRef<CachedAssertion>, IntHash<ProcessAssertionType>, WTF::StrongEnumHashTraits<ProcessAssertionType>> m_entries;
     bool m_isEnabled { true };
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(ProcessThrottlerProcessAssertionCache, ProcessThrottler::ProcessAssertionCache);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(ProcessThrottlerProcessAssertionCacheCachedAssertion, ProcessThrottler::ProcessAssertionCache::CachedAssertion);
 
 static uint64_t generatePrepareToSuspendRequestID()
 {
@@ -526,6 +530,8 @@ bool ProcessThrottler::isSuspended() const
     return m_isConnectedToProcess && !m_assertion;
 }
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessThrottlerTimedActivity);
+
 ProcessThrottlerTimedActivity::ProcessThrottlerTimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)
     : m_timer(RunLoop::main(), this, &ProcessThrottlerTimedActivity::activityTimedOut)
     , m_timeout(timeout)
@@ -560,6 +566,8 @@ void ProcessThrottlerTimedActivity::updateTimer()
 }
 
 #define PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d, throttler=%p] ProcessThrottler::Activity::" msg, this, m_throttler ? m_throttler->m_process->processID() : 0, m_throttler.get(), ##__VA_ARGS__)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessThrottlerActivity);
 
 ProcessThrottlerActivity::ProcessThrottlerActivity(ProcessThrottler& throttler, ASCIILiteral name, ProcessThrottlerActivityType type, IsQuietActivity isQuiet)
     : m_throttler(&throttler)

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -31,6 +31,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/RefCounter.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -67,7 +68,7 @@ enum class ProcessThrottleState : uint8_t { Suspended, Background, Foreground };
 enum class ProcessThrottlerActivityType : bool { Background, Foreground };
 
 class ProcessThrottlerActivity : public CanMakeWeakPtr<ProcessThrottlerActivity> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProcessThrottlerActivity);
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerActivity);
 public:
     ProcessThrottlerActivity(ProcessThrottler&, ASCIILiteral name, ProcessThrottlerActivityType, IsQuietActivity);
@@ -97,7 +98,7 @@ private:
 };
 
 class ProcessThrottlerTimedActivity {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProcessThrottlerTimedActivity);
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerTimedActivity);
     using Activity = ProcessThrottlerActivity;
     using ActivityVariant = std::variant<std::nullptr_t, UniqueRef<Activity>>;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -32,8 +32,11 @@
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProvisionalFrameProxy);
 
 ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess)
     : m_frame(frame)

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -27,6 +27,7 @@
 
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -37,7 +38,7 @@ class WebFrameProxy;
 class WebProcessProxy;
 
 class ProvisionalFrameProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProvisionalFrameProxy);
 public:
     explicit ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -59,6 +59,7 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
 
@@ -68,6 +69,8 @@ using namespace WebCore;
 
 #define PROVISIONALPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), process().processID(), m_navigationID.toUInt64(), ##__VA_ARGS__)
 #define PROVISIONALPAGEPROXY_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), process().processID(), m_navigationID.toUInt64(), ##__VA_ARGS__)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProvisionalPageProxy);
 
 ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>&& frameProcess, BrowsingContextGroup& group, std::unique_ptr<SuspendedPageProxy> suspendedPage, API::Navigation& navigation, bool isServerRedirect, const WebCore::ResourceRequest& request, ProcessSwapRequestedByClient processSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies* websitePolicies, WebsiteDataStore* replacedDataStoreForWebArchiveLoad)
     : m_page(page)

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -38,6 +38,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -91,7 +92,7 @@ using LayerHostingContextID = uint32_t;
 #endif
 
 class ProvisionalPageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProvisionalPageProxy);
 public:
     ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, std::unique_ptr<SuspendedPageProxy>, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
     ~ProvisionalPageProxy();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -32,6 +32,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS CAAnimation;
 OBJC_CLASS WKAnimationDelegate;
@@ -46,7 +47,7 @@ class RemoteLayerTreeDrawingAreaProxy;
 class WebPageProxy;
 
 class RemoteLayerTreeHost {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeHost);
 public:
     explicit RemoteLayerTreeHost(RemoteLayerTreeDrawingAreaProxy&);
     ~RemoteLayerTreeHost();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -44,9 +44,10 @@
 #import <WebCore/PlatformLayer.h>
 #import <WebCore/ShareableBitmap.h>
 #import <WebCore/WebCoreCALayerExtras.h>
-#import <pal/cocoa/QuartzCoreSoftLink.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <pal/cocoa/QuartzCoreSoftLink.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIView.h>
@@ -56,6 +57,8 @@ namespace WebKit {
 using namespace WebCore;
 
 #define REMOTE_LAYER_TREE_HOST_RELEASE_LOG(...) RELEASE_LOG(ViewState, __VA_ARGS__)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeHost);
 
 RemoteLayerTreeHost::RemoteLayerTreeHost(RemoteLayerTreeDrawingAreaProxy& drawingArea)
     : m_drawingArea(drawingArea)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -33,6 +33,7 @@
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/ScrollTypes.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 OBJC_CLASS CALayer;
@@ -56,7 +57,7 @@ class RemoteLayerTreeHost;
 class RemoteLayerTreeScrollbars;
 
 class RemoteLayerTreeNode : public CanMakeWeakPtr<RemoteLayerTreeNode> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeNode);
 public:
     RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<CALayer>);
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -29,6 +29,7 @@
 #import "RemoteLayerTreeLayers.h"
 #import <QuartzCore/CALayer.h>
 #import <WebCore/WebActionDisablingCALayerDelegate.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIView.h>
@@ -49,6 +50,8 @@ static NSString *const WKRemoteLayerTreeNodePropertyKey = @"WKRemoteLayerTreeNod
 #if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS)
 static NSString *const WKInteractionRegionContainerKey = @"WKInteractionRegionContainer";
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeNode);
 
 RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier layerID, Markable<WebCore::LayerHostingContextIdentifier> hostIdentifier, RetainPtr<CALayer> layer)
     : m_layerID(layerID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
@@ -26,15 +26,16 @@
 #pragma once
 
 #import <WebCore/FloatRect.h>
+#import <wtf/MonotonicTime.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
-#include <wtf/MonotonicTime.h>
 
 namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxy;
 
 class RemoteLayerTreeScrollingPerformanceData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeScrollingPerformanceData);
 public:
     RemoteLayerTreeScrollingPerformanceData(RemoteLayerTreeDrawingAreaProxy&);
     ~RemoteLayerTreeScrollingPerformanceData();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -32,10 +32,13 @@
 #import <QuartzCore/CALayer.h>
 #import <WebCore/PerformanceLoggingClient.h>
 #import <WebCore/TileController.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeScrollingPerformanceData);
 
 RemoteLayerTreeScrollingPerformanceData::RemoteLayerTreeScrollingPerformanceData(RemoteLayerTreeDrawingAreaProxy& drawingArea)
     : m_drawingArea(drawingArea)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -42,12 +42,15 @@
 #include <WebCore/RuntimeApplicationChecks.h>
 #include <WebCore/ScrollingStateTree.h>
 #include <WebCore/ScrollingTreeFrameScrollingNode.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 #define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, &connection, returnValue)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteScrollingCoordinatorProxy);
 
 RemoteScrollingCoordinatorProxy::RemoteScrollingCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -37,6 +37,7 @@
 #include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS UIScrollView;
@@ -66,7 +67,7 @@ class WebPageProxy;
 class WebWheelEvent;
 
 class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxy);
     WTF_MAKE_NONCOPYABLE(RemoteScrollingCoordinatorProxy);
 public:
     explicit RemoteScrollingCoordinatorProxy(WebPageProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -30,6 +30,7 @@
 #import <WebCore/ScrollingCoordinator.h>
 #import <WebCore/ScrollingTreeScrollingNode.h>
 #import <WebCore/ScrollingTreeScrollingNodeDelegate.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
 @class CALayer;
@@ -60,7 +61,7 @@ class ScrollingTreeScrollingNode;
 namespace WebKit {
 
 class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTreeScrollingNodeDelegate, public CanMakeWeakPtr<ScrollingTreeScrollingNodeDelegateIOS> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeScrollingNodeDelegateIOS);
 public:
     
     enum class AllowOverscrollToPreventScrollPropagation : bool { No, Yes };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -47,6 +47,7 @@
 #import <WebCore/ScrollingTreeScrollingNode.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/SetForScope.h>
+#import <wtf/TZoneMallocInlines.h>
 
 @interface WKScrollingNodeScrollViewDelegate () <WKBaseScrollViewDelegate>
 @end
@@ -247,6 +248,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeScrollingNodeDelegateIOS);
 
 ScrollingTreeScrollingNodeDelegateIOS::ScrollingTreeScrollingNodeDelegateIOS(ScrollingTreeScrollingNode& scrollingNode)
     : ScrollingTreeScrollingNodeDelegate(scrollingNode)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -46,6 +46,7 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -56,7 +57,7 @@ static NSString * const transientZoomScrollPositionOverrideAnimationKey = @"wkSc
 
 class RemoteLayerTreeDisplayLinkClient final : public DisplayLink::Client {
 public:
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDisplayLinkClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeDisplayLinkClient);
 public:
     explicit RemoteLayerTreeDisplayLinkClient(WebPageProxyIdentifier pageID)
@@ -69,6 +70,8 @@ private:
 
     WebPageProxyIdentifier m_pageIdentifier;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDisplayLinkClient);
 
 // This is called off the main thread.
 void RemoteLayerTreeDisplayLinkClient::displayLinkFired(WebCore::PlatformDisplayID /* displayID */, WebCore::DisplayUpdate /* displayUpdate */, bool /* wantsFullSpeedUpdates */, bool /* anyObserverWantsCallback */)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -43,13 +43,14 @@
 #include <WebCore/ScrollingThread.h>
 #include <WebCore/WheelEventDeltaFilter.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 class RemoteLayerTreeEventDispatcherDisplayLinkClient final : public DisplayLink::Client {
 public:
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteLayerTreeEventDispatcherDisplayLinkClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeEventDispatcherDisplayLinkClient);
 public:
     explicit RemoteLayerTreeEventDispatcherDisplayLinkClient(RemoteLayerTreeEventDispatcher& eventDispatcher)
@@ -95,6 +96,8 @@ Ref<RemoteLayerTreeEventDispatcher> RemoteLayerTreeEventDispatcher::create(Remot
 }
 
 static constexpr Seconds wheelEventHysteresisDuration { 500_ms };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeEventDispatcher);
 
 RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, PageIdentifier pageIdentifier)
     : m_scrollingCoordinator(WeakPtr { scrollingCoordinator })

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -35,10 +35,10 @@
 #include <pal/HysteresisActivity.h>
 #include <wtf/Condition.h>
 #include <wtf/Deque.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -66,7 +66,7 @@ class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 // This class exists to act as a threadsafe DisplayLink::Client client, allowing RemoteScrollingCoordinatorProxyMac to
 // be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
 class RemoteLayerTreeEventDispatcher : public ThreadSafeRefCounted<RemoteLayerTreeEventDispatcher>, public MomentumEventDispatcher::Client {
-    WTF_MAKE_FAST_ALLOCATED();
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeEventDispatcher);
     friend class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 public:
     static Ref<RemoteLayerTreeEventDispatcher> create(RemoteScrollingCoordinatorProxyMac&, WebCore::PageIdentifier);

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -29,8 +29,11 @@
 #include "DrawingAreaProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePageDrawingAreaProxy);
 
 RemotePageDrawingAreaProxy::RemotePageDrawingAreaProxy(DrawingAreaProxy& drawingArea, WebProcessProxy& process)
     : m_drawingArea(drawingArea)

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -28,6 +28,7 @@
 #include "DrawingAreaInfo.h"
 #include "MessageReceiver.h"
 #include "MessageReceiverMap.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class RemotePageDrawingAreaProxy;
@@ -44,7 +45,7 @@ class DrawingAreaProxy;
 class WebProcessProxy;
 
 class RemotePageDrawingAreaProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemotePageDrawingAreaProxy);
 public:
     RemotePageDrawingAreaProxy(DrawingAreaProxy&, WebProcessProxy&);
     ~RemotePageDrawingAreaProxy();

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -44,8 +44,11 @@
 #include "WebProcessMessages.h"
 #include "WebProcessProxy.h"
 #include <WebCore/RemoteUserInputEventData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePageProxy);
 
 RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, const Site& site, WebPageProxyMessageReceiverRegistration* registrationToTransfer)
     : m_webPageID(page.webPageIDInMainFrameProcess()) // FIXME: We should generate a new identifier so that it will be more obvious when we get things wrong.

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -34,6 +34,7 @@
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class RemotePageProxy;
@@ -77,7 +78,7 @@ struct FrameTreeCreationParameters;
 struct NavigationActionData;
 
 class RemotePageProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemotePageProxy);
 public:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const Site&, WebPageProxyMessageReceiverRegistration* = nullptr);
     ~RemotePageProxy();

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -27,11 +27,12 @@
 
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class RemotePageVisitedLinkStoreRegistration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemotePageVisitedLinkStoreRegistration);
 public:
     RemotePageVisitedLinkStoreRegistration(WebPageProxy& page, WebProcessProxy& process)
         : m_page(page)

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -31,8 +31,11 @@
 #include "MediaPermissionUtilities.h"
 #include "WebPageProxy.h"
 #include "WebPreferences.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognitionPermissionManager);
 
 static SpeechRecognitionPermissionManager::CheckResult computeMicrophoneAccess()
 {

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -27,6 +27,7 @@
 
 #include "SpeechRecognitionPermissionRequest.h"
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -43,7 +44,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SpeechRecognitionPermissionManager : public CanMakeWeakPtr<SpeechRecognitionPermissionManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionPermissionManager);
 public:
     enum class CheckResult { Denied, Granted, Unknown };
     explicit SpeechRecognitionPermissionManager(WebPageProxy&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -32,8 +32,11 @@
 #include "SpeechRecognitionRealtimeMediaSourceManagerMessages.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSource.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognitionRemoteRealtimeMediaSourceManager);
 
 SpeechRecognitionRemoteRealtimeMediaSourceManager::SpeechRecognitionRemoteRealtimeMediaSourceManager(const WebProcessProxy& process)
     : m_process(process)

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
@@ -60,7 +61,7 @@ class SpeechRecognitionRemoteRealtimeMediaSource;
 class WebProcessProxy;
 
 class SpeechRecognitionRemoteRealtimeMediaSourceManager final : public IPC::MessageReceiver, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionRemoteRealtimeMediaSourceManager);
 public:
     explicit SpeechRecognitionRemoteRealtimeMediaSourceManager(const WebProcessProxy&);
     void addSource(SpeechRecognitionRemoteRealtimeMediaSource&, const WebCore::CaptureDevice&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -32,10 +32,13 @@
 #include "WebSpeechRecognitionConnectionMessages.h"
 #include <WebCore/SpeechRecognitionRequestInfo.h>
 #include <WebCore/SpeechRecognitionUpdate.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, messageSenderConnection())
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognitionServer);
 
 SpeechRecognitionServer::SpeechRecognitionServer(WebProcessProxy& process, SpeechRecognitionServerIdentifier identifier, SpeechRecognitionPermissionChecker&& permissionChecker, SpeechRecognitionCheckIfMockSpeechRecognitionEnabled&& checkIfEnabled
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -34,6 +34,7 @@
 #include <WebCore/SpeechRecognitionResultData.h>
 #include <WebCore/SpeechRecognizer.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -61,7 +62,7 @@ using SpeechRecognitionPermissionChecker = Function<void(WebCore::SpeechRecognit
 using SpeechRecognitionCheckIfMockSpeechRecognitionEnabled = Function<bool()>;
 
 class SpeechRecognitionServer : public IPC::MessageReceiver, private IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionServer);
 public:
 #if ENABLE(MEDIA_STREAM)
     using RealtimeMediaSourceCreateFunction = Function<WebCore::CaptureSourceOrError()>;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -41,6 +41,7 @@
 #include "WebProcessPool.h"
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
@@ -54,6 +55,8 @@ static WeakHashSet<SuspendedPageProxy>& allSuspendedPages()
     static NeverDestroyed<WeakHashSet<SuspendedPageProxy>> map;
     return map;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
 
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, const API::PageConfiguration& pageConfiguration)
 {

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ using LayerHostingContextID = uint32_t;
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool { No, Yes };
 
 class SuspendedPageProxy final: public IPC::MessageReceiver, public CanMakeCheckedPtr<SuspendedPageProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SuspendedPageProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SuspendedPageProxy);
 public:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, ShouldDelayClosingUntilFirstLayerFlush);

--- a/Source/WebKit/UIProcess/SystemPreviewController.cpp
+++ b/Source/WebKit/UIProcess/SystemPreviewController.cpp
@@ -30,8 +30,11 @@
 
 #include "WebPageProxy.h"
 #include <WebCore/MIMETypeRegistry.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SystemPreviewController);
 
 SystemPreviewController::SystemPreviewController(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -33,6 +33,7 @@
 #include <WebCore/ResourceError.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -63,7 +64,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SystemPreviewController : public CanMakeWeakPtr<SystemPreviewController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SystemPreviewController);
 public:
     explicit SystemPreviewController(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -50,6 +50,7 @@
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakHashSet.h>
 
 #if ENABLE(GPU_PROCESS)
@@ -93,6 +94,8 @@ bool UserMediaPermissionRequestManagerProxy::permittedToCaptureVideo()
     return true;
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaPermissionRequestManagerProxy);
 
 UserMediaPermissionRequestManagerProxy::UserMediaPermissionRequestManagerProxy(WebPageProxy& page)
     : m_page(page)

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -70,7 +71,7 @@ class UserMediaPermissionRequestManagerProxy
     , private LoggerHelper
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserMediaPermissionRequestManagerProxy);
 public:
     explicit UserMediaPermissionRequestManagerProxy(WebPageProxy&);
     ~UserMediaPermissionRequestManagerProxy();

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -39,6 +39,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -72,6 +73,8 @@ static HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>& viewGest
     static NeverDestroyed<HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>> viewGestureControllers;
     return viewGestureControllers.get();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewGestureController);
 
 ViewGestureController::ViewGestureController(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -35,6 +35,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
@@ -107,7 +108,7 @@ class WebPageProxy;
 class WebProcessProxy;
 
 class ViewGestureController : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ViewGestureController);
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
 public:
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/PublicKeyCredentialCreationOptions.h>
 #include <WebCore/WebAuthenticationConstants.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -174,6 +175,8 @@ static String getUserName(const std::variant<PublicKeyCredentialCreationOptions,
 } // namespace
 
 const size_t AuthenticatorManager::maxTransportNumber = 5;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorManager);
 
 AuthenticatorManager::AuthenticatorManager()
     : m_requestTimeOutTimer(RunLoop::main(), this, &AuthenticatorManager::timeOutTimerFired)

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -37,6 +37,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 OBJC_CLASS LAContext;
@@ -57,7 +58,7 @@ class WebAuthenticationPanel;
 namespace WebKit {
 
 class AuthenticatorManager : public AuthenticatorTransportServiceObserver, public AuthenticatorObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AuthenticatorManager);
     WTF_MAKE_NONCOPYABLE(AuthenticatorManager);
 public:
     using Respond = std::variant<Ref<WebCore::AuthenticatorResponse>, WebCore::ExceptionData>;

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
@@ -37,8 +37,11 @@
 #include "MockNfcService.h"
 #include "NfcService.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorTransportService);
 
 UniqueRef<AuthenticatorTransportService> AuthenticatorTransportService::create(WebCore::AuthenticatorTransport transport, AuthenticatorTransportServiceObserver& observer)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
@@ -29,6 +29,7 @@
 
 #include "WebAuthenticationFlags.h"
 #include <WebCore/AuthenticatorTransport.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -60,7 +61,7 @@ public:
 };
 
 class AuthenticatorTransportService : public CanMakeWeakPtr<AuthenticatorTransportService> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AuthenticatorTransportService);
     WTF_MAKE_NONCOPYABLE(AuthenticatorTransportService);
 public:
     static UniqueRef<AuthenticatorTransportService> create(WebCore::AuthenticatorTransport, AuthenticatorTransportServiceObserver&);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS ASCAppleIDCredential;
@@ -58,7 +59,7 @@ namespace WebKit {
 class AuthenticatorManager;
 
 class AuthenticatorPresenterCoordinator : public CanMakeWeakPtr<AuthenticatorPresenterCoordinator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AuthenticatorPresenterCoordinator);
     WTF_MAKE_NONCOPYABLE(AuthenticatorPresenterCoordinator);
 public:
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -31,12 +31,15 @@
 #import "AuthenticatorManager.h"
 #import "WKASCAuthorizationPresenterDelegate.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 #import "AuthenticationServicesCoreSoftLink.h"
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorPresenterCoordinator);
 
 AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator(const AuthenticatorManager& manager, const String& rpId, const TransportSet& transports, ClientDataType type, const String& username)
     : m_manager(manager)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
@@ -34,11 +34,12 @@
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class HidConnection {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HidConnection);
     WTF_MAKE_NONCOPYABLE(HidConnection);
 public:
     enum class DataSent : bool { No, Yes };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -31,6 +31,7 @@
 #import <WebCore/FidoConstants.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace fido;
@@ -55,6 +56,8 @@ static void reportReceived(void* context, IOReturn status, void*, IOHIDReportTyp
     connection->receiveReport(std::span { report, static_cast<size_t>(reportLength) });
 }
 #endif // HAVE(SECURITY_KEY_API)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HidConnection);
 
 HidConnection::HidConnection(IOHIDDeviceRef device)
     : m_device(device)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
@@ -28,8 +28,8 @@
 #if ENABLE(WEB_AUTHN)
 
 #include <wtf/CompletionHandler.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -49,7 +49,7 @@ namespace WebKit {
 // that are not allowed in auto test environment such that some mocking
 // mechnism can override them.
 class LocalConnection {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LocalConnection);
     WTF_MAKE_NONCOPYABLE(LocalConnection);
 public:
     enum class UserVerification : uint8_t {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -33,6 +33,7 @@
 #import <WebCore/WebAuthenticationConstants.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 #import "AppAttestInternalSoftLink.h"
@@ -55,6 +56,8 @@ static inline String bundleName()
 }
 #endif
 } // namespace
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalConnection);
 
 LocalConnection::~LocalConnection()
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -43,9 +43,12 @@
 #include <WebCore/WebAuthenticationUtils.h>
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAuthenticatorCoordinatorProxy);
 
 WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(WEB_AUTHN_AS_MODERN)
 OBJC_CLASS _WKASDelegate;
@@ -81,7 +82,7 @@ using CapabilitiesCompletionHandler = CompletionHandler<void(Vector<KeyValuePair
 using RequestCompletionHandler = CompletionHandler<void(const WebCore::AuthenticatorResponseData&, WebCore::AuthenticatorAttachment, const WebCore::ExceptionData&)>;
 
 class WebAuthenticatorCoordinatorProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebAuthenticatorCoordinatorProxy);
     WTF_MAKE_NONCOPYABLE(WebAuthenticatorCoordinatorProxy);
 public:
     explicit WebAuthenticatorCoordinatorProxy(WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -46,7 +47,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::CtapDriver> :
 namespace WebKit {
 
 class CtapDriver : public CanMakeWeakPtr<CtapDriver> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CtapDriver);
     WTF_MAKE_NONCOPYABLE(CtapDriver);
 public:
     using ResponseCallback = Function<void(Vector<uint8_t>&&)>;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -30,12 +30,15 @@
 
 #include <WebCore/FidoConstants.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRandomNumber.h>
 #include <wtf/text/Base64.h>
 
 namespace WebKit {
 using namespace fido;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CtapHidDriverWorker);
 
 CtapHidDriverWorker::CtapHidDriverWorker(UniqueRef<HidConnection>&& connection)
     : m_connection(WTFMove(connection))

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
@@ -30,6 +30,7 @@
 #include "CtapDriver.h"
 #include "HidConnection.h"
 #include <WebCore/FidoHidMessage.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -49,7 +50,7 @@ namespace WebKit {
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#arbitration
 // FSM: Idle => Write => Read.
 class CtapHidDriverWorker : public CanMakeWeakPtr<CtapHidDriverWorker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CtapHidDriverWorker);
     WTF_MAKE_NONCOPYABLE(CtapHidDriverWorker);
 public:
     using MessageCallback = Function<void(std::optional<fido::FidoHidMessage>&&)>;

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -35,8 +35,11 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebBackForwardCache);
 
 WebBackForwardCache::WebBackForwardCache(WebProcessPool& processPool)
     : m_processPool(processPool)

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -29,6 +29,7 @@
 #include <pal/SessionID.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
 
 namespace WebKit {
@@ -41,7 +42,7 @@ class WebProcessPool;
 class WebProcessProxy;
 
 class WebBackForwardCache final : public CanMakeCheckedPtr<WebBackForwardCache> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCache);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebBackForwardCache);
 public:
     explicit WebBackForwardCache(WebProcessPool&);

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -31,10 +31,13 @@
 #include "WebBackForwardCache.h"
 #include "WebProcessMessages.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 static const Seconds expirationDelay { 30_min };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebBackForwardCacheEntry);
 
 WebBackForwardCacheEntry::WebBackForwardCacheEntry(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
     : m_backForwardCache(backForwardCache)

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -29,6 +29,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ class WebBackForwardCache;
 class WebProcessProxy;
 
 class WebBackForwardCacheEntry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCacheEntry);
 public:
     WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
     ~WebBackForwardCacheEntry();

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
@@ -30,9 +30,12 @@
 #include "WKAPICast.h"
 #include "WebFrameProxy.h"
 #include "WebProcessPool.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebContextInjectedBundleClient);
 
 WebContextInjectedBundleClient::WebContextInjectedBundleClient(const WKContextInjectedBundleClientBase* client)
 {

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.h
@@ -29,6 +29,7 @@
 #include "APIInjectedBundleClient.h"
 #include "WKContextInjectedBundleClient.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 class Object;
@@ -43,7 +44,7 @@ namespace WebKit {
 class WebProcessPool;
 
 class WebContextInjectedBundleClient : public API::InjectedBundleClient, public API::Client<WKContextInjectedBundleClientBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebContextInjectedBundleClient);
 public:
     explicit WebContextInjectedBundleClient(const WKContextInjectedBundleClientBase*);
 

--- a/Source/WebKit/UIProcess/WebFormClient.cpp
+++ b/Source/WebKit/UIProcess/WebFormClient.cpp
@@ -32,8 +32,11 @@
 #include "WebFormSubmissionListenerProxy.h"
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebFormClient);
 
 WebFormClient::WebFormClient(const WKPageFormClientBase* wkClient)
 {

--- a/Source/WebKit/UIProcess/WebFormClient.h
+++ b/Source/WebKit/UIProcess/WebFormClient.h
@@ -28,6 +28,7 @@
 #include "APIClient.h"
 #include "APIFormClient.h"
 #include "WKPageFormClient.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKPageFormClientBase> {
@@ -38,7 +39,7 @@ template<> struct ClientTraits<WKPageFormClientBase> {
 namespace WebKit {
 
 class WebFormClient : public API::FormClient, API::Client<WKPageFormClientBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebFormClient);
 public:
     explicit WebFormClient(const WKPageFormClientBase*);
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
@@ -53,6 +54,8 @@ static WorkQueue& sharedQuickLookFileQueue()
     return queue.get();
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebFullScreenManagerProxy);
 
 WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFullScreenManagerProxyClient& client)
     : m_page(page)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -36,6 +36,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
@@ -77,7 +78,7 @@ public:
 };
 
 class WebFullScreenManagerProxy : public IPC::MessageReceiver, public CanMakeCheckedPtr<WebFullScreenManagerProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebFullScreenManagerProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebFullScreenManagerProxy);
 public:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);

--- a/Source/WebKit/UIProcess/WebGeolocationProvider.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationProvider.cpp
@@ -28,8 +28,11 @@
 
 #include "WKAPICast.h"
 #include "WebGeolocationManagerProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGeolocationProvider);
 
 WebGeolocationProvider::WebGeolocationProvider(const WKGeolocationProviderBase* provider)
 {

--- a/Source/WebKit/UIProcess/WebGeolocationProvider.h
+++ b/Source/WebKit/UIProcess/WebGeolocationProvider.h
@@ -30,6 +30,7 @@
 #include "APIGeolocationProvider.h"
 #include "WKGeolocationManager.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKGeolocationProviderBase> {
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebGeolocationManagerProxy;
 
 class WebGeolocationProvider : public API::GeolocationProvider, API::Client<WKGeolocationProviderBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebGeolocationProvider);
 public:
     explicit WebGeolocationProvider(const WKGeolocationProviderBase*);
 

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
@@ -35,10 +35,13 @@
 #include <WebCore/WebLockIdentifier.h>
 #include <WebCore/WebLockManagerSnapshot.h>
 #include <WebCore/WebLockRegistry.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_process.connection())
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebLockRegistryProxy);
 
 WebLockRegistryProxy::WebLockRegistryProxy(WebProcessProxy& process)
     : m_process(process)

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -30,6 +30,7 @@
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/WebLockIdentifier.h>
 #include <WebCore/WebLockMode.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
@@ -47,7 +48,7 @@ class WebLockRegistryProxy;
 struct SharedPreferencesForWebProcess;
 
 class WebLockRegistryProxy final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebLockRegistryProxy);
 public:
     explicit WebLockRegistryProxy(WebProcessProxy&);
     ~WebLockRegistryProxy();

--- a/Source/WebKit/UIProcess/WebNavigationState.cpp
+++ b/Source/WebKit/UIProcess/WebNavigationState.cpp
@@ -29,9 +29,12 @@
 #include "APINavigation.h"
 #include "WebPageProxy.h"
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebNavigationState);
 
 WebNavigationState::WebNavigationState()
 {

--- a/Source/WebKit/UIProcess/WebNavigationState.h
+++ b/Source/WebKit/UIProcess/WebNavigationState.h
@@ -29,6 +29,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -57,7 +58,7 @@ class WebPageProxy;
 class WebBackForwardListItem;
 
 class WebNavigationState : public CanMakeWeakPtr<WebNavigationState> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebNavigationState);
 public:
     explicit WebNavigationState();
     ~WebNavigationState();

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
@@ -30,10 +30,13 @@
 #include "WKAPICast.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInjectedBundleClient);
 
 void WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody)
 {

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
@@ -28,6 +28,7 @@
 #include "APIClient.h"
 #include "WKPage.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 class Object;
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class WebPageInjectedBundleClient : public API::Client<WKPageInjectedBundleClientBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageInjectedBundleClient);
 public:
     void didReceiveMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*);
     void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -251,6 +251,7 @@
 #include <wtf/NumberOfCores.h>
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>
 #include <wtf/WeakPtr.h>
@@ -444,7 +445,8 @@ static WorkQueue& sharedFileQueue()
 #endif
 
 class StorageRequests {
-    WTF_MAKE_NONCOPYABLE(StorageRequests); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StorageRequests);
+    WTF_MAKE_NONCOPYABLE(StorageRequests);
     friend NeverDestroyed<StorageRequests>;
 public:
     static StorageRequests& singleton();
@@ -476,6 +478,8 @@ private:
     bool m_requestsAreBeingProcessed { false };
 };
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageRequests);
+
 StorageRequests& StorageRequests::singleton()
 {
     static NeverDestroyed<StorageRequests> requests;
@@ -486,7 +490,7 @@ StorageRequests& StorageRequests::singleton()
 
 class WebPageProxyFrameLoadStateObserver final : public FrameLoadStateObserver {
     WTF_MAKE_NONCOPYABLE(WebPageProxyFrameLoadStateObserver);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageProxyFrameLoadStateObserver);
 public:
     static constexpr size_t maxVisitedDomainsSize = 6;
 
@@ -529,6 +533,8 @@ private:
     Vector<URL> m_provisionalURLs;
     ListHashSet<RegistrableDomain> m_visitedDomains;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageProxyFrameLoadStateObserver);
 
 #endif // #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -37,6 +37,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/IntPoint.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 #include "DisplayCaptureSessionManager.h"
@@ -44,6 +45,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageProxyTesting);
 
 WebPageProxyTesting::WebPageProxyTesting(WebPageProxy& page)
     : m_page(page)

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -28,6 +28,7 @@
 #include "MessageSender.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class WebPageProxyTesting : public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageProxyTesting);
     WTF_MAKE_NONCOPYABLE(WebPageProxyTesting);
 public:
     explicit WebPageProxyTesting(WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -36,10 +36,13 @@
 #include <WebCore/SecurityOriginData.h>
 #include <optional>
 #include <wtf/GetPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPermissionControllerProxy);
 
 WebPermissionControllerProxy::WebPermissionControllerProxy(WebProcessProxy& process)
     : m_process(process)

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include "WebPageProxyIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum class PermissionQuerySource : uint8_t;
@@ -42,7 +43,7 @@ class WebPageProxy;
 class WebProcessProxy;
 
 class WebPermissionControllerProxy final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPermissionControllerProxy);
 public:
     explicit WebPermissionControllerProxy(WebProcessProxy&);
     ~WebPermissionControllerProxy();

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -33,11 +33,15 @@
 #include "WebProcessPool.h"
 #include <wtf/RAMSize.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define WEBPROCESSCACHE_RELEASE_LOG(fmt, ...) RELEASE_LOG(ProcessSwapping, "%p - [PID=%d] WebProcessCache::" fmt, this, ##__VA_ARGS__)
 #define WEBPROCESSCACHE_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ProcessSwapping, "%p - [PID=%d] WebProcessCache::" fmt, this, ##__VA_ARGS__)
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcessCache);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WebProcessCacheCachedProcess, WebProcessCache::CachedProcess);
 
 #if PLATFORM(COCOA)
 Seconds WebProcessCache::cachedProcessLifetime { 30_min };

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -41,7 +42,7 @@ class WebProcessPool;
 class WebsiteDataStore;
 
 class WebProcessCache final : public CanMakeCheckedPtr<WebProcessCache> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebProcessCache);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebProcessCache);
 public:
     explicit WebProcessCache(WebProcessPool&);
@@ -68,7 +69,7 @@ private:
     static Seconds clearingDelayAfterApplicationResignsActive;
 
     class CachedProcess {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(CachedProcess);
     public:
         CachedProcess(Ref<WebProcessProxy>&&);
         ~CachedProcess();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -104,6 +104,7 @@
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakListHashSet.h>
@@ -151,6 +152,8 @@ static WeakListHashSet<WebProcessProxy>& liveProcessesLRU()
     static NeverDestroyed<WeakListHashSet<WebProcessProxy>> processes;
     return processes;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcessProxy);
 
 void WebProcessProxy::setProcessCountLimit(unsigned limit)
 {
@@ -273,7 +276,7 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 class UIProxyForCapture final : public UserMediaCaptureManagerProxy::ConnectionProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(UIProxyForCapture);
 public:
     explicit UIProxyForCapture(WebProcessProxy& process)
         : m_process(process)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -58,6 +58,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -160,7 +161,7 @@ using WebProcessWithMediaStreamingToken = WebProcessWithMediaStreamingCounter::T
 enum class CheckBackForwardList : bool { No, Yes };
 
 class WebProcessProxy : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebProcessProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebProcessProxy);
 public:
     using WebPageProxyMap = HashMap<WebPageProxyIdentifier, WeakRef<WebPageProxy>>;

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -35,8 +35,11 @@
 #include "WebScreenOrientationManagerMessages.h"
 #include "WebScreenOrientationManagerProxyMessages.h"
 #include <WebCore/Exception.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebScreenOrientationManagerProxy);
 
 WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy& page, WebCore::ScreenOrientationType orientation)
     : m_page(page)

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -29,6 +29,7 @@
 #include <WebCore/ScreenOrientationLockType.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class Exception;
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebScreenOrientationManagerProxy);
 public:
     WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);
     ~WebScreenOrientationManagerProxy();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -32,6 +32,7 @@
 #include <WebCore/NotificationData.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 enum class WasPrivateRelayed : bool;
@@ -47,7 +48,7 @@ class WebPageProxy;
 class WebsiteDataStore;
 
 class WebsiteDataStoreClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebsiteDataStoreClient);
 public:
     virtual ~WebsiteDataStoreClient() { }
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -34,10 +34,13 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_page.legacyMainFrameProcess().connection())
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformXRSystem);
 
 PlatformXRSystem::PlatformXRSystem(WebPageProxy& page)
     : m_page(page)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -33,6 +33,7 @@
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/PlatformXR.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class PlatformXRSystem;
@@ -56,7 +57,7 @@ struct SharedPreferencesForWebProcess;
 struct XRDeviceInfo;
 
 class PlatformXRSystem : public IPC::MessageReceiver, public PlatformXRCoordinatorSessionEventClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PlatformXRSystem);
 public:
     PlatformXRSystem(WebPageProxy&);
     virtual ~PlatformXRSystem();

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -31,6 +31,7 @@
 #import "PlatformXRCoordinator.h"
 
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Threading.h>
 #import <wtf/threads/BinarySemaphore.h>
 
@@ -40,7 +41,7 @@
 namespace WebKit {
 
 class ARKitCoordinator final : public PlatformXRCoordinator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ARKitCoordinator);
     struct RenderState;
 public:
     ARKitCoordinator();

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -35,10 +35,13 @@
 #import <Metal/MTLEvent_Private.h>
 #import <Metal/MTLTexture_Private.h>
 #import <WebCore/PlatformXRPose.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #import "ARKitSoftLink.h"
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ARKitCoordinator);
 
 struct ARKitCoordinator::RenderState {
     RetainPtr<id<WKARPresentationSession>> presentationSession;

--- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
+++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/GeolocationPositionData.h>
 #include <gio/gio.h>
 #include <glib/gi18n-lib.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/Application.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/Sandbox.h>
@@ -39,6 +40,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GeoclueGeolocationProvider);
 
 GeoclueGeolocationProvider::GeoclueGeolocationProvider()
     : m_destroyLaterTimer(RunLoop::current(), this, &GeoclueGeolocationProvider::destroyState)

--- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
+++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/CString.h>
 
@@ -39,7 +40,8 @@ class GeolocationPositionData;
 namespace WebKit {
 
 class GeoclueGeolocationProvider {
-    WTF_MAKE_NONCOPYABLE(GeoclueGeolocationProvider); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GeoclueGeolocationProvider);
+    WTF_MAKE_NONCOPYABLE(GeoclueGeolocationProvider);
 public:
     GeoclueGeolocationProvider();
     ~GeoclueGeolocationProvider();

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
@@ -28,6 +28,7 @@
 
 #include "DisplayVBlankMonitorTimer.h"
 #include "Logging.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -37,6 +38,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DisplayVBlankMonitor);
 
 std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDisplayID displayID)
 {

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h
@@ -26,17 +26,17 @@
 #pragma once
 
 #include <wtf/Condition.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 using PlatformDisplayID = uint32_t;
 
 class DisplayVBlankMonitor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DisplayVBlankMonitor);
 public:
     static std::unique_ptr<DisplayVBlankMonitor> create(PlatformDisplayID);
     virtual ~DisplayVBlankMonitor();

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -30,6 +30,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/PlatformDisplay.h>
 #include <gtk/gtk.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 
 #if PLATFORM(GTK)
@@ -61,6 +62,8 @@ static bool gtkCanUseHardwareAcceleration()
     return canUseHardwareAcceleration;
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedBackingStore);
 
 bool AcceleratedBackingStore::checkRequirements()
 {

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
@@ -27,6 +27,7 @@
 
 #include "RendererBufferFormat.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 typedef struct _cairo cairo_t;
 
@@ -45,7 +46,8 @@ class LayerTreeContext;
 class WebPageProxy;
 
 class AcceleratedBackingStore {
-    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStore); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedBackingStore);
+    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStore);
 public:
     static bool checkRequirements();
     static std::unique_ptr<AcceleratedBackingStore> create(WebPageProxy&);

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/SharedMemory.h>
 #include <epoxy/egl.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -58,6 +59,8 @@ static constexpr uint64_t s_dmabufInvalidModifier = ((1ULL << 56) - 1);
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedBackingStoreDMABuf);
 
 OptionSet<DMABufRendererBufferMode> AcceleratedBackingStoreDMABuf::rendererBufferMode()
 {

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -36,6 +36,7 @@
 #include <gtk/gtk.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/unix/UnixFileDescriptor.h>
@@ -63,7 +64,8 @@ class WebPageProxy;
 enum class DMABufRendererBufferMode : uint8_t;
 
 class AcceleratedBackingStoreDMABuf final : public AcceleratedBackingStore, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedBackingStoreDMABuf);
+    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf);
 public:
     static OptionSet<DMABufRendererBufferMode> rendererBufferMode();
     static bool checkRequirements();

--- a/Source/WebKit/UIProcess/gtk/Clipboard.cpp
+++ b/Source/WebKit/UIProcess/gtk/Clipboard.cpp
@@ -27,6 +27,7 @@
 #include "Clipboard.h"
 #include <mutex>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -54,6 +55,8 @@ static Clipboard& primary()
 
     return object;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Clipboard);
 
 Clipboard& Clipboard::get(const String& name)
 {

--- a/Source/WebKit/UIProcess/gtk/Clipboard.h
+++ b/Source/WebKit/UIProcess/gtk/Clipboard.h
@@ -27,6 +27,7 @@
 
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 #if USE(GTK4)
 typedef struct _GdkClipboard GdkClipboard;
@@ -44,7 +45,8 @@ namespace WebKit {
 class WebFrameProxy;
 
 class Clipboard {
-    WTF_MAKE_NONCOPYABLE(Clipboard); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Clipboard);
+    WTF_MAKE_NONCOPYABLE(Clipboard);
 public:
     static Clipboard& get(const String& name);
 

--- a/Source/WebKit/UIProcess/gtk/PointerLockManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManager.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/PointerEvent.h>
 #include <WebCore/PointerID.h>
 #include <gtk/gtk.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(WAYLAND)
 #include "PointerLockManagerWayland.h"
@@ -44,6 +45,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerLockManager);
 
 std::unique_ptr<PointerLockManager> PointerLockManager::create(WebPageProxy& webPage, const FloatPoint& position, const FloatPoint& globalPosition, WebMouseEventButton button, unsigned short buttons, OptionSet<WebEventModifier> modifiers)
 {

--- a/Source/WebKit/UIProcess/gtk/PointerLockManager.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManager.h
@@ -28,6 +28,7 @@
 #include "WebMouseEvent.h"
 #include <WebCore/FloatPoint.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 typedef struct _GdkDevice GdkDevice;
 #if USE(GTK4)
@@ -41,7 +42,8 @@ namespace WebKit {
 class WebPageProxy;
 
 class PointerLockManager {
-    WTF_MAKE_NONCOPYABLE(PointerLockManager); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PointerLockManager);
+    WTF_MAKE_NONCOPYABLE(PointerLockManager);
 public:
     static std::unique_ptr<PointerLockManager> create(WebPageProxy&, const WebCore::FloatPoint&, const WebCore::FloatPoint&, WebMouseEventButton, unsigned short, OptionSet<WebEventModifier>);
     PointerLockManager(WebPageProxy&, const WebCore::FloatPoint&, const WebCore::FloatPoint&, WebMouseEventButton, unsigned short, OptionSet<WebEventModifier>);

--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.cpp
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 #include <gtk/gtk.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
@@ -41,6 +42,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerLockManagerWayland);
 
 PointerLockManagerWayland::PointerLockManagerWayland(WebPageProxy& webPage, const FloatPoint& position, const FloatPoint& globalPosition, WebMouseEventButton button, unsigned short buttons, OptionSet<WebEventModifier> modifiers)
     : PointerLockManager(webPage, position, globalPosition, button, buttons, modifiers)

--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.h
@@ -31,6 +31,7 @@
 
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include <wayland-client.h>
+#include <wtf/TZoneMalloc.h>
 
 struct zwp_locked_pointer_v1;
 struct zwp_pointer_constraints_v1;
@@ -40,7 +41,8 @@ namespace WebKit {
 class WebPageProxy;
 
 class PointerLockManagerWayland final : public PointerLockManager {
-    WTF_MAKE_NONCOPYABLE(PointerLockManagerWayland); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PointerLockManagerWayland);
+    WTF_MAKE_NONCOPYABLE(PointerLockManagerWayland);
 public:
     PointerLockManagerWayland(WebPageProxy&, const WebCore::FloatPoint&, const WebCore::FloatPoint&, WebMouseEventButton, unsigned short, OptionSet<WebEventModifier>);
     ~PointerLockManagerWayland();

--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include <X11/Xlib.h>
 #include <gtk/gtk.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
@@ -41,6 +42,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerLockManagerX11);
 
 PointerLockManagerX11::PointerLockManagerX11(WebPageProxy& webPage, const FloatPoint& position, const FloatPoint& globalPosition, WebMouseEventButton button, unsigned short buttons, OptionSet<WebEventModifier> modifiers)
     : PointerLockManager(webPage, position, globalPosition, button, buttons, modifiers)

--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h
@@ -29,12 +29,15 @@
 
 #if PLATFORM(X11)
 
+#include <wtf/TZoneMalloc.h>
+
 namespace WebKit {
 
 class WebPageProxy;
 
 class PointerLockManagerX11 final : public PointerLockManager {
-    WTF_MAKE_NONCOPYABLE(PointerLockManagerX11); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PointerLockManagerX11);
+    WTF_MAKE_NONCOPYABLE(PointerLockManagerX11);
 public:
     PointerLockManagerX11(WebPageProxy&, const WebCore::FloatPoint&, const WebCore::FloatPoint&, WebMouseEventButton, unsigned short, OptionSet<WebEventModifier>);
     ~PointerLockManagerX11() = default;

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
@@ -29,13 +29,15 @@
 
 #import <UIKit/UIKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 
 @class WKCompactContextMenuPresenterButton;
 
 namespace WebKit {
 
 class CompactContextMenuPresenter {
-    WTF_MAKE_NONCOPYABLE(CompactContextMenuPresenter); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CompactContextMenuPresenter);
+    WTF_MAKE_NONCOPYABLE(CompactContextMenuPresenter);
 public:
     CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate>);
     ~CompactContextMenuPresenter();

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
@@ -28,6 +28,8 @@
 
 #if USE(UICONTEXTMENU)
 
+#import <wtf/TZoneMallocInlines.h>
+
 @interface UIContextMenuInteraction (SPI)
 - (void)_presentMenuAtLocation:(CGPoint)location;
 @end
@@ -79,6 +81,8 @@
 @end
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CompactContextMenuPresenter);
 
 CompactContextMenuPresenter::CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate> delegate)
     : m_rootView(rootView)

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
@@ -31,6 +31,7 @@
 #import <wtf/Noncopyable.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKContentView;
@@ -39,7 +40,7 @@
 namespace WebKit {
 
 class GestureRecognizerConsistencyEnforcer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GestureRecognizerConsistencyEnforcer);
     WTF_MAKE_NONCOPYABLE(GestureRecognizerConsistencyEnforcer);
 public:
     GestureRecognizerConsistencyEnforcer(WKContentView *);

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
@@ -30,8 +30,11 @@
 
 #import "Logging.h"
 #import "WKContentViewInteraction.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GestureRecognizerConsistencyEnforcer);
 
 GestureRecognizerConsistencyEnforcer::GestureRecognizerConsistencyEnforcer(WKContentView *view)
     : m_view(view)

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
@@ -29,6 +29,7 @@
 
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS RBSProcessMonitor;
 
@@ -44,7 +45,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ProcessStateM
 namespace WebKit {
 
 class ProcessStateMonitor : public CanMakeWeakPtr<ProcessStateMonitor> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ProcessStateMonitor);
 public:
     ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler);
     ~ProcessStateMonitor();

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
@@ -32,10 +32,13 @@
 #import "NetworkProcessMessages.h"
 #import "ProcessAssertion.h"
 #import "RunningBoardServicesSPI.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 static constexpr double maxPrepareForSuspensionDelayInSecond = 15;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessStateMonitor);
 
 ProcessStateMonitor::ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler)
     : m_becomeSuspendedHandler(WTFMove(becomeSuspendedHandler))

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/FloatRect.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKContentView;
 OBJC_CLASS UIScrollView;
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SmartMagnificationController : private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SmartMagnificationController);
     WTF_MAKE_NONCOPYABLE(SmartMagnificationController);
 public:
     SmartMagnificationController(WKContentView *);

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -38,6 +38,7 @@
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
 #import <pal/system/ios/UserInterfaceIdiom.h>
+#import <wtf/TZoneMallocInlines.h>
 
 static const float smartMagnificationPanScrollThresholdZoomedOut = 60;
 static const float smartMagnificationPanScrollThresholdIPhone = 100;
@@ -49,6 +50,8 @@ static const double smartMagnificationMinimumScale = 0;
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SmartMagnificationController);
 
 SmartMagnificationController::SmartMagnificationController(WKContentView *contentView)
     : m_webPageProxy(*contentView.page)

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -29,13 +29,14 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/MotionManagerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
 class WebDeviceOrientationUpdateProviderProxy : public WebCore::MotionManagerClient, private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebDeviceOrientationUpdateProviderProxy);
 public:
     WebDeviceOrientationUpdateProviderProxy(WebPageProxy&);
     ~WebDeviceOrientationUpdateProviderProxy();

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -34,8 +34,11 @@
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
 #import <WebCore/WebCoreMotionManager.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDeviceOrientationUpdateProviderProxy);
 
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -47,6 +47,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 #if PLATFORM(VISION)
@@ -64,7 +65,7 @@ static const Seconds bannerMinimumHideDelay = 1_s;
 @class WKFullscreenStackView;
 
 class WKFullScreenViewControllerPlaybackSessionModelClient final : WebCore::PlaybackSessionModelClient, public CanMakeCheckedPtr<WKFullScreenViewControllerPlaybackSessionModelClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WKFullScreenViewControllerPlaybackSessionModelClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WKFullScreenViewControllerPlaybackSessionModelClient);
 public:
     void setParent(WKFullScreenViewController *parent) { m_parent = parent; }

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -41,6 +41,7 @@
 #import <wtf/CheckedPtr.h>
 #import <wtf/Deque.h>
 #import <wtf/NakedPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 // FIXME: Implement scrollFindMatchToVisible.
@@ -61,7 +62,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class TextFinderFindClient : public API::FindMatchesClient, public API::FindClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(TextFinderFindClient);
 public:
     explicit TextFinderFindClient(WKTextFinderClient *textFinderClient)
         : m_textFinderClient(textFinderClient)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -47,6 +47,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
@@ -199,7 +200,7 @@ typedef HashMap<String, ValidationVector> ValidationMap;
 
 class WebViewImpl final : public CanMakeWeakPtr<WebViewImpl>, public CanMakeCheckedPtr<WebViewImpl> {
     WTF_MAKE_NONCOPYABLE(WebViewImpl);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebViewImpl);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebViewImpl);
 public:
     WebViewImpl(NSView <WebViewImplDelegate> *, WKWebView *outerWebView, WebProcessPool&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -153,6 +153,7 @@
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/SetForScope.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/darwin/OSVariantSPI.h>
@@ -1216,6 +1217,8 @@ static bool isInRecoveryOS()
 {
     return os_variant_is_basesystem("WebKit");
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewImpl);
 
 WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWebView, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
     : m_view(view)

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/NotImplemented.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(GRAPHICS_LAYER_WC)
 #include "DrawingAreaProxyWC.h"
@@ -41,6 +42,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageClientImpl);
 
 PageClientImpl::PageClientImpl(PlayStationWebView& view)
     : m_view(view)

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PageClient.h"
+#include <wtf/TZoneMalloc.h>
 #if ENABLE(FULLSCREEN_API)
 #include "WebFullScreenManagerProxy.h"
 #endif
@@ -40,7 +41,7 @@ class PageClientImpl final : public PageClient
     , public WebFullScreenManagerProxyClient
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageClientImpl);
 public:
     PageClientImpl(PlayStationWebView&);
 

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -29,6 +29,7 @@
 #include "APIPageConfiguration.h"
 #include "DrawingAreaProxyCoordinatedGraphics.h"
 #include "WebProcessPool.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(WPE_BACKEND_PLAYSTATION)
 #include <wpe/playstation.h>
@@ -37,6 +38,8 @@
 namespace WebKit {
 
 #if USE(WPE_BACKEND_PLAYSTATION)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlayStationWebView);
 
 RefPtr<PlayStationWebView> PlayStationWebView::create(struct wpe_view_backend* backend, const API::PageConfiguration& configuration)
 {

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
@@ -30,11 +30,12 @@
 #include "PageClientImpl.h"
 #include "WKView.h"
 #include "WebPageProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class PlayStationWebView : public API::ObjectImpl<API::Object::Type::View> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PlayStationWebView);
 public:
 #if USE(WPE_BACKEND_PLAYSTATION)
     static RefPtr<PlayStationWebView> create(struct wpe_view_backend*, const API::PageConfiguration&);

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/ScrollbarTheme.h>
 #include <windowsx.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -73,6 +74,8 @@ static void translatePoint(LPARAM& lParam, HWND from, HWND to)
     ::MapWindowPoints(from, to, &pt, 1);
     lParam = MAKELPARAM(pt.x, pt.y);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPopupMenuProxyWin);
 
 LRESULT CALLBACK WebPopupMenuProxyWin::WebPopupMenuProxyWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -32,13 +32,14 @@
 #include <OleAcc.h>
 #include <WebCore/ScrollableArea.h>
 #include <WebCore/Scrollbar.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebView;
 
 class WebPopupMenuProxyWin final : public CanMakeCheckedPtr<WebPopupMenuProxyWin>, public WebPopupMenuProxy, private WebCore::ScrollableArea {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPopupMenuProxyWin);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPopupMenuProxyWin);
 public:
     static Ref<WebPopupMenuProxyWin> create(WebView* webView, WebPopupMenuProxy::Client& client)

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -33,6 +33,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/ShareableBitmap.h>
 #include <wpe/wpe-platform.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 
 #if USE(LIBDRM)
@@ -40,6 +41,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedBackingStoreDMABuf);
 
 std::unique_ptr<AcceleratedBackingStoreDMABuf> AcceleratedBackingStoreDMABuf::create(WebPageProxy& webPage, WPEView* view)
 {

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -32,6 +32,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/Region.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
@@ -52,7 +53,8 @@ namespace WebKit {
 class WebPageProxy;
 
 class AcceleratedBackingStoreDMABuf final : public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedBackingStoreDMABuf);
+    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf);
 public:
     static std::unique_ptr<AcceleratedBackingStoreDMABuf> create(WebPageProxy&, WPEView*);
     ~AcceleratedBackingStoreDMABuf();


### PR DESCRIPTION
#### 1d33ec42f2c6fc00caff5cbbf3ac24fa0aeaee35
<pre>
[TZone] WebKit/UIProcess: Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=277876">https://bugs.webkit.org/show_bug.cgi?id=277876</a>
<a href="https://rdar.apple.com/133557558">rdar://133557558</a>

Reviewed by Keith Miller and Michael Saboff.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebKit/UIProcess/API/APIAutomationClient.h:
* Source/WebKit/UIProcess/API/APIAutomationSessionClient.h:
* Source/WebKit/UIProcess/API/APIContextMenuClient.h:
* Source/WebKit/UIProcess/API/APICustomProtocolManagerClient.h:
* Source/WebKit/UIProcess/API/APIDataTaskClient.h:
* Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h:
* Source/WebKit/UIProcess/API/APIDownloadClient.h:
* Source/WebKit/UIProcess/API/APIFindClient.h:
* Source/WebKit/UIProcess/API/APIFindMatchesClient.h:
* Source/WebKit/UIProcess/API/APIFormClient.h:
* Source/WebKit/UIProcess/API/APIFullscreenClient.h:
* Source/WebKit/UIProcess/API/APIGeolocationProvider.h:
* Source/WebKit/UIProcess/API/APIHistoryClient.h:
* Source/WebKit/UIProcess/API/APIIconDatabaseClient.h:
* Source/WebKit/UIProcess/API/APIIconLoadingClient.h:
* Source/WebKit/UIProcess/API/APIInjectedBundleClient.h:
* Source/WebKit/UIProcess/API/APIInspectorClient.h:
* Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h:
* Source/WebKit/UIProcess/API/APILegacyContextHistoryClient.h:
* Source/WebKit/UIProcess/API/APILoaderClient.h:
* Source/WebKit/UIProcess/API/APINavigationClient.h:
* Source/WebKit/UIProcess/API/APINotificationProvider.h:
* Source/WebKit/UIProcess/API/APIPolicyClient.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
* Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setInputDelegate:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm:
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.h:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.h:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/gtk/DragSource.h:
* Source/WebKit/UIProcess/API/gtk/DropTarget.h:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp:
* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h:
* Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp:
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp:
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h:
* Source/WebKit/UIProcess/API/playstation/APIViewClient.h:
* Source/WebKit/UIProcess/API/wpe/APIViewClient.h:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/BackingStore.h:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
* Source/WebKit/UIProcess/Cocoa/FindClient.h:
* Source/WebKit/UIProcess/Cocoa/FindClient.mm:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.mm:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h:
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.h:
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h:
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/DisplayLink.cpp:
* Source/WebKit/UIProcess/DisplayLink.h:
* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp:
* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/EndowmentStateTracker.h:
* Source/WebKit/UIProcess/EndowmentStateTracker.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp:
* Source/WebKit/UIProcess/Gamepad/UIGamepad.h:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp:
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h:
* Source/WebKit/UIProcess/LegacyGlobalSettings.cpp:
* Source/WebKit/UIProcess/LegacyGlobalSettings.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/Media/MediaUsageManager.cpp:
(WebKit::MediaUsageManager::reset):
(WebKit::reset): Deleted.
* Source/WebKit/UIProcess/Media/MediaUsageManager.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/ModelElementController.cpp:
* Source/WebKit/UIProcess/ModelElementController.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp:
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h:
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp:
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/SystemPreviewController.cpp:
* Source/WebKit/UIProcess/SystemPreviewController.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebFormClient.cpp:
* Source/WebKit/UIProcess/WebFormClient.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebGeolocationProvider.cpp:
* Source/WebKit/UIProcess/WebGeolocationProvider.h:
* Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebNavigationState.cpp:
* Source/WebKit/UIProcess/WebNavigationState.h:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
* Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp:
* Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h:
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp:
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/Clipboard.cpp:
* Source/WebKit/UIProcess/gtk/Clipboard.h:
* Source/WebKit/UIProcess/gtk/PointerLockManager.cpp:
* Source/WebKit/UIProcess/gtk/PointerLockManager.h:
* Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.cpp:
* Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.h:
* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp:
* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm:
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.h:
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
* Source/WebKit/UIProcess/playstation/PlayStationWebView.h:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/282294@main">https://commits.webkit.org/282294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/110508137697e899cf9573631014a441f134af47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13599 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9205 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39134 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35843 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12191 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11653 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13918 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5577 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->