### PR TITLE
Implement CookieStoreManager for the CookieStore API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getSubscriptions returns an empty array when there are no subscriptions promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS getSubscriptions returns an empty array when there are no subscriptions
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getSubscriptions returns an empty array when there are no subscriptions promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS getSubscriptions returns an empty array when there are no subscriptions
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getSubscriptions returns a subscription passed to subscribe promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS getSubscriptions returns a subscription passed to subscribe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getSubscriptions returns a subscription passed to subscribe promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS getSubscriptions returns a subscription passed to subscribe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getSubscriptions returns a subscription passed to subscribe promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS getSubscriptions returns a subscription passed to subscribe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getSubscriptions returns a subscription passed to subscribe promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS getSubscriptions returns a subscription passed to subscribe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL cookieStore.subscribe without url in option promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.subscribe without url in option
 PASS cookieStore.subscribe with invalid url path in option
-FAIL cookieStore.subscribe is idempotent promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieStore.unsubscribe is idempotent promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.subscribe is idempotent
+PASS CookieStore.unsubscribe is idempotent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any.serviceworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL cookieStore.subscribe without url in option promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.subscribe without url in option
 PASS cookieStore.subscribe with invalid url path in option
-FAIL cookieStore.subscribe is idempotent promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieStore.unsubscribe is idempotent promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.subscribe is idempotent
+PASS CookieStore.unsubscribe is idempotent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscriptions_empty.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscriptions_empty.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Newly registered and activated service worker has no subscriptions promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Newly registered and activated service worker has no subscriptions
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookieStore_subscriptions_reset.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookieStore_subscriptions_reset.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL cookiechange subscriptions reset across service worker unregistrations promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookiechange subscriptions persist across service worker updates promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookiechange subscriptions reset across service worker unregistrations
+PASS cookiechange subscriptions persist across service worker updates
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookiechange not dispatched for change that does not match subscription promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT cookiechange not dispatched for change that does not match subscription Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookiechange dispatched with cookie change that matches subscription promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT cookiechange dispatched with cookie change that matches subscription Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL 1 cookiechange event dispatched with cookie change that matches multiple subscriptions promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT 1 cookiechange event dispatched with cookie change that matches multiple subscriptions Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_single_subscription.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_single_subscription.https.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookiechange dispatched with cookie change that matches subscription to cookiechange event handler registered with addEventListener promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT cookiechange dispatched with cookie change that matches subscription to cookiechange event handler registered with addEventListener Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_oncookiechange_eventhandler_single_subscription.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_oncookiechange_eventhandler_single_subscription.https.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookiechange dispatched with cookie change that matches subscription to cookiechange event handler registered with addEventListener promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT cookiechange dispatched with cookie change that matches subscription to cookiechange event handler registered with addEventListener Test timed out
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1939,6 +1939,7 @@ CookieStoreManagerEnabled:
       default: false
     WebCore:
       default: false
+  sharedPreferenceForWebProcess: true
 
 CoreMathMLEnabled:
   type: bool

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -349,6 +349,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/cookie-consent/CookieConsentDecisionResult.h
 
+    Modules/cookie-store/CookieChangeSubscription.h
     Modules/cookie-store/CookieStoreGetOptions.h
 
     Modules/credentialmanagement/CredentialRequestOptions.h

--- a/Source/WebCore/Modules/cookie-store/CookieChangeSubscription.h
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeSubscription.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashTraits.h>
+#include <wtf/Hasher.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct CookieChangeSubscription {
+    String name;
+    String url;
+
+    CookieChangeSubscription() = default;
+
+    CookieChangeSubscription(String&& name, String&& url)
+        : name(WTFMove(name))
+        , url(WTFMove(url))
+    { }
+
+    explicit CookieChangeSubscription(WTF::HashTableDeletedValueType deletedValue)
+        : name(deletedValue)
+    { }
+
+    bool operator==(const CookieChangeSubscription& other) const = default;
+
+    bool isHashTableDeletedValue() const { return name.isHashTableDeletedValue(); }
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+struct CookieChangeSubscriptionHash {
+    static unsigned hash(const WebCore::CookieChangeSubscription& subscription)
+    {
+        return computeHash(subscription.name, subscription.url);
+    }
+
+    static bool equal(const WebCore::CookieChangeSubscription& a, const WebCore::CookieChangeSubscription& b)
+    {
+        return a == b;
+    }
+
+    static const bool safeToCompareToEmptyOrDeleted = false;
+};
+
+template<typename T> struct DefaultHash;
+template<> struct DefaultHash<WebCore::CookieChangeSubscription> : CookieChangeSubscriptionHash { };
+
+template<> struct HashTraits<WebCore::CookieChangeSubscription> : SimpleClassHashTraits<WebCore::CookieChangeSubscription> {
+    static const bool emptyValueIsZero = false;
+    static const bool hasIsEmptyValueFunction = false;
+};
+
+} // namespace WTF

--- a/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl
@@ -25,7 +25,10 @@
 
 // https://wicg.github.io/cookie-store/#dictdef-cookiestoregetoptions
 
-dictionary CookieStoreGetOptions {
+[
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject
+] dictionary CookieStoreGetOptions {
     USVString name;
     USVString url;
 };

--- a/Source/WebCore/Modules/cookie-store/CookieStoreManager.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreManager.h
@@ -27,23 +27,28 @@
 
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-struct CookieStoreGetOptions;
 class DeferredPromise;
+class ServiceWorkerRegistration;
+class WeakPtrImplWithEventTargetData;
+struct CookieStoreGetOptions;
 
 class CookieStoreManager : public RefCounted<CookieStoreManager> {
 public:
-    static Ref<CookieStoreManager> create();
+    static Ref<CookieStoreManager> create(ServiceWorkerRegistration&);
     ~CookieStoreManager();
 
     void subscribe(Vector<CookieStoreGetOptions>&&, Ref<DeferredPromise>&&);
-    void getSubscriptions(Ref<DeferredPromise>&&);
     void unsubscribe(Vector<CookieStoreGetOptions>&&, Ref<DeferredPromise>&&);
+    void getSubscriptions(Ref<DeferredPromise>&&);
 
 private:
-    CookieStoreManager();
+    explicit CookieStoreManager(ServiceWorkerRegistration&);
+
+    WeakPtr<ServiceWorkerRegistration, WebCore::WeakPtrImplWithEventTargetData> m_serviceWorkerRegistration;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/CookieStoreManager.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreManager.idl
@@ -31,6 +31,6 @@
     SecureContext
 ] interface CookieStoreManager {
     Promise<undefined> subscribe(sequence<CookieStoreGetOptions> subscriptions);
-    Promise<sequence<CookieStoreGetOptions>> getSubscriptions();
     Promise<undefined> unsubscribe(sequence<CookieStoreGetOptions> subscriptions);
+    Promise<sequence<CookieStoreGetOptions>> getSubscriptions();
 };

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -35,6 +35,7 @@
 #include "ServiceWorkerJob.h"
 #include "ServiceWorkerTypes.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 
@@ -55,6 +56,7 @@ struct BackgroundFetchOptions;
 struct BackgroundFetchRecordInformation;
 struct BackgroundFetchRequest;
 struct CacheQueryOptions;
+struct CookieChangeSubscription;
 struct ClientOrigin;
 struct ExceptionData;
 struct MessageWithMessagePorts;
@@ -140,6 +142,11 @@ public:
     virtual void retrieveRecordResponse(BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&&) = 0;
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;
     virtual void retrieveRecordResponseBody(BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&) = 0;
+
+    virtual void addCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, ExceptionOrVoidCallback&&) = 0;
+    virtual void removeCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, ExceptionOrVoidCallback&&) = 0;
+    using ExceptionOrCookieChangeSubscriptionsCallback = CompletionHandler<void(ExceptionOr<Vector<CookieChangeSubscription>>&&)>;
+    virtual void cookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&&) = 0;
 
 protected:
     WEBCORE_EXPORT SWClientConnection();

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -52,6 +52,8 @@ class TrustedScriptURL;
 enum class ServiceWorkerUpdateViaCache : uint8_t;
 enum class WorkerType : bool;
 
+struct CookieChangeSubscription;
+
 class ServiceWorkerContainer final : public EventTarget, public ActiveDOMObject, public ServiceWorkerJobClient {
     WTF_MAKE_NONCOPYABLE(ServiceWorkerContainer);
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ServiceWorkerContainer);
@@ -112,6 +114,10 @@ public:
     void setNavigationPreloadHeaderValue(ServiceWorkerRegistrationIdentifier, String&&, VoidPromise&&);
     void getNavigationPreloadState(ServiceWorkerRegistrationIdentifier, NavigationPreloadStatePromise&&);
 
+    void addCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, Ref<DeferredPromise>&&);
+    void removeCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, Ref<DeferredPromise>&&);
+    void cookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Ref<DeferredPromise>&&);
+
 private:
     ServiceWorkerContainer(ScriptExecutionContext*, NavigatorBase&);
 
@@ -134,6 +140,7 @@ private:
     ScriptExecutionContext* context() final { return scriptExecutionContext(); }
 
     SWClientConnection& ensureSWClientConnection();
+    Ref<SWClientConnection> ensureProtectedSWClientConnection();
 
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ServiceWorkerContainer; }

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ServiceWorkerRegistration.h"
 
+#include "CookieChangeSubscription.h"
+#include "CookieStoreGetOptions.h"
 #include "CookieStoreManager.h"
 #include "Document.h"
 #include "Event.h"
@@ -48,6 +50,7 @@
 #include "WebCoreOpaqueRoot.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
 
 #define REGISTRATION_RELEASE_LOG(fmt, ...) RELEASE_LOG(ServiceWorker, "%p - ServiceWorkerRegistration::" fmt, this, ##__VA_ARGS__)
 #define REGISTRATION_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ServiceWorker, "%p - ServiceWorkerRegistration::" fmt, this, ##__VA_ARGS__)
@@ -352,8 +355,74 @@ void ServiceWorkerRegistration::getNotifications(const GetNotificationOptions& f
 CookieStoreManager& ServiceWorkerRegistration::cookies()
 {
     if (!m_cookieStoreManager)
-        m_cookieStoreManager = CookieStoreManager::create();
+        m_cookieStoreManager = CookieStoreManager::create(*this);
     return *m_cookieStoreManager;
+}
+
+void ServiceWorkerRegistration::addCookieChangeSubscriptions(Vector<CookieStoreGetOptions>&& subscriptions, Ref<DeferredPromise>&& promise)
+{
+    Vector<CookieChangeSubscription> cookieChangeSubscriptions;
+    cookieChangeSubscriptions.reserveInitialCapacity(subscriptions.size());
+    for (auto& subscription : subscriptions) {
+        if (isContextStopped()) {
+            promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
+            return;
+        }
+
+        // FIXME: Fall back to scope url since spec does not specify an alternative and WPT layout tests expect this behavior (https://github.com/WICG/cookie-store/issues/236).
+        String url;
+        if (subscription.url.isNull())
+            url = scope();
+        else {
+            url = scriptExecutionContext()->completeURL(subscription.url).string();
+            if (!url.startsWith(scope())) {
+                promise->reject(Exception { ExceptionCode::TypeError, "The service worker cannot subcribe to cookie changes for URLs outside of its scope"_s });
+                return;
+            }
+        }
+
+        cookieChangeSubscriptions.append({ WTFMove(subscription.name), WTFMove(url) });
+    }
+
+    protectedContainer()->addCookieChangeSubscriptions(identifier(), WTFMove(cookieChangeSubscriptions), WTFMove(promise));
+}
+
+void ServiceWorkerRegistration::removeCookieChangeSubscriptions(Vector<CookieStoreGetOptions>&& subscriptions, Ref<DeferredPromise>&& promise)
+{
+    Vector<CookieChangeSubscription> cookieChangeSubscriptions;
+    cookieChangeSubscriptions.reserveInitialCapacity(subscriptions.size());
+    for (auto& subscription : subscriptions) {
+        if (isContextStopped()) {
+            promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
+            return;
+        }
+
+        // FIXME: Fall back to scope url since spec does not specify an alternative and WPT layout tests expect this behavior (https://github.com/WICG/cookie-store/issues/236).
+        String url;
+        if (subscription.url.isNull())
+            url = scope();
+        else {
+            url = scriptExecutionContext()->completeURL(subscription.url).string();
+            if (!url.startsWith(scope())) {
+                promise->reject(Exception { ExceptionCode::TypeError, "The service worker cannot unsubcribe from cookie changes for URLs outside of its scope"_s });
+                return;
+            }
+        }
+
+        cookieChangeSubscriptions.append({ WTFMove(subscription.name), WTFMove(url) });
+    }
+
+    protectedContainer()->removeCookieChangeSubscriptions(identifier(), WTFMove(cookieChangeSubscriptions), WTFMove(promise));
+}
+
+void ServiceWorkerRegistration::cookieChangeSubscriptions(Ref<DeferredPromise>&& promise)
+{
+    protectedContainer()->cookieChangeSubscriptions(identifier(), WTFMove(promise));
+}
+
+Ref<ServiceWorkerContainer> ServiceWorkerRegistration::protectedContainer() const
+{
+    return m_container;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -38,8 +38,10 @@
 #include "ServiceWorkerRegistrationData.h"
 #include "Supplementable.h"
 #include "Timer.h"
+#include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
-#include <wtf/Vector.h>
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -50,6 +52,7 @@ class ScriptExecutionContext;
 class ServiceWorker;
 class ServiceWorkerContainer;
 class WebCoreOpaqueRoot;
+struct CookieStoreGetOptions;
 
 class ServiceWorkerRegistration final : public RefCounted<ServiceWorkerRegistration>, public Supplementable<ServiceWorkerRegistration>, public EventTarget, public ActiveDOMObject, public PushSubscriptionOwner {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ServiceWorkerRegistration, WEBCORE_EXPORT);
@@ -96,6 +99,7 @@ public:
 
     NavigationPreloadManager& navigationPreload();
     ServiceWorkerContainer& container() { return m_container.get(); }
+    Ref<ServiceWorkerContainer> protectedContainer() const;
 
 #if ENABLE(NOTIFICATION_EVENT)
     struct GetNotificationOptions {
@@ -107,6 +111,9 @@ public:
 #endif
 
     CookieStoreManager& cookies();
+    void addCookieChangeSubscriptions(Vector<CookieStoreGetOptions>&&, Ref<DeferredPromise>&&);
+    void removeCookieChangeSubscriptions(Vector<CookieStoreGetOptions>&&, Ref<DeferredPromise>&&);
+    void cookieChangeSubscriptions(Ref<DeferredPromise>&&);
 
 private:
     ServiceWorkerRegistration(ScriptExecutionContext&, Ref<ServiceWorkerContainer>&&, ServiceWorkerRegistrationData&&);

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.h
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.h
@@ -26,11 +26,15 @@
 #pragma once
 
 #include "SWClientConnection.h"
+#include <wtf/Forward.h>
+#include <wtf/ObjectIdentifier.h>
 
 namespace WebCore {
 
 class WorkerGlobalScope;
 class WorkerThread;
+
+struct CookieChangeSubscription;
 
 class WorkerSWClientConnection final : public SWClientConnection {
 public:
@@ -75,26 +79,33 @@ private:
     void retrieveRecordResponse(BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&&) final;
     void retrieveRecordResponseBody(BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&) final;
 
+    void addCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, ExceptionOrVoidCallback&&) final;
+    void removeCookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, Vector<CookieChangeSubscription>&&, ExceptionOrVoidCallback&&) final;
+    void cookieChangeSubscriptions(ServiceWorkerRegistrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&&) final;
+
     Ref<WorkerThread> m_thread;
 
-    uint64_t m_lastRequestIdentifier { 0 };
-    HashMap<uint64_t, RegistrationCallback> m_matchRegistrationRequests;
-    HashMap<uint64_t, GetRegistrationsCallback> m_getRegistrationsRequests;
-    HashMap<uint64_t, WhenRegistrationReadyCallback> m_whenRegistrationReadyRequests;
-    HashMap<uint64_t, CompletionHandler<void(ExceptionOr<bool>&&)>> m_unregisterRequests;
-    HashMap<uint64_t, SubscribeToPushServiceCallback> m_subscribeToPushServiceRequests;
-    HashMap<uint64_t, UnsubscribeFromPushServiceCallback> m_unsubscribeFromPushServiceRequests;
-    HashMap<uint64_t, GetPushSubscriptionCallback> m_getPushSubscriptionRequests;
-    HashMap<uint64_t, GetPushPermissionStateCallback> m_getPushPermissionStateCallbacks;
-    HashMap<uint64_t, ExceptionOrVoidCallback> m_voidCallbacks;
-    HashMap<uint64_t, ExceptionOrNavigationPreloadStateCallback> m_navigationPreloadStateCallbacks;
-    HashMap<uint64_t, GetNotificationsCallback> m_getNotificationsCallbacks;
-    HashMap<uint64_t, ExceptionOrBackgroundFetchInformationCallback> m_backgroundFetchInformationCallbacks;
-    HashMap<uint64_t, BackgroundFetchIdentifiersCallback> m_backgroundFetchIdentifiersCallbacks;
-    HashMap<uint64_t, AbortBackgroundFetchCallback> m_abortBackgroundFetchCallbacks;
-    HashMap<uint64_t, MatchBackgroundFetchCallback> m_matchBackgroundFetchCallbacks;
-    HashMap<uint64_t, RetrieveRecordResponseCallback> m_retrieveRecordResponseCallbacks;
-    HashMap<uint64_t, RetrieveRecordResponseBodyCallback> m_retrieveRecordResponseBodyCallbacks;
+    struct SWClientRequestIdentifierType;
+    using SWClientRequestIdentifier = AtomicObjectIdentifier<SWClientRequestIdentifierType>;
+
+    HashMap<SWClientRequestIdentifier, RegistrationCallback> m_matchRegistrationRequests;
+    HashMap<SWClientRequestIdentifier, GetRegistrationsCallback> m_getRegistrationsRequests;
+    HashMap<SWClientRequestIdentifier, WhenRegistrationReadyCallback> m_whenRegistrationReadyRequests;
+    HashMap<SWClientRequestIdentifier, CompletionHandler<void(ExceptionOr<bool>&&)>> m_unregisterRequests;
+    HashMap<SWClientRequestIdentifier, SubscribeToPushServiceCallback> m_subscribeToPushServiceRequests;
+    HashMap<SWClientRequestIdentifier, UnsubscribeFromPushServiceCallback> m_unsubscribeFromPushServiceRequests;
+    HashMap<SWClientRequestIdentifier, GetPushSubscriptionCallback> m_getPushSubscriptionRequests;
+    HashMap<SWClientRequestIdentifier, GetPushPermissionStateCallback> m_getPushPermissionStateCallbacks;
+    HashMap<SWClientRequestIdentifier, ExceptionOrVoidCallback> m_voidCallbacks;
+    HashMap<SWClientRequestIdentifier, ExceptionOrNavigationPreloadStateCallback> m_navigationPreloadStateCallbacks;
+    HashMap<SWClientRequestIdentifier, GetNotificationsCallback> m_getNotificationsCallbacks;
+    HashMap<SWClientRequestIdentifier, ExceptionOrBackgroundFetchInformationCallback> m_backgroundFetchInformationCallbacks;
+    HashMap<SWClientRequestIdentifier, BackgroundFetchIdentifiersCallback> m_backgroundFetchIdentifiersCallbacks;
+    HashMap<SWClientRequestIdentifier, AbortBackgroundFetchCallback> m_abortBackgroundFetchCallbacks;
+    HashMap<SWClientRequestIdentifier, MatchBackgroundFetchCallback> m_matchBackgroundFetchCallbacks;
+    HashMap<SWClientRequestIdentifier, RetrieveRecordResponseCallback> m_retrieveRecordResponseCallbacks;
+    HashMap<SWClientRequestIdentifier, RetrieveRecordResponseBodyCallback> m_retrieveRecordResponseBodyCallbacks;
+    HashMap<SWClientRequestIdentifier, ExceptionOrCookieChangeSubscriptionsCallback> m_cookieChangeSubscriptionsCallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -33,6 +33,7 @@
 #include "SWServerWorker.h"
 #include "ServiceWorkerTypes.h"
 #include "ServiceWorkerUpdateViaCache.h"
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -421,6 +422,21 @@ std::optional<ExceptionData> SWServerRegistration::setNavigationPreloadHeaderVal
     m_preloadState.headerValue = WTFMove(headerValue);
     protectedServer()->storeRegistrationForWorker(*activeWorker);
     return { };
+}
+
+void SWServerRegistration::addCookieChangeSubscriptions(Vector<CookieChangeSubscription>&& subscriptions)
+{
+    m_cookieChangeSubscriptions.add(subscriptions.begin(), subscriptions.end());
+}
+
+void SWServerRegistration::removeCookieChangeSubscriptions(Vector<CookieChangeSubscription>&& subscriptions)
+{
+    m_cookieChangeSubscriptions.remove(subscriptions.begin(), subscriptions.end());
+}
+
+Vector<CookieChangeSubscription> SWServerRegistration::cookieChangeSubscriptions() const
+{
+    return copyToVector(m_cookieChangeSubscriptions);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -25,13 +25,16 @@
 
 #pragma once
 
+#include "CookieChangeSubscription.h"
 #include "NavigationPreloadState.h"
 #include "SWServer.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerRegistrationData.h"
 #include "ServiceWorkerTypes.h"
 #include "Timer.h"
+#include <wtf/Forward.h>
 #include <wtf/HashCountedSet.h>
+#include <wtf/HashSet.h>
 #include <wtf/Identified.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WallTime.h>
@@ -113,6 +116,10 @@ public:
     WEBCORE_EXPORT std::optional<ExceptionData> setNavigationPreloadHeaderValue(String&&);
     const NavigationPreloadState& navigationPreloadState() const { return m_preloadState; }
 
+    WEBCORE_EXPORT void addCookieChangeSubscriptions(Vector<CookieChangeSubscription>&&);
+    WEBCORE_EXPORT void removeCookieChangeSubscriptions(Vector<CookieChangeSubscription>&&);
+    WEBCORE_EXPORT Vector<CookieChangeSubscription> cookieChangeSubscriptions() const;
+
 private:
     SWServerRegistration(SWServer&, const ServiceWorkerRegistrationKey&, ServiceWorkerUpdateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&&);
 
@@ -132,6 +139,8 @@ private:
     RefPtr<SWServerWorker> m_installingWorker;
     RefPtr<SWServerWorker> m_waitingWorker;
     RefPtr<SWServerWorker> m_activeWorker;
+
+    HashSet<CookieChangeSubscription> m_cookieChangeSubscriptions;
 
     WallTime m_lastUpdateTime;
     

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -37,6 +37,7 @@
 #include "NetworkSession.h"
 #include "RemoteWorkerType.h"
 #include "SharedBufferReference.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebProcess.h"
 #include "WebProcessMessages.h"
@@ -45,6 +46,7 @@
 #include "WebSWContextManagerConnectionMessages.h"
 #include "WebSWServerConnectionMessages.h"
 #include "WebSWServerToContextConnection.h"
+#include <WebCore/CookieChangeSubscription.h>
 #include <WebCore/ExceptionData.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/NotImplemented.h>
@@ -59,6 +61,7 @@
 #include <wtf/Algorithms.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
 
 namespace WebKit {
 using namespace PAL;
@@ -94,6 +97,11 @@ WebSWServerConnection::~WebSWServerConnection()
 NetworkProcess& WebSWServerConnection::networkProcess()
 {
     return m_networkConnectionToWebProcess->networkProcess();
+}
+
+const SharedPreferencesForWebProcess& WebSWServerConnection::sharedPreferencesForWebProcess() const
+{
+    return m_networkConnectionToWebProcess->sharedPreferencesForWebProcess();
 }
 
 void WebSWServerConnection::rejectJobInClient(ServiceWorkerJobIdentifier jobIdentifier, const ExceptionData& exceptionData)
@@ -754,6 +762,47 @@ void WebSWServerConnection::retrieveRecordResponseBody(WebCore::BackgroundFetchR
         }
         checkedThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyChunk(callbackIdentifier, IPC::SharedBufferReference(WTFMove(result.value()))));
     });
+}
+
+void WebSWServerConnection::addCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, Vector<WebCore::CookieChangeSubscription>&& subscriptions, ExceptionOrVoidCallback&& callback)
+{
+    RefPtr registration = protectedServer()->getRegistration(registrationIdentifier);
+    if (!registration) {
+        SWSERVERCONNECTION_RELEASE_LOG_ERROR("AddCookieChangeSubscriptions: Did not handle because no valid registration for registration identifier %" PRIu64, registrationIdentifier.toUInt64());
+        // FIXME: Spec is not clear about this case at this point and wpt test expects no error (https://github.com/WICG/cookie-store/issues/237).
+        callback({ });
+        return;
+    }
+
+    registration->addCookieChangeSubscriptions(WTFMove(subscriptions));
+    callback({ });
+}
+
+void WebSWServerConnection::removeCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, Vector<WebCore::CookieChangeSubscription>&& subscriptions, ExceptionOrVoidCallback&& callback)
+{
+    RefPtr registration = protectedServer()->getRegistration(registrationIdentifier);
+    if (!registration) {
+        SWSERVERCONNECTION_RELEASE_LOG_ERROR("RemoveCookieChangeSubscriptions: Did not handle because no valid registration for registration identifier %" PRIu64, registrationIdentifier.toUInt64());
+        // FIXME: Spec is not clear about this case at this point and wpt test expects no error (https://github.com/WICG/cookie-store/issues/237).
+        callback({ });
+        return;
+    }
+
+    registration->removeCookieChangeSubscriptions(WTFMove(subscriptions));
+    callback({ });
+}
+
+void WebSWServerConnection::cookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&& callback)
+{
+    RefPtr registration = protectedServer()->getRegistration(registrationIdentifier);
+    if (!registration) {
+        SWSERVERCONNECTION_RELEASE_LOG_ERROR("CookieChangeSubscriptions: Did not handle because no valid registration for registration identifier %" PRIu64, registrationIdentifier.toUInt64());
+        // FIXME: Spec is not clear about this case at this point and wpt test expects no error (https://github.com/WICG/cookie-store/issues/237).
+        callback({ });
+        return;
+    }
+
+    callback(registration->cookieChangeSubscriptions());
 }
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -38,6 +38,7 @@
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/SWServer.h>
 #include <pal/SessionID.h>
+#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -53,6 +54,7 @@ template<> struct AsyncReplyError<WebCore::ExceptionOr<bool>> {
 
 namespace WebCore {
 class ServiceWorkerRegistrationKey;
+struct CookieChangeSubscription;
 struct ClientOrigin;
 struct ExceptionData;
 struct MessageWithMessagePorts;
@@ -66,6 +68,7 @@ class NetworkProcess;
 class NetworkResourceLoadParameters;
 class NetworkResourceLoader;
 class ServiceWorkerFetchTask;
+struct SharedPreferencesForWebProcess;
 
 class WebSWServerConnection final : public WebCore::SWServer::Connection, public IPC::MessageSender, public IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(WebSWServerConnection);
@@ -82,6 +85,8 @@ public:
     IPC::Connection& ipcConnection() const { return m_contentConnection.get(); }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     NetworkSession* session();
     PAL::SessionID sessionID() const;
@@ -150,6 +155,11 @@ private:
     void getNavigationPreloadState(WebCore::ServiceWorkerRegistrationIdentifier, ExceptionOrNavigationPreloadStateCallback&&);
 
     void retrieveRecordResponseBody(WebCore::BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallbackIdentifier);
+
+    void addCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, Vector<WebCore::CookieChangeSubscription>&&, ExceptionOrVoidCallback&&);
+    void removeCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, Vector<WebCore::CookieChangeSubscription>&&, ExceptionOrVoidCallback&&);
+    using ExceptionOrCookieChangeSubscriptionsCallback = CompletionHandler<void(Expected<Vector<WebCore::CookieChangeSubscription>, WebCore::ExceptionData>&&)>;
+    void cookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&&);
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -64,6 +64,10 @@ messages -> WebSWServerConnection NotRefCounted {
     RetrieveRecordResponse(WebCore::BackgroundFetchRecordIdentifier recordIdentifier) -> (Expected<WebCore::ResourceResponse, WebCore::ExceptionData> result)
     RetrieveRecordResponseBody(WebCore::BackgroundFetchRecordIdentifier recordIdentifier, WebKit::RetrieveRecordResponseBodyCallbackIdentifier callbackIdentifier)
 
+    [EnabledBy=CookieStoreManagerEnabled] AddCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier identifier, Vector<WebCore::CookieChangeSubscription> subscriptions) -> (std::optional<WebCore::ExceptionData> result)
+    [EnabledBy=CookieStoreManagerEnabled] RemoveCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier identifier, Vector<WebCore::CookieChangeSubscription> subscriptions) -> (std::optional<WebCore::ExceptionData> result)
+    [EnabledBy=CookieStoreManagerEnabled] CookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier identifier) -> (Expected<Vector<WebCore::CookieChangeSubscription>, WebCore::ExceptionData> result)
+
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
 #endif

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -847,7 +847,6 @@ def headers_for_type(type):
         'WebCore::ColorSchemePreference': ['<WebCore/DocumentLoader.h>'],
         'WebCore::CompositeMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::CompositeOperator': ['<WebCore/GraphicsTypes.h>'],
-        'WebCore::Cookie': ['<WebCore/Cookie.h>'],
         'WebCore::COOPDisposition': ['<WebCore/CrossOriginOpenerPolicy.h>'],
         'WebCore::CreateNewGroupForHighlight': ['<WebCore/AppHighlight.h>'],
         'WebCore::CrossOriginOpenerPolicyValue': ['<WebCore/CrossOriginOpenerPolicy.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6676,6 +6676,11 @@ struct WebCore::CookieStoreGetOptions {
     String url;
 };
 
+struct WebCore::CookieChangeSubscription {
+    String name;
+    String url;
+};
+
 [RefCounted] class WebCore::Model {
     Ref<WebCore::SharedBuffer> data()
     String mimeType()

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -43,6 +43,7 @@
 #include "WebSWServerConnectionMessages.h"
 #include <WebCore/BackgroundFetchInformation.h>
 #include <WebCore/BackgroundFetchRequest.h>
+#include <WebCore/CookieChangeSubscription.h>
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>
@@ -59,6 +60,7 @@
 #include <WebCore/ServiceWorkerRegistrationKey.h>
 #include <WebCore/WorkerFetchResult.h>
 #include <WebCore/WorkerScriptLoader.h>
+#include <wtf/Vector.h>
 
 namespace WebKit {
 
@@ -427,6 +429,31 @@ void WebSWClientConnection::focusServiceWorkerClient(ScriptExecutionContextIdent
         }
         page->focusController().setFocusedFrame(frame.get());
         callback(ServiceWorkerClientData::from(*client));
+    });
+}
+
+void WebSWClientConnection::addCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, Vector<WebCore::CookieChangeSubscription>&& subscriptions, ExceptionOrVoidCallback&& callback)
+{
+    sendWithAsyncReply(Messages::WebSWServerConnection::AddCookieChangeSubscriptions { registrationIdentifier, subscriptions }, [callback = WTFMove(callback)](auto&& error) mutable {
+        if (error)
+            return callback(error->toException());
+        callback({ });
+    });
+}
+
+void WebSWClientConnection::removeCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, Vector<WebCore::CookieChangeSubscription>&& subscriptions, ExceptionOrVoidCallback&& callback)
+{
+    sendWithAsyncReply(Messages::WebSWServerConnection::RemoveCookieChangeSubscriptions { registrationIdentifier, subscriptions }, [callback = WTFMove(callback)](auto&& error) mutable {
+        if (error)
+            return callback(error->toException());
+        callback({ });
+    });
+}
+
+void WebSWClientConnection::cookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&& callback)
+{
+    sendWithAsyncReply(Messages::WebSWServerConnection::CookieChangeSubscriptions { registrationIdentifier }, [callback = WTFMove(callback)](auto&& result) mutable {
+        callExceptionOrResultCallback(WTFMove(callback), WTFMove(result));
     });
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
@@ -32,6 +32,7 @@
 #include <WebCore/MessageWithMessagePorts.h>
 #include <WebCore/SWClientConnection.h>
 #include <WebCore/SharedMemory.h>
+#include <wtf/Forward.h>
 #include <wtf/UniqueRef.h>
 
 namespace IPC {
@@ -39,6 +40,7 @@ class SharedBufferReference;
 }
 
 namespace WebCore {
+struct CookieChangeSubscription;
 struct ExceptionData;
 class ResourceLoader;
 }
@@ -112,6 +114,10 @@ private:
     void matchBackgroundFetch(WebCore::ServiceWorkerRegistrationIdentifier, const String&, WebCore::RetrieveRecordsOptions&&, MatchBackgroundFetchCallback&&) final;
     void retrieveRecordResponse(WebCore::BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&&) final;
     void retrieveRecordResponseBody(WebCore::BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&) final;
+
+    void addCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, Vector<WebCore::CookieChangeSubscription>&&, ExceptionOrVoidCallback&&) final;
+    void removeCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, Vector<WebCore::CookieChangeSubscription>&&, ExceptionOrVoidCallback&&) final;
+    void cookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&&) final;
 
     void focusServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&&);
     void notifyRecordResponseBodyChunk(RetrieveRecordResponseBodyCallbackIdentifier, IPC::SharedBufferReference&&);


### PR DESCRIPTION
#### c1a5c61946b9f75678be873346223d40f774f814
<pre>
Implement CookieStoreManager for the CookieStore API
<a href="https://rdar.apple.com/133575968">rdar://133575968</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277892">https://bugs.webkit.org/show_bug.cgi?id=277892</a>

Reviewed by Chris Dumez.

This patch implements the CookieStoreManager which allows
Service Workers to subscribe to events on cookie changes
(<a href="https://wicg.github.io/cookie-store/#CookieStoreManager).">https://wicg.github.io/cookie-store/#CookieStoreManager).</a>

We implement the subscribe, unsubscribe, and getSubscriptions
functions. The list of subscriptions is stored in the Service
Worker Registration on the Network Process side. The WebProcess
sends IPC messages to alter or get a copy of the list.

This patch causes some WPT Layout Tests that were previously
failing to now pass. Some of the tests whose results changed
to timeout are timing out because they are testing the
functionality of the ExtendableCookieChangeEvent for Service
Workers which has not yet been implemented. Since we currently
don&apos;t plan on firing cookie change events to the Service Workers,
there&apos;s no plan to implement ExtendableCookieChangeEvent yet.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscriptions_empty.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookieStore_subscriptions_reset.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_single_subscription.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_oncookiechange_eventhandler_single_subscription.https.any.serviceworker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/cookie-store/CookieChangeSubscription.h: Added.
(WebCore::CookieChangeSubscription::CookieChangeSubscription):
(WebCore::CookieChangeSubscription::isHashTableDeletedValue const):
(WTF::CookieChangeSubscriptionHash::hash):
(WTF::CookieChangeSubscriptionHash::equal):
* Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl:
* Source/WebCore/Modules/cookie-store/CookieStoreManager.cpp:
(WebCore::CookieStoreManager::create):
(WebCore::CookieStoreManager::CookieStoreManager):
(WebCore::CookieStoreManager::subscribe):
(WebCore::CookieStoreManager::unsubscribe):
(WebCore::CookieStoreManager::getSubscriptions):
* Source/WebCore/Modules/cookie-store/CookieStoreManager.h:
* Source/WebCore/Modules/cookie-store/CookieStoreManager.idl:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ensureProtectedSWClientConnection):
(WebCore::ServiceWorkerContainer::addCookieChangeSubscriptions):
(WebCore::ServiceWorkerContainer::removeCookieChangeSubscriptions):
(WebCore::ServiceWorkerContainer::cookieChangeSubscriptions):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::cookies):
(WebCore::ServiceWorkerRegistration::addCookieChangeSubscriptions):
(WebCore::ServiceWorkerRegistration::removeCookieChangeSubscriptions):
(WebCore::ServiceWorkerRegistration::cookieChangeSubscriptions):
(WebCore::ServiceWorkerRegistration::protectedContainer const):
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
(WebCore::WorkerSWClientConnection::~WorkerSWClientConnection):
(WebCore::WorkerSWClientConnection::matchRegistration):
(WebCore::WorkerSWClientConnection::getRegistrations):
(WebCore::WorkerSWClientConnection::whenRegistrationReady):
(WebCore::WorkerSWClientConnection::scheduleUnregisterJobInServer):
(WebCore::WorkerSWClientConnection::subscribeToPushService):
(WebCore::WorkerSWClientConnection::unsubscribeFromPushService):
(WebCore::WorkerSWClientConnection::getPushSubscription):
(WebCore::WorkerSWClientConnection::getPushPermissionState):
(WebCore::WorkerSWClientConnection::getNotifications):
(WebCore::WorkerSWClientConnection::enableNavigationPreload):
(WebCore::WorkerSWClientConnection::disableNavigationPreload):
(WebCore::WorkerSWClientConnection::setNavigationPreloadHeaderValue):
(WebCore::WorkerSWClientConnection::getNavigationPreloadState):
(WebCore::WorkerSWClientConnection::startBackgroundFetch):
(WebCore::WorkerSWClientConnection::backgroundFetchInformation):
(WebCore::WorkerSWClientConnection::backgroundFetchIdentifiers):
(WebCore::WorkerSWClientConnection::abortBackgroundFetch):
(WebCore::WorkerSWClientConnection::matchBackgroundFetch):
(WebCore::WorkerSWClientConnection::retrieveRecordResponse):
(WebCore::WorkerSWClientConnection::retrieveRecordResponseBody):
(WebCore::WorkerSWClientConnection::addCookieChangeSubscriptions):
(WebCore::WorkerSWClientConnection::removeCookieChangeSubscriptions):
(WebCore::WorkerSWClientConnection::cookieChangeSubscriptions):
* Source/WebCore/workers/service/WorkerSWClientConnection.h:
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::addCookieChangeSubscriptions):
(WebCore::SWServerRegistration::removeCookieChangeSubscriptions):
(WebCore::SWServerRegistration::cookieChangeSubscriptions const):
* Source/WebCore/workers/service/server/SWServerRegistration.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::sharedPreferencesForWebProcess const):
(WebKit::WebSWServerConnection::addCookieChangeSubscriptions):
(WebKit::WebSWServerConnection::removeCookieChangeSubscriptions):
(WebKit::WebSWServerConnection::cookieChangeSubscriptions):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::addCookieChangeSubscriptions):
(WebKit::WebSWClientConnection::removeCookieChangeSubscriptions):
(WebKit::WebSWClientConnection::cookieChangeSubscriptions):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.h:

Canonical link: <a href="https://commits.webkit.org/282417@main">https://commits.webkit.org/282417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4592fa1a835293d934af318a2503689627e0c665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14028 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31564 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/62651 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36148 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12620 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56250 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68856 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62383 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7086 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54742 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13989 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5909 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84146 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38316 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14827 "Found 1473 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39396 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->