### PR TITLE
Provide a fallback image to NowPlaying when a website doesn't specify one in MediaSession metadata

### DIFF
--- a/LayoutTests/http/tests/media/now-playing-info-media-session-artwork-favicon-expected.txt
+++ b/LayoutTests/http/tests/media/now-playing-info-media-session-artwork-favicon-expected.txt
@@ -1,0 +1,29 @@
+
+Tests that the NowPlaying metadata's artwork default to favicon.
+
+* NowPlaying should not be active before playback has started.
+RUN(video.src = findMediaFile("video", "../../media-resources/content/test"))
+EVENT(canplaythrough)
+RUN(nowPlayingState = internals.nowPlayingState)
+EXPECTED (nowPlayingState.registeredAsNowPlayingApplication == 'false') OK
+RUN(navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album"}))
+RUN(navigator.mediaSession.playbackState = "paused")
+RUN(navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime})
+RUN(navigator.mediaSession.setActionHandler("play", playAction))
+RUN(navigator.mediaSession.setActionHandler("pause", pauseAction))
+
+* Start to play, NowPlaying should become active.
+RUN(navigator.mediaSession.callActionHandler({action: "play"}))
+ACTION: play
+EVENT(playing)
+RUN(navigator.mediaSession.callActionHandler({action: "pause"}))
+ACTION: pause
+RUN(nowPlayingMetadata = internals.nowPlayingMetadata)
+EXPECTED (nowPlayingMetadata.title == 'title') OK
+EXPECTED (nowPlayingMetadata.artist == 'artist') OK
+EXPECTED (nowPlayingMetadata.album == 'album') OK
+EXPECTED (nowPlayingMetadata.artwork.mimeType == 'image/png') OK
+EXPECTED (nowPlayingMetadata.artwork.src == 'http://127.0.0.1:8000/media-resources/content/abe.png') OK
+
+END OF TEST
+

--- a/LayoutTests/http/tests/media/now-playing-info-media-session-artwork-favicon.html
+++ b/LayoutTests/http/tests/media/now-playing-info-media-session-artwork-favicon.html
@@ -1,0 +1,86 @@
+<!-- webkit-test-runner -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>now-playing-info-media-session-artwork-favicon</title>
+    <link rel="icon" type="image/png" href="../../media-resources/content/abe.png">
+    <script src=../../media-resources/video-test.js></script>
+    <script src=../../media-resources/media-file.js></script>
+    <script>
+
+        let nowPlayingState;
+
+        async function waitForAttributeToChange(attribute, expected) {
+            let start = new Date().getTime();
+            do {
+
+                if (internals.nowPlayingState[attribute] != expected)
+                    return;
+
+                await new Promise(resolve => setTimeout(resolve, 100));
+            } while (new Date().getTime() - start < 500);
+
+            failTest(`** Timed out waiting for "${attribute}" to change from "${expected}"`);
+        }
+
+        function playAction()
+        {
+            consoleWrite('ACTION: play');
+            runWithKeyDown(() => {
+                video.play();
+            });
+        }
+
+        function pauseAction()
+        {
+            consoleWrite('ACTION: pause');
+            runWithKeyDown(() => {
+                video.pause();
+            });
+        }
+
+        async function runTest()
+        {
+            findMediaElement();
+
+            consoleWrite('<br>* NowPlaying should not be active before playback has started.');
+            run('video.src = findMediaFile("video", "../../media-resources/content/test")');
+            await waitFor(video, 'canplaythrough');
+
+            run('nowPlayingState = internals.nowPlayingState');
+            testExpected('nowPlayingState.registeredAsNowPlayingApplication', false);
+
+            run('navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album"})');
+            run('navigator.mediaSession.playbackState = "paused"')
+            run('navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime}');
+            run('navigator.mediaSession.setActionHandler("play", playAction)');
+            run('navigator.mediaSession.setActionHandler("pause", pauseAction)');
+
+            consoleWrite('<br>* Start to play, NowPlaying should become active.');
+            run('navigator.mediaSession.callActionHandler({action: "play"})');
+
+            await waitFor(video, 'playing');
+            run('navigator.mediaSession.callActionHandler({action: "pause"})');
+            await waitForAttributeToChange('registeredAsNowPlayingApplication', false);
+
+            run('nowPlayingMetadata = internals.nowPlayingMetadata');
+            await testExpectedEventually('nowPlayingMetadata.title', 'title', '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.artist', 'artist', '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.album', 'album', '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.artwork.mimeType', 'image/png', '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.artwork.src', 'http://127.0.0.1:8000/media-resources/content/abe.png', '==', 1000);
+
+            consoleWrite('');
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+    </script>
+</head>
+<body">
+    <video controls></video>
+    <br>
+    Tests that the NowPlaying metadata's artwork default to favicon.
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2568,6 +2568,7 @@ fast/events/webkit-media-key-events-constructor.html [ Skip ]
 # NowPlaying is macOS and iOS only.
 http/tests/media/now-playing-info-private-browsing.html [ Skip ]
 http/tests/media/now-playing-info.html [ Skip ]
+http/tests/media/now-playing-info-media-session-artwork-favicon.html [ Skip ]
 media/now-playing-info-media-session-private-browsing.html [ Skip ]
 media/now-playing-info-media-session-suspend-playback.html [ Skip ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1767,6 +1767,9 @@ http/tests/inspector/network/resource-response-inspector-override.html [ Skip ]
 inspector/network/intercept-aborted-request.html [ Skip ]
 inspector/network/interceptContinue.html [ Skip ]
 
+# Test timeout with NowPlaying
+http/tests/media/now-playing-info-media-session-artwork-favicon.html [ Skip ]
+
 # Resource content retrival times out in WebKit1.
 webkit.org/b/257407 http/tests/inspector/network/xhr-request-type.html [ Skip ]
 

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -31,6 +31,7 @@
 #include "CachedResourceHandle.h"
 #include "MediaMetadataInit.h"
 #include "MediaSession.h"
+#include "Timer.h"
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -107,14 +108,19 @@ private:
     void refreshArtworkImage();
     void tryNextArtworkImage(uint32_t, Vector<Pair>&&);
 
+    void maybeStartTimer();
+
     static constexpr int s_minimumSize = 128;
     static constexpr int s_idealSize = 512;
+    static constexpr auto s_fallbackTimeout = 500_ms;
 
     WeakPtr<MediaSession> m_session;
     MediaSessionMetadata m_metadata;
     std::unique_ptr<ArtworkImageLoader> m_artworkLoader;
     String m_artworkImageSrc;
     RefPtr<Image> m_artworkImage;
+    bool m_fallbackAttempted { false };
+    Timer m_timer;
 };
 
 }


### PR DESCRIPTION
#### ebd5a388e5b0bcd0ea50fbb66a2fdb002e5d6816
<pre>
Provide a fallback image to NowPlaying when a website doesn&apos;t specify one in MediaSession metadata
<a href="https://bugs.webkit.org/show_bug.cgi?id=277904">https://bugs.webkit.org/show_bug.cgi?id=277904</a>
<a href="https://rdar.apple.com/131185836">rdar://131185836</a>

Reviewed by Eric Carlson.

Should the MediaSession&apos;s metadata fail to provide an artwork, attempt to use page&apos;s icon instead.
If the site modify the metadata content without setting a new object, we will wait a maximum of 500ms
before attempting to retrieve the icon, to give time for the site to finish setting up all the metadata.

Added test.

* LayoutTests/http/tests/media/now-playing-info-media-session-artwork-favicon-expected.txt: Added.
* LayoutTests/http/tests/media/now-playing-info-media-session-artwork-favicon.html: Added. Had make test to http
as the DocumentLoader&apos;s LinkIconCollector will ignore all icons not using http family protocol.
* LayoutTests/platform/glib/TestExpectations: No NowPlaying on glib platforms.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::MediaMetadata::MediaMetadata):
(WebCore::MediaMetadata::setTitle):
(WebCore::MediaMetadata::setArtist):
(WebCore::MediaMetadata::setAlbum):
(WebCore::MediaMetadata::refreshArtworkImage):
(WebCore::MediaMetadata::maybeStartTimer):
* Source/WebCore/Modules/mediasession/MediaMetadata.h:

Canonical link: <a href="https://commits.webkit.org/282096@main">https://commits.webkit.org/282096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87d6d186c54df68afc77362bfe54ca402ffd8631

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49975 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67767 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6002 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57599 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4916 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37213 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->