### PR TITLE
[masonry] Optimize items that span multiple tracks

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1699,7 +1699,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-0
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001.html [ ImageOnlyFailure ]
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Igalia S.L.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +35,7 @@
 #include "RenderGrid.h"
 #include "RenderStyleConstants.h"
 #include "StyleSelfAlignmentData.h"
+#include <wtf/StdMap.h>
 
 namespace WebCore {
 
@@ -231,7 +233,7 @@ LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
 {
     if (isDirectionInMasonryDirection())
         return m_renderGrid->masonryContentSize();
-    
+
     LayoutUnit size;
     auto& allTracks = tracks(m_direction);
     for (auto& track : allTracks)
@@ -270,22 +272,22 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const GridTrackSize& tra
     return infinity;
 }
 
-void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSpan& span, MasonryIndefiniteItems& masonryIndefiniteItems, GridTrack& track)
+void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSpan& span, MasonryMinMaxTrackSize& masonryIndefiniteItems, GridTrack& track)
 {
     auto trackPosition = span.startLine();
     const auto& trackSize = tracks(m_direction)[trackPosition].cachedTrackSize();
 
     if (trackSize.hasMinContentMinTrackBreadth())
-        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems));
+        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.minContentSize));
     else if (trackSize.hasMaxContentMinTrackBreadth())
-        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems));
+        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.maxContentSize));
     else if (trackSize.hasAutoMinTrackBreadth())
-        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.largestMinSizeForSingleTrackItems));
+        track.setBaseSize(std::max(track.baseSize(), masonryIndefiniteItems.minSize));
 
     if (trackSize.hasMinContentMaxTrackBreadth())
-        track.setGrowthLimit(std::max(track.growthLimit(), masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems));
+        track.setGrowthLimit(std::max(track.growthLimit(), masonryIndefiniteItems.minContentSize));
     else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
-        auto growthLimit = masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems;
+        auto growthLimit = masonryIndefiniteItems.maxContentSize;
         if (trackSize.isFitContent())
             growthLimit = std::min(growthLimit, valueForLength(trackSize.fitContentTrackBreadth().length(), availableSpace().value_or(0)));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
@@ -366,6 +368,26 @@ LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase(TrackS
     case TrackSizeComputationPhase::ResolveMaxContentMinimums:
     case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         return m_strategy->maxContentForGridItem(gridItem, gridLayoutState);
+    case TrackSizeComputationPhase::MaximizeTracks:
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhaseMasonry(TrackSizeComputationPhase phase, const MasonryMinMaxTrackSize& trackSize) const
+{
+    switch (phase) {
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
+        return trackSize.minSize;
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
+        return trackSize.minContentSize;
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
+        return trackSize.maxContentSize;
     case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return 0;
@@ -539,6 +561,152 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(const Gri
     increaseSizesToAccommodateSpanningItems<variant, TrackSizeComputationPhase::ResolveMaxContentMaximums>(gridItemsWithSpan, gridLayoutState);
 }
 
+
+template <TrackSizeComputationVariant variant>
+void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonry(StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>& definiteItemSizes)
+{
+    auto increaseSizes = [&]<TrackSizeComputationPhase phase>(Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizes)
+    {
+        Vector<GridTrack>& allTracks = tracks(m_direction);
+        for (const auto& trackIndex : m_contentSizedTracksIndex) {
+            auto& track = allTracks[trackIndex];
+            track.setPlannedSize(trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::AllowInfinity));
+        }
+
+        Vector<WeakPtr<GridTrack>> growBeyondGrowthLimitsTracks;
+        Vector<WeakPtr<GridTrack>> filteredTracks;
+
+        for (auto definiteItem : definiteItemSizes) {
+            const auto& itemSpan = definiteItem.gridSpan;
+            ASSERT(variant == TrackSizeComputationVariant::CrossingFlexibleTracks || itemSpan.integerSpan() > 1u);
+
+            filteredTracks.shrink(0);
+            growBeyondGrowthLimitsTracks.shrink(0);
+            LayoutUnit spanningTracksSize;
+            for (auto trackPosition : itemSpan) {
+                auto& track = allTracks[trackPosition];
+                const auto& trackSize = track.cachedTrackSize();
+                spanningTracksSize += trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::ForbidInfinity);
+
+                if (!shouldProcessTrackForTrackSizeComputationPhase(phase, trackSize))
+                    continue;
+
+                filteredTracks.append(track);
+
+                if (trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(phase, trackSize))
+                    growBeyondGrowthLimitsTracks.append(track);
+            }
+
+            if (filteredTracks.isEmpty())
+                continue;
+
+            spanningTracksSize += m_renderGrid->guttersSize(m_direction, itemSpan.startLine(), itemSpan.integerSpan(), availableSpace());
+
+            auto extraSpace = itemSizeForTrackSizeComputationPhaseMasonry(phase, definiteItem.trackSize) - spanningTracksSize;
+            extraSpace = std::max<LayoutUnit>(extraSpace, 0);
+            auto& tracksToGrowBeyondGrowthLimits = growBeyondGrowthLimitsTracks.isEmpty() ? filteredTracks : growBeyondGrowthLimitsTracks;
+            distributeSpaceToTracks<variant, phase>(filteredTracks, &tracksToGrowBeyondGrowthLimits, extraSpace);
+        }
+
+        for (const auto& trackIndex : m_contentSizedTracksIndex) {
+            auto& track = allTracks[trackIndex];
+            markAsInfinitelyGrowableForTrackSizeComputationPhase(phase, track);
+            updateTrackSizeForTrackSizeComputationPhase(phase, track);
+        }
+    };
+
+    for (auto definiteItemSpanGroup : definiteItemSizes) {
+        increaseSizes.template operator()<TrackSizeComputationPhase::ResolveIntrinsicMinimums>(definiteItemSpanGroup.second);
+        increaseSizes.template operator()<TrackSizeComputationPhase::ResolveContentBasedMinimums>(definiteItemSpanGroup.second);
+        increaseSizes.template operator()<TrackSizeComputationPhase::ResolveMaxContentMinimums>(definiteItemSpanGroup.second);
+        increaseSizes.template operator()<TrackSizeComputationPhase::ResolveIntrinsicMaximums>(definiteItemSpanGroup.second);
+        increaseSizes.template operator()<TrackSizeComputationPhase::ResolveMaxContentMaximums>(definiteItemSpanGroup.second);
+    }
+}
+
+template <TrackSizeComputationVariant variant>
+void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWithFlex(Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
+{
+    auto increaseSizes = [&]<TrackSizeComputationPhase phase>(Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
+    {
+        auto& allTracks = tracks(m_direction);
+        for (const auto& trackIndex : m_contentSizedTracksIndex) {
+            auto& track = allTracks[trackIndex];
+            track.setPlannedSize(trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::AllowInfinity));
+        }
+
+        Vector<WeakPtr<GridTrack>> growBeyondGrowthLimitsTracks;
+        Vector<WeakPtr<GridTrack>> filteredTracks;
+
+        for (auto& item : definiteItemSizesSpanFlexTracks) {
+            const auto& itemSpan = item.gridSpan;
+            ASSERT(variant == TrackSizeComputationVariant::CrossingFlexibleTracks || itemSpan.integerSpan() > 1u);
+
+            filteredTracks.shrink(0);
+            growBeyondGrowthLimitsTracks.shrink(0);
+            LayoutUnit spanningTracksSize;
+            for (auto trackPosition : itemSpan) {
+                auto& track = allTracks[trackPosition];
+                const auto& trackSize = track.cachedTrackSize();
+                spanningTracksSize += trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::ForbidInfinity);
+                if (!trackSize.maxTrackBreadth().isFlex())
+                    continue;
+                if (!shouldProcessTrackForTrackSizeComputationPhase(phase, trackSize))
+                    continue;
+
+                filteredTracks.append(track);
+
+                if (trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(phase, trackSize))
+                    growBeyondGrowthLimitsTracks.append(track);
+            }
+
+            if (filteredTracks.isEmpty())
+                continue;
+
+            spanningTracksSize += m_renderGrid->guttersSize(m_direction, itemSpan.startLine(), itemSpan.integerSpan(), availableSpace());
+
+            auto extraSpace = itemSizeForTrackSizeComputationPhaseMasonry(phase, item.trackSize) - spanningTracksSize;
+            extraSpace = std::max<LayoutUnit>(extraSpace, 0);
+            auto& tracksToGrowBeyondGrowthLimits = growBeyondGrowthLimitsTracks.isEmpty() ? filteredTracks : growBeyondGrowthLimitsTracks;
+            distributeSpaceToTracks<variant, phase>(filteredTracks, &tracksToGrowBeyondGrowthLimits, extraSpace);
+        }
+
+        for (const auto& trackIndex : m_contentSizedTracksIndex) {
+            auto& track = allTracks[trackIndex];
+            markAsInfinitelyGrowableForTrackSizeComputationPhase(phase, track);
+            updateTrackSizeForTrackSizeComputationPhase(phase, track);
+        }
+    };
+
+    increaseSizes.template operator()<TrackSizeComputationPhase::ResolveIntrinsicMinimums>(definiteItemSizesSpanFlexTracks);
+    increaseSizes.template operator()<TrackSizeComputationPhase::ResolveContentBasedMinimums>(definiteItemSizesSpanFlexTracks);
+    increaseSizes.template operator()<TrackSizeComputationPhase::ResolveMaxContentMinimums>(definiteItemSizesSpanFlexTracks);
+    increaseSizes.template operator()<TrackSizeComputationPhase::ResolveIntrinsicMaximums>(definiteItemSizesSpanFlexTracks);
+    increaseSizes.template operator()<TrackSizeComputationPhase::ResolveMaxContentMaximums>(definiteItemSizesSpanFlexTracks);
+}
+
+void GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry(const StdMap<SpanLength, MasonryMinMaxTrackSize>& indefiniteSpanSizes, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>& definiteItemSizes, Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTracks)
+{
+    auto& allTracks = tracks(m_direction);
+
+    for (auto& indefiniteItem : indefiniteSpanSizes) {
+        for (auto trackIndex = 0u; trackIndex < allTracks.size(); trackIndex++) {
+            auto endLine = trackIndex + indefiniteItem.first;
+            auto itemSpan = GridSpan::translatedDefiniteGridSpan(trackIndex, endLine);
+
+            if (endLine > allTracks.size())
+                continue;
+
+            // The spec requires items with a span of 1 to be handled earlier.
+            if (itemSpan.integerSpan() != 1 && !spanningItemCrossesFlexibleSizedTracks(itemSpan))
+                definiteItemSizes[itemSpan.integerSpan()].append(MasonryMinMaxTrackSizeWithGridSpan { indefiniteItem.second, itemSpan });
+
+            if (spanningItemCrossesFlexibleSizedTracks(itemSpan))
+                definiteItemSizesSpanFlexTracks.append(MasonryMinMaxTrackSizeWithGridSpan { indefiniteItem.second, itemSpan });
+        }
+    }
+}
+
 template <TrackSizeComputationVariant variant>
 static double getSizeDistributionWeight(const GridTrack& track)
 {
@@ -635,7 +803,7 @@ void GridTrackSizingAlgorithm::distributeSpaceToTracks(Vector<WeakPtr<GridTrack>
 
     if (freeSpace > 0 && growBeyondGrowthLimitsTracks)
         distributeItemIncurredIncreases<variant, phase, SpaceDistributionLimit::BeyondGrowthLimit>(*growBeyondGrowthLimitsTracks, freeSpace);
-    
+
     for (auto& track : tracks)
         track->setPlannedSize(track->plannedSize() == infinity ? track->tempSize() : std::max(track->plannedSize(), track->tempSize()));
 }
@@ -911,7 +1079,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentForGridItem(RenderBox& gr
         // For a grid item with relative width constraints to the grid area, such as percentaged paddings, we reset the overridingContainingBlockContentSizeForGridItem value for columns when we are executing a definite strategy
         // for columns. Since we have updated the overridingContainingBlockContentSizeForGridItem inline-axis/width value here, we might need to recompute the grid item's relative width. For some cases, we probably will not
         // be able to do it during the RenderGrid::layoutGridItems() function as the grid area does't change there any more. Also, as we are doing a layout inside GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem()
-        // function, let's take the advantage and set it here. 
+        // function, let's take the advantage and set it here.
         if (shouldClearOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection))
             gridItem.setPreferredLogicalWidthsDirty(true);
     }
@@ -999,7 +1167,7 @@ bool GridTrackSizingAlgorithm::canParticipateInBaselineAlignment(const RenderBox
         return false;
 
     // Baseline cyclic dependencies only happen in grid areas with
-    // intrinsically-sized tracks. 
+    // intrinsically-sized tracks.
     if (!isIntrinsicSizedGridArea(gridItem, baselineAxis))
         return true;
 
@@ -1496,116 +1664,68 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
         accumulateIntrinsicSizes(gridItem.get());
 }
 
-void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrackMasonry(GridTrack& track, unsigned trackIndex, GridIterator& iterator, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, MasonryIndefiniteItems& masonryIndefiniteItems, LayoutUnit currentAccumulatedMbp, GridLayoutState& gridLayoutState)
+void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry(StdMap<SpanLength, MasonryMinMaxTrackSize>& indefiniteSpanSizes, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>& definiteItemSizes, Vector<MasonryMinMaxTrackSizeWithGridSpan>& definiteItemSizesSpanFlexTrack, GridLayoutState& gridLayoutState)
 {
-    auto accumulateIntrinsicSizes = [&](RenderBox* gridItem) {
-        bool isNewEntry = itemsSet.add(*gridItem).isNewEntry;
-        GridSpan span = m_renderGrid->gridSpanForGridItem(*gridItem, m_direction);
+    auto populateDefiniteItems = [&](unsigned trackIndex, GridSpan& gridSpan, unsigned spanLength, RenderBox* gridItem, Vector<GridTrack> & allTracks) {
+        if (gridSpan.startLine() != trackIndex)
+            return;
 
-        // Masonry Track Sizing
-        // https://drafts.csswg.org/css-grid-3/#track-sizing
-        // We should only compute track sizes on a subset of items.
-        //
-        // - Items explicitly placed in that track contribute.
-        // - Items without an explicit placement contribute (regardless of whether they are ultimately placed in that track).
+        auto minContentForGridItem = m_strategy->minContentForGridItem(*gridItem, gridLayoutState);
+        auto maxContentForGridItem = m_strategy->maxContentForGridItem(*gridItem, gridLayoutState);
+        auto minSizeForGridItem = m_strategy->minSizeForGridItem(*gridItem, gridLayoutState);
 
-        // m_direction shall always be the gridAxisDirection.
-        ASSERT(!isDirectionInMasonryDirection());
+        bool spansFlexTracks = spanningItemCrossesFlexibleSizedTracks(gridSpan);
 
-        isNewEntry = true;
+        if (spanLength == 1 && !spansFlexTracks)
+            sizeTrackToFitNonSpanningItem(gridSpan, *gridItem, allTracks[trackIndex], gridLayoutState);
+        else {
+            auto minMaxTrackSizeWithGridSpan = MasonryMinMaxTrackSizeWithGridSpan { MasonryMinMaxTrackSize { minContentForGridItem, maxContentForGridItem, minSizeForGridItem }, gridSpan };
 
-        // Correct the span as the grid item is coming from another track.
-        auto shift = 0u;
-        auto gridItemEndIndex = span.integerSpan() + trackIndex;
-        if (span.integerSpan() > 1 && (gridItemEndIndex > tracks(m_direction).size())) {
-            shift = gridItemEndIndex - tracks(m_direction).size();
-            shift = (shift > trackIndex) ? 0 : shift;
+            if (spansFlexTracks)
+                definiteItemSizesSpanFlexTrack.append(minMaxTrackSizeWithGridSpan);
+            else
+                definiteItemSizes[spanLength].append(minMaxTrackSizeWithGridSpan);
         }
-
-        span = GridSpan::translatedDefiniteGridSpan(trackIndex - shift, trackIndex + span.integerSpan() - shift);
-
-        if (shouldExcludeGridItemForMasonryTrackSizing(*gridItem, trackIndex, span))
-            return;
-
-        if (CheckedPtr inner = dynamicDowncast<RenderGrid>(gridItem); inner && inner->isSubgridInParentDirection(iterator.direction())) {
-            // Contribute the mbp of wrapper to the first and last tracks that we span.
-            GridSpan subgridSpan = GridSpan::translatedDefiniteGridSpan(trackIndex, trackIndex + span.integerSpan());
-
-            auto accumulatedMbpWithSubgrid = currentAccumulatedMbp + computeSubgridMarginBorderPadding(m_renderGrid, m_direction, track, trackIndex, span, inner.get());
-            track.setBaseSize(std::max(track.baseSize(), accumulatedMbpWithSubgrid + extraMarginFromSubgridAncestorGutters(*gridItem, span, trackIndex, iterator.direction()).value_or(0_lu)));
-
-            GridIterator subgridIterator = GridIterator::createForSubgrid(*inner, iterator, subgridSpan);
-            MasonryIndefiniteItems subgridMasonryIndefiniteItems;
-
-            if (renderGrid()->isMasonry()) {
-                while (CheckedPtr<RenderBox> gridItem = subgridIterator.nextGridItem()) {
-                    if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite())
-                        subgridMasonryIndefiniteItems.indefiniteItems.add(*gridItem);
-                }
-            }
-
-            accumulateIntrinsicSizesForTrackMasonry(track, trackIndex, subgridIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, subgridMasonryIndefiniteItems, accumulatedMbpWithSubgrid, gridLayoutState);
-            return;
-        }
-
-        if (!isNewEntry)
-            return;
-
-        if (spanningItemCrossesFlexibleSizedTracks(span))
-            itemsCrossingFlexibleTracks.append(GridItemWithSpan(*gridItem, span));
-        else if (span.integerSpan() == 1)
-            sizeTrackToFitNonSpanningItem(span, *gridItem, track, gridLayoutState);
-        else
-            itemsSortedByIncreasingSpan.append(GridItemWithSpan(*gridItem, span));
     };
 
-    while (CheckedPtr gridItem = iterator.nextGridItem()) {
-        if (renderGrid()->isMasonry() && GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem.get(), m_direction).isIndefinite())
-            continue;
+    auto populateIndefiniteItems = [&](RenderBox* gridItem, unsigned spanLength) {
 
-        accumulateIntrinsicSizes(gridItem.get());
-    }
+        auto minContentForGridItem = m_strategy->minContentForGridItem(*gridItem, gridLayoutState);
+        auto maxContentForGridItem = m_strategy->maxContentForGridItem(*gridItem, gridLayoutState);
+        auto minSizeForGridItem = m_strategy->minSizeForGridItem(*gridItem, gridLayoutState);
 
-    for (auto& gridItem : masonryIndefiniteItems.indefiniteItems)
-        accumulateIntrinsicSizes(&gridItem);
+        if (!indefiniteSpanSizes.contains(spanLength))
+            indefiniteSpanSizes.insert({ spanLength, { } });
 
-    // Optimization for non flex tracks:
-    // If we are in a non flex track we can then skip having to evaluate every item.
-    //
-    // FIXME: Add support for optimizing the flex track scenario.
-    if (!(track.cachedTrackSize().minTrackBreadth().isFlex() || track.cachedTrackSize().maxTrackBreadth().isFlex()))
-        sizeTrackToFitSingleSpanMasonryGroup(GridSpan::translatedDefiniteGridSpan(trackIndex, trackIndex + 1), masonryIndefiniteItems, track);
-    else {
-        for (auto& gridItem : masonryIndefiniteItems.singleTrackIndefiniteItems)
-            accumulateIntrinsicSizes(&gridItem);
-    }
-}
+        auto& trackSize = indefiniteSpanSizes.find(spanLength)->second;
 
+        trackSize.minContentSize = std::max(trackSize.minContentSize, minContentForGridItem);
+        trackSize.maxContentSize = std::max(trackSize.maxContentSize, maxContentForGridItem);
+        trackSize.minSize = std::max(trackSize.minSize, minSizeForGridItem);
+    };
 
-void GridTrackSizingAlgorithm::computeIndefiniteItemsForMasonry(MasonryIndefiniteItems& masonryIndefiniteItems, GridLayoutState& gridLayoutState) const
-{
-    for (auto trackIndex : m_contentSizedTracksIndex) {
+    auto& allTracks = tracks(m_direction);
+    auto trackLength = allTracks.size();
+    for (auto trackIndex = 0u; trackIndex < trackLength; trackIndex++) {
         GridIterator iterator(m_grid, m_direction, trackIndex);
-        while (CheckedPtr<RenderBox> gridItem = iterator.nextGridItem()) {
-            if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite()) {
-                auto spanLength = m_renderGrid->gridSpanForGridItem(*gridItem, m_direction).integerSpan();
-                bool isSubgrid = gridItem->isRenderGrid() && downcast<RenderGrid>(gridItem.get())->isSubgridInParentDirection(iterator.direction());
 
-                if (spanLength == 1 && !isSubgrid) {
-                    auto minContentForGridItem = m_strategy->minContentForGridItem(*gridItem, gridLayoutState);
-                    auto maxContentForGridItem = m_strategy->maxContentForGridItem(*gridItem, gridLayoutState);
-                    auto minSizeForGridItem = m_strategy->minSizeForGridItem(*gridItem, gridLayoutState);
+        while (CheckedPtr gridItem = iterator.nextGridItem()) {
+            auto gridSpan = m_renderGrid->gridSpanForGridItem(*gridItem, m_direction);
+            auto spanLength = gridSpan.integerSpan();
 
-                    masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems, minContentForGridItem);
-                    masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems, maxContentForGridItem);
-                    masonryIndefiniteItems.largestMinSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMinSizeForSingleTrackItems, minSizeForGridItem);
-
-                    masonryIndefiniteItems.singleTrackIndefiniteItems.add(*gridItem);
-                } else
-                    masonryIndefiniteItems.indefiniteItems.add(*gridItem);
+            if (!GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite()) {
+                populateDefiniteItems(trackIndex, gridSpan, spanLength, gridItem.get(), allTracks);
+                continue;
             }
+
+            auto endLine = trackIndex + spanLength;
+            if (endLine > trackLength)
+                continue;
+
+            populateIndefiniteItems(gridItem.get(), spanLength);
         }
     }
+
 }
 
 void GridTrackSizingAlgorithm::handleInfinityGrowthLimit()
@@ -1654,38 +1774,38 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes(GridLayoutState& gridL
 
 void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizesMasonry(GridLayoutState& gridLayoutState)
 {
-    if (m_strategy->isComputingSizeContainment()) {
+    if (m_strategy->isComputingSizeContainment() || !m_grid.hasGridItems()) {
         handleInfinityGrowthLimit();
         return;
     }
+    StdMap<SpanLength, MasonryMinMaxTrackSize> indefiniteSpanSizes;
+    StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>> definiteItemSizes;
+    Vector<MasonryMinMaxTrackSizeWithGridSpan> definiteItemSizesSpanFlexTrack;
 
-    Vector<GridTrack>& allTracks = tracks(m_direction);
-    Vector<GridItemWithSpan> itemsSortedByIncreasingSpan;
-    Vector<GridItemWithSpan> itemsCrossingFlexibleTracks;
-    SingleThreadWeakHashSet<RenderBox> itemsSet;
-    MasonryIndefiniteItems masonryIndefiniteItems;
+    computeDefiniteAndIndefiniteItemsForMasonry(indefiniteSpanSizes, definiteItemSizes, definiteItemSizesSpanFlexTrack, gridLayoutState);
 
-    if (m_grid.hasGridItems()) {
-        computeIndefiniteItemsForMasonry(masonryIndefiniteItems, gridLayoutState);
+    // Update intrinsic tracks with single span items that do not cross flex tracks.
+    auto& allTracks = tracks(m_direction);
 
+    if (auto item = indefiniteSpanSizes.find(1); item != indefiniteSpanSizes.end()) {
+        auto& singleTrackSpanSize = item->second;
         for (auto trackIndex : m_contentSizedTracksIndex) {
-            GridIterator iterator(m_grid, m_direction, trackIndex);
-            GridTrack& track = allTracks[trackIndex];
+            auto& track = allTracks[trackIndex];
 
-            accumulateIntrinsicSizesForTrackMasonry(track, trackIndex, iterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, masonryIndefiniteItems, 0_lu, gridLayoutState);
+            auto itemSpan = GridSpan::translatedDefiniteGridSpan(trackIndex, trackIndex + 1);
+            if (spanningItemCrossesFlexibleSizedTracks(itemSpan))
+                continue;
+
+            sizeTrackToFitSingleSpanMasonryGroup(itemSpan, singleTrackSpanSize, track);
         }
-        std::sort(itemsSortedByIncreasingSpan.begin(), itemsSortedByIncreasingSpan.end());
     }
 
-    auto it = itemsSortedByIncreasingSpan.begin();
-    auto end = itemsSortedByIncreasingSpan.end();
-    while (it != end) {
-        GridItemsSpanGroupRange spanGroupRange = { it, std::upper_bound(it, end, *it) };
-        increaseSizesToAccommodateSpanningItems<TrackSizeComputationVariant::NotCrossingFlexibleTracks>(spanGroupRange, gridLayoutState);
-        it = spanGroupRange.rangeEnd;
-    }
-    GridItemsSpanGroupRange tracksGroupRange = { itemsCrossingFlexibleTracks.begin(), itemsCrossingFlexibleTracks.end() };
-    increaseSizesToAccommodateSpanningItems<TrackSizeComputationVariant::CrossingFlexibleTracks>(tracksGroupRange, gridLayoutState);
+    convertIndefiniteItemsToDefiniteMasonry(indefiniteSpanSizes, definiteItemSizes, definiteItemSizesSpanFlexTrack);
+
+    increaseSizesToAccommodateSpanningItemsMasonry<TrackSizeComputationVariant::NotCrossingFlexibleTracks>(definiteItemSizes);
+
+    increaseSizesToAccommodateSpanningItemsMasonryWithFlex<TrackSizeComputationVariant::CrossingFlexibleTracks>(definiteItemSizesSpanFlexTrack);
+
     handleInfinityGrowthLimit();
 }
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Igalia S.L.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +31,8 @@
 #include "GridTrackSize.h"
 #include "LayoutSize.h"
 #include "RenderBoxInlines.h"
+#include <wtf/StdMap.h>
+#include <wtf/StdMultimap.h>
 
 namespace WebCore {
 class GridTrack;
@@ -163,28 +166,18 @@ public:
 #endif
 
 private:
+    using SpanLength = unsigned;
+
     void setup(GridTrackSizingDirection, unsigned numTracks, SizingOperation, std::optional<LayoutUnit> availableSpace);
+    struct MasonryMinMaxTrackSize {
+        LayoutUnit minContentSize;
+        LayoutUnit maxContentSize;
+        LayoutUnit minSize;
+    };
 
-    struct MasonryIndefiniteItems {
-        // Optimization: Masonry Indefinite Items
-        // Indefinite items need to be considered in each track; this causes a runtime of O(N_track * M_items).
-        // We can simplfiy this to O(N_tracks) if we add some constraints.
-        //
-        // We will precompute the min-content, max-content and min-size for all indefinite items if they meet the below requirements:
-        // - item has a span length of 1
-        // - item is not a sub-grid
-        // - track is not 'fr'
-        //
-        // In case we hit an 'fr' track we will fallback to computing all indefinte items in the track.
-        //
-        // FIXME: Add support for multi-track items.
-        // FIXME: Add support for flex items.
-        SingleThreadWeakListHashSet<RenderBox> indefiniteItems;
-        SingleThreadWeakListHashSet<RenderBox> singleTrackIndefiniteItems;
-
-        LayoutUnit largestMinContentSizeForSingleTrackItems;
-        LayoutUnit largestMaxContentSizeForSingleTrackItems;
-        LayoutUnit largestMinSizeForSingleTrackItems;
+    struct MasonryMinMaxTrackSizeWithGridSpan {
+        MasonryMinMaxTrackSize trackSize;
+        GridSpan gridSpan;
     };
 
     std::optional<LayoutUnit> availableSpace() const;
@@ -198,13 +191,52 @@ private:
 
     // Helper methods for step 2. resolveIntrinsicTrackSizes().
     void sizeTrackToFitNonSpanningItem(const GridSpan&, RenderBox& gridItem, GridTrack&, GridLayoutState&);
-    void sizeTrackToFitSingleSpanMasonryGroup(const GridSpan&, MasonryIndefiniteItems&, GridTrack&);
+    void sizeTrackToFitSingleSpanMasonryGroup(const GridSpan&, MasonryMinMaxTrackSize&, GridTrack&);
 
     bool spanningItemCrossesFlexibleSizedTracks(const GridSpan&) const;
+
     typedef struct GridItemsSpanGroupRange GridItemsSpanGroupRange;
     template <TrackSizeComputationVariant variant, TrackSizeComputationPhase phase> void increaseSizesToAccommodateSpanningItems(const GridItemsSpanGroupRange& gridItemsWithSpan, GridLayoutState&);
     template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItems(const GridItemsSpanGroupRange& gridItemsWithSpan, GridLayoutState&);
+
+    // 12.5 Resolve Intrinsic Track Sizing : Step 3
+    // https://drafts.csswg.org/css-grid-2/#algo-spanning-items
+    //
+    // Take all grid items (definite and indefinite) that span 2 or more tracks, and distribute space to intrinsic tracks (non-flex).
+    // The implementation diverges from increaseSizesToAccommodateSpanningItems(), because we are grouping items together that are the same span length.
+    // This function is divided into two main sections:
+    //
+    // 1. Constructing the track items
+    // This step takes the definite and indefinite items, and merges them into one large map to send over to the second step.
+    // Since the indefinite items are grouped together from a prior computation, this step also need to create "fake" grid items that
+    // will be considered in each track.
+    //
+    // 2. Distribute space to intrinsic tracks
+    // This step behaves similar to increaseSizesToAccommodateSpanningItems() where we start at the lowest span length and distribute space to the tracks.
+    // Then look at the next smallest span length, and repeat step 2 until we exhaust all grid items.
+    template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItemsMasonry(StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&);
+
+    // 12.5 Resolve Intrinsic Track Sizing : Step 4
+    // https://drafts.csswg.org/css-grid-2/#algo-spanning-items
+    //
+    // Take all grid items (definite and indefinite) that span 1 or tracks, and distribute space to only flex tracks.
+    // The implementation diverges from increaseSizesToAccommodateSpanningItems(), because we are grouping items together that are the same span length.
+    // This function is divided into two main sections:
+    //
+    // 1. Constructing the track items
+    // This step takes the definite and indefinite items, and merges them into one large map to send over to the second step.
+    // Since the indefinite items are grouped together from a prior computation, this step also need to create "fake" grid items that
+    // will be considered in each track.
+    //
+    // 2. Distribute space to intrinsic tracks
+    // This step behaves similar to increaseSizesToAccommodateSpanningItems() where we consider all track items at once instead of per span length.
+    template <TrackSizeComputationVariant variant> void increaseSizesToAccommodateSpanningItemsMasonryWithFlex(Vector<MasonryMinMaxTrackSizeWithGridSpan>&);
+
+    void convertIndefiniteItemsToDefiniteMasonry(const StdMap<SpanLength, MasonryMinMaxTrackSize>& gridTrackSpans, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&, Vector<MasonryMinMaxTrackSizeWithGridSpan>&);
+
     LayoutUnit itemSizeForTrackSizeComputationPhase(TrackSizeComputationPhase, RenderBox&, GridLayoutState&) const;
+    LayoutUnit itemSizeForTrackSizeComputationPhaseMasonry(TrackSizeComputationPhase, const MasonryMinMaxTrackSize&) const;
+
     template <TrackSizeComputationVariant variant, TrackSizeComputationPhase phase> void distributeSpaceToTracks(Vector<WeakPtr<GridTrack>>& tracks, Vector<WeakPtr<GridTrack>>* growBeyondGrowthLimitsTracks, LayoutUnit& freeSpace) const;
 
     void computeBaselineAlignmentContext();
@@ -223,19 +255,30 @@ private:
 
 
     void handleInfinityGrowthLimit();
-    void computeIndefiniteItemsForMasonry(MasonryIndefiniteItems&, GridLayoutState&) const;
+
+    // Build up a map of min/max sizes for each span length for use during resolving intrinsic track sizes.
+    // We also need to keep track of definite items separately, since they do not contribute to every track like indefinite items do.
+    void computeDefiniteAndIndefiniteItemsForMasonry(StdMap<SpanLength, MasonryMinMaxTrackSize>&, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&, Vector<MasonryMinMaxTrackSizeWithGridSpan>&, GridLayoutState&);
     bool shouldExcludeGridItemForMasonryTrackSizing(const RenderBox& gridItem, unsigned trackIndex, GridSpan itemSpan) const;
     // Track sizing algorithm steps. Note that the "Maximize Tracks" step is done
     // entirely inside the strategies, that's why we don't need an additional
     // method at this level.
     void initializeTrackSizes();
     void resolveIntrinsicTrackSizes(GridLayoutState&);
+
+    // Masonry Implementation of https://drafts.csswg.org/css-grid-2/#algo-content.
+    // To implement Masonry performanently, we need to abandon the traditional Grid approach of treating
+    // each item individually and start grouping items based on their span. A grid item has 3 major values we care about
+    // the minContentSize, maxContentSize, and minSize. These values can be aggregated together and then the max will be chosen.
+    // The main three scenarios we need to focus on are items that only span 1 track, items that span multiple tracks without crossing a flex track,
+    // and items that span multiple tracks with crossing a flex track.
+    //
+    // Further details on the optimization can be found at https://fantasai.inkedblade.net/style/specs/masonry/performance.
     void resolveIntrinsicTrackSizesMasonry(GridLayoutState&);
     void stretchFlexibleTracks(std::optional<LayoutUnit> freeSpace, GridLayoutState&);
     void stretchAutoTracks();
 
     void accumulateIntrinsicSizesForTrack(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp, GridLayoutState&);
-    void accumulateIntrinsicSizesForTrackMasonry(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, MasonryIndefiniteItems&, LayoutUnit currentAccumulatedMbp, GridLayoutState&);
 
     bool copyUsedTrackSizesForSubgrid();
 


### PR DESCRIPTION
#### f10662fe88d05adea16c6cdccd850905acd342f2
<pre>
[masonry] Optimize items that span multiple tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=276733">https://bugs.webkit.org/show_bug.cgi?id=276733</a>
<a href="https://rdar.apple.com/problem/132435056">rdar://problem/132435056</a>

Reviewed by Sammy Gill and Yusuke Suzuki.

The implementation is split up into several steps.

1. Gather indefinite items into groups, and calculate their min/max sizes. Definite items
should be documented for later use too.

2. Update intrinsic tracks with single span items.

3. Convert indefinite items to definite items.

3. Update instrinsic tracks with multi span items that do not cross a flex track.

4. Update flex tracks with items that are single or multi span that cross a flex track.

Note: This masonry implementation does not support Subgrid at this point.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
 (WebCore::GridTrackSizingAlgorithm::computeTrackBasedSize const):
 (WebCore::GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup):
 (WebCore::GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhaseMasonry const):
 (WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonry):
 (WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItemsMasonryWithFlex):
 (WebCore::GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry):
 (WebCore::GridTrackSizingAlgorithm::distributeSpaceToTracks const):
 (WebCore::GridTrackSizingAlgorithmStrategy::minContentForGridItem const):
 (WebCore::GridTrackSizingAlgorithm::canParticipateInBaselineAlignment const):
 (WebCore::GridTrackSizingAlgorithm::computeIndefiniteItemsForMasonry):
 (WebCore::GridTrackSizingAlgorithm::resolveIntrinsicTrackSizesMasonry):
 (WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrackMasonry): Deleted.
 (WebCore::GridTrackSizingAlgorithm::computeIndefiniteItemsForMasonry const): Deleted.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/282464@main">https://commits.webkit.org/282464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef2a81f2af268f59e9317c9394a1e7e7d959917a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58243 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54789 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14005 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5955 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38373 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->