### PR TITLE
Add `-webkit-` prefix for text-decoration in UA stylesheet for <abbr> and <acronym> with title

### DIFF
--- a/LayoutTests/fast/html/abbr-acronym-rendering-expected.html
+++ b/LayoutTests/fast/html/abbr-acronym-rendering-expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<span style="text-decoration: dotted underline;">Cr</span>
-<span style="text-decoration: dotted underline;">Pt</span>
+<span style="text-decoration-style: dotted; text-decoration-line: underline;">Cr</span>
+<span style="text-decoration-style: dotted; text-decoration-line: underline;">Pt</span>
 </body>
 </html>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -111,8 +111,9 @@ hr {
     border-width: 1px;
 }
 
+/* FIXME: webkit.org/b/230083 - Remove `-webkit-` from below.  */
 abbr[title], acronym[title] {
-    text-decoration: dotted underline;
+    -webkit-text-decoration: dotted underline;
 }
 
 /* ::backdrop */


### PR DESCRIPTION
#### 1d7ae3d9446e4a64ead21befb5e8b9e62402cca4
<pre>
Add `-webkit-` prefix for text-decoration in UA stylesheet for &lt;abbr&gt; and &lt;acronym&gt; with title

<a href="https://bugs.webkit.org/show_bug.cgi?id=277889">https://bugs.webkit.org/show_bug.cgi?id=277889</a>
<a href="https://rdar.apple.com/problem/133580462">rdar://problem/133580462</a>

Reviewed by Tim Nguyen.

This patch fixes bug, which I tried to fix in 254710@main but it seems
that it never worked due to our &apos;text-decoration&apos; implementation issue
as covered by bug 230083.

This adds `-webkit-` to UA styles to make it work for &quot;abbr&quot; and &quot;acronym&quot;
with title in meanwhile.

* Source/WebCore/css/html.css:
(abbr[title], acronym[title]):
* LayoutTests/fast/html/abbr-acronym-rendering-expected.html: Rebaselined

Canonical link: <a href="https://commits.webkit.org/283368@main">https://commits.webkit.org/283368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cfbe4634b3a1d77670150cab66eff43dd77afb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70142 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17001 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69177 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/57235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38630 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10065 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57297 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14576 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8313 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/41291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->