### PR TITLE
[Grid] Incorrect margins used for grid items on relayout when computing DefiniteSizeStrategy::minContentForGridItem.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1649,7 +1649,6 @@ imported/w3c/web-platform-tests/css/css-grid/alignment/grid-content-distribution
 webkit.org/b/234879 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-intrinsic-maximums.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-contribution-003.html [ ImageOnlyFailure ]
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-size-with-orthogonal-child-dynamic.html [ ImageOnlyFailure ]
-webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-items/percentage-margin-dynamic.html [ ImageOnlyFailure ]
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-items/replaced-element-015.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/grid-gap-006.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/standalone-axis-size-005.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -115,16 +115,7 @@ ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection
 
 LayoutUnit marginLogicalSizeForGridItem(const RenderGrid& grid, GridTrackSizingDirection direction, const RenderBox& gridItem)
 {
-    LayoutUnit margin;
-    if (gridItem.needsLayout())
-        margin = computeMarginLogicalSizeForGridItem(grid, direction, gridItem);
-    else {
-        GridTrackSizingDirection flowAwareDirection = flowAwareDirectionForGridItem(grid, gridItem, direction);
-        bool isRowAxis = flowAwareDirection == GridTrackSizingDirection::ForColumns;
-        LayoutUnit marginStart = marginStartIsAuto(gridItem, flowAwareDirection) ? 0_lu : isRowAxis ? gridItem.marginStart() : gridItem.marginBefore();
-        LayoutUnit marginEnd = marginEndIsAuto(gridItem, flowAwareDirection) ? 0_lu : isRowAxis ? gridItem.marginEnd() : gridItem.marginAfter();
-        margin = marginStart + marginEnd;
-    }
+    auto margin = computeMarginLogicalSizeForGridItem(grid, direction, gridItem);
 
     if (&grid != gridItem.parent()) {
         GridTrackSizingDirection subgridDirection = flowAwareDirectionForGridItem(grid, *downcast<RenderGrid>(gridItem.parent()), direction);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -115,6 +115,7 @@ private:
 
 class GridTrackSizingAlgorithm final {
     friend class GridTrackSizingAlgorithmStrategy;
+    friend class DefiniteSizeStrategy;
 
 public:
     GridTrackSizingAlgorithm(const RenderGrid*, Grid&);


### PR DESCRIPTION
#### 5d11fc8e580bf9265c3b36c374415e17807b6510
<pre>
[Grid] Incorrect margins used for grid items on relayout when computing DefiniteSizeStrategy::minContentForGridItem.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260290">https://bugs.webkit.org/show_bug.cgi?id=260290</a>
<a href="https://rdar.apple.com/113984882">rdar://113984882</a>

Reviewed by Alan Baradlay.

In grid-items/percentage-margin-dynamic.html we fail to correctly
recompute the margins as part of the min content size of the grid item
when the constraints are changed. When GridLayoutFunctions::marginLogicalSizeForGridItem
is reached we end up taking the code path that grabs the margins on
the renderer since the renderer was not marked for layout.

To fix this we do two things:
1.) Expand the logic in DefiniteSizeStrategy::minContentForGridItem to
set the overriding containing block size to 0 when the grid item spans
intrinsic sized columns and has either percentage padding or
percentage/auto margins. This is because the size ends up becoming a
cyclic percentage size so these percentages should resolve against 0.
I also added another constraint to make sure that the grid item is
not orthogonal because it does not seem our helper functions seem to
handle these cases.

2.) Have GridLayoutFunctions::marginLogicalSizeForGridItem always
compute the margin values using the grid item&apos;s style since we cannot
know if the values on the renderer are stale.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::marginLogicalSizeForGridItem):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::DefiniteSizeStrategy::minContentForGridItem const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/282092@main">https://commits.webkit.org/282092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97e3138b32d1f3a4ee197fcba3066da83e40203f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49903 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67668 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57338 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57588 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13790 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4837 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37114 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->