### PR TITLE
[JSC] Add reverseFind{8,16,32,64}

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -640,6 +640,37 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncLastIndexOf(VM& vm, J
     scope.assertNoExceptionExceptTermination();
     RELEASE_ASSERT(!thisObject->isDetached());
 
+    if constexpr (ViewClass::Adaptor::isInteger) {
+        typename ViewClass::ElementType target = targetOption.value();
+        if constexpr (ViewClass::elementSize == 1) {
+            auto* result = bitwise_cast<typename ViewClass::ElementType*>(WTF::reverseFind8(bitwise_cast<const uint8_t*>(array), target, index + 1));
+            if (result)
+                return JSValue::encode(jsNumber(result - array));
+            return JSValue::encode(jsNumber(-1));
+        }
+
+        if constexpr (ViewClass::elementSize == 2) {
+            auto* result = bitwise_cast<typename ViewClass::ElementType*>(WTF::reverseFind16(bitwise_cast<const uint16_t*>(array), target, index + 1));
+            if (result)
+                return JSValue::encode(jsNumber(result - array));
+            return JSValue::encode(jsNumber(-1));
+        }
+
+        if constexpr (ViewClass::elementSize == 4) {
+            auto* result = bitwise_cast<typename ViewClass::ElementType*>(WTF::reverseFind32(bitwise_cast<const uint32_t*>(array), target, index + 1));
+            if (result)
+                return JSValue::encode(jsNumber(result - array));
+            return JSValue::encode(jsNumber(-1));
+        }
+
+        if constexpr (ViewClass::elementSize == 8) {
+            auto* result = bitwise_cast<typename ViewClass::ElementType*>(WTF::reverseFind64(bitwise_cast<const uint64_t*>(array), target, index + 1));
+            if (result)
+                return JSValue::encode(jsNumber(result - array));
+            return JSValue::encode(jsNumber(-1));
+        }
+    }
+
     // We always have at least one iteration, since we checked that length is different from 0 earlier.
     do {
         if (array[index] == targetOption.value())


### PR DESCRIPTION
#### 4750f55812c7988a4903be307691c5ec060e76c1
<pre>
[JSC] Add reverseFind{8,16,32,64}
<a href="https://bugs.webkit.org/show_bug.cgi?id=277927">https://bugs.webkit.org/show_bug.cgi?id=277927</a>
<a href="https://rdar.apple.com/133622615">rdar://133622615</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastIndexOf):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncLastIndexOf):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::findFirstNonZeroIndex):
(WTF::SIMD::findLastNonZeroIndex):
(WTF::SIMD::reverseFind):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::reverseFindImpl):
(WTF::reverseFind8):
(WTF::reverseFind16):
(WTF::reverseFind32):
(WTF::reverseFind64):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4750f55812c7988a4903be307691c5ec060e76c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19708 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54692 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13110 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16623 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18065 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/61681 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74326 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67811 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62196 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3740 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/89590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43756 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15866 "Found 5 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.default-wasm, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-collect-continuously, wasm.yaml/wasm/stress/tail-call-js-inline.js.wasm-slow-memory, wasm.yaml/wasm/stress/tail-call.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->