### PR TITLE
Fix background-images on table rows and sections

### DIFF
--- a/LayoutTests/fast/table/row-background-image-expected.html
+++ b/LayoutTests/fast/table/row-background-image-expected.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table row/col background image spans row/col</title>
+    <style type="text/css">
+      div { margin-bottom: 1em; }
+      table { border: 5px solid red; display: inline-table; }
+      td { border: 2px solid blue; }
+      td { width: 100px; }
+      td.v { width: initial; height: 50px; }
+      .b { background-color: black; }
+      .w { background-color: white; }
+    </style>
+  </head>
+  <body>
+    <div>
+      1.
+      <table>
+        <caption>Left black, right white</caption>
+        <tbody><tr class="bwh"><td class="b">&nbsp;</td><td class="w">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      2.
+      <table style="writing-mode: vertical-lr">
+        <caption>Top black, bottom white</caption>
+        <tbody><tr class="bwv"><td class="b v">&nbsp;</td><td class="w v">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      3.
+      <table>
+        <caption>Left cells black, right cells white</caption>
+        <tbody class="bwh"><tr><td class="b">&nbsp;</td><td class="b">&nbsp;</td><td class="w">&nbsp;</td><td class="w">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      4.
+      <table>
+        <caption>Top black, bottom white</caption>
+        <tbody class="bwv"><tr><td class="b">&nbsp;</td></tr><tr><td class="b">&nbsp;</td></tr><tr><td class="w">&nbsp;</td></tr><tr><td class="w">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      5.
+      <table>
+        <caption>Left cells black, right cells white, multiple sections</caption>
+        <tbody class="bwh"><tr><td class="b">&nbsp;</td><td class="b">&nbsp;</td><td class="w">&nbsp;</td><td class="w">&nbsp;</td></tr></tbody>
+        <tfoot class="bwh"><tr><td class="b">&nbsp;</td><td class="b">&nbsp;</td><td class="w">&nbsp;</td><td class="w">&nbsp;</td></tr></tfoot>
+      </table>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/table/row-background-image.html
+++ b/LayoutTests/fast/table/row-background-image.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table row/col background image spans row/col</title>
+    <style type="text/css">
+      div { margin-bottom: 1em; }
+      table { border: 5px solid red; display: inline-table; }
+      td { border: 2px solid blue; }
+      td { width: 100px; }
+      td.v { width: initial; height: 50px; }
+      .bwh { background-image: linear-gradient(to right, black, black 50%, white 50%, white); }
+      .bwv { background-image: linear-gradient(to bottom, black, black 50%, white 50%, white); }
+    </style>
+  </head>
+  <body>
+    <div>
+      1.
+      <table>
+        <caption>Left black, right white</caption>
+        <tbody><tr class="bwh"><td class="b">&nbsp;</td><td class="w">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      2.
+      <table style="writing-mode: vertical-lr">
+        <caption>Top black, bottom white</caption>
+        <tbody><tr class="bwv"><td class="b v">&nbsp;</td><td class="w v">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      3.
+      <table>
+        <caption>Left cells black, right cells white</caption>
+        <tbody class="bwh"><tr><td class="b">&nbsp;</td><td class="b">&nbsp;</td><td class="w">&nbsp;</td><td class="w">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      4.
+      <table>
+        <caption>Top black, bottom white</caption>
+        <tbody class="bwv"><tr><td class="b">&nbsp;</td></tr><tr><td class="b">&nbsp;</td></tr><tr><td class="w">&nbsp;</td></tr><tr><td class="w">&nbsp;</td></tr></tbody>
+      </table>
+    </div>
+    <div>
+      5.
+      <table>
+        <caption>Left cells black, right cells white, multiple sections</caption>
+        <tbody class="bwh"><tr><td class="b">&nbsp;</td><td class="b">&nbsp;</td><td class="w">&nbsp;</td><td class="w">&nbsp;</td></tr></tbody>
+        <tfoot class="bwh"><tr><td class="b">&nbsp;</td><td class="b">&nbsp;</td><td class="w">&nbsp;</td><td class="w">&nbsp;</td></tr></tfoot>
+      </table>
+    </div>
+  </body>
+</html>

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1351,12 +1351,47 @@ void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPo
     }
 }
 
-void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, const LayoutPoint& paintOffset, RenderElement* backgroundObject)
+static LayoutRect backgroundRectForRow(const RenderBox& tableRow, const RenderTable& table)
 {
-    if (!paintInfo.shouldPaintWithinRoot(*this))
-        return;
+    LayoutRect rect = tableRow.frameRect();
+    if (!table.collapseBorders()) {
+        // Row frameRects include unwanted hSpacing on both inline ends.
+        auto hSpacing = table.hBorderSpacing();
+        LayoutUnit vSpacing = 0_lu;
+        if (table.style().isHorizontalWritingMode())
+            rect.contract({ vSpacing, hSpacing, vSpacing, hSpacing });
+        else
+            rect.contract({ hSpacing, vSpacing, hSpacing, vSpacing });
+    }
+    return rect;
+}
 
-    if (!backgroundObject)
+static LayoutRect backgroundRectForSection(const RenderTableSection& tableSection, const RenderTable& table)
+{
+    LayoutRect rect = { { }, tableSection.size() };
+    if (!table.collapseBorders()) {
+        auto hSpacing = table.hBorderSpacing();
+        auto vSpacing = table.vBorderSpacing();
+        // All sections' size()s include unwanted vSpacing at the block-end
+        // position. The first section's size() includes additional unwanted
+        // vSpacing at the block-start position. All sections' size()s include
+        // unwanted hSpacing on both inline ends.
+        auto beforeBlockSpacing = &tableSection == table.topSection() ? vSpacing : 0_lu;
+        if (table.style().isHorizontalWritingMode())
+            rect.contract({ beforeBlockSpacing, hSpacing, vSpacing, hSpacing });
+        else if (table.style().isFlippedBlocksWritingMode())
+            rect.contract({ hSpacing, beforeBlockSpacing, hSpacing, vSpacing });
+        else
+            rect.contract({ hSpacing, vSpacing, hSpacing, beforeBlockSpacing });
+    }
+    return rect;
+}
+
+void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoint paintOffset, RenderBox* backgroundObject, LayoutPoint backgroundPaintOffset)
+{
+    ASSERT(backgroundObject);
+
+    if (!paintInfo.shouldPaintWithinRoot(*this))
         return;
 
     if (style().usedVisibility() != Visibility::Visible)
@@ -1379,17 +1414,31 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, const Lay
     if (backgroundObject != this)
         adjustedPaintOffset.moveBy(location());
 
+    // Background images attached to the row or row group must span the row
+    // or row group. Draw them at the backgroundObject's dimensions, but
+    // clipped to this cell.
+    // FIXME: This should also apply to columns and column groups.
+    bool paintBackgroundObject = backgroundObject != this && bgLayer.hasImage() && !is<RenderTableCol>(backgroundObject);
     // We have to clip here because the background would paint
     // on top of the borders otherwise. This only matters for cells and rows.
-    bool shouldClip = backgroundObject->hasLayer() && (backgroundObject == this || backgroundObject == parent()) && tableElt->collapseBorders();
+    bool shouldClip = paintBackgroundObject || (backgroundObject->hasLayer() && (backgroundObject == this || backgroundObject == parent()) && tableElt->collapseBorders());
     GraphicsContextStateSaver stateSaver(paintInfo.context(), shouldClip);
     if (shouldClip) {
         LayoutRect clipRect(adjustedPaintOffset.x() + borderLeft(), adjustedPaintOffset.y() + borderTop(),
             width() - borderLeft() - borderRight(), height() - borderTop() - borderBottom());
         paintInfo.context().clip(clipRect);
     }
+    LayoutRect fillRect;
+    if (paintBackgroundObject) {
+        if (auto* tableSectionRenderer = dynamicDowncast<RenderTableSection>(backgroundObject))
+            fillRect = backgroundRectForSection(*tableSectionRenderer, *tableElt);
+        else
+            fillRect = backgroundRectForRow(*backgroundObject, *tableElt);
+        fillRect.moveBy(backgroundPaintOffset);
+    } else
+        fillRect = LayoutRect { adjustedPaintOffset, size() };
     auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
-    BackgroundPainter { *this, paintInfo }.paintFillLayers(color, bgLayer, LayoutRect(adjustedPaintOffset, frameRect().size()), BackgroundBleedNone, compositeOp, backgroundObject);
+    BackgroundPainter { *this, paintInfo }.paintFillLayers(color, bgLayer, fillRect, BackgroundBleedNone, compositeOp, backgroundObject);
 }
 
 void RenderTableCell::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -1408,7 +1457,7 @@ void RenderTableCell::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoin
     backgroundPainter.paintBoxShadow(paintRect, style(), ShadowStyle::Normal);
     
     // Paint our cell background.
-    paintBackgroundsBehindCell(paintInfo, paintOffset, this);
+    paintBackgroundsBehindCell(paintInfo, paintOffset, this, paintOffset);
 
     backgroundPainter.paintBoxShadow(paintRect, style(), ShadowStyle::Inset);
 

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -83,7 +83,7 @@ public:
     void paint(PaintInfo&, const LayoutPoint&) override;
 
     void paintCollapsedBorders(PaintInfo&, const LayoutPoint&);
-    void paintBackgroundsBehindCell(PaintInfo&, const LayoutPoint&, RenderElement* backgroundObject);
+    void paintBackgroundsBehindCell(PaintInfo&, LayoutPoint paintOffset, RenderBox* backgroundObject, LayoutPoint backgroundPaintOffset);
 
     LayoutUnit cellBaselinePosition() const;
     bool isBaselineAligned() const;

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -239,7 +239,7 @@ void RenderTableRow::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     for (RenderTableCell* cell = firstCell(); cell; cell = cell->nextCell()) {
         // Paint the row background behind the cell.
         if (paintInfo.phase == PaintPhase::BlockBackground || paintInfo.phase == PaintPhase::ChildBlockBackground)
-            cell->paintBackgroundsBehindCell(paintInfo, paintOffset, this);
+            cell->paintBackgroundsBehindCell(paintInfo, paintOffset, this, paintOffset);
         if (!cell->hasSelfPaintingLayer())
             cell->paint(paintInfo, paintOffset);
     }

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -971,24 +971,25 @@ void RenderTableSection::paintCell(RenderTableCell* cell, PaintInfo& paintInfo, 
     if (paintPhase == PaintPhase::BlockBackground || paintPhase == PaintPhase::ChildBlockBackground) {
         // We need to handle painting a stack of backgrounds.  This stack (from bottom to top) consists of
         // the column group, column, row group, row, and then the cell.
-        RenderTableCol* column = table()->colElement(cell->col());
-        RenderTableCol* columnGroup = column ? column->enclosingColumnGroup() : nullptr;
 
         // Column groups and columns first.
         // FIXME: Columns and column groups do not currently support opacity, and they are being painted "too late" in
         // the stack, since we have already opened a transparency layer (potentially) for the table row group.
         // Note that we deliberately ignore whether or not the cell has a layer, since these backgrounds paint "behind" the
         // cell.
-        cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup);
-        cell->paintBackgroundsBehindCell(paintInfo, cellPoint, column);
+        if (RenderTableCol* column = table()->colElement(cell->col())) {
+            if (RenderTableCol* columnGroup = column->enclosingColumnGroup())
+                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup, cellPoint);
+            cell->paintBackgroundsBehindCell(paintInfo, cellPoint, column, cellPoint);
+        }
 
         // Paint the row group next.
-        cell->paintBackgroundsBehindCell(paintInfo, cellPoint, this);
+        cell->paintBackgroundsBehindCell(paintInfo, cellPoint, this, paintOffset);
 
         // Paint the row next, but only if it doesn't have a layer.  If a row has a layer, it will be responsible for
         // painting the row background for the cell.
         if (!row.hasSelfPaintingLayer())
-            cell->paintBackgroundsBehindCell(paintInfo, cellPoint, &row);
+            cell->paintBackgroundsBehindCell(paintInfo, cellPoint, &row, cellPoint);
     }
     if ((!cell->hasSelfPaintingLayer() && !row.hasSelfPaintingLayer()))
         cell->paint(paintInfo, cellPoint);


### PR DESCRIPTION
#### d59f182d669baa4fb54eda546e9f76aa9d29ed82
<pre>
Fix background-images on table rows and sections
<a href="https://bugs.webkit.org/show_bug.cgi?id=9268">https://bugs.webkit.org/show_bug.cgi?id=9268</a>

Reviewed by Alan Baradlay

In tables, background-images applied to table rows, columns, column
groups, and row groups (sections) should span the whole relevant area.
For instance, a gradient applied to a table row should span smoothly
across the cells. This is the behavior on Firefox and Chrome, but on
Safari, the image was applied to each cell separately, resulting in
multiple distinct gradients. This commit fixes that for rows and
sections, by rendering the image with the correct dimensions, but
clipped to the relevant cells.

* LayoutTests/fast/table/row-background-image-expected.html: Added.
* LayoutTests/fast/table/row-background-image.html: Added.
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):
Add support for correct row and section background rendering.
Change paintBackgroundsBehindCell signature to take the position
relevant to the background object.
* Source/WebCore/rendering/RenderTableRow.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
Pass new argument to paintBackgroundsBehindCell.

Canonical link: <a href="https://commits.webkit.org/282122@main">https://commits.webkit.org/282122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30a835137cc088d6c8b7a786e4aa3b4f141bae17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50088 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8785 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38557 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11092 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57688 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5031 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37304 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->