### PR TITLE
Add runtime flag for enabling Modern DownloadProgress

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -41,7 +41,7 @@
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
-OBJC_CLASS WKDownloadProgress;
+OBJC_CLASS NSProgress;
 OBJC_CLASS NSURLSessionDownloadTask;
 #endif
 
@@ -126,7 +126,11 @@ private:
     RefPtr<NetworkDataTask> m_download;
 #if PLATFORM(COCOA)
     RetainPtr<NSURLSessionDownloadTask> m_downloadTask;
-    RetainPtr<WKDownloadProgress> m_progress;
+    RetainPtr<NSProgress> m_progress;
+#endif
+#if HAVE(MODERN_DOWNLOADPROGRESS)
+    RetainPtr<NSData> m_bookmarkData;
+    RetainPtr<NSURL> m_bookmarkURL;
 #endif
     PAL::SessionID m_sessionID;
     bool m_hasReceivedData { false };

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.h
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.h
@@ -43,12 +43,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
 WKDOWNLOADPROGRESS_ADDITIONS
-#else
+#endif
+
 @interface WKDownloadProgress : NSProgress
 
 - (instancetype)initWithDownloadTask:(NSURLSessionDownloadTask *)task download:(WebKit::Download&)download URL:(NSURL *)fileURL sandboxExtension:(RefPtr<WebKit::SandboxExtension>)sandboxExtension;
 
 @end
-#endif
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -40,7 +40,8 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
 #import <WebKitAdditions/DownloadProgressAdditions.mm>
-#else
+#endif
+
 @implementation WKDownloadProgress {
     RetainPtr<NSURLSessionDownloadTask> m_task;
     WeakPtr<WebKit::Download> m_download;
@@ -86,8 +87,10 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
 - (void)publish
 #endif
 {
-    BOOL consumedExtension = m_sandboxExtension->consume();
-    ASSERT_UNUSED(consumedExtension, consumedExtension);
+    if (m_sandboxExtension) {
+        BOOL consumedExtension = m_sandboxExtension->consume();
+        ASSERT_UNUSED(consumedExtension, consumedExtension);
+    }
 
 #if HAVE(NSPROGRESS_PUBLISHING_SPI)
     [super _publish];
@@ -110,8 +113,10 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
     [super unpublish];
 #endif
 
-    m_sandboxExtension->revoke();
-    m_sandboxExtension = nullptr;
+    if (m_sandboxExtension) {
+        m_sandboxExtension->revoke();
+        m_sandboxExtension = nullptr;
+    }
 }
 
 - (void)_updateProgressExtendedAttributeOnProgressFile
@@ -151,4 +156,3 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
 }
 
 @end
-#endif


### PR DESCRIPTION
#### b15743dca320d15bb4916f24d6b230149e6950d7
<pre>
Add runtime flag for enabling Modern DownloadProgress
<a href="https://bugs.webkit.org/show_bug.cgi?id=277923">https://bugs.webkit.org/show_bug.cgi?id=277923</a>
<a href="https://rdar.apple.com/133618421">rdar://133618421</a>

Reviewed by Chris Dumez.

Add runtime flag for enabling Modern DownloadProgress. This feature can be enabled with
`defaults write -globalDomain EnableModernDownloadProgress&apos;.
`
* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::platformDestroyDownload):
(WebKit::Download::publishProgress):
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.h:
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm:
(-[WKDownloadProgress publish]):
(-[WKDownloadProgress unpublish]):

Canonical link: <a href="https://commits.webkit.org/282237@main">https://commits.webkit.org/282237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f6320de1856cef7a9c4a0ae6f35a8d3d5fbf29a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13121 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13457 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9043 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35682 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6515 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57984 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5435 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9414 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37724 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->