### PR TITLE
Implement rendering for `background-clip: border-area` and flip to preview

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-image: url(../resources/stripes-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+    }
+    
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: white;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"><div></div></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-image: url(../resources/stripes-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+    }
+    
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: white;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"><div></div></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip" >
+<link rel="match" href="clip-border-area-background-geometry-ref.html">
+<meta name="assert" content="The border-area fill respects background i geometry">
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/stripes-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-image: url(../resources/green-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+        border-image: url(../resources/stripes-100.png);
+    }
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: white;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"><div></div></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-image: url(../resources/green-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+        border-image: url(../resources/stripes-100.png);
+    }
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: white;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"><div></div></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip" >
+<link rel="match" href="clip-border-area-border-image-ref.html">
+<meta name="assert" content="The border-area fill respects background i geometry">
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/green-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+        border-image: url(../resources/stripes-100.png);
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid rgba(0, 128, 0, 0.75);
+        background-image: url(../resources/green-100.png);
+    }
+    
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: orange;
+    }
+</style>
+</head>
+<body>
+<div class="test"><div></div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid rgba(0, 128, 0, 0.75);
+        background-image: url(../resources/green-100.png);
+    }
+    
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: orange;
+    }
+</style>
+</head>
+<body>
+<div class="test"><div></div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-border-on-top-ref.html">
+<meta name="assert" content="A non-transparent border is painted on top of the filled border-area">
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid rgba(0, 128, 0, 0.75);
+        background-clip: border-area, border-box;
+        background-color: orange;
+        background-image: url(../resources/green-100.png), none;
+    }
+</style>
+</head>
+<body>
+<div class="test"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-expected.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 50px solid blue;
+    }
+    
+    .rounded {
+        border-radius: 40%;
+    }
+    
+    .missing-border {
+        border-right-style: hidden;
+    }
+
+    .double {
+        border-style: double;
+    }
+
+    .inset {
+        border-style: solid;
+    }
+    
+    .complex {
+        border-right-style: double;
+        border-bottom-style: dashed;
+        border-left-style: dotted;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+<div class="test rounded"></div>
+<div class="test missing-border"></div>
+<div class="test double"></div>
+<div class="test inset"></div>
+<div class="test complex"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px dotted blue;
+        background-clip: border-box;
+        background-color: red;
+        background-image: url(../resources/green-100.png);
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px dotted blue;
+        background-clip: border-box;
+        background-color: red;
+        background-image: url(../resources/green-100.png);
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-multiple-backgrounds-ref.html">
+<meta name="assert" content="Multiple backgrounds, some using border-area, are layered correctly.">
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px dotted transparent;
+        background-clip: border-area, border-box, content-box;
+        background-color: red;
+        background-image: url(../resources/blue-100.png), url(../resources/green-100.png), none;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 50px solid blue;
+    }
+    
+    .rounded {
+        border-radius: 40%;
+    }
+    
+    .missing-border {
+        border-right-style: hidden;
+    }
+
+    .double {
+        border-style: double;
+    }
+
+    .inset {
+        border-style: solid;
+    }
+    
+    .complex {
+        border-right-style: double;
+        border-bottom-style: dashed;
+        border-left-style: dotted;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+<div class="test rounded"></div>
+<div class="test missing-border"></div>
+<div class="test double"></div>
+<div class="test inset"></div>
+<div class="test complex"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-ref.html">
+<meta name="assert" content="border-area: The border area is filled with the background image">
+<meta name="fuzzy" content="maxDifference=0-130; totalPixels=0-1100">
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/blue-100.png);
+    }
+    
+    .rounded {
+        border-radius: 40%;
+    }
+    
+    .missing-border {
+        border-right-style: hidden;
+    }
+
+    .double {
+        border-style: double;
+    }
+
+    .inset {
+        border-style: inset;
+    }
+    
+    .complex {
+        border-right-style: double;
+        border-bottom-style: dashed;
+        border-left-style: dotted;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+<div class="test rounded"></div>
+<div class="test missing-border"></div>
+<div class="test double"></div>
+<div class="test inset"></div>
+<div class="test complex"></div>
+
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -980,7 +980,7 @@ CSSAnchorPositioningEnabled:
 
 CSSBackgroundClipBorderAreaEnabled:
   type: bool
-  status: testable
+  status: preview
   category: css
   humanReadableName: "CSS background-clip: border-area"
   humanReadableDescription: "Enable the border-area value for background-clip"

--- a/Source/WebCore/rendering/BorderPainter.h
+++ b/Source/WebCore/rendering/BorderPainter.h
@@ -39,9 +39,10 @@ public:
     bool paintNinePieceImage(const LayoutRect&, const RenderStyle&, const NinePieceImage&, CompositeOperator = CompositeOperator::SourceOver) const;
     static void drawLineForBoxSide(GraphicsContext&, const Document&, const FloatRect&, BoxSide, Color, BorderStyle, float adjacentWidth1, float adjacentWidth2, bool antialias = false);
 
+    static std::optional<Path> pathForBorderArea(const LayoutRect&, const RenderStyle&, float deviceScaleFactor, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true);
+
     static bool allCornersClippedOut(const RoundedRect&, const LayoutRect&);
     static bool shouldAntialiasLines(GraphicsContext&);
-    static Color calculateBorderStyleColor(const BorderStyle&, const BoxSide&, const Color&);
 
 private:
     struct Sides;
@@ -56,6 +57,8 @@ private:
     void clipBorderSidePolygon(const RoundedRect& outerBorder, const RoundedRect& innerBorder, BoxSide, bool firstEdgeMatches, bool secondEdgeMatches) const;
 
     LayoutRect borderInnerRectAdjustedForBleedAvoidance(const LayoutRect&, BackgroundBleedAvoidance) const;
+
+    static Color calculateBorderStyleColor(const BorderStyle&, const BoxSide&, const Color&);
 
     const Document& document() const;
 


### PR DESCRIPTION
#### cb3f53635881c69718ae71650954a080e4ab637f
<pre>
Implement rendering for `background-clip: border-area` and flip to preview
<a href="https://bugs.webkit.org/show_bug.cgi?id=277910">https://bugs.webkit.org/show_bug.cgi?id=277910</a>
<a href="https://rdar.apple.com/133606473">rdar://133606473</a>

Reviewed by Tim Nguyen.

Implement rendering for `background-clip: border-area` by adding code in `BackgroundPainter::paintFillLayer()`
that takes one of two code paths based on border complexity.

For simple borders (not dotted, dashed or double), we can compute a path for the inner and outer border edges,
and fill the path with the background.

For complex borders, create a temporary mask image (as we do for `background-clip: text`) and paint the borders
into the mask, which is then used to clip the background drawing.

Now that rendering works, flip the feature status to &quot;preview&quot;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-background-geometry.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-image.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-on-top.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::borderStyleFillsBorderArea):
(WebCore::decorationHasAllSimpleEdges):
(WebCore::BorderPainter::pathForBorderArea):
(WebCore::BorderPainter::paintBorder const):
* Source/WebCore/rendering/BorderPainter.h:

Canonical link: <a href="https://commits.webkit.org/282107@main">https://commits.webkit.org/282107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1002e69fac9533648de19b85809eea289a41aed6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50000 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8726 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11562 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55182 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67794 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61328 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57377 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57627 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4941 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83092 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37240 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14568 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->