### PR TITLE
[JSC] Clear StringSplitCache only when full GC runs

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2226,10 +2226,10 @@ void Heap::finalize()
     if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full) {
         vm().jsonAtomStringCache.clear();
         vm().numericStrings.clearOnGarbageCollection();
+        vm().stringSplitCache.clear();
         vm().stringReplaceCache.clear();
     }
     vm().keyAtomStringCache.clear();
-    vm().stringSplitCache.clear();
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();
 

--- a/Source/JavaScriptCore/runtime/StringSplitCache.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.h
@@ -53,6 +53,8 @@ public:
     JSImmutableButterfly* get(const String& subject, const String& separator);
     void set(const String& subject, const String& separator, JSImmutableButterfly*);
 
+    DECLARE_VISIT_AGGREGATE;
+
     void clear()
     {
         m_entries.fill(Entry { });

--- a/Source/JavaScriptCore/runtime/StringSplitCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCacheInlines.h
@@ -88,4 +88,13 @@ inline void StringSplitCache::set(const String& subject, const String& separator
     }
 }
 
+template<typename Visitor>
+inline void StringSplitCache::visitAggregateImpl(Visitor& visitor)
+{
+    for (auto& entry : m_entries)
+        visitor.appendUnbarriered(entry.m_butterfly);
+}
+
+DEFINE_VISIT_AGGREGATE(StringSplitCache);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1626,8 +1626,10 @@ void VM::visitAggregateImpl(Visitor& visitor)
     m_builtinExecutables->visitAggregate(visitor);
     m_regExpCache->visitAggregate(visitor);
 
-    if (heap.collectionScope() != CollectionScope::Full)
+    if (heap.collectionScope() != CollectionScope::Full) {
+        stringSplitCache.visitAggregate(visitor);
         stringReplaceCache.visitAggregate(visitor);
+    }
 
     visitor.append(structureStructure);
     visitor.append(structureRareDataStructure);


### PR DESCRIPTION
#### 18ccd86ac22a9c47a749fdd716ef44214818226f
<pre>
[JSC] Clear StringSplitCache only when full GC runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277926">https://bugs.webkit.org/show_bug.cgi?id=277926</a>
<a href="https://rdar.apple.com/133621030">rdar://133621030</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s just keep these entries alive during Eden GC. We mark them in Eden GC and clear them in Full GC.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/StringSplitCache.h:
* Source/JavaScriptCore/runtime/StringSplitCacheInlines.h:
(JSC::StringSplitCache::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::visitAggregateImpl):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18ccd86ac22a9c47a749fdd716ef44214818226f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12618 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49986 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8714 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10991 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11549 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55169 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67781 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61315 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11056 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57364 "Found 1 new test failure: imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57614 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4928 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83078 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37227 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14563 "Found 1466 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->