### PR TITLE
[TZone] WebKit misc: Convert FastMalloc to TZone

### DIFF
--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -29,10 +29,13 @@
 #if ENABLE(MODEL_PROCESS)
 
 #include "ModelProcessModelPlayerProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerManagerProxy);
 
 ModelProcessModelPlayerManagerProxy::ModelProcessModelPlayerManagerProxy(ModelConnectionToWebProcess& connection)
     : m_modelConnectionToWebProcess(connection)

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "ModelConnectionToWebProcess.h"
 #include <WebCore/ModelPlayerIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -48,7 +49,7 @@ class ModelProcessModelPlayerProxy;
 
 class ModelProcessModelPlayerManagerProxy
     : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ModelProcessModelPlayerManagerProxy);
 public:
     explicit ModelProcessModelPlayerManagerProxy(ModelConnectionToWebProcess&);
     ~ModelProcessModelPlayerManagerProxy();

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -40,6 +40,7 @@
 #include <simd/simd.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -59,7 +60,7 @@ class ModelProcessModelPlayerProxy final
     : public WebCore::ModelPlayer
     , public WebCore::REModelLoaderClient
     , private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ModelProcessModelPlayerProxy);
 public:
     static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
     ~ModelProcessModelPlayerProxy();

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -50,9 +50,12 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/MathExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerProxy);
 
 Ref<ModelProcessModelPlayerProxy> ModelProcessModelPlayerProxy::create(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <wtf/FileSystem.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
 
@@ -69,6 +70,8 @@ static GUniquePtr<char> cursorsPath(const char* basePath, Vector<GUniquePtr<char
 
     return nullptr;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CursorTheme);
 
 std::unique_ptr<CursorTheme> CursorTheme::create(const char* name, uint32_t size)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.h
@@ -24,14 +24,14 @@
  */
 
 #include <optional>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WPE {
 
 class CursorTheme {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CursorTheme);
 public:
     static std::unique_ptr<CursorTheme> create(const char* path, uint32_t size);
     static std::unique_ptr<CursorTheme> create();

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -30,10 +30,16 @@
 #include <drm_fourcc.h>
 #include <glib.h>
 #include <string.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
 
 namespace DRM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Crtc);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Connector);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Plane);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Buffer);
 
 static Property drmPropertyForName(int fd, drmModeObjectProperties* properties, const char* name)
 {

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -27,8 +27,8 @@
 
 #include <gbm.h>
 #include <optional>
-#include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 #include <xf86drmMode.h>
 
@@ -39,7 +39,7 @@ namespace DRM {
 using Property = std::pair<uint32_t, uint64_t>;
 
 class Crtc {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Crtc);
 public:
     struct Properties {
         Property active { 0, 0 };
@@ -73,7 +73,7 @@ private:
 };
 
 class Connector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Connector);
 public:
     struct Properties {
         Property crtcID { 0, 0 };
@@ -104,7 +104,7 @@ private:
 };
 
 class Plane {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Plane);
 public:
     enum class Type : uint8_t {
         Primary = DRM_PLANE_TYPE_PRIMARY,
@@ -150,7 +150,7 @@ private:
 };
 
 class Buffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Buffer);
 public:
     static std::unique_ptr<Buffer> create(struct gbm_bo*);
     Buffer(struct gbm_bo*, uint32_t);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
@@ -28,10 +28,13 @@
 
 #include "WPEDRM.h"
 #include "WPEDRMCursorTheme.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
 
 namespace DRM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Cursor);
 
 Cursor::Cursor(std::unique_ptr<Plane>&& plane, struct gbm_device* device, uint32_t cursorWidth, uint32_t cursorHeight)
     : m_plane(WTFMove(plane))

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <gbm.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WPE {
@@ -38,7 +38,7 @@ class CursorTheme;
 class Plane;
 
 class Cursor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Cursor);
 public:
     Cursor(std::unique_ptr<Plane>&&, struct gbm_device*, uint32_t cursorWidth, uint32_t cursorHeight);
     ~Cursor();

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp
@@ -28,10 +28,13 @@
 
 #include "WPECursorTheme.h"
 #include "WPEDRM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
 
 namespace DRM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CursorTheme);
 
 std::unique_ptr<CursorTheme> CursorTheme::create(const char* name, uint32_t size)
 {

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #include <optional>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -38,7 +38,7 @@ class CursorTheme;
 namespace DRM {
 
 class CursorTheme {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CursorTheme);
 public:
     static std::unique_ptr<CursorTheme> create(const char* path, uint32_t size);
     static std::unique_ptr<CursorTheme> create();

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
@@ -31,11 +31,14 @@
 #include "WPEViewDRMPrivate.h"
 #include <linux/input.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 
 namespace WPE {
 
 namespace DRM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Seat);
 
 static struct libinput_interface s_libinputInterface = {
     // open_restricted

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
@@ -28,8 +28,8 @@
 #include "WPEKeymap.h"
 #include "WPEView.h"
 #include <libinput.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GWeakPtr.h>
 
@@ -42,7 +42,7 @@ namespace DRM {
 class Session;
 
 class Seat {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Seat);
 public:
     static std::unique_ptr<Seat> create(struct udev*, Session&);
     explicit Seat(struct libinput*);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSession.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSession.cpp
@@ -29,10 +29,13 @@
 #include "WPEDRMSessionLogind.h"
 #include <fcntl.h>
 #include <unistd.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
 
 namespace DRM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Session);
 
 std::unique_ptr<Session> Session::create()
 {

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSession.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSession.h
@@ -25,14 +25,14 @@
 
 #pragma once
 
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WPE {
 
 namespace DRM {
 
 class Session {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Session);
 public:
     static std::unique_ptr<Session> create();
     Session() = default;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp
@@ -28,8 +28,11 @@
 
 #include "WPEDisplayWaylandPrivate.h"
 #include "WPEWaylandCursorTheme.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaylandCursor);
 
 WaylandCursor::WaylandCursor(WPEDisplayWayland* display)
     : m_display(display)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.h
@@ -27,15 +27,15 @@
 
 #include "WPEDisplayWayland.h"
 #include <wayland-client.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WPE {
 
 class WaylandCursorTheme;
 
 class WaylandCursor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaylandCursor);
 public:
     explicit WaylandCursor(WPEDisplayWayland*);
     ~WaylandCursor();

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
@@ -28,8 +28,11 @@
 
 #include "WPECursorTheme.h"
 #include "WPEWaylandSHMPool.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaylandCursorTheme);
 
 std::unique_ptr<WaylandCursorTheme> WaylandCursorTheme::create(const char* name, uint32_t size, struct wl_shm* shm)
 {

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.h
@@ -27,8 +27,8 @@
 
 #include <optional>
 #include <wayland-client.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -38,7 +38,7 @@ class CursorTheme;
 class WaylandSHMPool;
 
 class WaylandCursorTheme {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaylandCursorTheme);
 public:
     static std::unique_ptr<WaylandCursorTheme> create(const char* path, uint32_t size, struct wl_shm*);
     static std::unique_ptr<WaylandCursorTheme> create(struct wl_shm*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "WPEWaylandOutput.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WPE {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaylandOutput);
 
 WaylandOutput::WaylandOutput(struct wl_output* output)
     : m_output(output)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.h
@@ -26,16 +26,16 @@
 #pragma once
 
 #include <wayland-client.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 typedef struct _WPEViewWayland WPEViewWayland;
 
 namespace WPE {
 
 class WaylandOutput {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaylandOutput);
 public:
     explicit WaylandOutput(struct wl_output*);
     ~WaylandOutput();

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
@@ -40,6 +41,8 @@
 #endif
 
 namespace WPE {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaylandSHMPool);
 
 static UnixFileDescriptor createSharedMemory()
 {

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.h
@@ -26,13 +26,13 @@
 #pragma once
 
 #include <wayland-client.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WPE {
 
 class WaylandSHMPool {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaylandSHMPool);
 public:
     static std::unique_ptr<WaylandSHMPool> create(struct wl_shm*, size_t);
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -32,9 +32,12 @@
 #include "WPEToplevelWaylandPrivate.h"
 #include <linux/input.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 
 namespace WPE {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaylandSeat);
 
 WaylandSeat::WaylandSeat(struct wl_seat* seat)
     : m_seat(seat)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -29,16 +29,16 @@
 #include "WPEKeymap.h"
 #include "WPEToplevelWayland.h"
 #include <wayland-client.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GWeakPtr.h>
 
 namespace WPE {
 
 class WaylandSeat {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaylandSeat);
 public:
     explicit WaylandSeat(struct wl_seat*);
     ~WaylandSeat();

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -42,6 +42,7 @@
 #include <wtf/OSObjectPtr.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
@@ -70,7 +71,7 @@ enum class PushClientConnectionIdentifierType { };
 using PushClientConnectionIdentifier = AtomicObjectIdentifier<PushClientConnectionIdentifierType>;
 
 class PushClientConnection : public RefCounted<PushClientConnection>, public Identified<PushClientConnectionIdentifier>, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PushClientConnection);
 public:
     static RefPtr<PushClientConnection> create(xpc_connection_t, IPC::Decoder&);
 

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -41,6 +41,7 @@
 #import <WebCore/PushPermissionState.h>
 #import <wtf/ASCIICType.h>
 #import <wtf/HexNumber.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/Vector.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/text/MakeString.h>
@@ -118,6 +119,8 @@ static bool isValidPushPartition(String partition)
     return true;
 #endif
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PushClientConnection);
 
 RefPtr<PushClientConnection> PushClientConnection::create(xpc_connection_t connection, IPC::Decoder& initialMessageDecoder)
 {

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -34,6 +34,7 @@
 #include <wtf/Deque.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -46,7 +47,7 @@ class SubscribeRequest;
 class UnsubscribeRequest;
 
 class PushService {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PushService);
 public:
     using IncomingPushMessageHandler = Function<void(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&)>;
 

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -36,6 +36,7 @@
 #import <notify.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/Base64.h>
@@ -123,6 +124,8 @@ static void performAfterFirstUnlock(Function<void()>&& function)
 
 #endif
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PushService);
+
 void PushService::create(const String& incomingPushServiceName, const String& databasePath, IncomingPushMessageHandler&& messageHandler, CompletionHandler<void(std::unique_ptr<PushService>&&)>&& creationHandler)
 {
     auto transaction = adoptOSObject(os_transaction_create("com.apple.webkit.webpushd.push-service-init"));
@@ -209,7 +212,6 @@ static PushSubscriptionData makePushSubscriptionFromRecord(PushRecord&& record)
 }
 
 class PushServiceRequest {
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~PushServiceRequest() = default;
 
@@ -297,6 +299,7 @@ private:
 };
 
 class GetSubscriptionRequest : public PushServiceRequestImpl<std::optional<WebCore::PushSubscriptionData>> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(GetSubscriptionRequest);
 public:
     GetSubscriptionRequest(PushService&, const PushSubscriptionSetIdentifier&, const String& scope, ResultHandler&&);
     virtual ~GetSubscriptionRequest() = default;
@@ -326,6 +329,7 @@ void GetSubscriptionRequest::startInternal()
 }
 
 class SubscribeRequest : public PushServiceRequestImpl<WebCore::PushSubscriptionData> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SubscribeRequest);
 public:
     SubscribeRequest(PushService&, const PushSubscriptionSetIdentifier&, const String& scope, const Vector<uint8_t>& vapidPublicKey, ResultHandler&&);
     virtual ~SubscribeRequest() = default;
@@ -429,6 +433,7 @@ void SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError(String&& to
 }
 
 class UnsubscribeRequest : public PushServiceRequestImpl<bool> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(UnsubscribeRequest);
 public:
     UnsubscribeRequest(PushService&, const PushSubscriptionSetIdentifier&, const String& scope, std::optional<PushSubscriptionIdentifier>, ResultHandler&&);
     virtual ~UnsubscribeRequest() = default;

--- a/Source/WebKit/webpushd/PushServiceConnection.h
+++ b/Source/WebKit/webpushd/PushServiceConnection.h
@@ -30,6 +30,7 @@
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -50,7 +51,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PushServiceCo
 namespace WebPushD {
 
 class PushServiceConnection : public CanMakeWeakPtr<PushServiceConnection> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PushServiceConnection);
 public:
     using IncomingPushMessageHandler = Function<void(NSString *, NSDictionary *)>;
 

--- a/Source/WebKit/webpushd/PushServiceConnection.mm
+++ b/Source/WebKit/webpushd/PushServiceConnection.mm
@@ -26,10 +26,13 @@
 #import "config.h"
 #import "PushServiceConnection.h"
 
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WorkQueue.h>
 
 namespace WebPushD {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PushServiceConnection);
 
 PushCrypto::ClientKeys PushServiceConnection::generateClientKeys()
 {

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
@@ -59,7 +60,7 @@ enum class WaitForServiceToExist : bool {
 };
 
 class Connection final : public CanMakeWeakPtr<Connection>, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Connection);
 public:
     static std::unique_ptr<Connection> create(PreferTestService, String bundleIdentifier, String pushPartition);
     Connection(PreferTestService, String bundleIdentifier, String pushPartition);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -39,8 +39,11 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebPushTool {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Connection);
 
 std::unique_ptr<Connection> Connection::create(PreferTestService preferTestService, String bundleIdentifier, String pushPartition)
 {

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -30,6 +30,7 @@
 #import "WebPushToolConnection.h"
 #import <optional>
 #import <wtf/MainThread.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WTFProcess.h>
 
 #if HAVE(OS_LAUNCHD_JOB) && (PLATFORM(MAC) || PLATFORM(IOS))
@@ -162,7 +163,6 @@ static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestS
 namespace WebKit {
 
 class WebPushToolVerb {
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~WebPushToolVerb() = default;
     virtual void run(WebPushTool::Connection&) = 0;
@@ -170,6 +170,7 @@ public:
 };
 
 class InjectPushMessageVerb : public WebPushToolVerb {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InjectPushMessageVerb);
 public:
     InjectPushMessageVerb(PushMessageForTesting&& message)
         : m_pushMessage(WTFMove(message)) { }
@@ -191,6 +192,7 @@ private:
 };
 
 class GetPushPermissionStateVerb : public WebPushToolVerb {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(GetPushPermissionStateVerb);
 public:
     GetPushPermissionStateVerb(const String& scope)
         : m_scope(scope) { }
@@ -209,6 +211,7 @@ private:
 };
 
 class RequestPushPermissionVerb : public WebPushToolVerb {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RequestPushPermissionVerb);
 public:
     RequestPushPermissionVerb(const String& scope)
         : m_scope(scope) { }


### PR DESCRIPTION
#### 017d642ad8adf7289315343af0ae7300ca248b83
<pre>
[TZone] WebKit misc: Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=277880">https://bugs.webkit.org/show_bug.cgi?id=277880</a>
<a href="https://rdar.apple.com/133560125">rdar://133560125</a>

Reviewed by Keith Miller.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
* Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp:
* Source/WebKit/WPEPlatform/wpe/WPECursorTheme.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSession.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSession.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.mm:
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
* Source/WebKit/webpushd/PushServiceConnection.h:
* Source/WebKit/webpushd/PushServiceConnection.mm:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:

Canonical link: <a href="https://commits.webkit.org/282189@main">https://commits.webkit.org/282189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b455f3a713f5da50b0d0b8d91fb3de160508c494

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13860 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->