### PR TITLE
[WebGPU] RenderBundleEncoder::finish does not handle repeated calls

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277928-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277928-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277928.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277928.html
@@ -1,0 +1,15583 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u9584\ub831\u{1ff20}\u0c8c\u0bde',
+  defaultQueue: {label: '\u01c6\u81ae\u1ca0\u615f\u22b7\u23f2\u86d6\u{1fab8}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxVertexAttributes: 16,
+    maxVertexBuffers: 8,
+    minStorageBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 37509938,
+    maxStorageBufferBindingSize: 151984593,
+  },
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\ud1ae\u610d\ud043\u9321\u32d2\u{1fcec}\u{1fb6c}\ubb7f',
+  entries: [
+    {binding: 76, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 402, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u1335\u0001\ua993\u95c8\u783b\u815e\u5237\ubecf', bindGroupLayouts: []});
+let commandEncoder0 = device0.createCommandEncoder();
+let querySet0 = device0.createQuerySet({label: '\u0a01\u0640\u0f58', type: 'occlusion', count: 979});
+let commandBuffer0 = commandEncoder0.finish({});
+let commandEncoder1 = device0.createCommandEncoder({label: '\uec64\u{1ff1d}\u08b7\u022e\u63f8\u0dd0\u405c\u9119\u0b31'});
+let commandEncoder2 = device0.createCommandEncoder();
+let commandBuffer1 = commandEncoder1.finish({label: '\u1d73\u0890\u0abc\u4d03\u{1f634}\ufb2c\u02d7\u{1f887}\u300b'});
+let texture0 = device0.createTexture({
+  size: {width: 117, height: 16, depthOrArrayLayers: 26},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder0 = commandEncoder2.beginComputePass({label: '\u{1fd43}\u0e03'});
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer0 = device0.createBuffer({
+  label: '\uf292\u4cc8\u{1fc50}\u{1f973}\ua98c\u3b3d\u6ad4\u0d63\u0e86',
+  size: 8527,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let commandBuffer2 = commandEncoder3.finish({label: '\uc027\u6310\u{1fdaa}\u05ab\u042c\u5659\u{1f816}'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u{1fc35}\u{1fd3d}\u{1fcac}',
+  entries: [
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 3, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fdc3}\u055c\u0822\u0524\u{1ffc6}\u056a\uacb3\u8e52\u0a6b\ue8f3'});
+try {
+bindGroupLayout0.label = '\u{1f68a}\u098a';
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u6faf\udfb0\u07ca\u4799\u3e3e'});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u057c\ue225\u667d\u09a8\u06ed'});
+let commandBuffer3 = commandEncoder6.finish();
+let img0 = await imageWithData(6, 21, '#10101010', '#20202020');
+let commandEncoder7 = device0.createCommandEncoder();
+let computePassEncoder1 = commandEncoder5.beginComputePass({label: '\u4f3b\ubb1f\u79f9'});
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let commandBuffer4 = commandEncoder4.finish({label: '\u{1fa4b}\u0c78\u02cc'});
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u510e\u0460\u4d7a\ueb81\ub319'});
+let externalTexture0 = device0.importExternalTexture({label: '\u{1f651}\u41bc\u394d\u006d\u50f8', source: videoFrame0, colorSpace: 'srgb'});
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u{1f830}\u{1fbb7}\u1008\u0216',
+  entries: [
+    {binding: 446, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 334,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandBuffer5 = commandEncoder8.finish({label: '\u47a4\u7bb1\uf0b5\u008c\u78ae\u08db'});
+let texture1 = device0.createTexture({
+  label: '\ud276\u0b36\ue12d\u9ea7\u13a2\u{1fa8a}\u{1f6d8}\u0e11\u{1fd17}',
+  size: [280],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder2 = commandEncoder7.beginComputePass({label: '\ua154\ube24\u943f\u{1ff8c}\u934a\u5119\u85fd\u1f6d\u4eef'});
+let commandEncoder9 = device0.createCommandEncoder();
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder();
+let texture2 = device0.createTexture({
+  size: [90, 1, 655],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder10.beginComputePass({label: '\ud69f\u96a8\u4a48\ud770\u{1f75b}'});
+let commandBuffer6 = commandEncoder9.finish({label: '\u01b9\u042b\u6f36\u35af\u196a\u2e82\u00db\u{1fc3f}'});
+let img1 = await imageWithData(39, 4, '#10101010', '#20202020');
+let device1 = await adapter1.requestDevice({
+  label: '\u2693\u2fb1\u06ab\u072f\u0759\u03d3\u82e6\u{1fe0c}\u1a58\u9fdb\u059d',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 93223188,
+    maxStorageBufferBindingSize: 136799259,
+  },
+});
+let videoFrame1 = new VideoFrame(videoFrame0, {timestamp: 0});
+let commandEncoder11 = device1.createCommandEncoder();
+let renderBundleEncoder0 = device1.createRenderBundleEncoder({
+  label: '1',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+let externalTexture1 = device1.importExternalTexture({label: '\ub7db\u7113', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let commandEncoder12 = device1.createCommandEncoder();
+let commandBuffer7 = commandEncoder11.finish({});
+let renderBundle0 = renderBundleEncoder0.finish();
+let commandEncoder13 = device0.createCommandEncoder({label: '\u0870\u00a6\u5052\u06d8\u0744\u{1fff9}\u3ae9'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({label: '2', colorFormats: ['rg16uint'], stencilReadOnly: true});
+let renderBundle1 = renderBundleEncoder1.finish({label: '\u4385\ub849\u858e\u{1f856}\u0749\u12b1\ub2d4'});
+let commandBuffer8 = commandEncoder13.finish();
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({label: '3', colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+let externalTexture2 = device0.importExternalTexture({
+  label: '\u0145\u7ba5\u83e8\u{1f8dc}\u{1fd85}\ufb54\u6454\ua0a9\u{1f791}',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+let bindGroup0 = device0.createBindGroup({
+  label: '\uf5ba\u0469\u{1fe21}\ue442\ufcb9\ud04e\u59e8\u{1f813}',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 45, resource: {buffer: buffer0, offset: 2560, size: 660}},
+    {binding: 3, resource: externalTexture2},
+  ],
+});
+let externalTexture3 = device0.importExternalTexture({label: '\u{1fad1}\u{1f7de}\u{1fc42}', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup0);
+} catch {}
+let commandBuffer9 = commandEncoder12.finish({});
+let commandEncoder14 = device1.createCommandEncoder({});
+let texture3 = device1.createTexture({
+  label: '\ub410\u{1fc6c}\u65da\u02d7\uee26\u{1ff23}',
+  size: {width: 132, height: 135, depthOrArrayLayers: 19},
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder4 = commandEncoder14.beginComputePass({label: '\u{1f61b}\u0d10\u0c51\uac96\u6a70\u0ce9\uaf76\u7e4b\ua790'});
+let renderBundle2 = renderBundleEncoder0.finish();
+await gc();
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup0);
+} catch {}
+let commandEncoder15 = device1.createCommandEncoder({label: '\udef4\u010c\uae61\u94d2\ud852\u815e\u{1f69b}\u925a\u{1f8ae}\u0e8b\u219a'});
+let promise0 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(img0);
+let commandEncoder16 = device0.createCommandEncoder({});
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder17 = device1.createCommandEncoder({});
+let imageBitmap0 = await createImageBitmap(img1);
+let commandEncoder18 = device1.createCommandEncoder({label: '\u06ad\u026b\u7067\u0702\u01f8\u0285\u2cfe\ueeff\u555a'});
+let commandEncoder19 = device1.createCommandEncoder({label: '\u8b0d\u2148\u02e4\ud957\u0f44\u{1fea1}\u{1fa5d}'});
+let renderBundle3 = renderBundleEncoder0.finish({});
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(324), /* required buffer size: 324 */
+{offset: 324, bytesPerRow: 180, rowsPerImage: 153}, {width: 132, height: 135, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise0;
+} catch {}
+await gc();
+let commandEncoder20 = device1.createCommandEncoder({label: '\u66bc\uc314\u7a31'});
+let querySet1 = device1.createQuerySet({
+  label: '\u{1f979}\u{1ff2b}\u966c\ufd87\u5bf6\u00a2\u854c\uecfc\u{1f6fa}',
+  type: 'occlusion',
+  count: 490,
+});
+let textureView0 = texture3.createView({label: '\ub386\u0508', dimension: '2d', format: 'stencil8', baseMipLevel: 0, arrayLayerCount: 1});
+document.body.prepend(img1);
+let commandEncoder21 = device0.createCommandEncoder({label: '\u{1f607}\u4c7f\u{1fd1d}\u0e19'});
+let renderBundle4 = renderBundleEncoder1.finish({label: '\u040a\u0310'});
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 270, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 247},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let bindGroupLayout3 = device1.createBindGroupLayout({entries: []});
+let pipelineLayout1 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout3]});
+let commandEncoder22 = device1.createCommandEncoder({label: '\u067a\u{1f642}\uc335\u53ab'});
+let sampler0 = device1.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'clamp-to-edge', magFilter: 'nearest', lodMaxClamp: 70.98});
+let bindGroup1 = device1.createBindGroup({label: '\u0d51\u058a\ud84a\u2688\u062a\u0d77\u{1ff17}', layout: bindGroupLayout3, entries: []});
+let commandBuffer10 = commandEncoder19.finish({label: '\u97cb\u0a50\ub45d\u0ba0'});
+let textureView1 = texture3.createView({label: '\u4aab\u0b82\ub7ba\uef97\u5884\u8be7\u974b\u00a6', dimension: '2d', aspect: 'stencil-only'});
+let texture4 = device0.createTexture({
+  label: '\u46bd\u{1f622}',
+  size: {width: 132, height: 10, depthOrArrayLayers: 75},
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(4_294_967_295, undefined, 0, 587_653_088);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let bindGroupLayout4 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 19, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder23 = device1.createCommandEncoder({});
+let commandEncoder24 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({label: '\ue2ad\u0914\u53fd\u0448\u93db\u000e\u73e1\uf028', type: 'occlusion', count: 51});
+let commandBuffer11 = commandEncoder24.finish();
+let commandEncoder25 = device0.createCommandEncoder();
+let computePassEncoder5 = commandEncoder16.beginComputePass({label: '\ua3b0\u88f0\uc210\u62d2\ue7fe\uc067\u{1ff74}'});
+let renderBundle5 = renderBundleEncoder2.finish();
+let promise1 = device0.queue.onSubmittedWorkDone();
+let commandEncoder26 = device1.createCommandEncoder({label: '\u{1fed7}\u77d1\u{1fb1b}\u4ec3\ua5d0'});
+let textureView2 = texture3.createView({
+  label: '\u06b0\uaeba\u{1f6a2}\u{1f73d}\u800c\ub58c\u{1f803}\u0ddf\u{1fdb6}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseArrayLayer: 12,
+  arrayLayerCount: 1,
+});
+let sampler1 = device1.createSampler({
+  label: '\ud787\u{1fd64}\u2f50\u291a\ua04b',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.50,
+  lodMaxClamp: 52.45,
+  compare: 'less-equal',
+  maxAnisotropy: 10,
+});
+let pipelineLayout2 = device1.createPipelineLayout({label: '\u44d2\u06eb', bindGroupLayouts: []});
+let renderBundleEncoder3 = device1.createRenderBundleEncoder({label: '4', colorFormats: ['r8unorm'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let renderBundle6 = renderBundleEncoder3.finish({label: '\ub2c4\u01c9\u{1fe7f}\u{1f606}\udeb3\u34dd'});
+try {
+commandEncoder26.insertDebugMarker('\u0f2e');
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder();
+try {
+commandEncoder22.pushDebugGroup('\u{1ffc7}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 19, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(275_405), /* required buffer size: 275_405 */
+{offset: 521, bytesPerRow: 432, rowsPerImage: 159}, {width: 132, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let imageData0 = new ImageData(32, 88);
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 75},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u{1f770}\u{1f6c3}',
+  entries: [
+    {
+      binding: 92,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder28 = device0.createCommandEncoder({label: '\u062c\ua4e9\u6235\u5118\ue012\u{1f73f}\udfd9\u67e0\u0696'});
+let commandBuffer12 = commandEncoder21.finish({});
+let texture5 = device0.createTexture({
+  label: '\u025c\u0a26\u{1f646}\u96ac\u{1fb4b}\u0e86\ue1f1\u{1fe0e}\u334f\u75c4',
+  size: [960, 1, 1],
+  mipLevelCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder6 = commandEncoder28.beginComputePass({label: '\ud5d0\u4f6f\u{1f72d}\u0350\u3e72\u{1ff22}\uc180\u153d'});
+let commandEncoder29 = device0.createCommandEncoder({});
+let renderBundle7 = renderBundleEncoder2.finish({label: '\ub7f4\uc14b'});
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+document.body.prepend(img0);
+let imageBitmap1 = await createImageBitmap(videoFrame0);
+let querySet3 = device1.createQuerySet({
+  label: '\u6a4d\ub2a7\uabf5\ufed0\u4ddf\u{1fe3b}\ufb0b\u99ed\ubef0\ufcae',
+  type: 'occlusion',
+  count: 466,
+});
+let computePassEncoder7 = commandEncoder15.beginComputePass({label: '\u340a\uc153\uccc9\u79ee\u36db\ud40f\u6def\uecce\u255b'});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u03aa\u01d2'});
+let canvas0 = document.createElement('canvas');
+let computePassEncoder8 = commandEncoder25.beginComputePass();
+let renderBundle8 = renderBundleEncoder2.finish();
+try {
+computePassEncoder7.setBindGroup(0, bindGroup1, new Uint32Array(4165), 1077, 0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u03d3\uf967\u{1fda3}\u549a\u6674\ub592',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let computePassEncoder9 = commandEncoder30.beginComputePass({label: '\u6c8e\u{1fe74}\u{1fb05}\u0d75'});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise1;
+} catch {}
+document.body.prepend(img1);
+try {
+externalTexture1.label = '\u0a4c\u{1faeb}\u0c30\u004a\u{1f7ea}\u086d\u{1fe8e}';
+} catch {}
+let externalTexture4 = device1.importExternalTexture({
+  label: '\u8b19\u04b1\u179e\u0679\u059c\ubb8f\u004f\ub04e\u01c6',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+let commandEncoder32 = device0.createCommandEncoder();
+let commandBuffer13 = commandEncoder32.finish();
+let texture6 = device0.createTexture({
+  size: {width: 960},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle9 = renderBundleEncoder2.finish({label: '\u{1f8f3}\u0283\u0ec8\u0e8c'});
+let sampler2 = device0.createSampler({
+  label: '\u6055\u{1fc65}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.37,
+  lodMaxClamp: 93.60,
+});
+let buffer1 = device0.createBuffer({
+  label: '\u5ac4\u5be9\u8215\u0bb7\u{1f6da}',
+  size: 20062,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+try {
+commandEncoder31.clearBuffer(buffer1, 128, 500);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let bindGroup2 = device1.createBindGroup({label: '\u{1fbc7}\u59f7\u4085', layout: bindGroupLayout3, entries: []});
+let textureView3 = texture3.createView({aspect: 'stencil-only', baseArrayLayer: 6, arrayLayerCount: 1});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup2, new Uint32Array(4117), 669, 0);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView4 = texture3.createView({
+  label: '\u0724\u018d\u{1fc9f}\u{1fd39}\u96e4\ud641\u1a49',
+  aspect: 'all',
+  baseArrayLayer: 7,
+  arrayLayerCount: 2,
+});
+let commandBuffer14 = commandEncoder29.finish({label: '\u5393\u0326'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(2256), 566, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let externalTexture5 = device1.importExternalTexture({label: '\u{1fc89}\uf021\u9cb9\u5b0e\ud3c1\u0ad5', source: videoFrame1, colorSpace: 'srgb'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView5 = texture4.createView({dimension: '2d', baseArrayLayer: 1});
+let renderBundle10 = renderBundleEncoder2.finish({label: '\u056a\ue952\u{1fba9}\u0064\u{1ff84}\u0af6'});
+try {
+device0.queue.submit([commandBuffer12, commandBuffer4]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let imageData1 = new ImageData(128, 4);
+let pipelineLayout4 = device1.createPipelineLayout({
+  label: '\uc32d\ued81\u3fcf\u4385\u{1fd85}\u{1fc98}\u85cf\u2dc3',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout4, bindGroupLayout4],
+});
+let bindGroup3 = device1.createBindGroup({
+  label: '\ud9b4\u0c72\u019c\u{1fe3c}\u{1f7ec}\u96b0\u0275\u0d89\u{1fed4}\u{1fc61}',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let renderBundle11 = renderBundleEncoder3.finish({label: '\u93c7\u01e9\ufba0'});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let commandBuffer15 = commandEncoder31.finish({label: '\ua45f\u0099\ued3e\u{1fe9d}'});
+try {
+  await promise2;
+} catch {}
+let texture7 = device1.createTexture({
+  label: '\ufca5\u{1ff06}\u08bc\u{1ff9d}\u3ebb\u001b\u{1f9d7}\u02cc\u{1faa4}',
+  size: [33],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise3 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(img1);
+let bindGroup4 = device1.createBindGroup({
+  label: '\u0acc\u0378\u{1ff52}\u{1f79c}\u5061\u0a85\ue52f\u{1f74f}',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let querySet4 = device1.createQuerySet({type: 'occlusion', count: 232});
+let commandBuffer16 = commandEncoder23.finish({label: '\u{1fd05}\u{1febc}\u8d54\u0818\u1cfd\u{1fd15}\u{1fef5}\u95c2\u6a37'});
+let texture8 = device1.createTexture({
+  label: '\u0824\u{1fb1c}\uf0c2\u{1fd81}\u{1f895}\u74f5\u25d3\u{1faca}\u{1fc32}\u650c',
+  size: [33, 33, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle12 = renderBundleEncoder3.finish({label: '\u430a\u0dfc\u85e4\u{1f8d4}\u07e8\u{1fc8d}\u3d52'});
+let sampler3 = device1.createSampler({
+  label: '\u9b7c\u5538',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 90.04,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup4, new Uint32Array(3376), 278, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device1, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(21_958), /* required buffer size: 21_958 */
+{offset: 252, bytesPerRow: 161, rowsPerImage: 142}, {width: 132, height: 135, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder33 = device1.createCommandEncoder({label: '\u37d3\u{1f6f1}\u0e6c\u128b\u65ec\u02f4\u{1ffa6}\u035f\ud1e1\ua0f3'});
+let renderBundle13 = renderBundleEncoder3.finish();
+let imageData2 = new ImageData(12, 12);
+let commandEncoder34 = device1.createCommandEncoder({label: '\u54e5\u00f7\u{1f6fb}\u39bb'});
+let commandBuffer17 = commandEncoder33.finish({label: '\u646d\u0265\u08b2\u4899\u2f05\ud1d5'});
+let texture9 = device1.createTexture({
+  label: '\u4d13\u9b25\u{1f8fd}\u{1f71d}\u0b0e\u033f',
+  size: {width: 66, height: 67, depthOrArrayLayers: 58},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView6 = texture3.createView({dimension: '2d', aspect: 'stencil-only'});
+let computePassEncoder10 = commandEncoder27.beginComputePass();
+let commandEncoder35 = device1.createCommandEncoder({label: '\u{1fa05}\u{1f8d4}\ua261\u1971\u{1fc4e}\u{1fc39}\u{1f810}\uf461\u7aff\u7f16'});
+let textureView7 = texture7.createView({label: '\u2d9f\ucbbc\u0cf5\ubf32\u2d7b\u06eb'});
+let computePassEncoder11 = commandEncoder15.beginComputePass({label: '\u0e4e\u6027\u17b2\uf0f5\u{1f65f}\u{1f6bc}\u7419\ud919'});
+let renderBundle14 = renderBundleEncoder0.finish();
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+try {
+  await promise3;
+} catch {}
+let videoFrame2 = new VideoFrame(canvas0, {timestamp: 0});
+let commandEncoder37 = device1.createCommandEncoder({});
+let texture10 = device1.createTexture({
+  label: '\u{1fa00}\u126d\u44de\u6e57\u0984\u{1f6ec}\u4353\u045a\u{1f64f}\u0d21\ufc4e',
+  size: [33, 33, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let video0 = await videoWithData();
+let commandEncoder38 = device1.createCommandEncoder({label: '\u21bc\u0c97\ub1bf\u99ce'});
+let computePassEncoder12 = commandEncoder20.beginComputePass({label: '\u2c7f\u{1fcbd}\u03d1\u0cbe\ub7ba\u51b4\u3163\u5077\uc81d'});
+let bindGroup5 = device1.createBindGroup({layout: bindGroupLayout3, entries: []});
+let commandBuffer18 = commandEncoder38.finish({});
+let shaderModule0 = device0.createShaderModule({
+  label: '\u5911\ud82c\u2259\u2a2b',
+  code: `
+@group(0) @binding(402) var sam0: sampler;
+@group(1) @binding(76) var et1: texture_external;
+@group(1) @binding(402) var sam1: sampler;
+@group(0) @binding(76) var et0: texture_external;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0() {
+}
+
+struct S0 {
+  @location(2) f0: vec2h
+}
+struct VertexOutput0 {
+  @location(1) f0: vec3h,
+  @location(10) f1: vec2i,
+  @location(14) f2: vec2u,
+  @location(8) f3: vec4i,
+  @location(12) f4: vec3h,
+  @location(6) f5: vec2f,
+  @builtin(position) f6: vec4f
+}
+
+@vertex
+fn vertex0(a0: S0, @location(13) a1: vec4h, @location(14) a2: vec4u, @location(10) a3: vec3h, @location(1) a4: vec4u, @location(6) a5: vec4i, @location(4) a6: vec2u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f3 = vec4i(411, 101, 28, 262);
+  out.f4 = vec3h(-54507.8);
+  return out;
+}
+
+@fragment
+fn fragment0(@location(6) a0: vec2f, @builtin(position) a1: vec4f, @location(1) a2: vec3h) -> @location(200) vec4u {
+  var out: vec4u;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder39 = device0.createCommandEncoder({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(1180), 380, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13, commandBuffer14]);
+} catch {}
+let buffer2 = device1.createBuffer({
+  label: '\u50df\u2ada',
+  size: 15733,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let renderBundle15 = renderBundleEncoder0.finish({});
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 33, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise4;
+} catch {}
+try {
+computePassEncoder12.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+document.body.prepend(video0);
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(video0);
+let imageData3 = new ImageData(64, 8);
+let commandBuffer19 = commandEncoder36.finish({label: '\u01b9\u07d1\u115d\u1bd5\u0cb5\u0d86\u6ffc\u{1f996}\u0f53\u{1ff88}\ufe0e'});
+try {
+computePassEncoder5.insertDebugMarker('\u04e7');
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u{1ff3f}\u{1f67c}\uee90\u5f52\u52eb\u8de4\uba12\u51c0\u3e16\u3ce3'});
+let renderBundle16 = renderBundleEncoder1.finish({label: '\u08fa\u{1f856}\uc751\ud526\u0276\ufd6e'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0);
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+  label: '\u{1f96a}\u094f\u{1fd8a}\u{1ff34}\u0b64\u31d7\ua5f8\u0fab\u6696\uf142',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, constants: {}},
+});
+let bindGroupLayout6 = device1.createBindGroupLayout({
+  label: '\u{1fdd3}\u05b8\u0e86\u0e5a\u5685\ub78b',
+  entries: [
+    {
+      binding: 210,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let pipelineLayout5 = device1.createPipelineLayout({
+  label: '\u8e47\u{1fdf7}\u7c03\u{1febb}\ud2b7\u{1ffff}\u{1fd19}\u0780\u1fb7',
+  bindGroupLayouts: [bindGroupLayout3],
+});
+let commandBuffer20 = commandEncoder15.finish({label: '\u9734\ue6b2\u0f38\u{1fc06}\u04b4'});
+let textureView8 = texture7.createView({label: '\ua21f\u0774\ue554\u28e5\ua3e0\u03c3\u0da8\ud64a'});
+let renderBundle17 = renderBundleEncoder3.finish({label: '\u{1ff42}\u{1fa32}\udc7f\u87a1\uc775\u388f\u845a\u019b'});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+device1.queue.submit([commandBuffer9]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder41 = device1.createCommandEncoder({label: '\u7bfd\u{1fc1c}\u39be\u09b0\ud3b6\u{1ff12}\u{1fb55}\u{1f944}'});
+let commandBuffer21 = commandEncoder26.finish();
+let renderBundle18 = renderBundleEncoder3.finish({});
+let commandEncoder42 = device0.createCommandEncoder();
+let commandEncoder43 = device0.createCommandEncoder({label: '\u765a\uef7c\ucf53\ub3f6\u4e37\u{1fef2}\ub1d5\ubc1d\u1cc9\u8bc4'});
+let commandBuffer22 = commandEncoder42.finish();
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({label: '5', colorFormats: ['rg16uint'], depthReadOnly: true});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 404, 1_478);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer1, 328, buffer0, 124, 2028);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder44 = device1.createCommandEncoder({label: '\ub5ad\u{1fbb7}\u{1fd62}\u2f92\u{1fe60}\u{1f7e1}\u{1fbae}\u{1f834}\u8648\u0f13'});
+let computePassEncoder13 = commandEncoder22.beginComputePass();
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let buffer3 = device0.createBuffer({label: '\u0163\u429c\uffd4', size: 13845, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture11 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder40.clearBuffer(buffer0, 1124, 516);
+} catch {}
+let bindGroupLayout7 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let querySet5 = device1.createQuerySet({label: '\u{1fc92}\u130e\ue583', type: 'occlusion', count: 186});
+let commandBuffer23 = commandEncoder17.finish();
+let texture12 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder14 = commandEncoder43.beginComputePass({label: '\u1fb9\u0314\u0480\u0962\u{1f60d}'});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 400, 7_207);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer0);
+} catch {}
+let imageData4 = new ImageData(44, 52);
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint16', 158, 589);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+  label: '\ub905\u2fff\u{1f838}\uefcd\u0395\u09cf\u7faf\u7157\ub316\u9e27',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout8 = device0.createBindGroupLayout({label: '\u6c02\u0247\u8d88\u1789\u148a\uf465\u59e5\u{1ffa0}\u0ca7', entries: []});
+let commandEncoder45 = device0.createCommandEncoder({label: '\u0312\u0b44\u7d29\u4abb\u0d96\u5951\u0d81\u9a2f\ub800\u{1f9e0}'});
+let computePassEncoder15 = commandEncoder45.beginComputePass({label: '\u0f04\u067e'});
+let renderBundle19 = renderBundleEncoder1.finish({label: '\u51bb\u5996\ub10e\u6a9a\uc156\u0762\u27db\u7f26'});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 18, 3_808);
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({label: '\ued11\u041b\u{1f745}\u014e'});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 340, new Int16Array(11791), 772, 320);
+} catch {}
+let img2 = await imageWithData(3, 94, '#10101010', '#20202020');
+let commandEncoder47 = device1.createCommandEncoder({label: '\u00fb\u923c\u{1fbbd}\u{1fa3e}\u1175\u9ff5\u0398'});
+let renderBundle20 = renderBundleEncoder3.finish({label: '\u7ace\u4f26'});
+let externalTexture6 = device1.importExternalTexture({label: '\u0b5a\u006d\u{1fed8}\u942f\u028c\ua92d\u787b\ue090', source: video0, colorSpace: 'srgb'});
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.submit([commandBuffer17, commandBuffer20]);
+} catch {}
+await gc();
+let offscreenCanvas0 = new OffscreenCanvas(611, 213);
+let textureView9 = texture1.createView({label: '\u6271\u{1f782}\uf307\u9ca6\u7777'});
+let renderBundle21 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 128, 3_987);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer1, 15632, buffer3, 2548, 56);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 86, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView10 = texture5.createView({
+  label: '\u28ea\u{1f7ba}\u0dd9\u53f3\ud3f4\ud812\u034a\ue188\u0125\u0d10\u0774',
+  dimension: '2d-array',
+});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let commandEncoder48 = device0.createCommandEncoder({label: '\u020d\u537f\u{1f789}\u4f09'});
+let commandBuffer24 = commandEncoder40.finish({label: '\u14de\u0228\u0063\u{1f7ae}\u{1f75c}\ub058\u{1f98f}\u08f0\u{1f962}\ud811'});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 456, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet5, 57, 10, buffer2, 4864);
+} catch {}
+let commandBuffer25 = commandEncoder37.finish({label: '\u0636\u30db\u{1fa4b}\u2a8f\u5e29\ucd44\u2f48'});
+video0.width = 31;
+let renderBundle22 = renderBundleEncoder3.finish();
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+device1.queue.submit([commandBuffer21]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder49 = device1.createCommandEncoder({label: '\u0455\u0c1e\u3828\u8352\uc732\u11c9\u0583\u{1fd91}\ua825\u456f\u0ca9'});
+let commandBuffer26 = commandEncoder41.finish({label: '\ud8c5\u080d\u1a0a'});
+let computePassEncoder16 = commandEncoder47.beginComputePass();
+let renderBundleEncoder5 = device1.createRenderBundleEncoder({
+  label: '6',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+});
+let renderBundle23 = renderBundleEncoder3.finish({label: '\u{1f7df}\u{1fd39}'});
+let externalTexture7 = device1.importExternalTexture({label: '\u0fab\u7b6c\u3fd5\ud644\ud6bf', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer2, 'uint32', 4_968, 868);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer2, 156, 2_401);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandBuffer27 = commandEncoder48.finish({label: '\u0e2e\ufd15'});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 236, 8_011);
+} catch {}
+video0.width = 16;
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(2525), 439, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 220, 255);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer1, 1660, buffer0, 192, 708);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 206, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 98, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer1, 1112, 2236);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video0);
+let shaderModule1 = device0.createShaderModule({
+  code: `
+@group(1) @binding(76) var et3: texture_external;
+@group(0) @binding(402) var sam2: sampler;
+@group(1) @binding(402) var sam3: sampler;
+@group(0) @binding(76) var et2: texture_external;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(workgroup_id) a0: vec3u, @builtin(num_workgroups) a1: vec3u) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f7: vec4f
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(4) a1: vec2i, @builtin(vertex_index) a2: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2u,
+  @location(5) f1: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 = vec2u(88, 50);
+  out.f1 = vec4i(381, 52, 1, 425);
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandEncoder50 = device0.createCommandEncoder({label: '\u{1f640}\u{1f8f8}\u0348\ue0f9\u0ad3\u9d25\ua109\u44c9\u005f\u{1f792}\u7dd9'});
+let commandBuffer28 = commandEncoder46.finish({label: '\u6d5d\u4b36\u02d5\u0e53\u06d7\u0eae\ucf82\u0fdd\ubc2d\u004b\u0d4c'});
+let textureView11 = texture2.createView({label: '\u3cec\u{1fb0c}\u{1fa9d}', baseMipLevel: 1});
+let renderPassEncoder0 = commandEncoder50.beginRenderPass({
+  label: '\u{1f855}\u{1f6de}\u999f\uc453\u0f8c\u{1fb06}',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 143,
+  clearValue: { r: 201.8, g: 789.6, b: -902.2, a: 792.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint32', 2_412, 84);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, undefined, 106_039_961, 728_013_095);
+} catch {}
+let computePassEncoder17 = commandEncoder18.beginComputePass({});
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer2, 1_672);
+} catch {}
+try {
+commandEncoder14.insertDebugMarker('\u0d6c');
+} catch {}
+let commandBuffer29 = commandEncoder39.finish({label: '\ub725\u{1fc34}\u{1f825}\udb8f\u5366\u1c7d\u0985\u{1fadd}\u0d6f'});
+let renderPassEncoder1 = commandEncoder43.beginRenderPass({
+  label: '\u0224\u{1fed5}',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 11,
+  clearValue: { r: -438.5, g: -672.3, b: 963.6, a: -301.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+try {
+window.someLabel = commandBuffer16.label;
+} catch {}
+let commandEncoder51 = device1.createCommandEncoder({label: '\u010e\u7c37\uf2f6\ua8ff'});
+let computePassEncoder18 = commandEncoder49.beginComputePass({label: '\u{1f8a5}\uf07f\u0f97\u{1fccb}'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(659), 104, 0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer2, 'uint16', 338, 4_988);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 18, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(21_865), /* required buffer size: 21_865 */
+{offset: 41, bytesPerRow: 187, rowsPerImage: 29}, {width: 132, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+computePassEncoder6.setBindGroup(3, bindGroup0, new Uint32Array(1002), 80, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+let commandEncoder52 = device1.createCommandEncoder({label: '\u36fc\u7374\u02c0\u012f\u04ab\u082f\u{1fb68}\u8754\uee92\u90df'});
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer2, 0);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 204, 2_482);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup4);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder();
+let renderPassEncoder2 = commandEncoder53.beginRenderPass({
+  label: '\ufae1\ue849\u0d40\u622e\u0594\ubd44\u{1f7fd}',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 221,
+  clearValue: { r: -719.4, g: -635.0, b: 643.2, a: -673.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 470564175,
+});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+document.body.prepend(img0);
+let imageData5 = new ImageData(4, 12);
+let bindGroupLayout9 = device1.createBindGroupLayout({
+  label: '\ud26f\u6ff5\u080a\ub073\u8eda\u{1f99b}\u{1fccf}\u8866\u{1fb23}\u19d1\u8da3',
+  entries: [
+    {
+      binding: 339,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandBuffer30 = commandEncoder14.finish({label: '\ue160\u0374\u4ab5\u00f6\u0da8\u{1f736}\u5efa\u0259\u{1f838}\u9661\u{1fd5b}'});
+try {
+renderBundleEncoder5.setVertexBuffer(7, undefined, 158_437_160, 263_175_016);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas0.height = 130;
+let commandEncoder54 = device0.createCommandEncoder({label: '\u4354\u04c6\u{1fa52}\u0b8f\u5235'});
+let computePassEncoder19 = commandEncoder54.beginComputePass({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '7',
+  colorFormats: ['rg16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 120, 116);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer1, 'uint32', 1_416, 3_116);
+} catch {}
+try {
+device0.queue.submit([commandBuffer22]);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(1019), 29, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 7_188, 260);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView12 = texture6.createView({label: '\u6e35\u{1f6a0}\u4ed8', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundle24 = renderBundleEncoder2.finish();
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 589.3, g: 110.8, b: 900.0, a: 426.2, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4444, new BigUint64Array(9132), 69, 88);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer2, 'uint16', 2_018, 3_010);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({label: '\u9cf0\u8a99\u97bd\u0ec2\u04ef\u0c93\u{1fe48}\uedf3\ubb29'});
+let commandBuffer31 = commandEncoder55.finish({label: '\u{1f796}\u{1f937}\uad98'});
+try {
+renderPassEncoder2.setViewport(4.309795469404788, 0.9779095234095437, 22.22492368906899, 0.015205217627872266, 0.047712207630716486, 0.5271331135678665);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer0, 208);
+} catch {}
+await gc();
+let commandBuffer32 = commandEncoder44.finish({label: '\u453a\ud201\u32e6'});
+let computePassEncoder20 = commandEncoder35.beginComputePass({label: '\u031c\u6a41\u847e\u0777\u073a'});
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup4, new Uint32Array(496), 1, 0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer2, 'uint32', 8_116, 1_527);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 28, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(41_563), /* required buffer size: 41_563 */
+{offset: 15, bytesPerRow: 167, rowsPerImage: 31}, {width: 132, height: 1, depthOrArrayLayers: 9});
+} catch {}
+let renderBundle25 = renderBundleEncoder2.finish({label: '\uac4c\u0b72\ue06e\u04a0\u0051\u67cc\u02d1\u753e'});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(35.08221722386569, 0.10914894965382405, 7.2609073077089565, 0.21248904115190062, 0.4060986343266316, 0.8109043428955066);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer0, 0, 2_789);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup0, new Uint32Array(615), 422, 0);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\u1e1e');
+} catch {}
+try {
+adapter0.label = '\ufccb\u0cbc\u{1ffa1}\u62d9\ud537\u53cf\uae36\u{1f63b}';
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\u2c25\uf845\u{1fa82}\u{1fadf}\u9bdd\u2795\u0522\u04ec',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 45, resource: {buffer: buffer0, offset: 512, size: 476}},
+    {binding: 3, resource: externalTexture2},
+  ],
+});
+let textureView13 = texture6.createView({label: '\u{1f823}\u2fe9\u0af8\u{1fd40}'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(206), 52, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer1, 'uint16', 1_302, 5_866);
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({
+  label: '\u0df4\u0fac\u8f4a\u896f\udccd\u0d9e\u{1ffd5}\ubb07\u{1fd18}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, constants: {}},
+});
+let video1 = await videoWithData();
+let buffer4 = device0.createBuffer({size: 22961, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder56 = device0.createCommandEncoder({label: '\u{1fa81}\u{1fbc8}'});
+let computePassEncoder21 = commandEncoder56.beginComputePass({label: '\u{1f61f}\u0f42'});
+let renderBundle26 = renderBundleEncoder6.finish();
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 2_436, 234);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder();
+let renderBundle27 = renderBundleEncoder6.finish({label: '\u{1fe30}\udf89\u00e6\u{1f855}\u79cd\u264d\ucf2b\u646b\ua96b\u{1f9a0}\ua34c'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint32', 460, 2_643);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 309, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 94},
+  aspect: 'all',
+},
+{width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u{1f988}');
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder();
+let querySet6 = device0.createQuerySet({label: '\u662f\uf990\u51d2\u70ce\u0044\u2e2e', type: 'occlusion', count: 2752});
+let renderBundle28 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder0.setViewport(43.23672736242282, 0.32218252112745904, 0.4082074506226921, 0.07969469900974206, 0.6500187024274474, 0.7419372484572868);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint16', 1_734, 1_361);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer19, commandBuffer29]);
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder();
+let computePassEncoder22 = commandEncoder7.beginComputePass({label: '\u9857\u34ef\u25e6\ua4c7\u7397\u{1f9df}\u09af\u{1fdc9}\ue586'});
+try {
+renderPassEncoder2.executeBundles([renderBundle28, renderBundle26]);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer4, 12_848, 339);
+} catch {}
+let commandBuffer33 = commandEncoder59.finish();
+let renderBundle29 = renderBundleEncoder2.finish({label: '\ub7a2\u436a\u0a97\u2293\ue28e\u084a\ue9f1\u016e\uc687'});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\u915d\u0fb3\u847d\u{1f91c}\u080d\u95a6\u4b92\u0a43\udfda',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer4, 824, 18_347);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer1, 1024, buffer0, 724, 4704);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u1f93\u0531\u60d5',
+  entries: [
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 267});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer0, 1_608, 2_574);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup6, new Uint32Array(965), 138, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 7_080, 886);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer0, 0, 1_452);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandBuffer34 = commandEncoder57.finish({label: '\u03cb\u{1f707}\u0760\u{1fa4a}\ucfa9\u{1f9af}\u{1fe60}\u0adc\u0349\ud992\u{1f6ed}'});
+let textureView14 = texture1.createView({label: '\udf36\ud1c6\u8094\ud1af\ud29d\u8e55', mipLevelCount: 1});
+let renderPassEncoder3 = commandEncoder58.beginRenderPass({
+  label: '\uceb9\u896c\ue99a\u66ae\ue6e2\u9619\ufe1c\u0d8c\u{1fa76}',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 22,
+  clearValue: { r: -363.2, g: 124.6, b: 34.18, a: 840.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 752, 1_057);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 0, 10112);
+} catch {}
+document.body.prepend(img2);
+let bindGroup7 = device0.createBindGroup({
+  label: '\u3d72\ub180',
+  layout: bindGroupLayout5,
+  entries: [{binding: 92, resource: {buffer: buffer1, offset: 4608, size: 2254}}],
+});
+let texture13 = device0.createTexture({
+  size: [470, 66, 1],
+  mipLevelCount: 5,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView15 = texture5.createView({dimension: '2d-array'});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer0, 0, 102);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 1_196, 10_965);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer0, 0, 249);
+} catch {}
+let bindGroupLayout11 = device1.createBindGroupLayout({
+  label: '\u{1f644}\u0d7c\u101b\u0083\uf7ec\u09d7\u3648',
+  entries: [
+    {
+      binding: 196,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 118,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 4979852, hasDynamicOffset: true },
+    },
+    {
+      binding: 295,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 91,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 5506867, hasDynamicOffset: true },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 46,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 573,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 159,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 290, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 9580877, hasDynamicOffset: false },
+    },
+    {binding: 175, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 149,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 158,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {binding: 11, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 283,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {binding: 64, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {binding: 25, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 345,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 36744113, hasDynamicOffset: false },
+    },
+    {
+      binding: 187,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 11677263, hasDynamicOffset: false },
+    },
+    {binding: 190, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 81, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 261,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 220,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandBuffer35 = commandEncoder52.finish({label: '\uaef7\ua96f\uffa5\u{1f9a8}'});
+let computePassEncoder23 = commandEncoder51.beginComputePass({label: '\uff4e\uea60\u8a91'});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer2, 'uint16', 7_786, 1_553);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder60 = device1.createCommandEncoder();
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(4, undefined, 299_902_990);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 132 widthInBlocks: 132 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 11968 */
+  offset: 2108,
+  bytesPerRow: 256,
+  rowsPerImage: 38,
+  buffer: buffer2,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 1},
+  aspect: 'stencil-only',
+}, {width: 132, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint16', 1_836, 2_659);
+} catch {}
+let commandEncoder61 = device1.createCommandEncoder({});
+let commandBuffer36 = commandEncoder18.finish({});
+let texture14 = device1.createTexture({
+  label: '\u{1febf}\u{1f93b}\ufc75',
+  size: [16, 16, 9],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView16 = texture14.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup2);
+} catch {}
+let renderBundle30 = renderBundleEncoder5.finish({label: '\u{1fe09}\u5b9f\u96d6\ufb15\u4330\u{1ff5c}'});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup1, new Uint32Array(9491), 678, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device1, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+document.body.prepend(video1);
+let commandEncoder62 = device0.createCommandEncoder();
+let renderBundle31 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -947.2, g: 60.49, b: -374.2, a: 143.8, });
+} catch {}
+let commandBuffer37 = commandEncoder60.finish({});
+try {
+commandEncoder22.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(185), /* required buffer size: 185 */
+{offset: 53}, {width: 132, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter1.label = '\u0af1\u6299\u740a\u69dd\uc28c\u{1ffe4}';
+} catch {}
+let textureView17 = texture1.createView({label: '\u0aa7\u{1f6af}\ufb9c\u94c8\u{1fa36}\u5a98\u{1fc2e}\u{1fc44}\uc754', baseArrayLayer: 0});
+let renderPassEncoder4 = commandEncoder62.beginRenderPass({
+  label: '\u0987\u497e\u44d7\u09c7\u{1f943}\u{1fa54}\u4e50\u0e1f\ud358\u6dd2',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 75,
+  clearValue: { r: -384.7, g: -493.1, b: -362.3, a: -550.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 148403844,
+});
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer4, 8828, buffer3, 3740, 2824);
+} catch {}
+let commandBuffer38 = commandEncoder16.finish({label: '\ud08e\u89de\u03fa\u91c4\u{1fd10}\u0636\u02ba\u000f\u09c8\u0e0c\ue83b'});
+let texture15 = device0.createTexture({
+  label: '\u0b4c\ue71a\u0d3d\u{1ff88}',
+  size: [90],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView18 = texture15.createView({label: '\ud241\u098b\u8329\ue713\u{1fe87}\u3d10\u0bbd\u5dc8'});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+adapter1.label = '\u41dd\ued61\u9c88\u0bd7\u{1fc0a}\u4723\ua112\u0b9d\u0ff6';
+} catch {}
+try {
+textureView6.label = '\u{1f690}\ua640\ua604\ue8d2';
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\u4d28\ud34f\u1c93\u6261\u4181\udd89\u0e6d\ua759\ud93d',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout2],
+});
+let texture16 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(4, 0, 3, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup7, new Uint32Array(1387), 801, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+try {
+window.someLabel = device1.label;
+} catch {}
+let buffer5 = device1.createBuffer({
+  label: '\u8d32\u{1ff50}\uaf76\u0cee\u{1fae4}\u7981\u{1ff7c}',
+  size: 2074,
+  usage: GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder63 = device1.createCommandEncoder({label: '\ue9fa\u82fc\uf314\u{1f6cf}\u348f\u{1fda1}\u0aaa\u24d9\uf035\udafb\u45e9'});
+let computePassEncoder24 = commandEncoder20.beginComputePass({label: '\u03ed\ub835\u8181\u{1fef9}'});
+let renderBundle32 = renderBundleEncoder3.finish();
+let commandEncoder64 = device1.createCommandEncoder({label: '\u{1f9b8}\udfe2\u{1f9e8}\udc8c\ua2b8\ue961\ufe55\u0ddf\u7706'});
+let commandBuffer39 = commandEncoder34.finish({label: '\ue958\u{1f6c3}\u9e38\uc9f9\u28f6'});
+let computePassEncoder25 = commandEncoder61.beginComputePass({});
+let renderBundle33 = renderBundleEncoder3.finish({});
+let sampler4 = device1.createSampler({
+  label: '\u150d\u0d18\ua3cb\u0fc3\udfa9\u0901\ude7c\u{1fb74}\u3916\ueb51',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.82,
+  maxAnisotropy: 8,
+});
+document.body.prepend(video1);
+let commandBuffer40 = commandEncoder63.finish({label: '\u2636\u0c4a\uadde\u{1f635}\u0e85\u{1fe16}'});
+let computePassEncoder26 = commandEncoder22.beginComputePass({label: '\u0b99\u8db7\u0456\u541a\u0170\u2606\u995c\u0ad3\u{1f93e}\u6823'});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 33, height: 33, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle34 = renderBundleEncoder6.finish({label: '\u16d2\u196c\ub666\ud26a\u51b9\u2280\u{1f7d1}\u0bfe\u029c\u927b'});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(13, 0, 6, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 3_448, 2_685);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 2_140, 6_934);
+} catch {}
+try {
+device0.queue.submit([commandBuffer31]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video0.height = 16;
+let commandBuffer41 = commandEncoder64.finish({label: '\u{1ffd8}\u50da\u{1ffad}\ud67d\ude14\u{1fc2d}\u{1f7bc}\u{1fe26}\u{1f7d2}'});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup2);
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({label: '\u0608\u06f4\u5c12\u8da1\u{1fff4}'});
+let commandBuffer42 = commandEncoder65.finish({});
+let texture17 = device0.createTexture({
+  label: '\u5b40\u9c30\u0c34\uc677\u155d',
+  size: {width: 117, height: 16, depthOrArrayLayers: 38},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(10);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer0, 1_516, 225);
+} catch {}
+document.body.prepend(img1);
+let commandEncoder66 = device0.createCommandEncoder();
+let renderPassEncoder5 = commandEncoder66.beginRenderPass({
+  label: '\u05d4\u8099\u{1fc8a}\u{1fb7c}\uf94c\ua32e\u0728\u0a71\ubfa2\u104d',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 316,
+  clearValue: { r: -257.0, g: -512.3, b: 437.9, a: 99.12, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 131138332,
+});
+try {
+renderPassEncoder2.beginOcclusionQuery(517);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup7);
+} catch {}
+let pipelineLayout7 = device1.createPipelineLayout({
+  label: '\ucf06\u05f2\u{1fa04}\u3455\u07e0\u014d\u41f7\u4af1\u{1f9f1}\u1372',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout6, bindGroupLayout6],
+});
+let texture18 = gpuCanvasContext0.getCurrentTexture();
+try {
+device1.queue.submit([commandBuffer37]);
+} catch {}
+let commandEncoder67 = device1.createCommandEncoder();
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 132 widthInBlocks: 132 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 284 */
+  offset: 284,
+  buffer: buffer2,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 19, z: 2},
+  aspect: 'all',
+}, {width: 132, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder67.insertDebugMarker('\u877c');
+} catch {}
+let commandEncoder68 = device1.createCommandEncoder();
+let commandBuffer43 = commandEncoder68.finish({label: '\ud25b\u0154\u01cd\ua956\ufe3a'});
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  size: {width: 117},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder6 = commandEncoder69.beginRenderPass({
+  label: '\u{1fa1c}\uc8de\ud174\u0bd6\u0351\u0df6\u2742',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 170,
+  clearValue: { r: 418.2, g: 795.4, b: -26.99, a: 895.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 56954528,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({label: '8', colorFormats: ['rg16uint']});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 780, 6_977);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer0);
+} catch {}
+let bindGroupLayout12 = device1.createBindGroupLayout({
+  label: '\u09b5\u{1f6f3}\u{1ff00}\ub73c\u409f',
+  entries: [
+    {binding: 109, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 194, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 470,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 329, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 150,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder70 = device1.createCommandEncoder({label: '\u{1f7dd}\u{1fe59}\u5120\ue9ec\u199d'});
+let commandBuffer44 = commandEncoder70.finish({label: '\u83e3\u4ce1\uad72\uf9be\u5890\u7a23\u05a7'});
+let texture20 = device1.createTexture({
+  label: '\u065e\u1184',
+  size: {width: 2430, height: 8, depthOrArrayLayers: 2},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let commandBuffer45 = commandEncoder67.finish({label: '\u{1fd7c}\ufc05\u6914\ucfe2\u01de\u09e6\ub390\ud3cf\ub2ab\u1e3e'});
+let renderBundle35 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup2, new Uint32Array(2341), 171, 0);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+@group(1) @binding(61) var tex0: texture_1d<u32>;
+@group(1) @binding(334) var sam5: sampler_comparison;
+@group(1) @binding(446) var et5: texture_external;
+@group(1) @binding(53) var tex1: texture_multisampled_2d<f32>;
+@group(0) @binding(402) var sam4: sampler;
+@group(0) @binding(76) var et4: texture_external;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f8: vec4f,
+  @location(10) f9: vec4u
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec4i, @location(11) a1: vec4i, @location(4) a2: i32, @location(14) a3: vec4h, @location(7) a4: vec4f, @location(8) a5: f32, @location(5) a6: vec3h, @location(15) a7: vec3u, @builtin(instance_index) a8: u32, @location(10) a9: f16, @location(0) a10: f16, @location(2) a11: vec4h, @location(13) a12: vec4i, @builtin(vertex_index) a13: u32, @location(6) a14: f16, @location(3) a15: vec3u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec4u) -> @location(200) vec2u {
+  var out: vec2u;
+  _ = textureDimensions(et5);
+  _ = textureLoad(et5, vec2u());
+  _ = textureLoad(tex1, vec2i(), 0);
+  _ = textureLoad(tex0, 0, 0);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u0983\u{1f906}\u7686',
+  entries: [
+    {
+      binding: 211,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder71 = device0.createCommandEncoder({label: '\u58d8\u1b87\ub2b1\u2c5b\u{1fc6f}\uc4a3\u0bcf'});
+let texture21 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder27 = commandEncoder71.beginComputePass({label: '\u{1f842}\u83d3\u0183\u{1ff6b}'});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+adapter0.label = '\u{1fb59}\u0ed9\u6182\u08ab\u25f9\udca4\u{1fa95}\u{1fc8c}\u5d0e\ub1cb\u{1feaf}';
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({label: '\u{1fecf}\u0598\u{1fd7c}\u6dfa\u0e60\u1e7f\u8563\ud3ba\u0944\u{1f99a}'});
+let renderPassEncoder7 = commandEncoder72.beginRenderPass({
+  label: '\u1243\u0949\u{1fb56}\u{1fa8b}\u0220\u03b7\ue350\u29a2\u0d9b\u025f',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 309,
+  clearValue: { r: 186.8, g: 700.0, b: -585.2, a: -583.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup7, new Uint32Array(3403), 352, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint32', 5_600, 5_344);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup6, new Uint32Array(2281), 640, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup7, new Uint32Array(675), 78, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+await gc();
+let shaderModule3 = device1.createShaderModule({
+  label: '\u3dfd\u014c\u5922\u0fa2\u6a1f\u0d7e\u4aed\u{1f7bc}',
+  code: `
+@group(2) @binding(4) var st1: texture_storage_2d_array<rgba32sint, write>;
+@group(2) @binding(19) var et7: texture_external;
+@group(1) @binding(4) var st0: texture_storage_2d_array<rgba8snorm, write>;
+@group(1) @binding(19) var et6: texture_external;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(local_invocation_id) a0: vec3u) {
+}
+
+struct S1 {
+  @location(11) f0: vec3u,
+  @location(1) f1: vec3i,
+  @location(13) f2: vec3f,
+  @location(7) f3: vec2f
+}
+struct VertexOutput0 {
+  @builtin(position) f10: vec4f,
+  @location(10) f11: vec3u,
+  @location(2) f12: vec3u,
+  @location(0) f13: vec3u,
+  @location(1) f14: vec3i
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3i, a1: S1, @location(6) a2: vec3h, @location(9) a3: vec4h, @location(5) a4: vec3h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f10 = vec4f(0.02404, 0.03888, 0.1218, 0.02063);
+  out.f13 = vec3u(236, 130, 348);
+  out.f14 = vec3i(177, 245, 108);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec2f,
+  @location(7) f1: vec2i,
+  @location(0) f2: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 = vec2f(0.04049, 0.08513);
+  textureStore(st1, vec2i(), 0, vec4i(67, 102, 78, 384));
+  _ = textureDimensions(et7);
+  _ = textureLoad(et7, vec2u());
+  _ = textureDimensions(et6);
+  _ = textureLoad(et6, vec2u());
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder73 = device1.createCommandEncoder({});
+let externalTexture9 = device1.importExternalTexture({
+  label: '\u04dc\u132a\u37c6\u5301\u7bae\uc765\u8f4a\ubb3d\u7864',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup2);
+} catch {}
+let commandEncoder74 = device1.createCommandEncoder({label: '\u46df\udd19\u9c4d\u0760\u0345\u{1f6ce}\u0b94'});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+device1.queue.submit([commandBuffer35]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 67, y: 46 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView19 = texture1.createView({});
+let renderBundle36 = renderBundleEncoder6.finish({label: '\u{1fa64}\u0d0e\u05ca\u0446'});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({label: '\u0781\uacca\u1351\uc7cf\u0086'});
+let commandBuffer46 = commandEncoder75.finish({label: '\uf9e8\u8b76\ucfd3\u481b\u017f\u25fe\u{1f977}\u601b\ud45d'});
+let texture22 = device0.createTexture({
+  label: '\ua739\u0c29\u356e\u{1fc28}\ud92a\u{1fff0}\u0684\ucc39\u0332\u37ac',
+  size: {width: 90, height: 1, depthOrArrayLayers: 25},
+  mipLevelCount: 3,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView20 = texture13.createView({dimension: '2d-array', format: 'rg16uint', baseMipLevel: 1, mipLevelCount: 1});
+let externalTexture10 = device0.importExternalTexture({
+  label: '\u{1f63b}\u8d62\u9b02\ucd93\ub646\u5e4b\u{1f629}',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup6, new Uint32Array(838), 288, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint32', 4_048, 879);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer0, 0, 1_216);
+} catch {}
+try {
+renderBundleEncoder7.insertDebugMarker('\u0b1d');
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder({label: '\u0915\u{1f942}'});
+let commandBuffer47 = commandEncoder76.finish({label: '\u{1fa30}\u70d9\u0cfc'});
+let renderBundle37 = renderBundleEncoder1.finish({label: '\u7af3\u0990\u4cac\u4127'});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup7, new Uint32Array(3412), 428, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle37]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let promise5 = adapter0.requestAdapterInfo();
+try {
+commandBuffer35.label = '\ue8c2\u1f28\u01c2\u0c6a\u{1fa19}\u24eb\u30a1\u01d2\u0490';
+} catch {}
+let commandBuffer48 = commandEncoder27.finish();
+try {
+computePassEncoder24.setBindGroup(3, bindGroup1, new Uint32Array(2609), 273, 0);
+} catch {}
+let promise6 = device1.queue.onSubmittedWorkDone();
+let imageData6 = new ImageData(128, 16);
+try {
+computePassEncoder27.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer0, 908, 436);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup7, new Uint32Array(2098), 389, 0);
+} catch {}
+let textureView21 = texture5.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler5 = device0.createSampler({
+  label: '\u47a4\u84d5\u013a\ub985\u0fdb\u0927\u520e\u0a87\u6a3a',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 9.001,
+  lodMaxClamp: 70.30,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup6, []);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(2, bindGroup6, new Uint32Array(1370), 790, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(452);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer4, 0, 87);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 2172, new DataView(new ArrayBuffer(4110)), 122, 216);
+} catch {}
+let buffer6 = device1.createBuffer({
+  label: '\ub209\ue4cc\ua11b\u6b8b\u0184\uf5ae\u0f29\u30a0\u7f69',
+  size: 4205,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let commandBuffer49 = commandEncoder74.finish();
+let renderBundle38 = renderBundleEncoder5.finish({label: '\u54eb\u{1fdde}\u0a73\u0329\u{1f7aa}\u43f6\u4fb9\u7de5\ucc8f\u115e'});
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 22, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 0, new Int16Array(14168), 1796, 1204);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: canvas1,
+  origin: { x: 21, y: 9 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 471, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 87, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(buffer2, 1348, buffer6, 16, 948);
+} catch {}
+try {
+  await promise5;
+} catch {}
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 46},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 66 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1788 */
+  offset: 1788,
+  rowsPerImage: 218,
+  buffer: buffer6,
+}, {width: 66, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet4, 30, 1, buffer2, 0);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(260, 15);
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup6, new Uint32Array(1414), 742, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 7244, new DataView(new ArrayBuffer(5488)), 945, 36);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer4, 0, 2_544);
+} catch {}
+let texture23 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(2413), 1638, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint32', 1_948, 5_539);
+} catch {}
+let video2 = await videoWithData();
+let commandBuffer50 = commandEncoder73.finish({label: '\u0314\uc84a\u1cc8\u4432\u{1ff33}\ud443\ud2a8\u08b2\u093a'});
+let renderBundle39 = renderBundleEncoder5.finish({label: '\u0272\u{1f804}\u88ee\u07c7\u463b\u{1fd53}\u{1fa8e}'});
+let renderBundle40 = renderBundleEncoder3.finish({label: '\u083d\u0d19\u05ab\u{1f731}\u0a63\ud334\u8b19\u5920\u239a\ueb44\u7774'});
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer36, commandBuffer41, commandBuffer7, commandBuffer48]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 641, y: 1, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 32 */
+{offset: 32, bytesPerRow: 94}, {width: 84, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ufc63\uff76\u0eed\u0841\ue208\uc708\u12b4\u65a6\u0688';
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas1.getContext('webgpu');
+video2.height = 5;
+await gc();
+let bindGroupLayout14 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 53, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 268, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 27,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 404,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 339,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 153,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 81, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 8223917, hasDynamicOffset: true },
+    },
+    {
+      binding: 165,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 187, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 88,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 6, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 125,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 212, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 247,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 124, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {binding: 144, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 97,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 173, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 164,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 107,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 306, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 90,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 271, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 13081393, hasDynamicOffset: true },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder77 = device1.createCommandEncoder({label: '\u04a4\u16cc\u0a3e'});
+let computePassEncoder28 = commandEncoder77.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let texture24 = device0.createTexture({
+  label: '\u4a6c\uac7a\u5344\ua663',
+  size: {width: 560, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView22 = texture5.createView({
+  label: '\uaa01\u084b\u{1fc34}',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'rg16uint',
+  mipLevelCount: 1,
+});
+let externalTexture11 = device0.importExternalTexture({label: '\u05ed\uf485\u83b9\u02c9\u0c18\u0022\u6bdf', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4_294_967_295, undefined, 815_432_839);
+} catch {}
+let imageData7 = new ImageData(32, 16);
+let buffer7 = device1.createBuffer({
+  label: '\u5a10\u02fd\ud9db\u0ec8\u10be',
+  size: 4198,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let imageData8 = new ImageData(28, 28);
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 200, new BigUint64Array(10830), 714, 100);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\udda9\ue9b2\u6fa6',
+  entries: [
+    {
+      binding: 440,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet8 = device0.createQuerySet({label: '\u067b\ude53\u{1ff5b}', type: 'occlusion', count: 1429});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer0, 'uint16', 2_556, 974);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer4, 0, 665);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer4, 0, 3_180);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder78 = device1.createCommandEncoder({label: '\u{1f890}\u0e90\ud2f4\u{1f7e1}'});
+let commandBuffer51 = commandEncoder78.finish({label: '\ua31f\u0cf9\u2477\ubed8\uc7f1'});
+let renderBundle41 = renderBundleEncoder0.finish({label: '\u4355\u0d0b\u078d\u090b\u9295\u2d6e\ufda3\u4b66\u{1fb13}\u0b82\u{1f777}'});
+let commandEncoder79 = device1.createCommandEncoder({label: '\u093f\u0086\u0902'});
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder79.copyBufferToBuffer(buffer2, 5364, buffer6, 144, 76);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: video1,
+  origin: { x: 2, y: 3 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 387, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+try {
+device1.queue.submit([commandBuffer18, commandBuffer26]);
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u0dce\uead5\uc73a\ue2eb\ud254',
+  layout: bindGroupLayout10,
+  entries: [{binding: 137, resource: sampler5}],
+});
+let commandEncoder80 = device0.createCommandEncoder();
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -924.2, g: -898.4, b: -934.0, a: -572.9, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer0, 264, 96);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(1, buffer4, 0);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u307a');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder81 = device1.createCommandEncoder();
+let textureView23 = texture10.createView({aspect: 'stencil-only'});
+try {
+device1.queue.submit([commandBuffer10, commandBuffer25]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 662, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder82 = device1.createCommandEncoder({label: '\u041b\u{1f759}\u0e9e\uaebc\u{1fed9}\u0761\u1531\u{1fcaa}\ue989\uceb2'});
+let commandBuffer52 = commandEncoder79.finish({label: '\u055e\u4c43\u2c20\u9eb9\u8c48\uf148\u45be\uacac'});
+let renderBundle42 = renderBundleEncoder0.finish({});
+try {
+commandEncoder81.clearBuffer(buffer6, 760, 1700);
+} catch {}
+let promise7 = device1.queue.onSubmittedWorkDone();
+await gc();
+let renderBundle43 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture25 = device1.createTexture({
+  size: {width: 33},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+  await promise7;
+} catch {}
+let commandBuffer53 = commandEncoder82.finish({});
+let texture26 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandBuffer54 = commandEncoder77.finish({label: '\ud83e\u0eda\u2dbd'});
+let computePassEncoder29 = commandEncoder81.beginComputePass({});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 112, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({label: '\u85dd\u2f68\u0d57\u5741\u{1fbd6}\u4098\u{1fd97}\u8b08\u{1ffc2}\u20bb'});
+try {
+renderPassEncoder6.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint32', 352, 311);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer4, 0, 3_505);
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer3, 2344, 440);
+} catch {}
+try {
+device0.queue.submit([commandBuffer34]);
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+  label: '\u85b8\ufc18\u0c7a\u{1f853}\u00db\ubd30',
+  layout: pipelineLayout3,
+  multisample: {mask: 0xe161c2f},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 2029945847,
+    stencilWriteMask: 62760096,
+    depthBiasSlopeScale: 712.6042031221997,
+    depthBiasClamp: 208.96209417009504,
+  },
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {arrayStride: 152, stepMode: 'instance', attributes: []},
+      {arrayStride: 180, stepMode: 'instance', attributes: []},
+      {arrayStride: 200, attributes: [{format: 'unorm10-10-10-2', offset: 4, shaderLocation: 10}]},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 528, attributes: []},
+      {
+        arrayStride: 120,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x2', offset: 8, shaderLocation: 1}],
+      },
+      {arrayStride: 68, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 348,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 2},
+          {format: 'uint8x4', offset: 12, shaderLocation: 14},
+          {format: 'sint16x4', offset: 56, shaderLocation: 6},
+          {format: 'uint32x3', offset: 56, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw', cullMode: 'back'},
+});
+let texture27 = device1.createTexture({
+  label: '\u667c\u95de\u8008\u211d\u{1fc4b}\u38ff',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle44 = renderBundleEncoder3.finish({});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1556, new Float32Array(17328), 2012, 76);
+} catch {}
+let computePassEncoder30 = commandEncoder80.beginComputePass({label: '\ud238\uba0f\u{1f8a7}'});
+try {
+renderPassEncoder4.beginOcclusionQuery(45);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer0, 'uint16', 1_564, 383);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 1_052, 522);
+} catch {}
+try {
+device0.queue.submit([commandBuffer42]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3532, new BigUint64Array(1446), 50, 4);
+} catch {}
+let commandEncoder84 = device1.createCommandEncoder({});
+let querySet9 = device1.createQuerySet({
+  label: '\u0a7c\u{1ff53}\u{1f961}\uf90d\ue2ae\u939e\u87f3\u{1fb95}\u0332\u0f73\u0092',
+  type: 'occlusion',
+  count: 141,
+});
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 396, new BigUint64Array(1142), 98, 112);
+} catch {}
+let commandBuffer55 = commandEncoder83.finish({label: '\u07e1\udc0a\u07ef\u10ad\uf2be\uc9d4\ue7ab\u80ec\ubbde\u0f06'});
+let renderBundle45 = renderBundleEncoder1.finish({label: '\u9a1c\u{1fe46}\u03d6'});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 7_240, 2_057);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer4, 0, 942);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 176, new DataView(new ArrayBuffer(946)), 160, 8);
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({entries: []});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+commandEncoder84.insertDebugMarker('\u5129');
+} catch {}
+try {
+device1.queue.submit([commandBuffer40, commandBuffer44]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(7_241), /* required buffer size: 7_241 */
+{offset: 25, bytesPerRow: 225, rowsPerImage: 17}, {width: 16, height: 16, depthOrArrayLayers: 2});
+} catch {}
+let commandEncoder85 = device1.createCommandEncoder({});
+let texture28 = device1.createTexture({
+  label: '\u{1f665}\uace2\u4802\ua005\u21cd\ua2ab\u0627\u0478\ud33f\u{1ff97}\u07ed',
+  size: {width: 132, height: 135, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+adapter0.label = '\u04bc\u010e\u68ba\uf4f8\u7ce1\u0f21\u0069\ud6bb\u5a5a\u0d82';
+} catch {}
+try {
+computePassEncoder19.setBindGroup(1, bindGroup6, new Uint32Array(1889), 596, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer0, 0, 299);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer0, 1_256);
+} catch {}
+let commandBuffer56 = commandEncoder85.finish({label: '\uf6a6\u599b\u{1fb69}\u063e\u745b\u{1ffe1}\u04ae\u5e6c'});
+let textureView24 = texture20.createView({label: '\u{1f868}\u6812', dimension: '2d', baseMipLevel: 0});
+let renderBundle46 = renderBundleEncoder5.finish();
+let pipeline4 = await device1.createRenderPipelineAsync({
+  label: '\uc092\u{1f9d7}',
+  layout: pipelineLayout4,
+  multisample: {mask: 0x57ff1144},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'replace'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 627709271,
+    stencilWriteMask: 646298553,
+    depthBias: -1988609057,
+    depthBiasSlopeScale: 38.199997797488834,
+    depthBiasClamp: 620.2981599426253,
+  },
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {arrayStride: 536, attributes: []},
+      {arrayStride: 80, attributes: [{format: 'sint32x2', offset: 0, shaderLocation: 10}]},
+      {
+        arrayStride: 336,
+        attributes: [
+          {format: 'snorm8x4', offset: 0, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 20, shaderLocation: 5},
+          {format: 'sint8x4', offset: 144, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 238, shaderLocation: 13},
+          {format: 'uint8x2', offset: 128, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 40, stepMode: 'instance', attributes: []},
+      {arrayStride: 240, stepMode: 'instance', attributes: []},
+      {arrayStride: 516, stepMode: 'instance', attributes: []},
+      {arrayStride: 136, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 368,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 168, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 112, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+let textureView25 = texture0.createView({baseMipLevel: 2});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder4.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 724, 4_229);
+} catch {}
+try {
+device0.queue.submit([commandBuffer38, commandBuffer15]);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder86 = device1.createCommandEncoder();
+let texture29 = gpuCanvasContext1.getCurrentTexture();
+let commandEncoder87 = device0.createCommandEncoder({label: '\u4ed3\u4f39\u8e29\u1c07\u061c\u{1fbf9}'});
+let querySet10 = device0.createQuerySet({
+  label: '\ud759\u80d7\u4411\u03cd\udd32\u{1feb3}\ub338\u456b\u0048\u{1fb54}\u{1f611}',
+  type: 'occlusion',
+  count: 493,
+});
+let commandBuffer57 = commandEncoder87.finish({label: '\u534a\u{1f69a}\u4581\u{1f7d7}\u1ae4\ucd25'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '9',
+  colorFormats: ['rg16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 2_168, 1_310);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder();
+let renderBundle47 = renderBundleEncoder2.finish({label: '\u0f19\u{1f8a6}\u0952'});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup7, new Uint32Array(462), 15, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 2632, new Float32Array(25940), 262, 876);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({label: '\u824d\u{1fd09}\u{1fa25}\u0bb4'});
+let commandBuffer58 = commandEncoder89.finish({label: '\u5502\u0939\u00da\u{1ff31}\u1a81\u38b9\u0191\u07e2'});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder4.setViewport(22.869331785309512, 0.7447440864901296, 3.0493279350036304, 0.19691782789832876, 0.7567230210688713, 0.8527824960529538);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 2_480, 1_346);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder31 = commandEncoder84.beginComputePass({label: '\u{1fed2}\u8491\uefe5\ua55e'});
+try {
+device1.queue.writeBuffer(buffer6, 220, new Int16Array(1312), 931, 76);
+} catch {}
+let renderBundle48 = renderBundleEncoder5.finish({label: '\u9ea9\u026b'});
+try {
+commandEncoder86.copyBufferToBuffer(buffer2, 92, buffer6, 556, 1936);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder26.setBindGroup(3, bindGroup5, new Uint32Array(1607), 132, 0);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 195 widthInBlocks: 195 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1210 */
+  offset: 1210,
+  buffer: buffer2,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 423, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 195, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer6, 364, 32);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let commandEncoder90 = device1.createCommandEncoder({label: '\ueb12\u01c7\u0c6a'});
+let computePassEncoder32 = commandEncoder86.beginComputePass();
+let renderBundle49 = renderBundleEncoder5.finish({label: '\u0a9c\u7637\u2b3c\u0900'});
+document.body.prepend(canvas1);
+let shaderModule4 = device0.createShaderModule({
+  label: '\u0956\u0ce1',
+  code: `
+@group(1) @binding(446) var et9: texture_external;
+@group(1) @binding(53) var tex3: texture_multisampled_2d<f32>;
+@group(0) @binding(402) var sam6: sampler;
+@group(1) @binding(334) var sam7: sampler_comparison;
+@group(1) @binding(61) var tex2: texture_2d_array<i32>;
+@group(0) @binding(76) var et8: texture_external;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(local_invocation_id) a0: vec3u) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f15: vec4f
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3u, @location(3) a1: vec2u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct S2 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4u
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4f, a1: S2) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f1 = vec4u(497, 82, 33, 3);
+  _ = textureLoad(tex2, vec2i(), 0, 0);
+  _ = textureLoad(tex3, vec2i(), 0);
+  _ = textureLoad(et9, vec2u());
+  _ = textureDimensions(et9);
+  return out;
+}
+`,
+});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u02f3\u0a6b\u{1fd36}\u{1fe74}\u1943\u{1fee1}\u085d\u{1f86b}\u3456'});
+let commandBuffer59 = commandEncoder88.finish();
+let computePassEncoder33 = commandEncoder91.beginComputePass();
+let renderBundle50 = renderBundleEncoder2.finish({label: '\ue3b5\u02a2'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup7, new Uint32Array(875), 706, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 668, 1_604);
+} catch {}
+let commandEncoder92 = device1.createCommandEncoder({label: '\u38a5\u{1fa11}\udf1e\u029a\ud7aa\u{1ffdb}\ued3a'});
+let commandBuffer60 = commandEncoder90.finish({label: '\u0e88\u25a0\u45de\u0476\u0bef'});
+let texture30 = gpuCanvasContext0.getCurrentTexture();
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 0, 64);
+} catch {}
+let textureView26 = texture14.createView({aspect: 'stencil-only', baseArrayLayer: 2, arrayLayerCount: 3});
+let commandBuffer61 = commandEncoder92.finish({});
+let renderBundle51 = renderBundleEncoder0.finish({label: '\u35df\uaa71'});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 48, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({label: '\u8969\u01f5\u00fc\u8a09\u{1f8b5}\uf36f\u08a1', bindGroupLayouts: [bindGroupLayout5]});
+let buffer8 = device0.createBuffer({
+  label: '\u{1f778}\u36db\u{1fcf9}\u017c\ue9dd\ub5eb\u5043\uc393\u{1f832}\u5021',
+  size: 40923,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture31 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder6.setBindGroup(1, bindGroup7, new Uint32Array(4586), 90, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer0, 484, 1148);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 440, resource: {buffer: buffer0, offset: 6656, size: 1280}}],
+});
+let textureView27 = texture24.createView({dimension: '2d-array', baseMipLevel: 1});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup6, []);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(0, 0, 1, 0);
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+@group(1) @binding(61) var tex4: texture_2d_array<i32>;
+@group(0) @binding(402) var sam8: sampler;
+@group(1) @binding(334) var sam9: sampler_comparison;
+@group(1) @binding(53) var tex5: texture_multisampled_2d<i32>;
+@group(0) @binding(76) var et10: texture_external;
+@group(1) @binding(446) var et11: texture_external;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f16: vec4f
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3f) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> @location(200) vec4u {
+  var out: vec4u;
+  out = vec4u(233, 1000, 163, 68);
+  _ = textureLoad(tex4, vec2i(), 0, 0);
+  _ = textureDimensions(et11);
+  _ = textureLoad(et11, vec2u());
+  _ = textureLoad(tex5, vec2i(), 0);
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder93 = device0.createCommandEncoder({label: '\u0b18\u02d1\u02e0\u001b\u{1fe5d}\u4b2b\u19db\u5d0c\u73db'});
+let texture32 = device0.createTexture({
+  label: '\u7356\u093f\u{1fc3e}',
+  size: [180, 1, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle52 = renderBundleEncoder7.finish({label: '\u1033\u02f7\u5ddc\u{1fde4}\u3def\ub561\u0628'});
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer4, 0, 1_818);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame1);
+let renderPassEncoder8 = commandEncoder93.beginRenderPass({
+  label: '\u7114\uf4e6\u09fe\ub051\u27c3\u72bf\u{1fb71}\u42a7\u52b1\u0086',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 142,
+  clearValue: { r: -544.0, g: -532.6, b: -570.8, a: -680.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+});
+let renderBundle53 = renderBundleEncoder4.finish({});
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer4, 2_756, 417);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+await gc();
+let commandEncoder94 = device0.createCommandEncoder();
+let commandBuffer62 = commandEncoder5.finish();
+let renderPassEncoder9 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 72,
+  clearValue: { r: -281.7, g: -342.6, b: 583.1, a: 336.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup0);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+video0.width = 35;
+let commandEncoder95 = device0.createCommandEncoder({});
+let renderPassEncoder10 = commandEncoder95.beginRenderPass({
+  label: '\u0f61\u01e1\u{1f930}\udbdb\u{1f83d}',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -77.69, g: 664.6, b: -240.3, a: -519.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder();
+let renderPassEncoder11 = commandEncoder96.beginRenderPass({
+  label: '\u29a5\u81fd\u3152',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 235,
+  clearValue: { r: 852.4, g: -2.938, b: 811.2, a: -942.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({label: '10', colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(35);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle53, renderBundle28, renderBundle19]);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup7, new Uint32Array(2059), 478, 0);
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder();
+let commandBuffer63 = commandEncoder97.finish();
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer4, 1_252, 14_201);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint32', 2_472, 2_704);
+} catch {}
+try {
+device0.queue.submit([commandBuffer46, commandBuffer24]);
+} catch {}
+let videoFrame3 = new VideoFrame(canvas1, {timestamp: 0});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [{binding: 95, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let renderBundle54 = renderBundleEncoder7.finish({label: '\u086d\u0ed9\u0f87\u0671\u9c66\uc72a\u{1fab3}\u0099\u{1ffc1}'});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint16', 3_252, 2_814);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(7, buffer0, 4_912, 1_351);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 960, new BigUint64Array(2807), 357, 120);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle55 = renderBundleEncoder6.finish({label: '\u{1f641}\u3ee8\u024b\ueb60\u85b6'});
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer4);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4608, new Int16Array(5529), 241, 808);
+} catch {}
+await gc();
+let renderBundle56 = renderBundleEncoder3.finish();
+let externalTexture14 = device1.importExternalTexture({label: '\u039c\u598b\u36f1', source: videoFrame3, colorSpace: 'srgb'});
+let video3 = await videoWithData();
+let commandEncoder98 = device1.createCommandEncoder();
+let texture33 = device1.createTexture({
+  label: '\u09b4\u64b0\u4101',
+  size: {width: 30, height: 15, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle57 = renderBundleEncoder0.finish({});
+try {
+commandEncoder98.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3680 */
+  offset: 3680,
+  bytesPerRow: 256,
+  rowsPerImage: 70,
+  buffer: buffer6,
+}, {width: 16, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder99 = device1.createCommandEncoder({label: '\u{1fdbc}\u{1fe25}\u5b8c\udb46'});
+let commandBuffer64 = commandEncoder99.finish({label: '\ua623\u0746\u6859\u7737\u0cad\u05dd\ud815'});
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let commandBuffer65 = commandEncoder98.finish({});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder32.insertDebugMarker('\u4dc7');
+} catch {}
+let promise10 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData6,
+  origin: { x: 6, y: 4 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 163, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let texture34 = gpuCanvasContext1.getCurrentTexture();
+let arrayBuffer0 = buffer5.getMappedRange(24, 0);
+try {
+device1.queue.submit([commandBuffer64]);
+} catch {}
+try {
+  await promise9;
+} catch {}
+let texture35 = device1.createTexture({
+  label: '\u{1fc8e}\ue779\uc1c2\ufad9\u{1fede}',
+  size: {width: 132, height: 135, depthOrArrayLayers: 35},
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let renderBundle58 = renderBundleEncoder5.finish({label: '\u5050\u0c0f\ucd67\u055c\u6375\u1e47\ub6a8'});
+try {
+device1.queue.submit([commandBuffer60]);
+} catch {}
+let texture36 = device0.createTexture({
+  size: {width: 960},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup7, new Uint32Array(1296), 141, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint16', 58, 5_356);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint32', 548, 1_096);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+await gc();
+let commandEncoder100 = device1.createCommandEncoder({});
+let commandBuffer66 = commandEncoder100.finish({label: '\u{1f8c6}\u{1ff13}\u{1fc1f}\ud41e\u{1fecd}\u{1ff1a}\ue488\u9e8c\u0080\uc929\u{1f718}'});
+let renderBundleEncoder10 = device1.createRenderBundleEncoder({
+  label: '11',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer2, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout8, entries: []});
+let commandEncoder101 = device0.createCommandEncoder({label: '\u0481\ue514\uf2d6\u5e88'});
+let commandBuffer67 = commandEncoder101.finish({label: '\u8b77\u0aa7'});
+let textureView28 = texture17.createView({label: '\u01b3\u{1f88a}\u7ec3\u0af0\u0914\u7072', dimension: '3d', arrayLayerCount: 1});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer0, 1_824);
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({label: '\u{1fbcf}\u2307\u0150'});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup6, new Uint32Array(3291), 57, 0);
+} catch {}
+let renderPassEncoder12 = commandEncoder102.beginRenderPass({
+  label: '\u0fe4\u90cd\u9b70\u8d1a',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 156,
+  clearValue: { r: -143.2, g: 802.3, b: 482.8, a: 398.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+let commandEncoder103 = device1.createCommandEncoder({label: '\u{1feda}\ud424\u0ef1\u1307\u{1fdb8}'});
+let renderBundle59 = renderBundleEncoder5.finish({label: '\u029b\u6a30\ua096\u{1fa46}\u0729\u0cc4'});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(0, bindGroup3, new Uint32Array(1659), 369, 0);
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer2, 'uint32', 396, 2_778);
+} catch {}
+try {
+device1.queue.submit([commandBuffer49]);
+} catch {}
+let commandEncoder104 = device1.createCommandEncoder({label: '\u3129\u{1fa42}\u8e9f\u0fb1\u6c1a\u0d3e\u{1fe28}\u0bbb'});
+let commandBuffer68 = commandEncoder47.finish();
+let computePassEncoder34 = commandEncoder104.beginComputePass({});
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup3, new Uint32Array(1864), 8, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer2, 0, 1_975);
+} catch {}
+try {
+device1.queue.submit([commandBuffer53, commandBuffer50]);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img3 = await imageWithData(56, 130, '#10101010', '#20202020');
+let shaderModule6 = device0.createShaderModule({
+  label: '\u095f\udf2d\u9f55\u{1f6af}\u0849\u061d\u6b53\u6f9f\u0367\uf169',
+  code: `
+@group(0) @binding(92) var<uniform> buffer9: array<mat4x2h, 1>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(4) f17: vec3f,
+  @location(7) f18: vec2f,
+  @location(8) f19: vec4i,
+  @builtin(position) f20: vec4f
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4f, @location(2) a1: vec2h, @location(5) a2: vec2i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f19 = vec4i(64, 231, 67, 362);
+  out.f20 = vec4f(0.1993, 0.1245, 0.1587, 0.00814);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = buffer9;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet11 = device0.createQuerySet({label: '\u{1f7d4}\u0ef6\ued9f\u{1f8c9}\u037e\u3da7', type: 'occlusion', count: 414});
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView29 = texture5.createView({label: '\uc3d7\u73f4\u5ac2\u036e\u00d7\u7229\u1224\u0770', dimension: '2d-array', aspect: 'all'});
+try {
+computePassEncoder30.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(211);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup10);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder105 = device1.createCommandEncoder();
+let commandBuffer69 = commandEncoder103.finish({label: '\u9458\u{1fa2b}\u0922\u0caf\ud5e5\u06a2\u6ed3\u8c86'});
+let renderBundle60 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup5, new Uint32Array(1273), 113, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer2, 'uint16', 1_394, 879);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer70 = commandEncoder105.finish();
+try {
+renderBundleEncoder10.setIndexBuffer(buffer2, 'uint16', 8_354, 1_034);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(13_619), /* required buffer size: 13_619 */
+{offset: 131, bytesPerRow: 159, rowsPerImage: 28}, {width: 132, height: 1, depthOrArrayLayers: 4});
+} catch {}
+let renderBundle61 = renderBundleEncoder9.finish({label: '\ue0ec\u0a0b\u0a94\ue66a\u{1f9b7}\u06da\u07d0\u07b8\u0b6e\ue156\u0818'});
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 220, 13_673);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint16', 1_632, 1_909);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let pipelineLayout9 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout4, bindGroupLayout7]});
+let textureView30 = texture8.createView({label: '\u02a3\u0cfe\udd6a\ud2f7', aspect: 'all', format: 'stencil8'});
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer2, 'uint32', 1_136, 104);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(849);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer4, 0, 1_422);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let texture37 = device1.createTexture({
+  label: '\u{1faeb}\u{1fec5}\u0a91\u{1f798}\u090d\u20af\uaf70',
+  size: [2430, 8, 2],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup1, new Uint32Array(1643), 56, 0);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker('\uac0d');
+} catch {}
+try {
+  await promise11;
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({label: '\u00e0\u4146\u{1f967}\u3dd2'});
+let renderBundle62 = renderBundleEncoder4.finish({label: '\udd05\ubd47\uc403\u08de\u068e\u709a'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer4, 0, 1_855);
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(buffer4, 5168, buffer0, 788, 180);
+} catch {}
+let bindGroupLayout18 = device1.createBindGroupLayout({label: '\u0782\u0ebc\u198e\u0fbd\u7c6c\u{1ff76}\u5ff3\u{1fe19}\u06b2\u{1fa2f}', entries: []});
+let texture38 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder35 = commandEncoder81.beginComputePass();
+let renderBundleEncoder11 = device1.createRenderBundleEncoder({
+  label: '12',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer2, 976, 927);
+} catch {}
+let commandBuffer71 = commandEncoder106.finish();
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 2_780, 2_863);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint16', 3_156, 906);
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder();
+let renderPassEncoder13 = commandEncoder107.beginRenderPass({
+  label: '\u0aef\u7885\uf841\u0471\u{1fe0f}\u15fc\u4416\u0305\uc606',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 27,
+  clearValue: { r: -245.6, g: 615.7, b: -323.7, a: -472.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 369064703,
+});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint32', 5_692, 2_438);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  label: '\u{1f7bf}\u0cad',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    buffers: [
+      {arrayStride: 424, stepMode: 'instance', attributes: []},
+      {arrayStride: 172, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 408, attributes: []},
+      {arrayStride: 312, attributes: []},
+      {arrayStride: 1476, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 396,
+        attributes: [
+          {format: 'unorm8x4', offset: 20, shaderLocation: 0},
+          {format: 'sint16x4', offset: 152, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip'},
+});
+let imageData9 = new ImageData(4, 20);
+let bindGroup11 = device1.createBindGroup({label: '\udf67\u2d08\ud082\uac72\u{1f77f}', layout: bindGroupLayout3, entries: []});
+let commandEncoder108 = device1.createCommandEncoder({label: '\u{1fe83}\u0190\uc2dc\u0e59\u0072\uf519'});
+let commandBuffer72 = commandEncoder108.finish();
+let renderBundle63 = renderBundleEncoder5.finish();
+try {
+  await promise8;
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+let commandBuffer73 = commandEncoder109.finish({label: '\ua89d\u4d1c\ub1e7\u03ce\u{1f8ce}\u{1f902}\u0b6b\ufded\ubcb2\u{1ffc7}\u{1f8e9}'});
+let texture39 = device0.createTexture({
+  label: '\ua312\u0914\u074f\u{1ff30}\u1315\ua241\u9fe9',
+  size: [140],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView31 = texture19.createView({
+  label: '\u{1fc41}\u06bd\u880f\uf694\u00f1\u031e\u6524\u8cd7\ub8e5\u96ed\ua3e2',
+  format: 'rg16uint',
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -398.4, g: 361.4, b: 776.4, a: 854.5, });
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint16', 2_232, 1_094);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer55]);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({label: '\u1e68\u0662\uce31\ua5fe\ubd7b\ud7e0\u1959'});
+let commandBuffer74 = commandEncoder110.finish({});
+let renderBundle64 = renderBundleEncoder8.finish({label: '\u2658\u7ecd\u6409\u4e1f\u{1fe61}'});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -560.8, g: 432.2, b: 679.5, a: 466.8, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 9760, new Int16Array(846), 63, 60);
+} catch {}
+let bindGroupLayout19 = device1.createBindGroupLayout({
+  label: '\ued1f\u06f4\u2bcb\u6f88\u0d17\u0ed8\u0901',
+  entries: [
+    {
+      binding: 4,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder111 = device1.createCommandEncoder({label: '\u02ff\u{1fb85}\u0917\u8dad\u{1fcca}\u80a1\u4128'});
+let commandBuffer75 = commandEncoder111.finish({label: '\u1c61\ua7bb\u0787'});
+let texture40 = device1.createTexture({
+  label: '\u{1f7af}\u0dc4\u0c3c\u0345\ubce6\u0fdb\u{1faba}\u0a4a\u0b8d\u3341',
+  size: {width: 16, height: 16, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint32', 1_956, 1_066);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let arrayBuffer1 = buffer5.getMappedRange(32, 4);
+let promise13 = device1.queue.onSubmittedWorkDone();
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint16', 2_980, 1_914);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData8,
+  origin: { x: 17, y: 8 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 362, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u65f2\uedd9\u1fd8\u{1fd94}', bindGroupLayouts: [bindGroupLayout8, bindGroupLayout5]});
+let commandEncoder112 = device0.createCommandEncoder({label: '\u0ac2\u{1fbcd}\u{1fb60}\ua9ab\udab7\u2845\uaaef'});
+let commandBuffer76 = commandEncoder112.finish({label: '\u0f66\uf4fc\u4dfc\u9dfc\u{1f752}\ub050\u{1f6f3}\u02fc\ub5ca\u3df5\u0d8b'});
+let renderBundle65 = renderBundleEncoder4.finish({label: '\u05d9\u3d5e\ub424\u045c\u7113'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(2418), 542, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint16', 80, 652);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder113 = device1.createCommandEncoder({label: '\u1a4d\u{1ff4b}\u{1fe91}\u01d8\u8020\u59f6\ueb2a'});
+let renderBundle66 = renderBundleEncoder3.finish({label: '\u0191\u252a\u0d8f\u0785\u{1f685}\u0412\u0404\u{1f9fa}\u400c\u{1f86e}\u{1fe5f}'});
+let arrayBuffer2 = buffer5.getMappedRange(0, 0);
+await gc();
+let commandEncoder114 = device1.createCommandEncoder({label: '\u00bc\u8aa6\u3e4e\u067c\u01bb\u4af5\uee47\u0915\uaab7\u01d9'});
+let texture41 = device1.createTexture({
+  label: '\u0de2\u91eb\ucbc3\u05bd\u111a\u7434',
+  size: {width: 30},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(5, buffer2);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let querySet12 = device0.createQuerySet({label: '\u{1f8b1}\ue19a', type: 'occlusion', count: 186});
+let textureView32 = texture15.createView({label: '\u{1fbe7}\u0952\u0e1b\u0c4b\u1b22\u7e84\u{1f9fe}\u9a12'});
+try {
+computePassEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(7.043521991225491, 0.1061167167058572, 27.535293911125677, 0.24983283662246542, 0.5976936883008903, 0.6181539508691218);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27, commandBuffer63]);
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({label: '\u0635\u704f\u88fc\u0612\u4eb3'});
+let renderPassEncoder14 = commandEncoder115.beginRenderPass({
+  label: '\u054f\ud882\u0816\u89c1\u00c7',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 121,
+  clearValue: { r: -263.1, g: -535.0, b: 184.8, a: -819.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 71292300,
+});
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer0, 424, 498);
+} catch {}
+let commandBuffer77 = commandEncoder114.finish({label: '\ud542\u33ea\u3b07\u{1f8ee}\u{1feae}\u7ba5\u7d90\u03cd\u0c96\u444f'});
+let renderBundleEncoder12 = device1.createRenderBundleEncoder({
+  label: '13',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let renderBundle67 = renderBundleEncoder12.finish();
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer2, 916);
+} catch {}
+let pipeline6 = device1.createComputePipeline({
+  label: '\ue43c\u1cf4\u438a\ucb95\u091a\u58dc\u{1f851}\u{1f922}\u7821',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule3, constants: {}},
+});
+let commandEncoder116 = device0.createCommandEncoder({label: '\uf8b4\u40b6\u08bf\u28b0\u{1f727}\u7d0f\u85c8\u061a\u2ab6\u0e88'});
+let commandBuffer78 = commandEncoder116.finish();
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer57]);
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+let renderBundle68 = renderBundleEncoder2.finish({label: '\u{1fde3}\u0a05\u7017\u0f92\ub8a9\u66f1\u{1f7d6}'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 4064, new Float32Array(42912), 7765, 208);
+} catch {}
+try {
+  await promise13;
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup2, new Uint32Array(913), 11, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 56, new Float32Array(64248), 7813, 180);
+} catch {}
+let commandEncoder117 = device1.createCommandEncoder({label: '\u7980\ua3ca'});
+let renderBundle69 = renderBundleEncoder10.finish();
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 456 */
+  offset: 456,
+  buffer: buffer6,
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 79, y: 10 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 99, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 105, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer79 = commandEncoder22.finish();
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint32', 528, 2_337);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer7, 916, buffer6, 900, 120);
+} catch {}
+let commandEncoder118 = device1.createCommandEncoder({label: '\u4454\u{1ff5f}'});
+let commandBuffer80 = commandEncoder113.finish({label: '\u07c1\u{1f714}\u0ac4\u13a1\u{1fc87}\u5820'});
+let texture42 = device1.createTexture({
+  label: '\u0cf0\u3df9\u04dd\u0ffc',
+  size: {width: 132, height: 135, depthOrArrayLayers: 100},
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup11, new Uint32Array(181), 16, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder117.copyBufferToTexture({
+  /* bytesInLastRow: 132 widthInBlocks: 132 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 140 */
+  offset: 140,
+  bytesPerRow: 256,
+  buffer: buffer2,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+}, {width: 132, height: 135, depthOrArrayLayers: 0});
+} catch {}
+let imageData10 = new ImageData(36, 4);
+let commandBuffer81 = commandEncoder118.finish();
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+commandEncoder117.insertDebugMarker('\u0583');
+} catch {}
+let commandEncoder119 = device1.createCommandEncoder({label: '\u{1faa0}\u{1fc41}\u0c25\u87cd\u82e8\u5bb1\uc340\u{1fada}\u3e14\u0809\uaaf1'});
+let querySet13 = device1.createQuerySet({
+  label: '\ucb90\u{1f6a6}\u22ce\u06ce\u0ba4\u{1fc48}\u4f7c\u{1f9ad}\udd6f',
+  type: 'occlusion',
+  count: 260,
+});
+let textureView33 = texture37.createView({label: '\u4306\u0f0d\uf512\u6d0b\u5098\u9a8e\uf2d2\u1b16', arrayLayerCount: 1});
+let renderBundleEncoder13 = device1.createRenderBundleEncoder({
+  label: '15\u5083\uc5f9\u6b37\u{1f6ce}\u{1fb5f}\u254d\u{1fa43}\u6841',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+});
+let renderBundle70 = renderBundleEncoder10.finish();
+try {
+computePassEncoder18.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint16', 4_944, 840);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder120 = device1.createCommandEncoder({label: '\ue7b2\u0ea8'});
+let commandBuffer82 = commandEncoder117.finish({label: '\u5363\u0c03\u02c5\u2012\ue3e7\u07a2\u{1fa28}'});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({
+  label: '16\u03ab\u0300\u0177\u0fea\u0b82\uff85\u5764\u{1fef0}',
+  colorFormats: ['r8unorm'],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle71 = renderBundleEncoder0.finish({});
+let externalTexture15 = device1.importExternalTexture({label: '\u09e3\u{1f7d6}\u{1fe8e}', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1);
+} catch {}
+let promise14 = device1.createRenderPipelineAsync({
+  label: '\u6776\u9e4c',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {arrayStride: 540, attributes: [{format: 'snorm16x2', offset: 0, shaderLocation: 6}]},
+      {arrayStride: 24, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 132, stepMode: 'instance', attributes: []},
+      {arrayStride: 488, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1320,
+        attributes: [
+          {format: 'sint32x2', offset: 84, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 116, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 228,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x4', offset: 24, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 0, shaderLocation: 7},
+          {format: 'sint8x2', offset: 12, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\ufeef\ua395\u{1f60d}\u{1fad7}\u0370\u06e8\u0414\ud58d\ua6ed',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout9, bindGroupLayout18],
+});
+let renderBundle72 = renderBundleEncoder3.finish({label: '\u{1ff18}\uf803\u0301\ua4a0\u2fa4\u{1f697}\u{1fd61}\u96be\u0243\u{1f888}'});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup5, new Uint32Array(3752), 123, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint32', 1_396, 4_716);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer2);
+} catch {}
+try {
+renderBundleEncoder14.insertDebugMarker('\ub4c8');
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData11 = new ImageData(28, 12);
+try {
+renderPassEncoder11.end();
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder();
+let commandBuffer83 = commandEncoder121.finish({label: '\uf224\u{1f848}\u0ca0\u49c2\u4fff\u031c\u{1fde5}\u69f4\u0eab\ubf10'});
+try {
+renderPassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder122 = device0.createCommandEncoder({});
+let renderPassEncoder15 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 42,
+  clearValue: { r: 930.0, g: 556.1, b: 732.9, a: 742.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle73 = renderBundleEncoder9.finish();
+try {
+computePassEncoder9.setBindGroup(0, bindGroup10, new Uint32Array(1490), 182, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer0, 0, 1_744);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8, commandBuffer78, commandBuffer58, commandBuffer83]);
+} catch {}
+let img4 = await imageWithData(8, 53, '#10101010', '#20202020');
+try {
+computePassEncoder9.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer4, 5_228, 5_470);
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({label: '\u{1fa36}\u0820'});
+let commandBuffer84 = commandEncoder123.finish({label: '\u4d99\u{1f878}\ude71\u0489\u0b50\ubc6a\ub4a3\u{1fca5}\uf313'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({label: '17',colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer0, 'uint32', 2_336, 4_195);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u2b6d');
+} catch {}
+let commandEncoder124 = device0.createCommandEncoder();
+let querySet14 = device0.createQuerySet({
+  label: '\u{1f7db}\u0d37\u{1f9c5}\u{1fb0c}\u{1f9bb}\uc6c4\u{1f9c8}\u{1ff8f}',
+  type: 'occlusion',
+  count: 399,
+});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer1, 'uint32', 1_764, 1_942);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+document.body.prepend(img4);
+let pipelineLayout13 = device0.createPipelineLayout({
+  label: '\ua4f9\udee0\u{1fa13}\ub103\u08c9\u37ea\u2fe0\u3590',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout10, bindGroupLayout8, bindGroupLayout8],
+});
+let textureView34 = texture6.createView({label: '\u033f\u03ae\uce3a\u5b46\u002b\uf372\u{1f87c}\u0d9d\uef90\u076e\ue0b1', format: 'rg16uint'});
+let renderPassEncoder16 = commandEncoder124.beginRenderPass({
+  label: '\u0e04\u2a1d\u5e43\u73e0\u266d\u{1f779}',
+  colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'discard'}],
+});
+let renderBundle74 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder12.setIndexBuffer(buffer0, 'uint16', 52, 7_015);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(1286);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer0);
+} catch {}
+let commandBuffer85 = commandEncoder119.finish({label: '\u{1fe42}\u{1fa0b}\u{1fa74}\u038c\u416f\u3a4b\u{1fc3f}\ueb35\u{1ff6d}\u015d'});
+let computePassEncoder36 = commandEncoder120.beginComputePass({label: '\u46dd\uc9bd\u29cf\uba5e\u0faf\u09c7\u0d30\u4a4f\u{1fc59}'});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint16', 1_828, 619);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer2);
+} catch {}
+let externalTexture16 = device1.importExternalTexture({
+  label: '\ufde5\u08a4\u2b50\u{1ffcc}\u028f\ue41f\uea48\u0f45\u0a3e\u5f92\u{1f6de}',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup3, new Uint32Array(1347), 8, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer0, 0, 783);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer0, 'uint16', 808, 489);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 2728, 272);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11, commandBuffer73]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 2252, new BigUint64Array(1629), 38, 200);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer2, 'uint32', 1_852, 4_769);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer2, 0, 6_126);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let textureView35 = texture4.createView({
+  label: '\u8707\u3352\u{1ff95}\u6b38\u2b81\u{1f81c}\u056a',
+  dimension: '2d-array',
+  format: 'astc-12x10-unorm-srgb',
+  arrayLayerCount: 10,
+});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle55, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 2_908, 1_453);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer74, commandBuffer71]);
+} catch {}
+let renderBundle75 = renderBundleEncoder3.finish();
+try {
+device1.queue.submit([commandBuffer82, commandBuffer85, commandBuffer79]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 8, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData11,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule7 = device1.createShaderModule({
+  code: `
+@group(0) @binding(26) var<storage, read> buffer14: array<vec2u, 1>;
+@group(0) @binding(187) var sam13: sampler_comparison;
+@group(0) @binding(345) var<uniform> buffer16: mat3x3f;
+@group(0) @binding(17) var tex8: texture_multisampled_2d<u32>;
+@group(0) @binding(44) var tex7: texture_depth_2d_array;
+@group(0) @binding(54) var<storage, read_write> buffer17: atomic<i32>;
+@group(0) @binding(46) var sam10: sampler_comparison;
+@group(0) @binding(283) var tex10: texture_multisampled_2d<f32>;
+@group(1) @binding(339) var<uniform> buffer19: array<array<mat3x3f, 1>, 1>;
+@group(0) @binding(91) var<uniform> buffer12: mat3x2h;
+@group(0) @binding(220) var tex11: texture_depth_2d;
+@group(0) @binding(19) var st5: texture_storage_2d<r32sint, read_write>;
+@group(0) @binding(149) var et14: texture_external;
+@group(0) @binding(323) var tex6: texture_multisampled_2d<f32>;
+@group(0) @binding(261) var sam15: sampler;
+@group(0) @binding(290) var sam11: sampler;
+@group(0) @binding(64) var sam12: sampler;
+@group(0) @binding(25) var et16: texture_external;
+@group(0) @binding(118) var<storage, read_write> buffer11: array<mat3x2h>;
+@group(0) @binding(73) var<uniform> buffer18: vec2i;
+@group(0) @binding(81) var sam14: sampler;
+@group(0) @binding(573) var st3: texture_storage_1d<rg32uint, read>;
+@group(0) @binding(159) var st4: texture_storage_3d<rgba16sint, read>;
+@group(0) @binding(65) var tex9: texture_multisampled_2d<u32>;
+@group(0) @binding(295) var et12: texture_external;
+@group(0) @binding(158) var<storage, read_write> buffer15: array<atomic<u32>, 1>;
+@group(0) @binding(196) var<storage, read> buffer10: array<u32, 1>;
+@group(0) @binding(175) var et13: texture_external;
+@group(0) @binding(33) var st2: texture_storage_3d<rgba32uint, write>;
+@group(0) @binding(190) var et17: texture_external;
+@group(0) @binding(11) var et15: texture_external;
+@group(0) @binding(88) var<storage, read_write> buffer13: array<vec4f>;
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+  textureStore(st5, vec2i(), vec4i(151, 51, 485, 12));
+}
+
+struct VertexOutput0 {
+  @location(13) f21: vec2i,
+  @location(8) f22: vec3f,
+  @location(7) f23: vec3h,
+  @builtin(position) f24: vec4f,
+  @location(10) f25: vec2u,
+  @location(14) f26: vec4h,
+  @location(5) f27: vec3h,
+  @location(2) f28: vec3u
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f23 = vec3h(-40740.4);
+  out.f24 = vec4f(0.08327, 0.3074, 0.2430, 0.05616);
+  out.f25 = vec2u(279, 186);
+  out.f26 = vec4h(-39096.1);
+  return out;
+}
+
+struct S3 {
+  @location(14) f0: vec4h,
+  @location(8) f1: vec3f,
+  @location(5) f2: vec3h
+}
+struct S4 {
+  @location(7) f0: vec3h,
+  @location(2) f1: vec3u
+}
+struct S5 {
+  @builtin(sample_mask) f0: u32
+}
+
+@fragment
+fn fragment0(a0: S3, @location(13) a1: vec2i, a2: S4, @location(10) a3: vec2u, @builtin(front_facing) a4: bool, @builtin(position) a5: vec4f, a6: S5, @builtin(sample_index) a7: u32) -> @location(200) vec3f {
+  var out: vec3f;
+  buffer11[12345] = mat3x2h();
+  buffer13[12345] = vec4f(0.07482, 0.1201, 0.1852, 0.2053);
+  textureStore(st2, vec3i(), vec4u(364, 122, 36, 135));
+  _ = textureLoad(tex9, vec2i(), 0);
+  _ = textureDimensions(et12);
+  _ = textureDimensions(et13);
+  _ = textureLoad(et16, vec2u());
+  _ = buffer12;
+  _ = buffer13;
+  _ = buffer10;
+  _ = textureLoad(et13, vec2u());
+  _ = buffer18;
+  _ = textureLoad(tex10, vec2i(), 0);
+  _ = textureLoad(et12, vec2u());
+  _ = textureLoad(et14, vec2u());
+  _ = textureLoad(et17, vec2u());
+  _ = buffer11;
+  _ = textureLoad(tex6, vec2i(), 0);
+  _ = textureDimensions(et14);
+  _ = textureLoad(st3, 0);
+  _ = textureDimensions(et16);
+  _ = textureLoad(tex7, vec2i(), 0, 0);
+  _ = textureDimensions(et17);
+  _ = textureLoad(st5, vec2i());
+  _ = textureLoad(tex11, vec2i(), 0);
+  _ = textureLoad(tex8, vec2i(), 0);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture43 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder31.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(5, buffer2, 3_256);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({label: '\u5b65\u0100\u0e4d\uf456\u{1fd81}\ua378\u{1fe13}\u13b1\u05bf'});
+let renderPassEncoder17 = commandEncoder125.beginRenderPass({
+  label: '\u0c9d\u08d8\u9ba2\ucda3\u8432',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 227,
+  clearValue: { r: -90.54, g: -874.6, b: 150.3, a: 848.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle76 = renderBundleEncoder4.finish({label: '\u7618\ua69a\u37da\u0bfa\ub535'});
+try {
+renderBundleEncoder15.setIndexBuffer(buffer0, 'uint16', 1_080, 2_114);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer4, 2_664, 1_345);
+} catch {}
+let arrayBuffer3 = buffer3.getMappedRange(2744, 64);
+let renderBundle77 = renderBundleEncoder3.finish({label: '\u0491\u{1f745}\u40b6\u0b5a\u9c02\ue4f9\u30fb\ua172\u09a3\u0704\u{1ff93}'});
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise15 = device1.queue.onSubmittedWorkDone();
+try {
+device1.destroy();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView36 = texture36.createView({label: '\uc200\ubbe6\u5d35', arrayLayerCount: 1});
+try {
+renderPassEncoder10.setIndexBuffer(buffer1, 'uint16', 152, 774);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer1, 'uint16', 4_622, 630);
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint16', 10_014, 2_502);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let querySet15 = device0.createQuerySet({
+  label: '\u0af4\ue07d\u8299\uf70e\u3b07\u0bb3\uc347\u{1fcc3}\u03a4\u4040\u5bfd',
+  type: 'occlusion',
+  count: 89,
+});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(181.1541207386386, 11.705266711462492, 38.02388544554713, 9.328412261013849, 0.48959255367099763, 0.9726943129877862);
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData6);
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer0, 0, 148);
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  label: '\u2701\u0130',
+  code: `
+@group(1) @binding(92) var<uniform> buffer20: array<array<array<mat3x2f, 1>, 1>, 1>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f29: vec4f,
+  @location(10) f30: vec4i,
+  @location(12) f31: vec3i
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f30 = vec4i(50, 287, 29, 23);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3u,
+  @location(6) f1: vec4u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 = vec3u(169, 76, 13);
+  _ = buffer20;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder126 = device0.createCommandEncoder();
+let commandBuffer86 = commandEncoder126.finish({label: '\u09ab\ud92e\u{1f9e8}\u0101\u{1f6d7}\u{1fb30}'});
+try {
+computePassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup7, new Uint32Array(519), 288, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle65, renderBundle53, renderBundle65]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 436);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 3_716);
+} catch {}
+let renderBundle78 = renderBundleEncoder15.finish({label: '\u{1f7f2}\u455a'});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup6, new Uint32Array(487), 128, 0);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 1_044);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 664);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise16 = adapter0.requestAdapterInfo();
+let bindGroup12 = device0.createBindGroup({
+  label: '\u4cf7\uf670\u26fd\ud08b\u{1f63b}\u3a16\ue6d0\u8189',
+  layout: bindGroupLayout17,
+  entries: [{binding: 95, resource: externalTexture12}],
+});
+let textureView37 = texture32.createView({label: '\u0e4a\u{1fb9a}', dimension: '2d-array'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '18',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(6, 0, 8, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 11_396);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, undefined);
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({label: '\u{1fbbb}\u05de\u04a3\u005d\u04d7\u52a6'});
+let commandBuffer87 = commandEncoder127.finish({label: '\u{1fd57}\u41e1\u{1fe87}\u7bd5'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({label: '19', colorFormats: ['rg16uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder4.draw(4, 59, 0, 918_613_074);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 2_776);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 4_468);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup12, new Uint32Array(1554), 314, 0);
+} catch {}
+let bindGroup13 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 95, resource: externalTexture13}]});
+let commandEncoder128 = device0.createCommandEncoder({label: '\u488d\uab55\u7c6c\uba18\u{1fa1f}\u{1fae0}\u0867'});
+let renderPassEncoder18 = commandEncoder128.beginRenderPass({
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 309,
+  clearValue: { r: 937.4, g: -431.9, b: -107.8, a: 216.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+renderPassEncoder4.draw(5, 251, 0, 1_325_365_334);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer1, 'uint16', 2_434, 349);
+} catch {}
+let arrayBuffer4 = buffer3.getMappedRange(2728, 0);
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+window.someLabel = commandEncoder19.label;
+} catch {}
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas2);
+try {
+renderPassEncoder12.beginOcclusionQuery(619);
+} catch {}
+try {
+renderPassEncoder4.draw(5, 273, 0, 680_126_702);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 2_468);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer4, 16_712, 231);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint32', 2_056, 806);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer4, 3_284, 4_150);
+} catch {}
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.34,
+  lodMaxClamp: 82.68,
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle19, renderBundle65]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint32', 6_132, 8_033);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer0, 1_600, 610);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup10, new Uint32Array(1564), 433, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint32', 704, 1_181);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer4, 8_860);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u{1f92c}\u36a2',
+  layout: bindGroupLayout0,
+  entries: [{binding: 402, resource: sampler2}, {binding: 76, resource: externalTexture8}],
+});
+let pipelineLayout14 = device0.createPipelineLayout({
+  label: '\ua6a7\u{1f6f7}\u7950\u2ff1\uf4f4\u809b\u{1f9d3}\ucf9a',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout15, bindGroupLayout5],
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup0, new Uint32Array(360), 96, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 12_312);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 3_004);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup14);
+} catch {}
+let promise18 = adapter2.requestDevice({
+  label: '\u54c0\u{1fa40}\u{1f8c5}\ub664\u0a5d',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxDynamicStorageBuffersPerPipelineLayout: 4,
+    maxTextureDimension1D: 8192,
+    maxUniformBufferBindingSize: 14590864,
+    maxStorageBufferBindingSize: 145638583,
+    maxInterStageShaderComponents: 64,
+  },
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder({});
+let commandBuffer88 = commandEncoder129.finish({label: '\u{1f729}\u8a54\u{1f81f}\u06c4\u00f6\u09b4\u{1fb5b}\u872b'});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.draw(4, 406, 2, 272_215_170);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 2_404);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup12, new Uint32Array(135), 16, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer4, 0, 1_740);
+} catch {}
+try {
+device0.queue.submit([commandBuffer62, commandBuffer87]);
+} catch {}
+await gc();
+let externalTexture17 = device0.importExternalTexture({label: '\u86b1\u08fe\u{1fe49}\uccd7\u{1fd90}', source: video2});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.draw(0, 351, 6, 295_954_481);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 232);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer0, 'uint32', 308, 3_152);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup14, []);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer4, 4_840);
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+let textureView38 = texture17.createView({label: '\u{1ffdf}\u0343\uebde\u05e1', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer1, 'uint16', 4_828, 2_483);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint16', 18, 955);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder130.insertDebugMarker('\u4145');
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout13, bindGroupLayout15]});
+let commandEncoder131 = device0.createCommandEncoder({label: '\u80e3\u{1f914}\u571b\u9cc4\u8890\u{1fa2d}'});
+let commandBuffer89 = commandEncoder131.finish();
+let sampler7 = device0.createSampler({label: '\u0f97\ud835\u25da', addressModeU: 'mirror-repeat', lodMinClamp: 45.73, lodMaxClamp: 47.78});
+let externalTexture18 = device0.importExternalTexture({label: '\u02d7\u06e6\u{1fd33}', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 1_924, 128);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer4, 5344, buffer1, 3528, 172);
+} catch {}
+try {
+commandEncoder130.resolveQuerySet(querySet10, 151, 14, buffer4, 768);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+await gc();
+let imageData12 = new ImageData(4, 76);
+try {
+  await promise17;
+} catch {}
+let videoFrame4 = new VideoFrame(img0, {timestamp: 0});
+let bindGroup15 = device0.createBindGroup({label: '\ub420\u7d39\ua7ce\u0c66\u3e91\u0de4', layout: bindGroupLayout16, entries: []});
+let renderPassEncoder19 = commandEncoder130.beginRenderPass({
+  label: '\u22f7\ub59b\ucb8b\u0070',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 485.2, g: -605.3, b: 150.1, a: 300.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 448571039,
+});
+try {
+renderPassEncoder4.draw(0, 50, 8, 1_917_617_529);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 3_244);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 544);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer76]);
+} catch {}
+document.body.prepend(img0);
+try {
+externalTexture11.label = '\u{1fd4d}\u0e28\u043c\u{1f897}\uc35d\u194b\ub26e';
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 9_688);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 5_920);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer0, 'uint32', 1_912, 1_313);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint16', 3_984, 8);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 2_044);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer4, 0, 1_529);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let promise19 = adapter0.requestAdapterInfo();
+let commandEncoder132 = device0.createCommandEncoder({label: '\u08d5\ubd12\u4c2f'});
+let commandBuffer90 = commandEncoder132.finish({label: '\u{1fc53}\u0a7b\u21f7\uc120\u8fd9\ue1a7\uf38c'});
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.draw(3, 43, 0, 586_512_013);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(11, 7, 7, 978_674_023, 1_868_808_332);
+} catch {}
+let videoFrame5 = new VideoFrame(videoFrame0, {timestamp: 0});
+let commandEncoder133 = device0.createCommandEncoder({label: '\uec33\u3d26\u6937\u{1f882}\ue5db\u2834\u868e\u1a25\u3102\u{1fcc2}\ubd63'});
+let commandBuffer91 = commandEncoder133.finish();
+try {
+computePassEncoder8.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.draw(6, 134, 0, 26_920_562);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer1, 'uint32', 2_240, 1_050);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer4, 0, 390);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(2, 100, 3, 201_546_190, 1_660_246_261);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 1_668);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer4, 0, 582);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+  await promise16;
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 3_732);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 2_112);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4_294_967_295, undefined, 0, 500_150_121);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let imageData13 = new ImageData(48, 236);
+try {
+window.someLabel = externalTexture11.label;
+} catch {}
+try {
+renderPassEncoder4.draw(1, 47, 7, 157_328_692);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(1, 70, 18, 296_291_224, 439_678_494);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer4, 0, 1_762);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle61, renderBundle1, renderBundle61]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(1, 79, 6, 630_541_465, 109_512_795);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 7_520, 7_388);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint16', 962, 2_858);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 188, new Float32Array(3505), 61, 116);
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({});
+let commandBuffer92 = commandEncoder134.finish({label: '\u5e17\uc8e7\ub6aa'});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle65, renderBundle62, renderBundle78]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(105, 378, 133, 839_957_092, 109_551_979);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 3_004);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 624);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint16', 58, 1_111);
+} catch {}
+let arrayBuffer5 = buffer3.getMappedRange(2824, 0);
+video2.width = 10;
+let commandEncoder135 = device0.createCommandEncoder({label: '\u6728\u6f33\udf56'});
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(481, 275, 39, 2_147_483_647, 689_802_570);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 2_912);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer1, 'uint32', 2_088, 3_174);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder135.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(img1, {timestamp: 0});
+let imageData14 = new ImageData(108, 20);
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout15, bindGroupLayout1, bindGroupLayout13]});
+let computePassEncoder37 = commandEncoder135.beginComputePass({label: '\u96a3\u{1f982}\u5dea\ud267\uf6e8\u{1fd67}\uc42d'});
+let renderBundle79 = renderBundleEncoder4.finish({label: '\u{1f899}\ub1f9\u0586\u0f7c\u761f\u06a4'});
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(528, 38, 16, -2_001_387_740, 2_851_677_458);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 4_116, 1_123);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer1, 'uint32', 1_608, 1_051);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(183, 5, 249, 569_146_968, 1_766_162_872);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 11_412);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline5);
+} catch {}
+await gc();
+let commandEncoder136 = device0.createCommandEncoder({label: '\u0287\u3f43\u0f6e\ud46c\u77fd\ub216\u0f1b\u07a7\u1563\u05f9\u{1fc87}'});
+let commandBuffer93 = commandEncoder136.finish({label: '\u9b2d\u5f1f\u5112\u2d08\u948e\u0ea5\u792e\u{1fc7f}'});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '20',
+  colorFormats: ['rg16uint'],
+});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder4.draw(3, 472, 1, 231_141_919);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(338, 135, 111, -2_089_345_113, 1_881_695_440);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 1_972);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 828);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer4, 0, 956);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint32', 192, 5_532);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer6 = buffer3.getMappedRange(2808, 4);
+await gc();
+let renderBundle80 = renderBundleEncoder8.finish({label: '\uedfa\uedb0\u0dd4\u2ca7\u0de3\u68d2\u2c59\uaf8f\u0839\u4b00\u02ab'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup13, new Uint32Array(4174), 1117, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle78, renderBundle27, renderBundle64, renderBundle16, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(848, 220, 15, 251_460_520, 1_227_346_503);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline5);
+} catch {}
+let commandEncoder137 = device0.createCommandEncoder();
+let commandBuffer94 = commandEncoder137.finish({label: '\u89a0\ufab3\u0c03\u29aa'});
+let renderBundle81 = renderBundleEncoder4.finish();
+try {
+computePassEncoder27.setBindGroup(2, bindGroup0, new Uint32Array(5354), 382, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 1_528);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 4_164);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 440, resource: {buffer: buffer0, offset: 0, size: 48}}],
+});
+try {
+computePassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 307, 4, 228_622_960);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 11_328);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup13, new Uint32Array(832), 122, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint32', 3_260, 54);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer90]);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+await gc();
+let commandEncoder138 = device0.createCommandEncoder({label: '\u09bf\u{1fe16}\u8252\u0202\u083a\u4363\u0aef\ua580'});
+let computePassEncoder38 = commandEncoder138.beginComputePass({});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer1, 'uint16', 3_218, 5_365);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({entries: [{binding: 442, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }}]});
+try {
+renderPassEncoder4.executeBundles([renderBundle37, renderBundle81, renderBundle65, renderBundle78]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 7_196);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 2_300);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer0, 'uint16', 3_260, 1_385);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer4, 0, 959);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1416, new Float32Array(199), 8, 60);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(73, 71);
+let shaderModule9 = device0.createShaderModule({
+  label: '\u60ec\u084d\u57f0\u615f\u00e4\uc6e2\u4a05\u{1f631}\u05d1',
+  code: `
+@group(1) @binding(61) var tex12: texture_2d_array<i32>;
+@group(1) @binding(53) var tex13: texture_depth_multisampled_2d;
+@group(1) @binding(446) var et19: texture_external;
+@group(0) @binding(76) var et18: texture_external;
+@group(1) @binding(334) var sam17: sampler_comparison;
+@group(0) @binding(402) var sam16: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u) {
+}
+
+struct VertexOutput0 {
+  @location(10) f32: vec2h,
+  @location(5) f33: vec3h,
+  @location(7) f34: vec4u,
+  @location(11) f35: vec2i,
+  @builtin(position) f36: vec4f,
+  @location(9) f37: vec3i
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f33 = vec3h(-29537.9);
+  out.f34 = vec4u(41, 634, 176, 69);
+  out.f36 = vec4f(0.3857, 1.000, 0.1435, 0.1453);
+  return out;
+}
+
+@fragment
+fn fragment0(@location(5) a0: vec3h, @location(9) a1: vec3i) -> @location(200) vec4u {
+  var out: vec4u;
+  out = vec4u(401, 227, 334, 89);
+  _ = textureDimensions(et19);
+  _ = textureLoad(tex12, vec2i(), 0, 0);
+  _ = textureLoad(tex13, vec2i(), 0);
+  _ = textureLoad(et19, vec2u());
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder15.executeBundles([renderBundle81, renderBundle79]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(173, 139, 485, 98_882_452, 2_084_110_828);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder139 = device0.createCommandEncoder({label: '\ue6cc\u04aa\u8714'});
+let commandBuffer95 = commandEncoder139.finish({label: '\ue96c\ud792\u04eb\u{1ff67}\uffe9\ue389\u355f\u{1f979}\ued47'});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 188);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer1, 'uint32', 3_812, 3_238);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer0, 0, 928);
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({label: '\uec63\uba11\u08df\u1814\ud712\u2cff\ufc79'});
+let commandBuffer96 = commandEncoder140.finish({label: '\u003b\uc4e0\u{1f656}\u083e\u{1fb7c}\u09cb\ud26e\u07e7\ubaed'});
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder10.setViewport(56.59827401488759, 26.773062147120584, 105.41481226992994, 5.433130070153536, 0.19773714676199405, 0.36924435967856795);
+} catch {}
+try {
+renderPassEncoder4.draw(7, 109, 2, 882_405_447);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 1_728);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 3_964);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline5);
+} catch {}
+let commandEncoder141 = device0.createCommandEncoder({label: '\uc2a5\ubc87\u4f16\u{1fd2c}\u7238\udb86\u{1f705}\u{1fef5}'});
+let renderPassEncoder20 = commandEncoder141.beginRenderPass({
+  label: '\u00b1\u8531\ue6f8',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 0,
+  clearValue: { r: -399.6, g: -89.62, b: 154.7, a: -798.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder4.drawIndexed(168, 323, 141, 173_224_095, 189_180_960);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer0, 'uint16', 1_324, 95);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video1);
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '21',
+  colorFormats: ['rg16uint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle74]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(135, 132, 221, 182_445_921, 1_042_842_505);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 472);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\u{1f752}');
+} catch {}
+try {
+device0.queue.submit([commandBuffer91, commandBuffer59]);
+} catch {}
+document.body.prepend(img3);
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 372);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup7, new Uint32Array(2705), 61, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer0, 1_272, 506);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder15.setBindGroup(0, bindGroup6, new Uint32Array(4696), 80, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup15, new Uint32Array(671), 105, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(10, 97, 0, 605_801_047);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(137, 305, 177, 9_940_195, 621_072_012);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 736);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint16', 410, 319);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer0, 0);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder({});
+let texture44 = device0.createTexture({
+  label: '\u78ce\ub592\u686e',
+  size: {width: 720, height: 1, depthOrArrayLayers: 19},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder21 = commandEncoder142.beginRenderPass({
+  label: '\u0201\ua983\u6b05\u3e65\ued78\u{1f678}\u{1ffb5}',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 123.5, g: 354.2, b: 916.1, a: 420.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '22',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle82 = renderBundleEncoder4.finish({label: '\u0108\udb4b\ubbfc'});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 7_844);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint32', 664, 1_291);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer0, 'uint32', 488, 3_019);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 724, new DataView(new ArrayBuffer(1131)), 101, 88);
+} catch {}
+try {
+adapter0.label = '\u69d6\u0158\u6e32\ufff6\u01cd\u668d\u{1f932}\ued3c\u{1fe78}\u5335';
+} catch {}
+let video4 = await videoWithData();
+let commandEncoder143 = device0.createCommandEncoder({label: '\u075d\u{1f696}\u0e33'});
+let commandBuffer97 = commandEncoder143.finish();
+let renderBundle83 = renderBundleEncoder2.finish({label: '\u04ed\ue45a'});
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.draw(2, 105, 0, 402_447_310);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 8_900);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 9_640);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 37496, 756);
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  label: '\u{1fb78}\u{1f7cf}\u{1fd53}\u7c40\u8a7c\u06b5\u61e5',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x51bbe48},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 708, attributes: []},
+      {
+        arrayStride: 560,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 116, shaderLocation: 4}],
+      },
+      {arrayStride: 32, attributes: [{format: 'snorm16x2', offset: 0, shaderLocation: 10}]},
+      {arrayStride: 92, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 412, stepMode: 'instance', attributes: []},
+      {arrayStride: 40, attributes: []},
+      {
+        arrayStride: 484,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 0, shaderLocation: 1},
+          {format: 'float32x2', offset: 276, shaderLocation: 13},
+          {format: 'sint8x2', offset: 108, shaderLocation: 6},
+          {format: 'float16x2', offset: 12, shaderLocation: 2},
+          {format: 'uint8x2', offset: 66, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+  await promise20;
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(175, 45, 221, -2_026_278_229, 684_351_618);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 4_284);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer0, 0, 1_052);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 148, new Float32Array(8667), 1570, 1040);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder();
+let commandBuffer98 = commandEncoder144.finish();
+try {
+renderPassEncoder4.draw(3, 231, 2, 132_299_930);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 844);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer0, 'uint16', 228, 1_333);
+} catch {}
+let promise21 = adapter2.requestAdapterInfo();
+let commandEncoder145 = device0.createCommandEncoder({label: '\u{1fb67}\ud958\u0452\u{1fe6d}\u518f\uc705\u0462\u2ba9\u5e10\u{1f7d9}'});
+let texture45 = device0.createTexture({
+  label: '\u0f99\u{1f719}\u{1f97b}\u8191\u0f0d\udc3c\u3132\u{1fbbb}\u6899\u0c74\u0e84',
+  size: {width: 360, height: 1, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+let renderPassEncoder22 = commandEncoder145.beginRenderPass({
+  label: '\ue627\u00da\u{1fdce}',
+  colorAttachments: [{view: textureView20, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder4.draw(1, 9, 0, 626_708_347);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint32', 412, 2_690);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer1, 'uint32', 2_356, 532);
+} catch {}
+let commandEncoder146 = device0.createCommandEncoder();
+let renderPassEncoder23 = commandEncoder146.beginRenderPass({
+  label: '\ud3f4\u0cae\u79a9\ud591',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 123,
+  clearValue: { r: 394.9, g: 535.3, b: -803.4, a: 899.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder4.draw(3, 10, 2, 147_944_895);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 2_788);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 1_456);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer1, 'uint32', 700, 904);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet16 = device0.createQuerySet({label: '\u085f\u5604\u{1fcea}\u0eea\u9adf\u0488\u3e9c\u02e4', type: 'occlusion', count: 124});
+try {
+computePassEncoder37.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, undefined, 588_695_480);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise22 = adapter0.requestAdapterInfo();
+let sampler8 = device0.createSampler({
+  label: '\u111f\u65b3\ucd89',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 54.10,
+  lodMaxClamp: 78.93,
+});
+try {
+computePassEncoder33.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer4, 0, 2_349);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '23',
+  colorFormats: ['rg16uint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 516);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint16', 3_344, 728);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline5);
+} catch {}
+let img5 = await imageWithData(124, 50, '#10101010', '#20202020');
+document.body.prepend(video0);
+let commandBuffer99 = commandEncoder91.finish({label: '\u6fa5\u8851\ud0cd\u07b3'});
+let texture46 = gpuCanvasContext3.getCurrentTexture();
+let renderBundle84 = renderBundleEncoder8.finish({label: '\u3eb8\uf886\u0ab9\u961c\u5aff\u3305\u7f15\u{1ff9b}\u0164'});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup9, [0]);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 5_340, 670);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup6, new Uint32Array(1449), 497, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder({label: '\u{1f8c8}\u{1ffa1}\u09ad\u3eda\u087b\u08f1\u012e\u{1fe37}\u03db'});
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle53, renderBundle81]);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4, buffer4, 64);
+} catch {}
+video1.height = 21;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData15 = new ImageData(12, 4);
+let commandBuffer100 = commandEncoder147.finish({label: '\u51c6\u071f\ua14d\u55a3\uc3ef\u5cf9\u552f\ua489'});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup15);
+} catch {}
+document.body.prepend(img5);
+let commandBuffer101 = commandEncoder135.finish({label: '\uc8e6\u043f\u0fde\ud814'});
+let renderBundle85 = renderBundleEncoder6.finish({label: '\u6543\u{1f6f2}\u{1fa41}\u2243\u85fa\u0e87'});
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -249.3, g: 901.8, b: 41.00, a: -411.4, });
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer4);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer0, 4_092, 4);
+} catch {}
+let arrayBuffer7 = buffer3.getMappedRange(2832, 24);
+try {
+buffer8.unmap();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup12, new Uint32Array(489), 56, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle1, renderBundle76, renderBundle76, renderBundle81, renderBundle37, renderBundle73]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer1, 'uint16', 2_788, 2_427);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(7, buffer0, 1_136);
+} catch {}
+try {
+  await promise21;
+} catch {}
+try {
+  await promise22;
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(120, 5);
+try {
+window.someLabel = device1.label;
+} catch {}
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({label: '24', colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(1178), 145, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer4, 3_984, 4_168);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(2, buffer4, 0, 6_653);
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\u599f');
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup16, [2560]);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer4, 0);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder148 = device0.createCommandEncoder({label: '\u0222\u03da\u94d5\u8bbe\u4f9d\ufbb6\ub8de\u07c7\u0e7b\u03a4\u0b3b'});
+let textureView39 = texture4.createView({label: '\u{1fa30}\u0a93\u244c\u01b2\u0eae', baseArrayLayer: 4, arrayLayerCount: 9});
+let computePassEncoder39 = commandEncoder148.beginComputePass();
+try {
+computePassEncoder6.setBindGroup(1, bindGroup10, new Uint32Array(2289), 119, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer0);
+} catch {}
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({label: '25', colorFormats: ['rg16uint'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle86 = renderBundleEncoder7.finish();
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup16, [256]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u6820\u1fc9\u375d',
+  entries: [{binding: 501, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let renderBundle87 = renderBundleEncoder17.finish({label: '\u0f62\u058f\u4314\u0c94\u{1fb55}\u7c71'});
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle76]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(4, buffer4, 0, 3_219);
+} catch {}
+let promise23 = device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule9}});
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup13, new Uint32Array(2840), 271, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer1, 'uint32', 144, 7_330);
+} catch {}
+try {
+device0.queue.submit([commandBuffer94, commandBuffer101, commandBuffer92]);
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder();
+let renderPassEncoder24 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{view: textureView11, depthSlice: 56, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 216248439,
+});
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer4);
+} catch {}
+let promise24 = adapter0.requestAdapterInfo();
+let commandEncoder150 = device0.createCommandEncoder({label: '\ub863\u001d\u0c25\u{1ff96}\u0aae'});
+let renderPassEncoder25 = commandEncoder150.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 16,
+  clearValue: { r: 566.0, g: 527.9, b: 518.9, a: -807.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 142533015,
+});
+let renderBundle88 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup9, [0]);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(2, buffer0);
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder();
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle16, renderBundle61, renderBundle16, renderBundle37, renderBundle28, renderBundle37, renderBundle62]);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(0, 0, 9, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer0, 2_424);
+} catch {}
+try {
+commandEncoder151.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 896 */
+  offset: 896,
+  buffer: buffer8,
+}, {width: 64, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder151.resolveQuerySet(querySet12, 67, 2, buffer4, 5632);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 6376, new BigUint64Array(16735), 1215, 200);
+} catch {}
+let commandEncoder152 = device0.createCommandEncoder({label: '\u0eef\u436d\u05ea\u{1fc1a}\u0181\u{1fabc}\u{1fdd5}\ua5dc\u95fd\u00f5\u5bd0'});
+let renderPassEncoder26 = commandEncoder152.beginRenderPass({
+  label: '\u4dd1\uad72',
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 3,
+  clearValue: { r: 864.4, g: 817.0, b: 171.1, a: 599.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle89 = renderBundleEncoder8.finish({label: '\u9252\u12eb'});
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer0, 'uint32', 2_308, 1_767);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer0, 'uint32', 96, 7_874);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(2, buffer0, 0, 2_046);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+document.body.prepend(video4);
+let buffer21 = device0.createBuffer({
+  label: '\u918a\u05be\uc364\u5bd5\u0666\u{1f8af}\u2a11\u{1fad1}\u073a',
+  size: 12451,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder153 = device0.createCommandEncoder({label: '\u{1fd33}\uda0f\u00b8\u{1fae1}\u76e7\u0226\u01aa\u080b'});
+let texture47 = gpuCanvasContext2.getCurrentTexture();
+let textureView40 = texture6.createView({mipLevelCount: 1});
+let renderBundle90 = renderBundleEncoder4.finish({label: '\u03f1\u0a45\u0499\u{1fef3}\u{1fe2b}'});
+try {
+renderPassEncoder19.setIndexBuffer(buffer1, 'uint16', 4_482, 2_032);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer1, 7524, buffer0, 120, 3268);
+} catch {}
+let computePassEncoder40 = commandEncoder153.beginComputePass({label: '\ua10a\u0d17\u{1fad1}'});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup12, new Uint32Array(6891), 274, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer0, 'uint16', 588, 1_862);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint16', 2_902, 2_973);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer1, 1688, buffer8, 2644, 8000);
+} catch {}
+try {
+commandEncoder151.clearBuffer(buffer0, 780, 4296);
+} catch {}
+let videoFrame7 = new VideoFrame(videoFrame5, {timestamp: 0});
+let commandEncoder154 = device0.createCommandEncoder({label: '\u09ea\u6f50\u5b75\u0b04\u20f8'});
+try {
+computePassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle21, renderBundle26, renderBundle87, renderBundle55, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer0, 1_104, 477);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+commandEncoder154.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 540, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 5},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder23.insertDebugMarker('\u0549');
+} catch {}
+try {
+  await promise24;
+} catch {}
+try {
+externalTexture6.label = '\u0879\u5a64\u{1f96c}\u51f9\u0e13\u0020\u{1fe21}\u{1ffa8}\u43ba';
+} catch {}
+let commandEncoder155 = device0.createCommandEncoder();
+let commandBuffer102 = commandEncoder155.finish({label: '\u{1fb46}\u651a'});
+let renderBundle91 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder13.executeBundles([renderBundle82]);
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant({ r: 358.3, g: 7.718, b: -149.2, a: -622.2, });
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer0, 860, 703);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let commandBuffer103 = commandEncoder151.finish({label: '\u49f5\u2133\uf828\uec3a\u{1fb5f}\ud57f'});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup8, new Uint32Array(1250), 129, 0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer4, 0, 1_698);
+} catch {}
+try {
+renderPassEncoder21.pushDebugGroup('\ue463');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\u{1fb5a}\u{1fa77}\uaedc\u946c\u8929\u01f9\u0fe9\u0056\u0545',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 3, resource: externalTexture12},
+    {binding: 45, resource: {buffer: buffer0, offset: 2048, size: 564}},
+  ],
+});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle47, renderBundle50, renderBundle52, renderBundle45]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup15, new Uint32Array(695), 111, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 444, new BigUint64Array(10307), 123, 484);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+offscreenCanvas1.height = 65;
+let commandBuffer104 = commandEncoder154.finish({label: '\u{1fa05}\u2490\ufe86\ud5c8'});
+let renderPassEncoder27 = commandEncoder25.beginRenderPass({
+  label: '\u6fd5\u4dd8\u9065\u0c90\u{1f7d9}\u08b7',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -236.8, g: -716.6, b: -394.6, a: -375.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline5);
+} catch {}
+let texture48 = device0.createTexture({
+  label: '\u237b\u{1f6d7}\uf3a1\u0b24\u01a0',
+  size: [720],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle73, renderBundle37]);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer0, 2_360);
+} catch {}
+let video5 = await videoWithData();
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let renderPassEncoder28 = commandEncoder54.beginRenderPass({
+  label: '\u3141\ub4be\u{1f607}\uc590\ue43c\u8ffe\udbe1\u1d0e',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 27,
+  clearValue: { r: -594.6, g: 731.4, b: -913.3, a: 475.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 497848283,
+});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer4, 3_000, 1_056);
+} catch {}
+try {
+device0.queue.submit([commandBuffer98, commandBuffer102, commandBuffer97]);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup14, new Uint32Array(2485), 260, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer0, 'uint16', 2_044, 1_330);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer4, 0, 14_188);
+} catch {}
+try {
+device0.queue.submit([commandBuffer104]);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer1, 'uint32', 556, 2_006);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer95]);
+} catch {}
+try {
+texture25.label = '\u062a\u{1ff9f}\u{1febf}\u0ec4\u6cad\u1e65\u3420\uf963';
+} catch {}
+let querySet17 = device0.createQuerySet({
+  label: '\ua321\u{1fc1c}\u03e1\u8ffd\u9991\u6c1a\u50e6\u0c77\u{1f7b0}\u8f20',
+  type: 'occlusion',
+  count: 317,
+});
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer4, 0, 2_130);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4, buffer4, 0, 3_104);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 48, new DataView(new ArrayBuffer(57556)), 7836, 6268);
+} catch {}
+let video6 = await videoWithData();
+let pipelineLayout17 = device0.createPipelineLayout({label: '\u78f3\u05c2\u04f4\u{1f694}\ue555\u88d5\u0756', bindGroupLayouts: []});
+let commandEncoder156 = device0.createCommandEncoder({label: '\ue34b\u0c73\u4429\u0142\uad57\ubb88\u082d\u3717\u7e01'});
+let computePassEncoder41 = commandEncoder156.beginComputePass({label: '\u031f\u{1fd2f}\uac3f'});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup16, [1536]);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup9, new Uint32Array(1443), 192, 1);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer4, 0);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  label: '\u07b2\u00ad\u{1f9a9}\u{1fab5}\uc76a\u03e1\u0949',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 45, resource: {buffer: buffer21, offset: 1792, size: 244}},
+    {binding: 3, resource: externalTexture17},
+  ],
+});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle16, renderBundle82, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4_294_967_294, undefined, 0, 33_799_409);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+device0.queue.submit([commandBuffer103, commandBuffer5]);
+} catch {}
+try {
+  await promise25;
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder22.setBindGroup(3, bindGroup8, new Uint32Array(3861), 657, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint16', 1_404, 1_850);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer4, 0, 5_025);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 872, new BigUint64Array(5444), 20, 28);
+} catch {}
+try {
+externalTexture2.label = '\u4fb4\u063a\u{1f9d0}\u92c6\ua2a8';
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\ua537\u11ac\ud5cb\u0c1d\u08fa',
+  entries: [
+    {
+      binding: 205,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 470,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 148,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 469, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 170,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 151,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 5, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 15, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 335,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 259, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder157 = device0.createCommandEncoder({label: '\u{1fbef}\u{1faae}\u681e\u{1f896}\u1dd9'});
+let renderPassEncoder29 = commandEncoder157.beginRenderPass({
+  label: '\uee72\u70a8\u{1fccb}\u2af5\ue719\u589b\u0c0c\u1220',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: -868.8, g: -330.3, b: -598.7, a: -69.20, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 335322199,
+});
+try {
+computePassEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle84, renderBundle80, renderBundle52, renderBundle79, renderBundle73]);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup14, []);
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilReadMask: 290717065,
+    stencilWriteMask: 77167869,
+    depthBiasSlopeScale: 143.27935862944662,
+    depthBiasClamp: 745.2619455429888,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 340, attributes: [{format: 'float16x2', offset: 28, shaderLocation: 14}]},
+      {arrayStride: 108, attributes: []},
+      {
+        arrayStride: 92,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 0, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 332,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x3', offset: 128, shaderLocation: 5}],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 68, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32', offset: 172, shaderLocation: 4},
+          {format: 'float32', offset: 744, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 112, shaderLocation: 10},
+          {format: 'float32', offset: 104, shaderLocation: 8},
+          {format: 'uint32x2', offset: 684, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 248, shaderLocation: 0},
+          {format: 'sint32x2', offset: 280, shaderLocation: 1},
+          {format: 'sint32x4', offset: 220, shaderLocation: 11},
+          {format: 'sint8x4', offset: 572, shaderLocation: 13},
+          {format: 'float32x2', offset: 288, shaderLocation: 2},
+          {format: 'uint32', offset: 116, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup13, new Uint32Array(3478), 1143, 0);
+} catch {}
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(9.022812620221519, 14.346180527792948, 17.74728116726034, 0.1846287168473685, 0.3033554342761158, 0.6298688992941097);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer4, 4_548);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup8, new Uint32Array(4), 2, 0);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let video7 = await videoWithData();
+let renderPassEncoder30 = commandEncoder148.beginRenderPass({
+  label: '\u4af9\u4034\ued27\u36aa',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 292,
+  clearValue: { r: -957.4, g: -927.2, b: -144.2, a: 889.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 897485417,
+});
+let renderBundle92 = renderBundleEncoder1.finish({label: '\udcfb\ufb37\u{1f9c4}\u0e9f\u7ee9\u0e1c'});
+try {
+renderPassEncoder26.setScissorRect(1, 0, 12, 6);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+let querySet18 = device0.createQuerySet({
+  label: '\u7a22\u5322\u014f\u10e3\u25a6\u7b01\u9184\ucb93\u{1fa18}\ue645',
+  type: 'occlusion',
+  count: 638,
+});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer1, 'uint16', 5_048, 1_693);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup9, new Uint32Array(449), 76, 1);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(2, buffer0, 0, 1_749);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\u007b\u007c\uf6aa\u3953\u015c\ucd7e\u{1fdcc}',
+  code: `
+@group(1) @binding(53) var tex15: texture_multisampled_2d<f32>;
+@group(1) @binding(446) var et21: texture_external;
+@group(0) @binding(402) var sam18: sampler;
+@group(0) @binding(76) var et20: texture_external;
+@group(1) @binding(61) var tex14: texture_depth_cube;
+@group(1) @binding(334) var sam19: sampler_comparison;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32, @builtin(num_workgroups) a1: vec3u) {
+}
+
+struct S6 {
+  @location(8) f0: vec4f
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4f, @location(15) a1: vec4u, @location(10) a2: f32, @location(12) a3: f16, a4: S6, @location(5) a5: f32, @location(9) a6: vec2h) -> @builtin(position) vec4f {
+  var position: vec4f;
+  position = vec4f(0.09820, 0.02626, 0.1889, 0.02918);
+  return position;
+}
+
+struct S7 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @location(6) f0: vec3f,
+  @location(0) f1: vec4u,
+  @location(4) f2: vec2i
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4f, a1: S7) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 = vec3f(0.1274, 0.6285, 0.2294);
+  out.f1 = vec4u(22, 98, 176, 124);
+  out.f2 = vec2i(204, 166);
+  _ = textureLoad(tex15, vec2i(), 0);
+  _ = textureDimensions(et21);
+  _ = textureLoad(et21, vec2u());
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let externalTexture20 = device0.importExternalTexture({label: '\uf63e\u0fe6\u3b84\u7d86', source: video5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\ucdf8');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer0);
+} catch {}
+await gc();
+let adapter3 = await navigator.gpu.requestAdapter();
+let device2 = await adapter3.requestDevice({
+  label: '\uef2c\u{1fb6c}',
+  defaultQueue: {label: '\u7bad\u3218\u0158\udc42\u{1f8d1}\u0bf3\u{1fd9c}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    maxTextureDimension2D: 8192,
+    maxUniformBufferBindingSize: 1357437,
+    maxStorageBufferBindingSize: 134993413,
+    maxUniformBuffersPerShaderStage: 12,
+  },
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup15, new Uint32Array(2278), 105, 0);
+} catch {}
+try {
+computePassEncoder30.insertDebugMarker('\u19ff');
+} catch {}
+try {
+device0.queue.submit([commandBuffer86, commandBuffer84, commandBuffer47]);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer4, 3_768);
+} catch {}
+try {
+renderPassEncoder21.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1052, new Float32Array(6722), 22, 236);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({
+  label: '\u{1fd32}\uf02f\u{1f95f}\u7af7\uf002\u4688\u9c71\u02fe\u{1fd50}\ucf9e',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout2, bindGroupLayout10, bindGroupLayout8],
+});
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup15, new Uint32Array(2966), 592, 0);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let querySet19 = device2.createQuerySet({type: 'occlusion', count: 141});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let buffer22 = device2.createBuffer({
+  label: '\u781f\u{1f8e5}\u396f\u8d21\ucd8f\u7db2\ub767\u0e14\u93f7\u0855',
+  size: 1420,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder158 = device2.createCommandEncoder({label: '\u{1fc5a}\u54e4\u8a28\ud462\u0711\u0b42\u17ed\ue52f\u{1f7a0}\u0cf8\u0884'});
+let querySet20 = device2.createQuerySet({type: 'occlusion', count: 97});
+let renderBundleEncoder24 = device2.createRenderBundleEncoder({
+  label: '26',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true,
+});
+let renderBundle93 = renderBundleEncoder24.finish();
+try {
+  await promise26;
+} catch {}
+let videoFrame8 = new VideoFrame(videoFrame3, {timestamp: 0});
+let commandBuffer105 = commandEncoder158.finish({});
+let commandEncoder159 = device0.createCommandEncoder();
+let textureView41 = texture48.createView({baseMipLevel: 0});
+let renderPassEncoder31 = commandEncoder159.beginRenderPass({
+  label: '\u{1ff1c}\u{1fb9b}\u8c86',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 206,
+  clearValue: { r: 193.1, g: 464.4, b: -693.1, a: -987.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 606109526,
+});
+try {
+renderPassEncoder26.setPipeline(pipeline5);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer88, commandBuffer99]);
+} catch {}
+let commandEncoder160 = device2.createCommandEncoder({});
+let computePassEncoder42 = commandEncoder160.beginComputePass({label: '\u2490\u2015\u27c1\uf88a\u0fc5\u026c\u1472\ub2ff\u0122\u8aca'});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup16, new Uint32Array(601), 111, 1);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer4, 0, 2_935);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup18, []);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let bindGroupLayout24 = device2.createBindGroupLayout({label: '\u2b18\u{1ff67}\u498a\u5a06\u4445\u33bc\ue924\u3a95', entries: []});
+let texture49 = device2.createTexture({
+  label: '\u6881\u{1f618}\u08ee\u{1fdc1}\u0877\u71d2\uf3ca\u82ab\udcfb\u0b6e',
+  size: [25],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+video5.height = 4;
+try {
+window.someLabel = device2.queue.label;
+} catch {}
+let pipelineLayout19 = device2.createPipelineLayout({
+  label: '\u083c\u02bb\ua7ad\u0aff\u77d5\u0fcd\ua096\udfab\u9132\u02cb\u{1fedb}',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout24],
+});
+let buffer23 = device2.createBuffer({size: 11654, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let sampler9 = device2.createSampler({
+  label: '\u0dfb\uf622\u31aa\u414c\u405b\u{1f719}\u018e\u{1f61b}\u0f88\u0fa3\u598e',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 73.24,
+  lodMaxClamp: 83.95,
+  compare: 'never',
+});
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 137, resource: sampler5}]});
+let commandEncoder161 = device0.createCommandEncoder();
+let commandBuffer106 = commandEncoder161.finish({});
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+let videoFrame9 = videoFrame5.clone();
+try {
+externalTexture6.label = '\ue48c\u9f54';
+} catch {}
+await gc();
+let buffer24 = device2.createBuffer({
+  size: 15448,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let querySet21 = device2.createQuerySet({label: '\u195c\u14ef\u{1f69b}\u3903\u4c6e\u0138\ueb15\u{1fa34}', type: 'occlusion', count: 557});
+let promise27 = adapter0.requestAdapterInfo();
+let texture50 = device0.createTexture({
+  label: '\u769d\u00f5\u0533\u{1fcda}\u07b2\u0474\u43df\u0301\u0b68',
+  size: {width: 470, height: 66, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder26.setIndexBuffer(buffer1, 'uint32', 6_916, 2_592);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint32', 7_468, 99);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+  await promise27;
+} catch {}
+let commandEncoder162 = device2.createCommandEncoder({});
+let renderBundle94 = renderBundleEncoder24.finish();
+let externalTexture21 = device2.importExternalTexture({label: '\u05e0\u0349\u{1fafc}', source: videoFrame9});
+let commandEncoder163 = device0.createCommandEncoder({label: '\u5519\u35d1\u1d23\u0217\u974a'});
+let commandBuffer107 = commandEncoder163.finish();
+let renderBundle95 = renderBundleEncoder17.finish({label: '\u09dd\u464c\uecc9\u{1fc17}\uaa9e\u07d6'});
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 4, 5_545);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer4, 0);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({});
+let commandEncoder164 = device2.createCommandEncoder({});
+let renderBundle96 = renderBundleEncoder24.finish({label: '\ub245\u755f\ufe0c\udfc9\u5c5e\ue717\u{1f9a1}\u9083\u04af\u{1fb0c}'});
+let imageData16 = new ImageData(36, 20);
+let bindGroup20 = device2.createBindGroup({label: '\u8cf8\u6ca7\u{1f8a5}\u0033\u09c7\u0179\u8a2d\u1f91', layout: bindGroupLayout24, entries: []});
+let commandEncoder165 = device2.createCommandEncoder({label: '\u0daa\uffb7\u0bc7\ua183\u01ae\ue4a0\u6cdb\u2e34\u7f8f'});
+let renderBundle97 = renderBundleEncoder24.finish({label: '\u024f\ua300\u09ef\ub63c\u1f21'});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup20);
+} catch {}
+let promise28 = device2.queue.onSubmittedWorkDone();
+let texture51 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderPassEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+document.body.prepend(img4);
+let commandBuffer108 = commandEncoder164.finish({});
+let computePassEncoder43 = commandEncoder165.beginComputePass({label: '\u{1ff61}\u{1f844}\u{1f92a}'});
+let renderBundle98 = renderBundleEncoder24.finish({label: '\u0a9f\u03cc\uc48a'});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter();
+let commandEncoder166 = device2.createCommandEncoder({});
+let commandBuffer109 = commandEncoder166.finish({});
+let texture52 = gpuCanvasContext5.getCurrentTexture();
+let computePassEncoder44 = commandEncoder162.beginComputePass();
+try {
+buffer22.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let externalTexture22 = device0.importExternalTexture({
+  label: '\u14f4\u4dfc\u{1f876}\u434a\u{1fd23}\u07e2\ua916\udb7f\u{1fb25}',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\udb6b');
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder167 = device0.createCommandEncoder({label: '\u3e74\u81e4\u3bbb\u{1feb9}\u0a38\u617b\u497c\ub917\u{1ff14}'});
+let commandBuffer110 = commandEncoder167.finish();
+let sampler10 = device0.createSampler({
+  label: '\u0c9e\ub44c',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 65.48,
+  compare: 'not-equal',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup12, new Uint32Array(3424), 723, 0);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle89, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 484, new Float32Array(5490), 1665, 848);
+} catch {}
+let renderBundle99 = renderBundleEncoder24.finish({label: '\uf85c\u4b5a\ub307\uaf32'});
+try {
+computePassEncoder43.insertDebugMarker('\u179e');
+} catch {}
+document.body.prepend(video8);
+await gc();
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint32', 1_528, 3_480);
+} catch {}
+let video9 = await videoWithData();
+let querySet22 = device0.createQuerySet({
+  label: '\u0205\u{1fb22}\uad10\u{1f6ea}\ue6d9\u{1fb8d}\u3d19\u5b7b\u00b7',
+  type: 'occlusion',
+  count: 2763,
+});
+let texture53 = device0.createTexture({
+  label: '\u2d56\u0652\u091d\u328d\u696f\u8ddc\uad81\u{1fa81}',
+  size: {width: 560, height: 40, depthOrArrayLayers: 1},
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer1, 'uint32', 2_808, 1_900);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(4, buffer0);
+} catch {}
+let commandEncoder168 = device2.createCommandEncoder({});
+let textureView42 = texture49.createView({label: '\u3489\u7484\u{1f760}\u00dc\ud9ea'});
+let renderBundle100 = renderBundleEncoder24.finish({});
+let externalTexture23 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+renderPassEncoder21.beginOcclusionQuery(79);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: -869.2, g: 605.4, b: -568.4, a: -686.1, });
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\u0dd6');
+} catch {}
+let commandEncoder169 = device2.createCommandEncoder({label: '\u0784\u0799\u{1fbf2}\u47e9\u2b37\u{1f90e}'});
+let computePassEncoder45 = commandEncoder168.beginComputePass({label: '\uf245\u83af\uc64b\u5cf4\u{1fb0c}\u0278\u4ac0\u045a\u6330\u079d\u07ec'});
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+commandEncoder169.resolveQuerySet(querySet19, 4, 18, buffer22, 512);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder170 = device0.createCommandEncoder({label: '\u{1f97c}\u4982\u02a5\u{1f9a3}\u{1fc3e}\u0cf6\udac4\u3d8a'});
+let commandBuffer111 = commandEncoder170.finish({label: '\ud3ac\u0080\u8d8d\u07b3\u2242\u6dcd'});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup9, [0]);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(1, bindGroup10, new Uint32Array(1159), 24, 0);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint32', 304, 5_348);
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\udf0c');
+} catch {}
+try {
+computePassEncoder43.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let imageData17 = new ImageData(8, 64);
+let bindGroupLayout25 = device0.createBindGroupLayout({label: '\u0635\u0c49\u9357', entries: []});
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup7, new Uint32Array(2298), 1536, 0);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer0, 0, 827);
+} catch {}
+let gpuCanvasContext7 = canvas3.getContext('webgpu');
+let texture54 = device0.createTexture({
+  label: '\u{1f7b3}\u655f\u{1fa57}\u9143\uc792\u07d2\udc2e\u71bd\u{1fe85}',
+  size: {width: 240, height: 1, depthOrArrayLayers: 15},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder21.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup9, new Uint32Array(2034), 411, 1);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+canvas2.width = 2026;
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+let bindGroupLayout26 = device2.createBindGroupLayout({
+  label: '\u{1fb8e}\u4b6b\u8be9\u49c0\u0371\u{1fc8e}\u07ae\u0f65',
+  entries: [
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 155,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder171 = device2.createCommandEncoder({label: '\u17e6\u36bb\u0691'});
+let commandBuffer112 = commandEncoder171.finish({});
+try {
+computePassEncoder43.end();
+} catch {}
+let pipelineLayout20 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout24, bindGroupLayout26, bindGroupLayout26, bindGroupLayout26]});
+let commandBuffer113 = commandEncoder169.finish();
+try {
+buffer22.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer22, 184, new DataView(new ArrayBuffer(16493)), 3373, 36);
+} catch {}
+let bindGroupLayout27 = device2.createBindGroupLayout({
+  entries: [{binding: 115, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder172 = device2.createCommandEncoder({label: '\u470f\uef47\u75aa\uf1a0\u2149\u{1fbd5}\uc137\u0155'});
+let commandBuffer114 = commandEncoder160.finish();
+let commandEncoder173 = device2.createCommandEncoder();
+let commandBuffer115 = commandEncoder173.finish({label: '\u0659\u619d\uf9b7\u572e\u5522\u0ac2\u002d\ucba8\u3557'});
+let renderBundle101 = renderBundleEncoder24.finish({});
+let bindGroup21 = device2.createBindGroup({label: '\u85ea\u0079', layout: bindGroupLayout24, entries: []});
+let commandEncoder174 = device2.createCommandEncoder({label: '\uc8af\u6cf9\u8a88\uf28f\u4621\u{1f629}\ub4aa\u0ee6'});
+let commandBuffer116 = commandEncoder165.finish({});
+let texture55 = device2.createTexture({
+  label: '\ucc99\u22a9\u29d6\u01fe\u073e\u0a07\u0e6f\u26bd\u{1feff}\u{1fe71}\u{1fb65}',
+  size: [200, 24, 1],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle102 = renderBundleEncoder24.finish({label: '\u0bae\u03ea\u01f4\u{1fc8f}\u502b\u{1f809}\u2233\u56b9\uc314'});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+device2.queue.submit([commandBuffer114]);
+} catch {}
+let renderBundle103 = renderBundleEncoder20.finish({});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup16, [1536]);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(21);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 80, new DataView(new ArrayBuffer(5781)), 752, 1864);
+} catch {}
+let renderBundle104 = renderBundleEncoder16.finish({label: '\ua423\u6c92\ubd37\u{1ffd2}'});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer4, 1_792, 11_496);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer0, 'uint16', 1_404, 107);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer93]);
+} catch {}
+document.body.prepend(img3);
+let commandEncoder175 = device2.createCommandEncoder({label: '\u880b\ud4fe\u0cb9\u{1ff8e}\u0271\ud9bd\u4159\u86f7'});
+let commandBuffer117 = commandEncoder175.finish({label: '\u1412\u0688\ub622\u1e90\uf941\u7e29'});
+let commandEncoder176 = device2.createCommandEncoder();
+try {
+computePassEncoder44.setBindGroup(2, bindGroup20, new Uint32Array(940), 337, 0);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let computePassEncoder46 = commandEncoder174.beginComputePass({label: '\u982b\u1417'});
+try {
+bindGroup12.label = '\u7862\uf983\u342f\u020a\u0a7e\u4eb8\uc9f4\u0244\u0d4b\u0f62\u9576';
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let textureView43 = texture15.createView({});
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 2256, new Float32Array(29474), 4207, 84);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let pipeline9 = await promise23;
+let commandEncoder178 = device2.createCommandEncoder();
+let commandBuffer118 = commandEncoder178.finish({label: '\u0276\ubbda\u{1f6a7}\u09c5\uc06a'});
+let texture56 = device2.createTexture({
+  label: '\ubd88\u{1f6a6}\u{1fb7d}\u5aa2\u8259\ua01f\u{1f93e}\u788a\ue9e1\u{1faad}',
+  size: [200, 24, 503],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture24 = device2.importExternalTexture({label: '\u042d\ueb19\u5d54', source: videoFrame5});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup20, []);
+} catch {}
+let querySet23 = device0.createQuerySet({label: '\ub093\u19a1', type: 'occlusion', count: 1242});
+let commandBuffer119 = commandEncoder177.finish({});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle95, renderBundle65, renderBundle53]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer4, 180, 538);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer3, 11408, 116);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img6 = await imageWithData(74, 46, '#10101010', '#20202020');
+let commandBuffer120 = commandEncoder172.finish({label: '\u{1f699}\uad46\u{1fe2f}\u5d3d\u9d45'});
+let renderBundle105 = renderBundleEncoder24.finish({label: '\u4869\u{1fd1f}\u9406\u01d7\ue932\u30ff\u01c1\uced7\u0d74\ucd48\u{1fbf3}'});
+try {
+buffer24.unmap();
+} catch {}
+let shaderModule11 = device2.createShaderModule({
+  code: `
+@group(2) @binding(155) var<storage, read> buffer26: array<u32>;
+@group(1) @binding(155) var<storage, read> buffer25: array<mat3x3h, 1>;
+@group(3) @binding(155) var<storage, read> buffer27: array<array<vec2u, 1>>;
+@group(1) @binding(75) var sam20: sampler;
+@group(2) @binding(75) var sam21: sampler;
+@group(3) @binding(75) var sam22: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct S8 {
+  @location(14) f0: vec3u
+}
+struct VertexOutput0 {
+  @builtin(position) f38: vec4f,
+  @location(5) f39: vec3u
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4f, @location(6) a1: vec4h, @location(8) a2: u32, @location(10) a3: u32, @location(0) a4: vec2i, @location(4) a5: vec2h, @location(2) a6: vec2u, @location(3) a7: vec3f, @location(15) a8: vec4h, @location(13) a9: vec3h, @location(11) a10: vec4f, @location(1) a11: f16, @location(12) a12: vec2h, a13: S8) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4i,
+  @location(0) f1: vec2i,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(@location(5) a0: vec3u) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f1 = vec2i(365, 84);
+  _ = buffer26;
+  _ = buffer27;
+  _ = buffer25;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer28 = device2.createBuffer({
+  label: '\udbae\u0d05\u0727\u0b4c\ud135\u{1ff6f}',
+  size: 3131,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder47 = commandEncoder176.beginComputePass({label: '\u0934\u012d\u0986\u9028\uacfc\u{1fb03}\ufec7\ud85e\u00a4\u0a91\u{1fbf8}'});
+let renderBundle106 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup20, new Uint32Array(2485), 128, 0);
+} catch {}
+document.body.prepend(img6);
+let commandBuffer121 = commandEncoder10.finish();
+let texture57 = device0.createTexture({
+  label: '\ucce8\u0dce\u{1f687}\u8d3b\u{1ff5d}\uaa1e\u5a94\u9510\uce2d\u0524\u056d',
+  size: {width: 120, height: 1, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle107 = renderBundleEncoder15.finish({label: '\u0b55\u0834\u082d\u{1fabd}\u{1fa14}\u7000\u{1f8a5}\u007b'});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint32', 6_520, 8_001);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(1265);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(7, buffer4, 0, 6_213);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+  await promise29;
+} catch {}
+document.body.prepend(img5);
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder179 = device2.createCommandEncoder({label: '\u{1f8a9}\u{1ff68}\u07ae\u03ce\u0de9\u409c\uecb6\u3858\ub959\u02e1'});
+let renderBundle108 = renderBundleEncoder24.finish({label: '\u0210\u0cc4\u5e7d\uc405'});
+await gc();
+let videoFrame10 = videoFrame9.clone();
+let imageData18 = new ImageData(24, 16);
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 229});
+let textureView44 = texture0.createView({label: '\u09e5\u05f4\u{1fb4c}\u02fb\u0b55\u05d6\u1d31\u0af5\u0330\u7fc7\u9b2c', baseMipLevel: 2});
+try {
+renderPassEncoder25.executeBundles([renderBundle82, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer4, 2_312);
+} catch {}
+try {
+renderBundleEncoder19.draw(4, 103, 0, 903_911_114);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(181, 4, 292, 576_108_733, 421_383_470);
+} catch {}
+try {
+device0.queue.submit([commandBuffer100]);
+} catch {}
+let commandEncoder180 = device0.createCommandEncoder();
+let renderPassEncoder32 = commandEncoder180.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 28,
+  clearValue: { r: 365.9, g: -918.2, b: -922.9, a: 142.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+});
+let renderBundle109 = renderBundleEncoder19.finish({label: '\u5b7d\u{1f82a}\u{1fa5f}\u{1f81c}\u{1fcb2}\u1580'});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer4, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer0, 'uint16', 36, 244);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint16', 504, 4_727);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer96]);
+} catch {}
+let img7 = await imageWithData(2, 152, '#10101010', '#20202020');
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup15, new Uint32Array(414), 47, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 2_730, 1_211);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline10 = device0.createRenderPipeline({
+  label: '\u0ef7\u90e8\u0502\u{1ff73}\u3cab\u{1f6ae}\ucd2e\uea4b\u0ad5\u{1f837}',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    buffers: [
+      {arrayStride: 144, stepMode: 'instance', attributes: []},
+      {arrayStride: 388, attributes: []},
+      {arrayStride: 216, stepMode: 'instance', attributes: []},
+      {arrayStride: 1060, stepMode: 'instance', attributes: []},
+      {arrayStride: 396, stepMode: 'instance', attributes: []},
+      {arrayStride: 36, attributes: []},
+      {arrayStride: 100, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 164,
+        attributes: [
+          {format: 'float32x3', offset: 8, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 2},
+          {format: 'sint32x3', offset: 8, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+await gc();
+let videoFrame11 = new VideoFrame(videoFrame4, {timestamp: 0});
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\udded\u3dfc\u{1fe87}',
+  bindGroupLayouts: [bindGroupLayout16, bindGroupLayout16, bindGroupLayout2, bindGroupLayout1],
+});
+let renderBundle110 = renderBundleEncoder4.finish({label: '\u{1fedc}\uf21e\u0c27\u7c12\u{1fdc2}\u{1fac6}\u8c7e\u{1f896}\u{1ff18}\u03e7'});
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer1, 'uint32', 5_244, 3_489);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer4, 3_644);
+} catch {}
+await gc();
+let commandBuffer122 = commandEncoder179.finish({label: '\u093d\u0e87\u00ed'});
+let shaderModule12 = device0.createShaderModule({
+  code: `
+@group(2) @binding(61) var tex16: texture_3d<f32>;
+@group(3) @binding(3) var et23: texture_external;
+@group(2) @binding(334) var sam23: sampler_comparison;
+@group(2) @binding(446) var et22: texture_external;
+@group(2) @binding(53) var tex17: texture_depth_multisampled_2d;
+@group(3) @binding(45) var<storage, read_write> buffer29: array<array<mat4x3f, 1>, 1>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  buffer29[0][0] = mat4x3f();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f40: vec4f
+}
+
+@vertex
+fn vertex0(@location(13) a0: i32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3u
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureLoad(tex16, vec3i(), 0);
+  _ = textureDimensions(et22);
+  _ = textureLoad(et22, vec2u());
+  _ = textureLoad(tex17, vec2i(), 0);
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let renderBundle111 = renderBundleEncoder1.finish();
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle45]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer0, 'uint16', 1_108, 7_124);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+renderPassEncoder24.insertDebugMarker('\u230c');
+} catch {}
+try {
+device0.queue.submit([commandBuffer89, commandBuffer67]);
+} catch {}
+let renderBundleEncoder25 = device2.createRenderBundleEncoder({
+  label: '27',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup20, new Uint32Array(3040), 101, 0);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer22, 0, 437);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\u1038\u{1f607}\ud1b4\u3a02\u991d\u{1f9f4}\u{1fe8f}',
+  entries: [
+    {
+      binding: 283,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 729,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 63556, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder181 = device0.createCommandEncoder();
+let commandBuffer123 = commandEncoder181.finish({label: '\u0223\u096a\u0d87\u7e52'});
+let textureView45 = texture24.createView({label: '\u0c7d\u0b09\u0404\u7799\u{1f7e9}\u9a4e\u0a63\udad6\u9ca7\u9634', baseMipLevel: 1});
+try {
+computePassEncoder6.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup18, new Uint32Array(80), 5, 0);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(49);
+} catch {}
+let renderBundle112 = renderBundleEncoder6.finish();
+try {
+computePassEncoder30.setBindGroup(1, bindGroup14, new Uint32Array(668), 448, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle45]);
+} catch {}
+let textureView46 = texture49.createView({label: '\uf69e\u{1f830}\ua2f5\u{1f868}\u6915\u00a3\u6814\u0193'});
+let renderBundle113 = renderBundleEncoder25.finish({label: '\uc37f\u0ada\u0422\u873b\uc7a0\u0c5c\uc9ea'});
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder({label: '\ufbc5\uead1\u0761\u0225\u53e3\u{1fa3f}\u6edd'});
+let commandBuffer124 = commandEncoder182.finish({label: '\u0ebb\u0186\uaac1\u{1ffe7}\u04e3\u34be\u01b1\u{1fb8c}\u24c1'});
+try {
+renderBundleEncoder23.setIndexBuffer(buffer1, 'uint32', 4_588, 807);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let textureView47 = texture1.createView({label: '\u{1f86a}\u{1f99f}\u{1ffb1}\u0ec7\u804d\ufa6d\u06d0\u{1fd7d}\u81fc', dimension: '1d'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline10);
+} catch {}
+document.body.prepend(video2);
+let renderBundle114 = renderBundleEncoder25.finish();
+try {
+device2.queue.writeBuffer(buffer22, 124, new Float32Array(11659), 1125, 32);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setViewport(71.54595721087905, 8.46177511267437, 154.9577780958578, 10.747479865709481, 0.23935026751959454, 0.8007217557124529);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint32', 168, 1_523);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline10);
+} catch {}
+let commandEncoder183 = device0.createCommandEncoder();
+try {
+renderPassEncoder20.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer4);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 770, 1_477);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline10);
+} catch {}
+try {
+externalTexture5.label = '\u7164\uc705\u17e3\u07fb\u439b\u029a\u4b5b\u71b4\u034c\u3431';
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(video8);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+externalTexture21.label = '\u0848\uc608\u054c\uad8e\ub69c\u{1f786}\ue8cf';
+} catch {}
+let bindGroupLayout29 = device2.createBindGroupLayout({label: '\ufb8d\u38ce\u{1fd2a}\u76ea\u7dcf\u2a56\u0533\u0249', entries: []});
+let renderBundle115 = renderBundleEncoder24.finish({label: '\u{1febb}\u{1f668}'});
+let sampler11 = device2.createSampler({
+  label: '\u9289\u26bd\u{1fe7d}\u{1f866}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 14.08,
+  lodMaxClamp: 32.44,
+});
+let promise30 = device2.queue.onSubmittedWorkDone();
+let renderPassEncoder33 = commandEncoder183.beginRenderPass({
+  label: '\u052e\u0160\u{1f973}',
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 13,
+  clearValue: { r: -217.1, g: 825.5, b: 249.3, a: 339.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet24,
+  maxDrawCount: 240963452,
+});
+try {
+renderPassEncoder29.setIndexBuffer(buffer0, 'uint16', 274, 1_041);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer0, 0, 108);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+offscreenCanvas2.width = 825;
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let commandEncoder184 = device2.createCommandEncoder({label: '\u7cf1\uac09\ua9a0\u069e\u0b34'});
+let commandBuffer125 = commandEncoder184.finish();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise30;
+} catch {}
+let imageData19 = new ImageData(8, 92);
+let commandEncoder185 = device2.createCommandEncoder({label: '\u014b\u307e\u0a87\u{1fc34}\u1e6b\u0e8a'});
+let commandBuffer126 = commandEncoder185.finish({label: '\u{1f99d}\uf25a\u3ad8\uc290'});
+let textureView48 = texture49.createView({label: '\u09a3\u99ca\uebd4\u{1f77e}\u{1f9e9}\u09e7\ue4ec\u05ca\ua6df\uf0b0\ue2ba'});
+let renderBundle116 = renderBundleEncoder25.finish({label: '\u{1ff60}\u0333\udad9\u3f0a\u{1fe01}'});
+try {
+computePassEncoder47.insertDebugMarker('\u{1fa93}');
+} catch {}
+try {
+device2.queue.submit([commandBuffer113, commandBuffer122]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer28, 632, new DataView(new ArrayBuffer(7247)), 1602, 128);
+} catch {}
+document.body.prepend(img7);
+let img8 = await imageWithData(168, 192, '#10101010', '#20202020');
+let commandEncoder186 = device0.createCommandEncoder({label: '\ud540\u{1f718}\ubdca\u8212\u46a6\u{1fc34}\ub52d'});
+let commandBuffer127 = commandEncoder186.finish({label: '\u{1ff10}\u0049\ucbf1\u2d32\u{1f84f}\uc442'});
+try {
+renderBundleEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer4, 492);
+} catch {}
+let bindGroupLayout30 = device2.createBindGroupLayout({
+  label: '\u3051\ue430\ueacf\uad51\u007d\u47a5\u1d26\u7387\u8134\u975d\u5687',
+  entries: [
+    {
+      binding: 589,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 163, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder187 = device2.createCommandEncoder({});
+try {
+commandEncoder187.resolveQuerySet(querySet19, 28, 3, buffer22, 0);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder({});
+let texture58 = device0.createTexture({
+  label: '\u4702\u09eb\u1546\u{1fc96}\uf674\u07c4\u0cf0\u062e',
+  size: {width: 240, height: 1, depthOrArrayLayers: 38},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder34 = commandEncoder188.beginRenderPass({
+  label: '\u0569\uec3f\u4c42\u0608\u0f12\ua2af',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 409.9, g: 385.8, b: -437.4, a: 721.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+});
+try {
+computePassEncoder38.pushDebugGroup('\u0ce6');
+} catch {}
+let externalTexture25 = device0.importExternalTexture({label: '\u{1f68a}\u821c\u{1fb3a}\u2a09\u8537\u0b9e\u075b', source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(0, bindGroup6, new Uint32Array(6627), 2269, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle110]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer0, 'uint16', 222, 459);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint16', 2_274, 2_388);
+} catch {}
+try {
+renderPassEncoder24.pushDebugGroup('\uc0d4');
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({label: '\u2413\ud89f', layout: pipelineLayout6, compute: {module: shaderModule4, constants: {}}});
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer0, 'uint16', 3_420, 970);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder189 = device2.createCommandEncoder({label: '\u955e\u99c9\u3c21'});
+let commandBuffer128 = commandEncoder187.finish({label: '\u0eb5\uf812\u0561\u72c6\u0e79\u{1fc42}\u2a4a'});
+let textureView49 = texture56.createView({aspect: 'all'});
+let renderBundleEncoder26 = device2.createRenderBundleEncoder({label: '28', colorFormats: ['rgba8unorm', 'rgba32uint', 'rgba8uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+renderBundleEncoder26.setIndexBuffer(buffer28, 'uint32', 312, 324);
+} catch {}
+let texture59 = gpuCanvasContext4.getCurrentTexture();
+let renderBundle117 = renderBundleEncoder8.finish({label: '\u{1fd1b}\u{1f94b}\ude05\uf74d\u{1f689}\u8f7c\u1311'});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup15, new Uint32Array(1618), 834, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer4, 2_220, 107);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup18, []);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer0, 'uint16', 560, 13);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline5);
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video1);
+let bindGroup22 = device2.createBindGroup({layout: bindGroupLayout29, entries: []});
+let commandEncoder190 = device2.createCommandEncoder();
+let querySet25 = device2.createQuerySet({
+  label: '\u{1f8ca}\u03f4\u0012\u935a\u2c3a\u94f5\u0419\u7587\u{1faa8}\u1b09',
+  type: 'occlusion',
+  count: 374,
+});
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup20, new Uint32Array(3746), 197, 0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer28);
+} catch {}
+try {
+commandEncoder189.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2688 */
+  offset: 2688,
+  bytesPerRow: 256,
+  buffer: buffer28,
+}, {width: 5, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+computePassEncoder38.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle53, renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer0, 'uint16', 224, 1_004);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer4, 176);
+} catch {}
+let arrayBuffer8 = buffer3.getMappedRange(2736, 0);
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 3040, 2176);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise31;
+} catch {}
+let imageData20 = new ImageData(72, 156);
+try {
+computePassEncoder45.setBindGroup(3, bindGroup22, []);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(2, buffer22, 0, 0);
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+await gc();
+await gc();
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  label: '\ud507\u{1f9d0}\u51f8\u02da\u0276\u{1ff92}',
+  entries: [
+    {binding: 40, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 128,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 4, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 182,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 193, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 237,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 600,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 225,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 241, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup0, new Uint32Array(874), 117, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer1, 'uint16', 1_008, 1_334);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+let renderBundle118 = renderBundleEncoder19.finish();
+try {
+renderPassEncoder20.executeBundles([renderBundle79]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer0, 1_476);
+} catch {}
+try {
+  await promise32;
+} catch {}
+let commandEncoder191 = device2.createCommandEncoder({});
+let computePassEncoder48 = commandEncoder190.beginComputePass({label: '\uaa52\u{1fa6c}\u2c16\u07fc\u0e7f'});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup21, new Uint32Array(638), 100, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup20, new Uint32Array(565), 18, 0);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({label: '\u441a\uf124\u46c8\u0abf\u638c'});
+let textureView50 = texture54.createView({aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 5});
+let computePassEncoder49 = commandEncoder192.beginComputePass({label: '\u7289\u{1f7df}\u2847\u{1fe11}\u07a7\u332d\u{1f6b1}'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup14, new Uint32Array(1206), 298, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle91]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer4, 4_828, 1_209);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint16', 5_314, 753);
+} catch {}
+try {
+computePassEncoder38.popDebugGroup();
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule8, constants: {}}});
+let textureView51 = texture45.createView({});
+let renderBundle119 = renderBundleEncoder4.finish();
+try {
+renderPassEncoder23.setBlendConstant({ r: 213.8, g: -773.6, b: -748.5, a: 40.51, });
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer0, 232, 2_709);
+} catch {}
+try {
+renderPassEncoder29.pushDebugGroup('\u00e0');
+} catch {}
+let pipelineLayout22 = device2.createPipelineLayout({label: '\u9e7d\u093b\uf017\u1321', bindGroupLayouts: [bindGroupLayout27, bindGroupLayout26]});
+let commandEncoder193 = device2.createCommandEncoder({label: '\ufa51\u1e19\u0f7f\u0b90\u{1f825}'});
+let querySet26 = device2.createQuerySet({type: 'occlusion', count: 317});
+let commandBuffer129 = commandEncoder193.finish({});
+let texture60 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder50 = commandEncoder189.beginComputePass({label: '\u0830\u0611\u30b1\u{1fddf}\u0ab2\u01e9\uee0a\u6076\ucafd\u830f\u{1fff0}'});
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup20, new Uint32Array(1140), 80, 0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, buffer28, 452, 931);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer28, 172, new DataView(new ArrayBuffer(4170)), 307, 184);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+device2.queue.submit([commandBuffer129, commandBuffer115]);
+} catch {}
+let commandBuffer130 = commandEncoder191.finish({label: '\u0b92\u{1f6e8}\uaffd'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup20, new Uint32Array(2467), 721, 0);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder194 = device2.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder194.beginComputePass({});
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer22, 0);
+} catch {}
+try {
+renderBundleEncoder26.insertDebugMarker('\ue2ef');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({label: '\u0dec\u{1fe9e}\u4a5b\u7273\u{1fe1d}\ud21b\u1615'});
+let commandBuffer131 = commandEncoder195.finish({label: '\u{1fd1d}\ued05\u0082\uc14f'});
+let renderBundle120 = renderBundleEncoder23.finish({label: '\u735c\ub3b4\u39d0\u4b62\u0ec8\u0c0d\u{1fca1}\uc48f\u3760\u0f95'});
+try {
+computePassEncoder40.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder10.setViewport(3.278959410993412, 26.593655799939263, 101.14490075643043, 3.4867153180879025, 0.05416398533617672, 0.6562622603029926);
+} catch {}
+video6.width = 48;
+try {
+window.someLabel = device2.label;
+} catch {}
+let renderBundle121 = renderBundleEncoder24.finish();
+try {
+renderBundleEncoder26.setIndexBuffer(buffer28, 'uint32', 680, 605);
+} catch {}
+try {
+adapter2.label = '\uf4da\uc442\u51ff\u0aeb\u967b\u4a81\u0485\u5e14\u071b\ueef9';
+} catch {}
+let commandEncoder196 = device0.createCommandEncoder();
+let commandBuffer132 = commandEncoder196.finish();
+let texture61 = device0.createTexture({
+  label: '\ud564\u0024',
+  size: [240],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint16', 168, 2_731);
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas3);
+let imageBitmap4 = await createImageBitmap(img5);
+let imageData21 = new ImageData(24, 88);
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup18, new Uint32Array(386), 98, 0);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(2, bindGroup20, new Uint32Array(2873), 452, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup20, new Uint32Array(1585), 164, 0);
+} catch {}
+try {
+device2.queue.submit([commandBuffer108]);
+} catch {}
+try {
+  await promise33;
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let texture62 = device0.createTexture({
+  label: '\u42ef\u{1f825}\udb03\ud0d4\ua964',
+  size: {width: 940, height: 132, depthOrArrayLayers: 402},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+document.body.prepend(video0);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.prepend(video3);
+let imageData22 = new ImageData(4, 84);
+let commandEncoder197 = device0.createCommandEncoder({label: '\u0cbe\uf3de\u0ef1\u40ac\u0216\u{1fa17}\u5f25\u5dcb\u010e\ua159'});
+let commandBuffer133 = commandEncoder197.finish({label: '\u8f00\u0a24\u070b\uc7b3\u09a9\u0cfa\u2372\u0f86\u3640\u{1f986}'});
+let texture63 = device0.createTexture({
+  label: '\u04b1\udfc8\u0fb2\u{1fb4b}\u0d82\u{1f90d}\u{1f682}\u3b8a\u3e33\u09cb\u0b62',
+  size: [470, 66, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup17, new Uint32Array(48), 7, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer4, 11_120, 1_352);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(1, buffer4);
+} catch {}
+let arrayBuffer9 = buffer3.getMappedRange(2856, 60);
+try {
+device0.queue.submit([commandBuffer127]);
+} catch {}
+let device3 = await promise18;
+let commandEncoder198 = device3.createCommandEncoder({label: '\uf61e\u{1f842}\u02a2\u44fe\u{1f92f}\u1ff1'});
+let querySet27 = device3.createQuerySet({type: 'occlusion', count: 856});
+video6.width = 15;
+try {
+adapter2.label = '\u7ba0\u4fac\u0e8e\u0685\u38b8\u0b31\u0a93\u{1f9e7}';
+} catch {}
+let commandEncoder199 = device0.createCommandEncoder();
+let commandBuffer134 = commandEncoder199.finish({label: '\u{1f838}\u0ea7\uf13f\u{1fdc5}\u77d5\u5cfa\u07ea\u050c\u2e7b\u088f'});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup9, [0]);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle78, renderBundle109, renderBundle65, renderBundle118, renderBundle76, renderBundle16, renderBundle37, renderBundle95, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer23, 'uint32', 340, 540);
+} catch {}
+await gc();
+let bindGroupLayout32 = device3.createBindGroupLayout({
+  label: '\u3c7b\u{1fc9c}\u201c\ube2e\u{1ffed}\u0469\u8364',
+  entries: [
+    {
+      binding: 312,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 10377623, hasDynamicOffset: false },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 332,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 441, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 292, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 91,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 74,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {binding: 80, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 214,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 444082, hasDynamicOffset: false },
+    },
+    {binding: 16, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 98,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 476,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 537, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder52 = commandEncoder198.beginComputePass();
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let buffer30 = device2.createBuffer({
+  label: '\ueab7\u3747\u0a20',
+  size: 615,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder200 = device2.createCommandEncoder();
+try {
+device2.queue.writeBuffer(buffer30, 64, new BigUint64Array(928), 20, 0);
+} catch {}
+let commandEncoder201 = device3.createCommandEncoder({});
+let video10 = await videoWithData();
+let imageData23 = new ImageData(56, 100);
+let texture64 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder53 = commandEncoder200.beginComputePass({label: '\ubb64\u{1f730}\u5bf8\u{1f95f}'});
+let renderBundle122 = renderBundleEncoder26.finish({});
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({});
+let commandEncoder202 = device3.createCommandEncoder();
+let commandBuffer135 = commandEncoder201.finish({});
+let buffer31 = device0.createBuffer({
+  label: '\ue7a9\u64ea\u0128\ubc9f\u0000\u0b78\u0b33\u0ee3\ufc94',
+  size: 31388,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundle123 = renderBundleEncoder17.finish({label: '\u3737\u9021\u{1ff0c}\uad72\u3169\ucdb1\u9664\u47da\u0af7\u{1f86d}\u7259'});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint32', 708, 2_142);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroupLayout33 = device3.createBindGroupLayout({label: '\u{1fb26}\u0e1c\u6dad\u05e9\u0ecd\u{1ff61}', entries: []});
+let canvas4 = document.createElement('canvas');
+let commandBuffer136 = commandEncoder202.finish({label: '\u7230\u7a9f\u{1f77b}\u06d9\u0257\ufd25'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder47.setBindGroup(0, bindGroup22, new Uint32Array(4880), 30, 0);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+document.body.prepend(canvas3);
+let pipelineLayout23 = device3.createPipelineLayout({label: '\ub8a5\u{1fd32}\u43ee\u{1f842}\u{1f988}\u0dea\u{1fe3a}\ua450', bindGroupLayouts: []});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+let commandBuffer137 = commandEncoder80.finish({label: '\u{1f6b3}\u{1fa47}\u695c\u{1f6f8}\u08d5\u62d0\u{1f61e}'});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle95]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer1, 'uint16', 966, 419);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u0baf');
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+await gc();
+let pipelineLayout24 = device2.createPipelineLayout({label: '\u6858\u09dd\u4794\ue7c2', bindGroupLayouts: []});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup9, new Uint32Array(2190), 54, 1);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint16', 330, 455);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+let imageData24 = new ImageData(8, 20);
+try {
+canvas4.getContext('webgl2');
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({label: '\u08b7\u024c\u85a3\u61c4\u03f5\u0345\u093a\u{1fbad}\u5a6e\u291f\u5432'});
+let computePassEncoder54 = commandEncoder203.beginComputePass();
+try {
+renderPassEncoder27.setIndexBuffer(buffer1, 'uint32', 1_340, 76);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer4, 1_740, 871);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 1360);
+} catch {}
+let commandEncoder204 = device2.createCommandEncoder({});
+try {
+device2.queue.submit([commandBuffer128]);
+} catch {}
+let commandBuffer138 = commandEncoder204.finish({});
+try {
+window.someLabel = commandBuffer109.label;
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({label: '\u45d2\u{1ffe3}\u6579\u{1ff7f}\u0d3b\ua7ef\uf452\u0a7b\u0720'});
+let renderBundle124 = renderBundleEncoder6.finish();
+try {
+renderPassEncoder10.setStencilReference(183);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer0, 'uint16', 2_144, 258);
+} catch {}
+let commandEncoder206 = device2.createCommandEncoder({label: '\ud4a1\u5363\udebf\u372f\u0483\u{1f90d}\u0bed'});
+try {
+device2.queue.submit([commandBuffer130, commandBuffer138, commandBuffer125, commandBuffer117]);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+document.body.prepend(canvas3);
+let buffer32 = device3.createBuffer({
+  label: '\u4568\u038d',
+  size: 1183,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder207 = device0.createCommandEncoder();
+let commandBuffer139 = commandEncoder207.finish({});
+let externalTexture26 = device0.importExternalTexture({
+  label: '\u{1ffb1}\ufe61\u1cae\u4ec7\u3d33\ubefc\uf070\ue441',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder9.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker('\u6349');
+} catch {}
+let buffer33 = device2.createBuffer({
+  label: '\u{1fc37}\u00d7\u3a62\u634f\u0eb3\u{1f861}\ua562\u0a2b\u0db2\ubc0b',
+  size: 3469,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet28 = device2.createQuerySet({label: '\u0c92\u22a5', type: 'occlusion', count: 335});
+let computePassEncoder55 = commandEncoder206.beginComputePass();
+let renderBundle125 = renderBundleEncoder24.finish({});
+let sampler12 = device2.createSampler({
+  label: '\u7488\u{1fcc4}\ud6e7\uc77b\u9e47\u118f\u0847\ud9cd\u04ee',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.13,
+  lodMaxClamp: 70.89,
+});
+let commandEncoder208 = device2.createCommandEncoder({label: '\u0b4a\uad9b\u{1ffb3}\ucdf3\u41b1\u0cbd'});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup20);
+} catch {}
+await gc();
+let commandEncoder209 = device3.createCommandEncoder();
+let commandBuffer140 = commandEncoder209.finish({label: '\u8ac8\u05a8'});
+try {
+gpuCanvasContext1.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer34 = device0.createBuffer({
+  label: '\uad4a\uca8b\u{1f728}\u7ac0\uac9e\uf2e4\ue73c\u0053\u985e',
+  size: 12204,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandBuffer141 = commandEncoder205.finish();
+try {
+computePassEncoder21.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1012, new DataView(new ArrayBuffer(5685)), 574, 128);
+} catch {}
+let commandEncoder210 = device2.createCommandEncoder({label: '\u{1fd73}\uc7db\u0838'});
+let commandBuffer142 = commandEncoder208.finish({label: '\u08b6\u1e81\u7802\u0851\u{1fe82}\u{1f61d}\u09ea\ue728'});
+try {
+gpuCanvasContext7.configure({device: device2, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let pipelineLayout25 = device3.createPipelineLayout({
+  label: '\u{1ff87}\u{1f764}\u7110\u0a2e\u0f41\ue8ab\u0a77\u051b\u225a\u3c2c',
+  bindGroupLayouts: [bindGroupLayout32],
+});
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer136]);
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+adapter0.label = '\ufcb1\ufab0\uf300\u1572\u{1fe30}\u01cf\u09d5\u0426';
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder();
+let renderPassEncoder35 = commandEncoder211.beginRenderPass({
+  label: '\u8f2f\u{1fa8c}\u081d\ufffa\ud946\u062c\uad7e\ufe68\u8ed8',
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 0,
+  clearValue: { r: -128.7, g: -296.3, b: -581.7, a: -903.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 30987136,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer4, 2_144);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup10);
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\u849e\u{1f801}\ub0d7\u0250\u0726\u5a69\u{1ff7f}\u0e95\udcf6\u{1fcbb}\u0491',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule6, constants: {}},
+});
+let commandEncoder212 = device0.createCommandEncoder({label: '\u0cb1\u9ba7\ue41a\u06ca'});
+let querySet29 = device0.createQuerySet({
+  label: '\u{1fd75}\u0f58\u294e\u{1f6ca}\u0d51\ucdbd\u{1f817}\u2c9b\u08bf\u6047',
+  type: 'occlusion',
+  count: 2983,
+});
+let renderPassEncoder36 = commandEncoder212.beginRenderPass({
+  label: '\u0ffa\u{1f73c}\u{1fdae}\u0b6c\ue08d\u0877\u031e\u09fb\u0051',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 736.3, g: -764.7, b: -74.00, a: -243.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u8fa9\u5392\u22ca\u{1fd5d}\u{1fbd5}\u0d64\ub170\u41ac\u21fc\u1d44',
+  colorFormats: ['rg16uint'],
+});
+try {
+computePassEncoder9.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup9, [0]);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+let commandEncoder213 = device3.createCommandEncoder();
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData25 = new ImageData(4, 68);
+let commandEncoder214 = device3.createCommandEncoder({label: '\u2169\u0aee\u7d64\u173f\u1aa2'});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let buffer35 = device0.createBuffer({
+  label: '\u18c9\u2b35\u523a',
+  size: 1259,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer35, 60);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+renderPassEncoder29.popDebugGroup();
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+let promise34 = adapter7.requestAdapterInfo();
+let texture65 = device0.createTexture({size: [120, 1, 31], format: 'rg16uint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder22.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer33, commandBuffer141]);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(88, 297);
+let textureView52 = texture48.createView({
+  label: '\u23cb\u0070\udf39\u8fb1\uca62\u6e37\u0614\u07dd\u062f\u0594\u04b3',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer1, 'uint32', 6_528, 2_437);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(4, buffer34);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer4, 0, 1_904);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(11_324), /* required buffer size: 11_324 */
+{offset: 53, bytesPerRow: 51, rowsPerImage: 22}, {width: 0, height: 2, depthOrArrayLayers: 11});
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder215 = device3.createCommandEncoder();
+let texture66 = gpuCanvasContext3.getCurrentTexture();
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let bindGroupLayout34 = device2.createBindGroupLayout({
+  label: '\u1e5d\u465c\u0955\uc98f\u0b7a\u4bc2',
+  entries: [
+    {
+      binding: 73,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder216 = device2.createCommandEncoder({label: '\u{1fb99}\uaded\u{1fe8c}\u{1f922}\ud597\u0ee8\u{1f9f2}\u{1f854}\u022a\u4d4f\u4f88'});
+let renderBundle126 = renderBundleEncoder24.finish({label: '\u060c\ubec2\u064e\u0d20'});
+await gc();
+let computePassEncoder56 = commandEncoder213.beginComputePass({label: '\u0e8c\u08bd\u0831\u83c9\ud7ee\u7019'});
+try {
+buffer32.unmap();
+} catch {}
+let commandEncoder217 = device3.createCommandEncoder({label: '\u{1faca}\u4496\uf8c0\u0198\u980f\u1053'});
+let gpuCanvasContext9 = offscreenCanvas4.getContext('webgpu');
+let bindGroup23 = device3.createBindGroup({layout: bindGroupLayout33, entries: []});
+let commandEncoder218 = device3.createCommandEncoder({label: '\u{1fab3}\ub48e\u37fd\u097e\u5037\u090b\u{1f9e8}\u0731\u58c1'});
+let computePassEncoder57 = commandEncoder218.beginComputePass({label: '\ue3cd\ufbb1\uf890\u01a2\u{1fe25}\u0f33\ue75e\u{1fe11}\u0c32\u0ba5'});
+let imageData26 = new ImageData(84, 116);
+let commandEncoder219 = device3.createCommandEncoder({label: '\u{1f775}\u{1fc01}\u31a5\u4a54\u03d0\ue6c8'});
+let computePassEncoder58 = commandEncoder214.beginComputePass();
+try {
+renderPassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer0, 0, 887);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint32', 868, 2_628);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer35, 0, 202);
+} catch {}
+try {
+device0.queue.submit([commandBuffer124, commandBuffer137]);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u0f52\u1b2a\u4414\u{1fa59}\u9481\u0453',
+  code: `
+@group(1) @binding(137) var sam24: sampler;
+struct S9 {
+  @builtin(workgroup_id) f0: vec3u
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(a0: S9) {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f41: vec4f,
+  @location(1) f42: vec3u
+}
+
+@vertex
+fn vertex0(@location(8) a0: i32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f42 = vec3u(496, 118, 296);
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder220 = device0.createCommandEncoder({label: '\uee73\u07f1\u07cd\u0a70\u0879\u{1f733}\u5be7\ud550\u6b67'});
+let commandBuffer143 = commandEncoder220.finish({label: '\u5c60\u{1f82a}\u09f4\uabfa\ud4a5'});
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline10);
+} catch {}
+let videoFrame12 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let pipelineLayout26 = device3.createPipelineLayout({
+  label: '\u0087\ubf8a\u0ed5\uf545\u0d19\u0813\u{1f7e8}\u634f',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout33],
+});
+let commandBuffer144 = commandEncoder219.finish({label: '\u073c\u5afa\u1704\u51be'});
+let texture67 = device3.createTexture({
+  label: '\u0791\u081b\u09cd\u0898\u0392\u0b49',
+  size: {width: 563, height: 96, depthOrArrayLayers: 187},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder59 = commandEncoder217.beginComputePass({});
+video1.height = 24;
+let commandBuffer145 = commandEncoder215.finish({label: '\u{1f93b}\u9fba\ua9de\u18be\uc1bd\u0845\u0369'});
+let pipelineLayout27 = device3.createPipelineLayout({label: '\u037f\u{1feca}\u0ba0\ue798\u8c22\u062b\u9187', bindGroupLayouts: [bindGroupLayout33]});
+let commandEncoder221 = device3.createCommandEncoder({label: '\ue9cf\u01ee\u7e25\u0bd0\u08f8\ue875'});
+let commandBuffer146 = commandEncoder221.finish({label: '\u0b27\ua847\u445b'});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer1, 'uint32', 7_752, 465);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer35, 0, 187);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup7, new Uint32Array(1045), 35, 0);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(77, 104, 81, 973_046_296, 347_512_110);
+} catch {}
+try {
+renderBundleEncoder21.insertDebugMarker('\u46d8');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 116, new DataView(new ArrayBuffer(16028)), 1256, 268);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 60, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(102), /* required buffer size: 102 */
+{offset: 102, bytesPerRow: 158}, {width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+computePassEncoder6.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(1, buffer35, 276, 111);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(37, 94, 3, 22_887_124, 1_832_508_728);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer35, 52);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer35);
+} catch {}
+let commandEncoder222 = device0.createCommandEncoder({});
+let renderPassEncoder37 = commandEncoder222.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 13,
+  clearValue: { r: 407.1, g: 361.3, b: -48.27, a: 32.82, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer1, 'uint32', 3_328, 1_000);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer35, 272);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline10);
+} catch {}
+let commandEncoder223 = device3.createCommandEncoder();
+let texture68 = device3.createTexture({
+  label: '\u0a60\u4cba\u08b3\ufd73\u04ee\u{1fa0d}\ue0b3\u0fd0\u6857\u3b91\u5ffa',
+  size: [140, 24, 19],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let renderBundle127 = renderBundleEncoder4.finish({label: '\u8f71\u585f\u5bc0\uf58d\u950f\u0a24\u58e5\uf2da\u643c'});
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer35, 120, 63);
+} catch {}
+try {
+computePassEncoder41.insertDebugMarker('\u0df0');
+} catch {}
+let promise35 = adapter0.requestAdapterInfo();
+let externalTexture27 = device3.importExternalTexture({source: video7, colorSpace: 'srgb'});
+await gc();
+let commandEncoder224 = device0.createCommandEncoder({label: '\u00e5\u7b2d'});
+let commandBuffer147 = commandEncoder224.finish({label: '\uedd0\ue44d\u0caa\u{1fa30}\u{1f610}\ubb63\u762c\u{1fc70}\uc833\u9856'});
+let textureView53 = texture65.createView({
+  label: '\uf462\ud58f\u0a1c\u5b29\u1b47\u0b02\u78f9\u{1f8fa}',
+  dimension: '2d',
+  aspect: 'all',
+  baseArrayLayer: 3,
+});
+let renderBundle128 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup7, new Uint32Array(58), 11, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle54, renderBundle64]);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer0, 0, 2_073);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(58, 49, 41, 1_524_811_602, 599_660_024);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer1, 952);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer106, commandBuffer134]);
+} catch {}
+document.body.prepend(video0);
+let commandEncoder225 = device2.createCommandEncoder({label: '\u3e01\u32cb\ucb85\ucf54\u06c1\u{1fd70}\ub96f\u0af2\u36e5\udc3a\u654c'});
+let querySet30 = device2.createQuerySet({
+  label: '\u0577\uf091\u0a0f\ud990\u{1f639}\u9b69\u{1ff48}\u4ede\u0e48\u0368',
+  type: 'occlusion',
+  count: 297,
+});
+let commandBuffer148 = commandEncoder216.finish({label: '\u04b5\uc87c\ud168\u0a65\u{1fbe9}\u1d2a\uaa19\u41da'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder226 = device2.createCommandEncoder({label: '\u635c\u7efc\u016b\ue791\ubfb3\u{1fd05}'});
+let commandBuffer149 = commandEncoder225.finish({label: '\u494b\u0895\ue381\ud914\u{1ff2c}\u7170\u48bd\u0a59\u0a8b\u3b6e\u0837'});
+let renderBundle129 = renderBundleEncoder25.finish({label: '\u09a9\u0f56\u5903\u0e93\u0803\u0e5d\ue4c7\u0db0\u{1f75b}\uce5b'});
+try {
+device2.queue.writeBuffer(buffer28, 76, new DataView(new ArrayBuffer(15192)), 6213, 232);
+} catch {}
+await gc();
+let promise36 = adapter7.requestDevice({
+  label: '\u07ac\u0952\ua3fa\u0d3e\u{1fa5f}\u2a65\u{1fed5}',
+  defaultQueue: {label: '\u68a1\ua3ad\ucc92\u9081\u55fc\u1760\u056f\u5b92'},
+});
+try {
+window.someLabel = externalTexture24.label;
+} catch {}
+let pipelineLayout28 = device2.createPipelineLayout({
+  label: '\uf06b\ud787\u0d81\u{1f7d1}\ud044\u{1fe77}\u6401\u03ad\uee2a\u0ae0\u0b36',
+  bindGroupLayouts: [bindGroupLayout29],
+});
+let computePassEncoder60 = commandEncoder210.beginComputePass({});
+try {
+commandEncoder226.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 12, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 304 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 336 */
+  offset: 336,
+  bytesPerRow: 512,
+  rowsPerImage: 305,
+  buffer: buffer28,
+}, {width: 19, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder227 = device2.createCommandEncoder({label: '\u0423\u{1fa13}\u3aa5\u{1fbd5}\u{1f7e2}\u9383\u09be\u{1fa4c}\u46b5\u91c4\u0616'});
+try {
+device2.queue.writeBuffer(buffer28, 192, new BigUint64Array(2136), 438, 24);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({label: '\u0df8\uf550\u8ca9\u{1fd15}', colorFormats: ['rg16uint'], depthReadOnly: true});
+try {
+computePassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer0, 'uint32', 340, 3_661);
+} catch {}
+try {
+renderBundleEncoder18.draw(3, 94, 9, 721_365_541);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer1, 100);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync({
+  label: '\u01d9\u{1f7ac}\u421a\ud99b\u0120\u0413\ue604\u4012\u06c2\u{1fa0a}\u{1fed0}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule4, constants: {}},
+});
+canvas5.height = 509;
+let renderBundle130 = renderBundleEncoder4.finish({label: '\uc965\u{1f839}\u2c34\u00d3\uf217\ub8af'});
+try {
+computePassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder18.draw(11, 179, 0, 178_530_840);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer35, 328);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer35, 'uint16', 174, 41);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer4, 0);
+} catch {}
+let arrayBuffer10 = buffer8.getMappedRange(3072, 216);
+let commandEncoder228 = device0.createCommandEncoder({label: '\u0833\u{1fded}\u{1ffc3}\u{1fe4a}\u0b25\u0296\u524e\u6351\u526d\uc5f1'});
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer1, 4_236);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer1, 'uint16', 3_432, 336);
+} catch {}
+try {
+renderPassEncoder24.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 236, new BigUint64Array(16458), 1791, 168);
+} catch {}
+try {
+  await promise34;
+} catch {}
+let commandEncoder229 = device2.createCommandEncoder({label: '\u0e70\u2799\u09d5\udd1a\u58df\u0dec\u425f\u0684'});
+let commandBuffer150 = commandEncoder227.finish({label: '\u096d\u{1fcca}\u025e\u{1fd7d}\u9e84\ued48\u0a08\u{1fa85}\ue417\ue797\u{1f8e1}'});
+video1.width = 7;
+let commandEncoder230 = device0.createCommandEncoder({});
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup9, [0]);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.draw(5, 214, 5, 459_105_564);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer1, 228);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer1, 'uint32', 3_016, 245);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder228.resolveQuerySet(querySet14, 125, 2, buffer21, 2816);
+} catch {}
+let commandBuffer151 = commandEncoder226.finish({label: '\u{1ffb2}\u0858\u{1f634}\u3f2b\u9439\u0a24\u069f\u331c\u09e0\ua033\uae5a'});
+let sampler13 = device2.createSampler({
+  label: '\ud34f\u03ef\u5c53\u026a\u0e20\u0eca\u83bf\u4cbb\u668d',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 38.09,
+});
+let commandEncoder231 = device2.createCommandEncoder({});
+let commandEncoder232 = device0.createCommandEncoder({label: '\uc727\u877b'});
+let renderBundle131 = renderBundleEncoder28.finish({label: '\u038e\u5a3b\u{1ff7b}\u03e7\ubddb\u0bdc\u{1f8e5}\u978b\u{1fab0}\u0416\u0635'});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup12, new Uint32Array(759), 5, 0);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer21, 448);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer0, 'uint16', 2_586, 1_566);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(7, buffer34, 0, 11_885);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandBuffer152 = commandEncoder229.finish();
+try {
+computePassEncoder45.insertDebugMarker('\u0bdd');
+} catch {}
+let commandBuffer153 = commandEncoder230.finish({label: '\u0b6e\u96a1\u078d\u6f09\udeae\u{1fac3}\u{1fb15}\u{1f748}\uac5e\u6759'});
+let computePassEncoder61 = commandEncoder203.beginComputePass({label: '\u43b1\u1f36\u3eec\u91dd\ufa15\u04dc\u7d7f\u6925\ue61f\u51bb'});
+let renderPassEncoder38 = commandEncoder228.beginRenderPass({
+  label: '\u0829\u{1ffce}\u4f71\ud59f\u09eb\u047a\u{1f96f}\u411f\u76e1\ud057\u0848',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 29,
+  clearValue: { r: -629.5, g: -54.27, b: 441.9, a: -397.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup16, new Uint32Array(1441), 360, 1);
+} catch {}
+try {
+renderBundleEncoder18.draw(2, 150, 0, 439_292_809);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(173, 166, 12, 68_400_977, 336_405_662);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer35, 692);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 116, 315);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline10);
+} catch {}
+let commandBuffer154 = commandEncoder223.finish({label: '\u755f\uca87\u7297\ud73b\u27e9\u7265\u2b37\u885d\u{1fb37}\u{1f9a3}\u542b'});
+try {
+device3.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 33, y: 11, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(5_414), /* required buffer size: 5_414 */
+{offset: 216, bytesPerRow: 169, rowsPerImage: 15}, {width: 32, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let imageData27 = new ImageData(68, 136);
+let commandEncoder233 = device2.createCommandEncoder({label: '\u{1ff38}\u058a\ubb10\u31bb\ueb6b\u0d12'});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup21, new Uint32Array(4389), 1872, 0);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer22, 36, new BigUint64Array(17130), 8189, 0);
+} catch {}
+try {
+  await promise35;
+} catch {}
+let buffer36 = device0.createBuffer({label: '\u6423\u0f37\ua70a', size: 43647, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder234 = device0.createCommandEncoder({label: '\u{1fcce}\u4620\u{1f87b}\u{1ff4e}\u{1f873}\u095a\u0040\u{1fd9b}\ub354\u4c60\u{1fd61}'});
+let commandBuffer155 = commandEncoder232.finish({});
+let renderPassEncoder39 = commandEncoder234.beginRenderPass({colorAttachments: [{view: textureView38, depthSlice: 32, loadOp: 'load', storeOp: 'store'}]});
+let renderBundle132 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer35, 36);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer35, 368);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(2, undefined);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let commandEncoder235 = device3.createCommandEncoder({label: '\uafbd\u73cf\u03fc\ucba3\u42a6\u5968\u4637\u{1fc6a}\u0e81\u0aeb'});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup23, new Uint32Array(879), 353, 0);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandBuffer156 = commandEncoder235.finish({label: '\u{1f8ef}\u4dba\uf45b\u0ed3\u581a\u210b\u0f29\u{1fb64}'});
+let texture69 = device3.createTexture({
+  label: '\uae4a\uc9b0\u7e22\uc046\u0343\u{1ff5b}\u{1fbf7}',
+  size: [281],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device3.queue.submit([commandBuffer145]);
+} catch {}
+let texture70 = gpuCanvasContext6.getCurrentTexture();
+try {
+renderPassEncoder22.setIndexBuffer(buffer35, 'uint32', 100, 369);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(0, 3, 7, -1_827_131_693, 1_701_957_281);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer35, 88);
+} catch {}
+let commandEncoder236 = device2.createCommandEncoder();
+let commandBuffer157 = commandEncoder231.finish({});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+pipelineLayout23.label = '\u{1ffe4}\u{1f8c6}\u{1fb2a}\uf22e\u16d1\u{1ff4a}';
+} catch {}
+let commandEncoder237 = device3.createCommandEncoder({label: '\u60f9\u7f42\ub15f\u{1fceb}\uef84\u56c8\u9e98\ua38f\u7789\ue430\u1e3c'});
+let querySet31 = device3.createQuerySet({type: 'occlusion', count: 241});
+try {
+buffer32.unmap();
+} catch {}
+let promise37 = device3.queue.onSubmittedWorkDone();
+let shaderModule14 = device3.createShaderModule({
+  code: `
+@group(0) @binding(16) var sam25: sampler_comparison;
+@group(0) @binding(91) var st8: texture_storage_2d<rgba32uint, read>;
+@group(0) @binding(332) var st6: texture_storage_2d_array<rg32uint, read>;
+@group(0) @binding(74) var tex20: texture_2d<i32>;
+@group(0) @binding(8) var<storage, read_write> buffer41: atomic<i32>;
+@group(0) @binding(33) var st7: texture_storage_2d_array<r32float, read_write>;
+@group(0) @binding(312) var<storage, read_write> buffer37: array<f16>;
+@group(0) @binding(476) var<storage, read_write> buffer40: vec2h;
+@group(0) @binding(214) var<storage, read> buffer38: array<array<array<mat2x2f, 1>, 1>>;
+@group(0) @binding(50) var et24: texture_external;
+@group(0) @binding(37) var tex19: texture_cube<f32>;
+@group(0) @binding(98) var<storage, read_write> buffer39: array<mat3x4f>;
+@group(0) @binding(62) var tex18: texture_3d<f32>;
+@group(0) @binding(80) var et27: texture_external;
+@group(0) @binding(441) var et25: texture_external;
+@group(0) @binding(537) var sam26: sampler_comparison;
+@group(0) @binding(292) var et26: texture_external;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  buffer37[12345] = f16(-26198.6);
+  textureStore(st7, vec2i(), 0, vec4f(0.3629, 0.4398, 0.02997, 0.04740));
+}
+
+struct VertexOutput0 {
+  @builtin(position) f43: vec4f,
+  @location(6) f44: vec2i
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4u,
+  @location(6) f1: vec3i,
+  @location(0) f2: vec4u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  buffer39[12345] = mat3x4f();
+  out.f1 = vec3i(173, 35, 93);
+  out.f2 = vec4u(726, 152, 140, 133);
+  _ = textureLoad(tex18, vec3i(), 0);
+  _ = textureLoad(st6, vec2i(), 0);
+  _ = textureLoad(et24, vec2u());
+  _ = buffer39;
+  _ = buffer41;
+  _ = textureLoad(st8, vec2i());
+  _ = textureLoad(tex20, vec2i(), 0);
+  _ = textureDimensions(et24);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout29 = device3.createPipelineLayout({
+  label: '\ue336\u{1f9cd}\u020c\u4d6b\u0d5c\u{1f73b}\u0b9e\u{1f71f}\ua306\u2497\u420b',
+  bindGroupLayouts: [bindGroupLayout32],
+});
+let commandEncoder238 = device3.createCommandEncoder({label: '\u{1fe70}\u0720\ucf58\uac7a\u0752'});
+let textureView54 = texture68.createView({label: '\ue807\u0d78\u027f', baseArrayLayer: 3, arrayLayerCount: 3});
+let externalTexture28 = device3.importExternalTexture({source: videoFrame12, colorSpace: 'srgb'});
+try {
+  await promise37;
+} catch {}
+document.body.prepend(canvas5);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let imageData28 = new ImageData(28, 80);
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer0, 'uint32', 172, 2_035);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer1, 3_044);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 2_336, 762);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(34_382), /* required buffer size: 34_382 */
+{offset: 6, bytesPerRow: 48, rowsPerImage: 142}, {width: 2, height: 7, depthOrArrayLayers: 6});
+} catch {}
+document.body.prepend(img1);
+let buffer42 = device3.createBuffer({
+  label: '\u{1f9fa}\ud66c\uab3b\u573e\u0b6c\u{1fe02}\u{1fcff}',
+  size: 2004,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder239 = device3.createCommandEncoder({label: '\u76d2\ufb12\u0367\u02e0\u{1fcf9}'});
+let computePassEncoder62 = commandEncoder237.beginComputePass();
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer32, 48, new DataView(new ArrayBuffer(50072)), 4367, 84);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+video10.height = 120;
+let commandEncoder240 = device2.createCommandEncoder({label: '\u{1fcfc}\u0695\u06aa'});
+let textureView55 = texture49.createView({label: '\u{1fb7f}\uba61\u03fd\u00ed\u955e\u6bb8\u8096\u3b7c', dimension: '1d'});
+try {
+commandEncoder240.copyBufferToBuffer(buffer33, 244, buffer30, 216, 84);
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  label: '\u0cfa\u{1f686}\u4c37\u0e6b\ubbf6\u1a6c\u03c8\u{1f902}\ud7df\uf573',
+  entries: [
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder241 = device0.createCommandEncoder({label: '\u{1f92b}\u{1fd51}\u08f1\u02bb\u0f01\u45f1\u709b\ub8f0'});
+try {
+renderPassEncoder24.setIndexBuffer(buffer34, 'uint32', 1_492, 203);
+} catch {}
+try {
+renderBundleEncoder18.draw(11, 57, 0, 1_237_007_673);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer34, 'uint32', 3_440, 3_123);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+document.body.prepend(img2);
+let device4 = await adapter4.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxVertexBufferArrayStride: 2048,
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 6270370,
+    maxStorageBufferBindingSize: 140668885,
+  },
+});
+let imageBitmap5 = await createImageBitmap(offscreenCanvas4);
+let querySet32 = device3.createQuerySet({type: 'occlusion', count: 691});
+let commandBuffer158 = commandEncoder239.finish({label: '\u04bf\u{1f705}\u{1f917}\ua6df\u5e9a\ud313\u05e0\u483f\u{1f7e0}\u821e\uff96'});
+let textureView56 = texture68.createView({dimension: '2d', aspect: 'all'});
+let arrayBuffer11 = buffer42.getMappedRange(120);
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer154]);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer32, 516, new BigUint64Array(4042), 308, 4);
+} catch {}
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  label: '\u6ea8\u2f00\u{1fa47}\uec9f\u0533\u{1fc3b}\u{1fc2b}\u9b90\u322f\u797e',
+  layout: bindGroupLayout10,
+  entries: [{binding: 137, resource: sampler2}],
+});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup9, [0]);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup8, new Uint32Array(4183), 40, 0);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer1, 1_288);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer21, 3_396);
+} catch {}
+try {
+commandEncoder241.resolveQuerySet(querySet15, 5, 30, buffer4, 768);
+} catch {}
+let pipelineLayout30 = device2.createPipelineLayout({
+  label: '\ub7c6\u0c00\u01c1\ub441\u0513\u{1fa69}\ube81\u{1fd92}',
+  bindGroupLayouts: [bindGroupLayout29, bindGroupLayout30, bindGroupLayout24],
+});
+let commandEncoder242 = device2.createCommandEncoder({label: '\u{1fdb5}\u275d\u76ff\u086a\u0e39\u{1fd03}\u2c82'});
+let commandBuffer159 = commandEncoder240.finish({label: '\ud6f6\u07bc\u{1f667}\ud0fe\u89bb\ua02b\uc180\uea89\u8174\u0f8e'});
+try {
+commandEncoder242.clearBuffer(buffer22);
+} catch {}
+let querySet33 = device2.createQuerySet({label: '\u0b7e\ucfd2\u03fc', type: 'occlusion', count: 681});
+let texture71 = device2.createTexture({
+  label: '\u067a\u12f8\u0cdc\ueadb\u070f',
+  size: {width: 100, height: 12, depthOrArrayLayers: 1},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder242.clearBuffer(buffer28, 224, 236);
+} catch {}
+let imageData29 = new ImageData(80, 72);
+let commandEncoder243 = device2.createCommandEncoder({});
+let textureView57 = texture71.createView({label: '\u00bb\u{1f81d}\ub50a\uf3eb\u57f2', dimension: '2d-array'});
+let renderBundle133 = renderBundleEncoder24.finish({label: '\u{1f934}\uc655\u8fff\uf6c1\uc894\uad73\ucee5\u{1fdf5}\u4aef\u319a'});
+let commandBuffer160 = commandEncoder233.finish({});
+let computePassEncoder63 = commandEncoder243.beginComputePass({label: '\u8d22\u6994\u0e65\ua12b'});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup20, new Uint32Array(1200), 147, 0);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let buffer43 = device4.createBuffer({
+  label: '\u0625\u5966',
+  size: 7177,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let imageBitmap6 = await createImageBitmap(imageBitmap2);
+let commandEncoder244 = device2.createCommandEncoder({label: '\u{1fc2d}\u0522\u1477\u{1f75e}\u3746\u97fa\ued7c\u074f\u3ffd\u6e18'});
+let commandBuffer161 = commandEncoder244.finish({label: '\u3e9b\ua1bb\u24f1\u8e33\u80e9\u{1fdf6}\u7e1a\u0bb7\u{1fbf7}\u306d'});
+let textureView58 = texture55.createView({baseMipLevel: 1});
+try {
+device2.queue.submit([commandBuffer116]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer28, 1620, new Int16Array(43081), 4238, 596);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4_294_967_295, undefined, 3_191_800_482, 30_533_743);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint32', 2_464, 5_919);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer36, 0, 2_186);
+} catch {}
+let commandBuffer162 = commandEncoder236.finish({label: '\u{1fc51}\u{1f71f}\u{1f80a}\ufdfe\u17f4\u0f60\ud65a\u62f0'});
+let texture72 = device2.createTexture({
+  label: '\u0361\u04c7\u{1fda5}',
+  size: [40],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView59 = texture71.createView({label: '\u{1fc99}\u78b8\u193a\u{1f9d1}\u09fb', dimension: '2d-array'});
+let computePassEncoder64 = commandEncoder242.beginComputePass({label: '\u4929\u{1faed}\u9f6a\u0518\ud9d2\uf820\u{1f873}'});
+await gc();
+let commandEncoder245 = device2.createCommandEncoder({label: '\u91a8\u86ff\u17b9\ua0a8\u{1fa4c}\u3a69\u067a\uf823\ua0b3\u8385\u269c'});
+let querySet34 = device2.createQuerySet({label: '\uf49a\u2316\u{1ff76}\u5a4e\u655b', type: 'occlusion', count: 395});
+let textureView60 = texture49.createView({label: '\u824a\u{1fb07}\u1f90\u0bcd\u04d9\u0f44\u{1fa71}', dimension: '1d', arrayLayerCount: 1});
+try {
+device2.queue.submit([commandBuffer120, commandBuffer118, commandBuffer151]);
+} catch {}
+let commandEncoder246 = device4.createCommandEncoder({});
+let commandEncoder247 = device2.createCommandEncoder({label: '\u{1f7b6}\u{1fc68}'});
+let commandBuffer163 = commandEncoder247.finish({});
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder248 = device0.createCommandEncoder();
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(155, 363, 33, -1_983_791_609, 141_275_176);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer1, 13_012);
+} catch {}
+try {
+commandEncoder241.clearBuffer(buffer36, 360, 16912);
+} catch {}
+try {
+device0.queue.submit([commandBuffer107, commandBuffer111, commandBuffer133]);
+} catch {}
+document.body.prepend(video5);
+let promise38 = adapter6.requestDevice({
+  label: '\u1dfb\u2faf\uc428\u030f\u2461',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxTextureArrayLayers: 256,
+    maxUniformBufferBindingSize: 16700208,
+    maxStorageBufferBindingSize: 144222570,
+  },
+});
+let commandEncoder249 = device2.createCommandEncoder({label: '\u9c51\u0feb\u{1fa8a}\u4e01\u36cb\uce8a\ucfe5\u{1fc7c}\u{1f90e}\u696c'});
+let commandBuffer164 = commandEncoder249.finish({label: '\uccb7\u2e18\uc9b4\u2e5b\u4256'});
+let texture73 = gpuCanvasContext7.getCurrentTexture();
+let renderBundle134 = renderBundleEncoder25.finish({label: '\u0782\ue749\u05a4\u86af\u3254\u0d5f\u0c95\u8a5f\u0d61'});
+let promise39 = navigator.gpu.requestAdapter({});
+let commandBuffer165 = commandEncoder246.finish({label: '\uca2f\u0e96\u34c6\u4050'});
+try {
+renderBundleEncoder18.draw(1, 41, 7, 118_111_290);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer1, 1_212);
+} catch {}
+let commandEncoder250 = device2.createCommandEncoder();
+let commandBuffer166 = commandEncoder250.finish({label: '\u023c\u55bd\uad2c\u3e69\u0d23\u{1fa68}\ub9a7\ue312'});
+let renderPassEncoder40 = commandEncoder245.beginRenderPass({colorAttachments: [{view: textureView58, loadOp: 'clear', storeOp: 'store'}]});
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer159, commandBuffer157]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 2128, new DataView(new ArrayBuffer(4008)), 1277, 156);
+} catch {}
+let buffer44 = device3.createBuffer({
+  label: '\u0ad6\u3c59\u5580\u90f5\u{1fea1}\u734b\u08e1\u2220\u00f6',
+  size: 2865,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder251 = device3.createCommandEncoder({label: '\u0e32\u87e2\u{1fad2}\u9722\uc6df\u07dc'});
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+commandEncoder251.clearBuffer(buffer32, 108, 104);
+} catch {}
+let commandBuffer167 = commandEncoder251.finish({label: '\u6059\u0f8d\u0734\u{1f720}\u{1fff0}\u64a7\u4b23\u7fab'});
+let texture74 = gpuCanvasContext4.getCurrentTexture();
+try {
+commandEncoder238.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 28, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder252 = device0.createCommandEncoder({});
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint16', 862, 628);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(65, 92, 8, 142_052_249, 235_746_841);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer4, 1_316);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder253 = device2.createCommandEncoder({label: '\u{1f8fe}\u074b'});
+let renderBundle135 = renderBundleEncoder25.finish({label: '\ud3b3\u0b6b\u6593\u{1fb0d}\u70d3\u0168\u0766\u93d1\u39b4\u48a2\u6474'});
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup20, new Uint32Array(656), 17, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer30, 'uint32', 48, 80);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device2, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  label: '\u3726\u5f35\u00c1\u0600\ue7e3\u8f65\ud297\u02e6',
+  layout: bindGroupLayout0,
+  entries: [{binding: 76, resource: externalTexture19}, {binding: 402, resource: sampler8}],
+});
+let pipelineLayout31 = device0.createPipelineLayout({
+  label: '\ue326\u8fd3\uc139\u3539\u427d\u0172\uaf16\u0555\u0763',
+  bindGroupLayouts: [bindGroupLayout20, bindGroupLayout35, bindGroupLayout17, bindGroupLayout13],
+});
+let textureView61 = texture45.createView({dimension: '2d-array', baseMipLevel: 0});
+let renderPassEncoder41 = commandEncoder252.beginRenderPass({
+  label: '\u1a8b\u751c',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 32,
+  clearValue: { r: 314.7, g: -758.6, b: 399.8, a: 841.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet14,
+});
+let renderBundle136 = renderBundleEncoder19.finish({label: '\ua2ee\u00bc\u00de\u08a5'});
+try {
+computePassEncoder41.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(27, 4, 154, 14);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer34, 'uint32', 428, 5_194);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder18.draw(9, 404, 9, 870_001_727);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer1, 544);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+video10.height = 118;
+let commandEncoder254 = device3.createCommandEncoder();
+let commandBuffer168 = commandEncoder238.finish();
+document.body.prepend(video3);
+await gc();
+video3.height = 18;
+let bindGroupLayout36 = device4.createBindGroupLayout({
+  label: '\u{1fc37}\u08ea\u{1f935}',
+  entries: [
+    {
+      binding: 148,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout32 = device4.createPipelineLayout({bindGroupLayouts: []});
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder255 = device3.createCommandEncoder({label: '\u95f9\u{1fb12}\u3cce\u0bec\u{1f9ac}\u{1fd2a}\u959f\uaac8\u{1f63f}\u8647'});
+let textureView62 = texture67.createView({label: '\ufcb8\u{1fcd3}\u003e\u{1fe50}'});
+let sampler14 = device3.createSampler({
+  label: '\u470d\u18d1\u{1fce6}\u5466\u{1fb5e}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 17.61,
+  lodMaxClamp: 19.58,
+});
+document.body.prepend(img3);
+let commandEncoder256 = device4.createCommandEncoder({label: '\u{1f899}\u{1ffa3}\ud48c\u0c0b\ubda9\u0d67\u06ec\ud5eb\u{1fc5a}\u{1f746}\u{1f7be}'});
+let querySet35 = device4.createQuerySet({label: '\u5dd6\u5831', type: 'occlusion', count: 1523});
+let commandBuffer169 = commandEncoder256.finish({label: '\u09e0\u{1fb4d}\u091f\u{1f6d9}\u0dbe'});
+let texture75 = gpuCanvasContext7.getCurrentTexture();
+try {
+buffer43.unmap();
+} catch {}
+let renderPassEncoder42 = commandEncoder248.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 18,
+  clearValue: { r: -78.67, g: 759.9, b: -637.0, a: -857.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer21, 8_620);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder241.clearBuffer(buffer34);
+} catch {}
+let bindGroupLayout37 = device3.createBindGroupLayout({
+  label: '\u031c\ud9c4\u1037\u1971\u0495\u{1f770}\u0646\u00ec\ud56d',
+  entries: [
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let renderBundleEncoder29 = device3.createRenderBundleEncoder({label: '\u0f15\u4997\u{1fb38}\u04c6\uad82\u4ceb', colorFormats: ['rgba8uint'], stencilReadOnly: true});
+let renderBundle137 = renderBundleEncoder29.finish();
+let arrayBuffer12 = buffer42.getMappedRange(8, 8);
+try {
+commandEncoder254.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 13, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder257 = device2.createCommandEncoder({});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(3, buffer22, 0);
+} catch {}
+let commandBuffer170 = commandEncoder218.finish({label: '\u0021\u9904\u4c67\ua2b1\u{1ff79}\ubcc8\u094e\u06af\u0075'});
+let computePassEncoder65 = commandEncoder255.beginComputePass();
+try {
+computePassEncoder52.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+commandEncoder254.copyBufferToBuffer(buffer32, 12, buffer42, 68, 56);
+} catch {}
+let bindGroupLayout38 = device2.createBindGroupLayout({
+  label: '\ue963\ube69',
+  entries: [{binding: 352, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }}],
+});
+let commandEncoder258 = device2.createCommandEncoder({label: '\u0a09\u2ecd\u225e'});
+try {
+buffer23.unmap();
+} catch {}
+let img9 = await imageWithData(15, 28, '#10101010', '#20202020');
+let imageData30 = new ImageData(72, 88);
+try {
+device4.queue.label = '\u0911\u3337\u0444';
+} catch {}
+let commandEncoder259 = device2.createCommandEncoder({label: '\u{1f9c3}\u9352\u0f3c\ud034\ua1cb'});
+let commandBuffer171 = commandEncoder258.finish({});
+let computePassEncoder66 = commandEncoder259.beginComputePass();
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint16', 1_472, 2_615);
+} catch {}
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+let texture76 = device4.createTexture({
+  label: '\u01d3\u{1fa49}',
+  size: {width: 2250},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture29 = device4.importExternalTexture({label: '\u1bf7\u0d53\ufa28\uf5c6\u0209\ua4d4\u0922', source: video6, colorSpace: 'display-p3'});
+try {
+device4.queue.writeBuffer(buffer43, 216, new Int16Array(6020), 525, 404);
+} catch {}
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 652});
+let commandBuffer172 = commandEncoder241.finish({label: '\u0088\u{1ff97}\ub676\ue72f\u4830\u02d2\uf319\ua504\u{1fe71}\ud95c'});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer34);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(5, 740, 13, 243_857_273, 555_224_268);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer143, commandBuffer153, commandBuffer139]);
+} catch {}
+let renderPassEncoder43 = commandEncoder257.beginRenderPass({
+  label: '\u00c8\ua306\u52a5\u7b76',
+  colorAttachments: [{
+  view: textureView58,
+  clearValue: { r: 979.3, g: -489.4, b: -768.3, a: 911.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 18044315,
+});
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(34, 0, 1, 6);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer21, 1_532);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer1, 'uint16', 2_160, 2_330);
+} catch {}
+try {
+computePassEncoder9.insertDebugMarker('\u40f2');
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+let commandEncoder260 = device4.createCommandEncoder();
+let commandBuffer173 = commandEncoder260.finish();
+let renderBundleEncoder30 = device4.createRenderBundleEncoder({
+  label: '\u571a\u0396\u3ebc\u02e3\u36e4\u021b\ud996\u0373\u{1f789}\u09db\u{1f759}',
+  colorFormats: ['r8sint'],
+});
+try {
+renderBundleEncoder30.setVertexBuffer(6, buffer43, 68);
+} catch {}
+let videoFrame13 = new VideoFrame(video4, {timestamp: 0});
+let bindGroup26 = device2.createBindGroup({label: '\u054e\uc41e\u7d89\u07f3\u{1f8cd}\ube89', layout: bindGroupLayout29, entries: []});
+try {
+renderPassEncoder43.setIndexBuffer(buffer30, 'uint16', 10, 113);
+} catch {}
+let querySet37 = device0.createQuerySet({label: '\uaa10\u53dd\uccb2\u1a00\ud57a', type: 'occlusion', count: 11});
+let renderBundle138 = renderBundleEncoder15.finish({label: '\u{1f6e4}\ua194\u0acb'});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: 745.5, g: -85.46, b: 99.67, a: -825.4, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(4, 0, 8, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer34, 'uint16', 3_008, 3_322);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer0, 0);
+} catch {}
+let commandEncoder261 = device4.createCommandEncoder({});
+let commandBuffer174 = commandEncoder261.finish();
+let textureView63 = texture76.createView({label: '\u{1fc0d}\u{1f9c5}'});
+try {
+renderBundleEncoder30.setIndexBuffer(buffer43, 'uint32', 512, 643);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(1, buffer43, 2_144, 96);
+} catch {}
+let renderBundle139 = renderBundleEncoder29.finish({label: '\u{1fd4a}\u926b'});
+try {
+device3.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 8, y: 9, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(501), /* required buffer size: 501 */
+{offset: 15, bytesPerRow: 165}, {width: 39, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder262 = device3.createCommandEncoder();
+let renderPassEncoder44 = commandEncoder254.beginRenderPass({
+  label: '\u53a6\u00be\u03b2\u{1fa9a}\u03bd\u05e9\u{1fe83}\u666a\u494d\u0525',
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 21,
+  clearValue: { r: -677.3, g: -867.7, b: 990.8, a: 380.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 205841819,
+});
+let renderBundle140 = renderBundleEncoder29.finish({label: '\u5e5b\uc7cc\udd03\uf7ab\u7d36\u7945\ucfb4'});
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup23, []);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder({label: '\u{1fb56}\u057a\u3b2c\u04b3'});
+let commandBuffer175 = commandEncoder263.finish({label: '\u0930\u{1fe95}'});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup7, new Uint32Array(2878), 469, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 656);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer35, 0, 529);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer34, 'uint16', 1_994, 1_472);
+} catch {}
+try {
+device0.queue.submit([commandBuffer155]);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+computePassEncoder49.setBindGroup(0, bindGroup25, new Uint32Array(965), 282, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer35, 'uint32', 1_120, 13);
+} catch {}
+let arrayBuffer13 = buffer31.getMappedRange(1360, 64);
+try {
+device0.queue.submit([commandBuffer175]);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+await gc();
+let promise41 = adapter7.requestAdapterInfo();
+let offscreenCanvas5 = new OffscreenCanvas(119, 105);
+let commandEncoder264 = device3.createCommandEncoder();
+try {
+renderPassEncoder44.executeBundles([renderBundle139, renderBundle137, renderBundle139]);
+} catch {}
+try {
+renderPassEncoder44.setViewport(142.61917540887717, 57.86762813494734, 315.30102923512607, 10.053338665976128, 0.7619097260201748, 0.768675050980673);
+} catch {}
+let img10 = await imageWithData(18, 45, '#10101010', '#20202020');
+let videoFrame14 = new VideoFrame(videoFrame0, {timestamp: 0});
+let renderBundle141 = renderBundleEncoder25.finish();
+try {
+renderPassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(7, buffer30, 4);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandBuffer176 = commandEncoder262.finish();
+try {
+renderPassEncoder44.setVertexBuffer(1, buffer42, 0, 166);
+} catch {}
+let promise42 = device3.queue.onSubmittedWorkDone();
+let gpuCanvasContext10 = offscreenCanvas5.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+adapter5.label = '\u554f\ub161\u0e8b\u{1fa14}\u0a90\u22f5\ua174\u85b2\u35f2\u05b8';
+} catch {}
+let commandBuffer177 = commandEncoder264.finish({label: '\u0473\u147b\u08fc\u{1f719}\uf8de'});
+try {
+renderPassEncoder44.setIndexBuffer(buffer32, 'uint16', 50, 227);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(6, buffer42, 736, 21);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise43 = device3.queue.onSubmittedWorkDone();
+document.body.prepend(video0);
+let commandEncoder265 = device2.createCommandEncoder({});
+let commandBuffer178 = commandEncoder265.finish();
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer30, 68, 33);
+} catch {}
+await gc();
+let buffer45 = device3.createBuffer({
+  label: '\u3a2c\u0545',
+  size: 5020,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let texture77 = device3.createTexture({
+  label: '\u{1f955}\u0a12\u7485\u040c\u06cd',
+  size: [16],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let texture78 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder59.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(2, buffer42, 0, 98);
+} catch {}
+try {
+  await promise43;
+} catch {}
+let textureView64 = texture68.createView({label: '\u{1f83e}\u{1fee4}\u{1f6cb}', baseArrayLayer: 3, arrayLayerCount: 1});
+try {
+renderPassEncoder44.executeBundles([renderBundle139, renderBundle139, renderBundle139, renderBundle140, renderBundle140]);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer42, 'uint32', 868, 421);
+} catch {}
+let bindGroup27 = device2.createBindGroup({label: '\u{1f9d2}\uc534\u76b4\ue837\u6ebf', layout: bindGroupLayout29, entries: []});
+let commandEncoder266 = device2.createCommandEncoder({});
+let externalTexture30 = device2.importExternalTexture({label: '\ud858\u0fe6\u{1fb0e}\ufb4a\u123d', source: videoFrame12});
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer30);
+} catch {}
+try {
+device2.queue.submit([commandBuffer171]);
+} catch {}
+let renderBundle142 = renderBundleEncoder30.finish({label: '\uf06a\u0fa8\u{1fc93}'});
+try {
+  await promise42;
+} catch {}
+try {
+  await promise40;
+} catch {}
+await gc();
+let commandEncoder267 = device3.createCommandEncoder({label: '\u1b03\u{1f84c}\u08fa\u079e\ud5cd\ue10e\u{1fbdd}'});
+let querySet38 = device3.createQuerySet({label: '\ueeba\u0b58\u0558\ubfb7\u{1ffce}\u0f2d\uce8f', type: 'occlusion', count: 981});
+let commandBuffer179 = commandEncoder267.finish({label: '\u1e25\u0fe9\uaeb3\u{1f6f6}\u{1f794}\u47eb\u0dfc'});
+try {
+renderPassEncoder44.end();
+} catch {}
+let commandEncoder268 = device3.createCommandEncoder({label: '\u6048\u0f06\uf0a0'});
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let video11 = await videoWithData();
+try {
+renderPassEncoder39.setBlendConstant({ r: 647.0, g: -830.5, b: -669.9, a: 619.5, });
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 1_012);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup0, new Uint32Array(3344), 1261, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+  await promise41;
+} catch {}
+let renderBundleEncoder31 = device4.createRenderBundleEncoder({label: '\u004a\u{1f95b}\u02a1\u0375\u6f62\u905a\u0815', colorFormats: ['r8sint'], sampleCount: 1});
+let renderBundle143 = renderBundleEncoder30.finish({label: '\uafef\u8fd0\u0e8b\ue27c\u1180'});
+let commandBuffer180 = commandEncoder266.finish();
+try {
+renderPassEncoder40.setBlendConstant({ r: -50.81, g: 72.16, b: 958.2, a: -848.5, });
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let sampler15 = device0.createSampler({
+  label: '\ude58\u58a7\u{1fd82}\u0a95\u{1fd57}\u{1f9d5}\u{1fbce}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 98.16,
+  lodMaxClamp: 99.51,
+});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 4_300);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer36, 5_076, 9_816);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint16', 3_356, 1_436);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u8ff1');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 356, new Float32Array(9956), 1316, 144);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+offscreenCanvas1.width = 10;
+let commandEncoder269 = device4.createCommandEncoder();
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint32', 1_816, 383);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer43, 0, 330);
+} catch {}
+let promise44 = device4.queue.onSubmittedWorkDone();
+let img11 = await imageWithData(10, 7, '#10101010', '#20202020');
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint32', 1_108, 1_219);
+} catch {}
+try {
+commandEncoder269.clearBuffer(buffer43, 1160, 192);
+} catch {}
+try {
+device4.queue.submit([commandBuffer174]);
+} catch {}
+let renderPassEncoder45 = commandEncoder268.beginRenderPass({
+  label: '\ub062\u0345\u0ff8\u{1ff7e}\u{1f6d5}\u3148\ue98c',
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 49,
+  clearValue: { r: -444.6, g: -752.9, b: -819.4, a: -255.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet32,
+});
+let renderBundle144 = renderBundleEncoder29.finish({label: '\ufc5f\ufe0f\u13eb\udaca\u{1fd92}\u05df\u6d33\u{1f903}\u{1f9cf}\u8c34'});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle137, renderBundle139]);
+} catch {}
+try {
+  await promise44;
+} catch {}
+let commandEncoder270 = device3.createCommandEncoder({label: '\u{1ffbf}\u{1fed7}\u02e6\u6f91\u3cd5'});
+let commandBuffer181 = commandEncoder270.finish({label: '\u08a6\u4c21\u0358\u{1f6f1}\u{1fee9}\u{1fc5c}\u21ec\u0fad\u0fec'});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup23, new Uint32Array(2328), 1334, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup23, new Uint32Array(691), 120, 0);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle137, renderBundle144, renderBundle137]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer32, 'uint16', 330, 305);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer32, 8, new Int16Array(6892), 2451, 160);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let renderPassEncoder46 = commandEncoder237.beginRenderPass({
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 23,
+  clearValue: { r: 695.1, g: -581.2, b: -849.6, a: -958.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle145 = renderBundleEncoder29.finish();
+try {
+renderPassEncoder45.setBlendConstant({ r: 317.9, g: -777.5, b: 699.7, a: 922.7, });
+} catch {}
+let textureView65 = texture17.createView({label: '\u{1f907}\u{1fe57}\u5684\ua2fa\u4abb\u6354\u03ef'});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup9, [0]);
+} catch {}
+try {
+renderPassEncoder4.draw(2, 178, 5, 212_716_202);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup9, [0]);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4444, new DataView(new ArrayBuffer(18248)), 618, 608);
+} catch {}
+let renderBundle146 = renderBundleEncoder30.finish({label: '\u{1f821}\u{1f8a1}\u{1fff1}'});
+try {
+externalTexture19.label = '\u07a1\uef0c\uc2ee\u9e9f\ubdac\u{1f94f}\u14f3\u9815\u{1f99d}\u{1f9d0}';
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({label: '\u76da\u{1f97c}\u0ff7\ub15e\u5fda\uac56\u0f1b\u6343\u2d95'});
+let commandBuffer182 = commandEncoder271.finish({label: '\u{1f776}\u{1fe90}\u002a\ua320\ucebd\ud5d0\udf92\u0ac7\u0bf2\u{1fd3b}'});
+let renderBundle147 = renderBundleEncoder6.finish({label: '\u9bf5\ud47c\u7e71\ud74d\u044a\u0ee7\u7fa4\udbf1\uf91b\u{1f9c5}\u0552'});
+try {
+computePassEncoder61.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(1, 0, 13, 2);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 1_800);
+} catch {}
+let commandBuffer183 = commandEncoder253.finish({label: '\ud677\u085b\u0d81\u8397\u{1fa97}'});
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint16', 314, 1_263);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer22, 0, 115);
+} catch {}
+document.body.prepend(video4);
+try {
+computePassEncoder46.setBindGroup(2, bindGroup20, new Uint32Array(149), 0, 0);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer28, 248, new DataView(new ArrayBuffer(22894)), 10160, 1876);
+} catch {}
+await gc();
+let commandBuffer184 = commandEncoder269.finish({label: '\u{1fbc5}\u22d4\u69d5\u8ce6\u4527\u02bb\uf26b\u843b\u{1f7a9}\u5c8b\u3b6e'});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let commandEncoder272 = device0.createCommandEncoder({label: '\u00fd\u170e\u{1ffb4}\u{1f8a7}\u{1fe20}\u0a71\u010d\u7afd\u{1fee1}\u0467\u0e51'});
+let textureView66 = texture13.createView({mipLevelCount: 1});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer34, 'uint32', 3_720, 3_138);
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\uf0c1\u05ea\u9db4\u0ee4\u4366',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, constants: {}},
+});
+let adapter8 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let renderBundle148 = renderBundleEncoder30.finish();
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint32', 1_468, 1_917);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer43, 2692, new DataView(new ArrayBuffer(13783)), 773, 420);
+} catch {}
+let commandEncoder273 = device0.createCommandEncoder({label: '\u{1fecc}\uf542'});
+let renderPassEncoder47 = commandEncoder273.beginRenderPass({
+  label: '\u{1fede}\u0646\u0f16\u4fa0\u316e',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 479.4, g: -430.8, b: -239.4, a: 915.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 57561204,
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(0, bindGroup18, new Uint32Array(953), 169, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(11, 50, 0, 2_161_063_335);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 1_744);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 5_316);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder274 = device4.createCommandEncoder({label: '\ud4cb\u575e\u{1fdc7}\u{1f602}\u6015\udc48\u48da\u{1f6b9}\uebb5\u6a4c\u077c'});
+let computePassEncoder67 = commandEncoder274.beginComputePass({label: '\ua4a5\u{1fe43}\uad60\u5f8e\u88f6\u{1fdf5}\u4288\uf1ce\u7a70\u7720'});
+let renderBundle149 = renderBundleEncoder30.finish({label: '\u58f2\u8b35\u4071\u944e\u38a9'});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let texture79 = device0.createTexture({
+  label: '\u075b\u{1f99f}\u04bb\uf5f3\u{1feff}\u{1fd3d}\uf41a\u0f43\u0cfa\u0940',
+  size: [235, 33, 78],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder48 = commandEncoder272.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  depthSlice: 8,
+  clearValue: { r: 744.0, g: 738.5, b: -560.2, a: 275.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder6.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder4.draw(5, 189, 13, 812_984_768);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer35, 52);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer35, 'uint16', 52, 60);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(6, undefined, 0, 708_435_313);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint32', 3_644, 227);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let pipeline16 = device0.createComputePipeline({layout: pipelineLayout21, compute: {module: shaderModule12, constants: {}}});
+let pipeline17 = await device0.createRenderPipelineAsync({
+  label: '\ucde2\u0ee6\u0be5\u0249',
+  layout: pipelineLayout21,
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 4294967295,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 96, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 160, attributes: []},
+      {arrayStride: 268, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, attributes: []},
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 796,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 40, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+let textureView67 = texture77.createView({label: '\u0d01\u78c5\u0c58\u40ac\u052c\u3104'});
+let renderBundle150 = renderBundleEncoder29.finish({label: '\u8d33\u1160\u{1fcf1}\u3515\u00ee\uf1d0\u04cd\ub312\ud2c9\u{1fed5}\ue99d'});
+try {
+renderPassEncoder45.setViewport(281.58313261496676, 22.421411750445067, 101.95744913133106, 46.86700309913412, 0.31817412448421034, 0.779917858938413);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout39 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 73,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 184,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 268,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 296,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 91,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 29,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 96,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 100, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 127,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 60, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 139, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 218,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 172, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+try {
+device4.queue.writeBuffer(buffer43, 1056, new Float32Array(985), 54, 8);
+} catch {}
+let buffer46 = device2.createBuffer({
+  label: '\ud917\u0bf7\u0784\u3431\u4314\u{1fbbd}\u4d0c\u09e7\u1a73\u99e8\u{1fa97}',
+  size: 38032,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle151 = renderBundleEncoder25.finish({});
+let pipelineLayout33 = device2.createPipelineLayout({label: '\u{1fa43}\udd1e', bindGroupLayouts: [bindGroupLayout34, bindGroupLayout24]});
+let querySet39 = device2.createQuerySet({label: '\u01da\u6e52\u{1fd62}', type: 'occlusion', count: 383});
+let renderBundle152 = renderBundleEncoder26.finish({label: '\uba62\u0b33\u9a03\u05e9\u69ee\ua452\u07d1\ubbb0\u11d7\u{1fc51}\u7da1'});
+try {
+buffer28.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer148, commandBuffer183]);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let renderPassEncoder49 = commandEncoder138.beginRenderPass({
+  label: '\u{1fde0}\u0a9f\u0848',
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 3,
+  clearValue: { r: -375.7, g: 418.0, b: -924.0, a: -266.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet22,
+  maxDrawCount: 84047881,
+});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.draw(1, 15, 12, 1_206_817_070);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 1_224);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 464);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer34, 'uint32', 1_172, 1_751);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 1_172);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 136);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer0, 0);
+} catch {}
+try {
+computePassEncoder41.pushDebugGroup('\u26d9');
+} catch {}
+try {
+device0.queue.submit([commandBuffer123]);
+} catch {}
+let pipeline18 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  multisample: {mask: 0x314c0d66},
+  fragment: {module: shaderModule8, entryPoint: 'fragment0', targets: [{format: 'rg16uint', writeMask: 0}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilWriteMask: 1199937863,
+    depthBiasSlopeScale: 687.006644000076,
+  },
+  vertex: {module: shaderModule8, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup23, new Uint32Array(917), 29, 0);
+} catch {}
+try {
+renderPassEncoder45.end();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer42, 'uint16', 84, 3);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer42, 0, 538);
+} catch {}
+try {
+device3.queue.submit([commandBuffer146, commandBuffer176, commandBuffer140]);
+} catch {}
+let pipelineLayout34 = device4.createPipelineLayout({label: '\u{1fa6d}\u3953\ud745\u{1ff9a}\u0800\ub941\u0674', bindGroupLayouts: []});
+let commandEncoder275 = device4.createCommandEncoder({label: '\u{1f677}\ua5fa\u8220\u0ef2\u461c\udd1d\u0696\u{1ff76}\u00bb\u0d7f\u8d63'});
+let renderBundle153 = renderBundleEncoder31.finish({label: '\u1b03\u{1f86c}\u{1fb0d}\u5d43\u8252\u{1fb52}\u{1fd9a}'});
+try {
+computePassEncoder67.insertDebugMarker('\u0904');
+} catch {}
+try {
+gpuCanvasContext8.configure({device: device4, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+externalTexture1.label = '\uba55\u4e74\u{1f6f2}\u8a77\u14fd\u{1ff9d}';
+} catch {}
+let promise45 = adapter8.requestDevice({
+  label: '\udb87\u0824\uf4a5\u{1fa10}\u4c77\u{1faab}\u{1fbf7}\u42bb\ue68a\u6a0f\u819f',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let bindGroupLayout40 = device4.createBindGroupLayout({
+  label: '\u0698\ue67b\udb34\u5591\u{1fcd3}\u{1fe5a}\uf5b5\u92cf\u0a05\u81df\u{1fcc7}',
+  entries: [
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 345, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 198,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 123, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder276 = device4.createCommandEncoder({label: '\uc269\u{1f794}\u9d0d\u{1f942}\u76a6'});
+let commandBuffer185 = commandEncoder276.finish();
+try {
+buffer43.unmap();
+} catch {}
+let buffer47 = device2.createBuffer({
+  label: '\u0e27\u2731\u5fee',
+  size: 18022,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer47, 'uint16', 3_240, 69);
+} catch {}
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 23, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 112,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 144,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 10, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 27, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder277 = device0.createCommandEncoder({});
+let commandBuffer186 = commandEncoder277.finish({label: '\ub66b\u0dc8\u{1f75f}\u876d\uef72\u255f\u0c4a\u{1f721}\u{1fc73}\u0f87'});
+let textureView68 = texture22.createView({aspect: 'all', mipLevelCount: 2, baseArrayLayer: 2, arrayLayerCount: 2});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder278 = device0.createCommandEncoder({label: '\u1bbd\u0fc0\u0c4c\u05f8\u{1f9f3}\u4f57'});
+let commandBuffer187 = commandEncoder278.finish();
+let externalTexture31 = device0.importExternalTexture({source: video8, colorSpace: 'display-p3'});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup19, new Uint32Array(489), 385, 0);
+} catch {}
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 376);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(6, buffer4, 0, 5_554);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer35, 'uint32', 656, 130);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer35, 'uint32', 20, 441);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer4, 712, 2_406);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle145, renderBundle144, renderBundle150, renderBundle139]);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer32, 48, new Float32Array(1074), 195, 8);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(409), /* required buffer size: 409 */
+{offset: 25, bytesPerRow: 38}, {width: 1, height: 11, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder279 = device0.createCommandEncoder({label: '\ua3c4\u{1f7fc}\u0532\u0445\u27ab\u407e\u0a61\u0eb7\u5a08\u{1fef9}\u{1f8e8}'});
+let computePassEncoder68 = commandEncoder279.beginComputePass();
+try {
+computePassEncoder15.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 30, 4, 261_257_203);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer36, 0, 4_091);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup23, new Uint32Array(963), 34, 0);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let commandEncoder280 = device2.createCommandEncoder({label: '\u1348\u0c24\u08f6\u4fcf\u5a9a\u8b5c\u{1ff08}\uc8c0\ub71f'});
+let textureView69 = texture49.createView({label: '\u{1fc06}\u0cb6\u{1f8e9}\u0dc2\u07bb\u{1f9b1}'});
+try {
+renderPassEncoder40.insertDebugMarker('\u0448');
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder281 = device3.createCommandEncoder({label: '\u0f66\u{1fbf7}\u2c4a\u0620\u59db\u{1fc6b}\u396c'});
+let renderPassEncoder50 = commandEncoder281.beginRenderPass({
+  label: '\uc48b\u0327',
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 24,
+  clearValue: { r: 145.6, g: 148.6, b: 485.0, a: -42.90, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet32,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder46.setScissorRect(155, 15, 67, 54);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+renderPassEncoder4.draw(6, 567, 6, 502_487_766);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer36, 0, 580);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+let commandBuffer188 = commandEncoder280.finish({label: '\u0b2e\u2dbc\u0dfe\ub16e\u0eb3\u092b\u0533\u0b91\u881c\uc6dd\ud821'});
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+document.body.prepend(canvas4);
+try {
+computePassEncoder48.setBindGroup(2, bindGroup26, new Uint32Array(201), 22, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+adapter6.label = '\u00f8\u83e6\u0da1\u0502\u9289\ud771\ue0a1\u025d';
+} catch {}
+let commandEncoder282 = device4.createCommandEncoder({label: '\ucd26\u{1f7a8}\u7f69\u29c1\u0db1\u17f1\u{1fcbe}'});
+let querySet40 = device4.createQuerySet({label: '\u4150\ue59d\udd61', type: 'occlusion', count: 269});
+let renderBundle154 = renderBundleEncoder30.finish({});
+try {
+gpuCanvasContext7.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData31 = new ImageData(40, 24);
+let commandEncoder283 = device3.createCommandEncoder({label: '\u{1fef0}\ue544'});
+let renderPassEncoder51 = commandEncoder283.beginRenderPass({
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 46,
+  clearValue: { r: -423.5, g: 901.4, b: -287.5, a: 840.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup23, []);
+} catch {}
+let commandEncoder284 = device3.createCommandEncoder({label: '\ue9fb\u0004'});
+let renderPassEncoder52 = commandEncoder284.beginRenderPass({
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 26,
+  clearValue: { r: -132.8, g: 489.5, b: -611.1, a: -567.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet32,
+  maxDrawCount: 8679861,
+});
+try {
+renderPassEncoder52.setViewport(497.4118564664584, 83.9286498960541, 57.50848928397455, 9.657530234216846, 0.9150090203398733, 0.9753454429451964);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer42, 'uint16', 68, 345);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder285 = device3.createCommandEncoder({label: '\u0be8\u{1fed7}\u01c2'});
+let commandBuffer189 = commandEncoder285.finish({});
+try {
+renderPassEncoder52.executeBundles([renderBundle145]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(11_454), /* required buffer size: 11_454 */
+{offset: 26, bytesPerRow: 64, rowsPerImage: 16}, {width: 9, height: 3, depthOrArrayLayers: 12});
+} catch {}
+try {
+computePassEncoder44.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(1, buffer47, 4_980, 3_834);
+} catch {}
+let promise46 = device2.queue.onSubmittedWorkDone();
+let commandEncoder286 = device2.createCommandEncoder({});
+let renderPassEncoder53 = commandEncoder286.beginRenderPass({
+  label: '\u0942\u6f3c\u5be9\u07ac\ue218\u482b\u{1ff0e}',
+  colorAttachments: [{view: textureView58, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet34,
+});
+let pipelineLayout35 = device4.createPipelineLayout({
+  label: '\u{1f944}\uc627\u407c\u0746\u10e7\u04fd\u{1f79c}',
+  bindGroupLayouts: [bindGroupLayout36, bindGroupLayout40, bindGroupLayout40],
+});
+try {
+device4.queue.submit([commandBuffer185, commandBuffer184]);
+} catch {}
+document.body.prepend(img6);
+let imageData32 = new ImageData(56, 24);
+let commandEncoder287 = device4.createCommandEncoder({});
+let renderBundleEncoder32 = device4.createRenderBundleEncoder({label: '\ua194\ubace\u1bef', colorFormats: ['r8sint'], stencilReadOnly: true});
+let renderBundle155 = renderBundleEncoder32.finish({label: '\uc2f0\u0ca0\u77c6\u9c13\u{1f692}\ub2c8\uc1fe\u4dfe\u0cdb\u7c0b\ua953'});
+try {
+buffer43.unmap();
+} catch {}
+try {
+commandEncoder275.clearBuffer(buffer43, 384, 4856);
+} catch {}
+try {
+device4.queue.submit([commandBuffer173]);
+} catch {}
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 262});
+let texture80 = device0.createTexture({
+  label: '\u78e9\u{1febf}\u9a84\u9717\ubfa0\u{1f72a}\u086b\u{1f6d1}\u059b\u0fa2\u07c5',
+  size: [70],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+try {
+renderPassEncoder4.draw(2, 94, 3, 1_188_295_805);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 5_092);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer35, 108);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer14 = buffer3.getMappedRange(2920, 12);
+let pipeline19 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    depthBiasClamp: 506.89935980183157,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 940, attributes: []},
+      {arrayStride: 44, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, stepMode: 'vertex', attributes: []},
+      {arrayStride: 96, attributes: []},
+      {arrayStride: 424, stepMode: 'instance', attributes: []},
+      {arrayStride: 300, stepMode: 'vertex', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 160,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 10, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let canvas6 = document.createElement('canvas');
+let querySet42 = device2.createQuerySet({label: '\u0301\u{1f7fa}\u68e3\uaca5\u3cb8\u0c0c\u4b62\udcc2', type: 'occlusion', count: 548});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(1, buffer47);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+canvas6.getContext('webgpu');
+} catch {}
+let commandEncoder288 = device2.createCommandEncoder({label: '\u4aa1\u8aea\u0453\u9e04\u72cf\ua86f\u{1f710}'});
+let renderBundle156 = renderBundleEncoder26.finish({label: '\u7d02\u329b\u03fb'});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup27, new Uint32Array(5144), 1304, 0);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+let textureView70 = texture68.createView({label: '\uc753\u{1ff56}\u{1fbf3}\u{1fb7a}\u1426\u9338', baseArrayLayer: 4, arrayLayerCount: 2});
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup23, new Uint32Array(1033), 31, 0);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise47 = device3.queue.onSubmittedWorkDone();
+let commandEncoder289 = device0.createCommandEncoder({label: '\u26d4\u{1f92e}\u22d8\u{1f938}\u3994\u0289\u{1f8e7}\u6d4c'});
+let commandBuffer190 = commandEncoder289.finish({});
+let renderBundle157 = renderBundleEncoder27.finish({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 516);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline5);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+document.body.prepend(img3);
+try {
+computePassEncoder51.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup26, new Uint32Array(1304), 408, 0);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer28, 'uint16', 688, 516);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(7, buffer30, 0, 65);
+} catch {}
+try {
+commandEncoder288.clearBuffer(buffer30, 352, 104);
+} catch {}
+try {
+device2.queue.submit([commandBuffer178]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter4.label = '\u1aeb\ubfc8\u9b79\u0c79\u{1fe69}';
+} catch {}
+let imageData33 = new ImageData(20, 108);
+let renderBundle158 = renderBundleEncoder29.finish({label: '\u{1fa9f}\uf4cf\u3fb4\u{1fdd7}\ud6d7\ud98d\ub13e\u8b30\u0f63'});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup23, new Uint32Array(963), 144, 0);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(0, buffer42);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer42, 160, new BigUint64Array(107));
+} catch {}
+let promise48 = device3.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder4.draw(1, 11, 2, 746_720_383);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 204);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer0, 'uint16', 1_470, 2_455);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer1, 'uint32', 640, 12_125);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let commandBuffer191 = commandEncoder288.finish({label: '\u5973\u0256\ubafb\u0047\uf5c9\u036b'});
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer47, 3_904, 2_729);
+} catch {}
+try {
+device2.queue.submit([commandBuffer112]);
+} catch {}
+let commandEncoder290 = device2.createCommandEncoder({label: '\u{1fabd}\u2e41'});
+let querySet43 = device2.createQuerySet({
+  label: '\u{1fa5c}\u5485\u00ad\uf0bb\u0ac0\u99f3\u0544\u{1f6ec}\u3929\u{1f740}',
+  type: 'occlusion',
+  count: 119,
+});
+try {
+renderPassEncoder53.setIndexBuffer(buffer47, 'uint16', 174, 4_222);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipelineLayout36 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout8, bindGroupLayout1, bindGroupLayout28, bindGroupLayout5]});
+let commandEncoder291 = device0.createCommandEncoder();
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 112);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder291.copyBufferToBuffer(buffer4, 2896, buffer8, 7020, 164);
+} catch {}
+try {
+commandEncoder291.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 256, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture81 = device4.createTexture({
+  label: '\u{1f667}\u63d2\u0ce9\u8c66\ud4b1\u{1f6a3}',
+  size: {width: 127, height: 1, depthOrArrayLayers: 27},
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle159 = renderBundleEncoder31.finish({});
+try {
+commandEncoder275.clearBuffer(buffer43, 252, 412);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(5, buffer28);
+} catch {}
+try {
+device2.queue.submit([commandBuffer149, commandBuffer180]);
+} catch {}
+let commandEncoder292 = device0.createCommandEncoder({label: '\u{1fea7}\u0c59\u0d0b\u05bc\u{1ffaa}\u{1fd51}\uf4b2\u{1f726}\ufd59\u896f\u{1fd47}'});
+let renderPassEncoder54 = commandEncoder291.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 8,
+  clearValue: { r: -795.4, g: -752.6, b: 36.84, a: -727.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+});
+let externalTexture32 = device0.importExternalTexture({label: '\u3b9e\ua1c4\u8d3a\u0d9f\u6ceb\u0c92', source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.draw(5, 8, 1, 851_508_088);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 3_268);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 5_012);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer36, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup9, new Uint32Array(1377), 428, 1);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4_294_967_294, undefined, 0, 350_295_411);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let computePassEncoder69 = commandEncoder292.beginComputePass({});
+try {
+computePassEncoder0.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer35, 0, 484);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer34, 'uint32', 796, 1_798);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let renderBundle160 = renderBundleEncoder30.finish({label: '\u0983\ub37b\u4073\u19e0'});
+try {
+commandEncoder275.clearBuffer(buffer43, 1220, 528);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+  await promise46;
+} catch {}
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  label: '\ua047\u03e7\u118d\u09f3\u5252\u6c7a\u{1fdcb}',
+  entries: [
+    {binding: 142, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 105,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 12, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 335,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 175,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 690, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 612,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 6, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 312,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 187,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 104,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 249, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 574,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 304,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 118,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 346, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 618, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 546, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder293 = device3.createCommandEncoder();
+let commandBuffer192 = commandEncoder293.finish({label: '\u0663\u4c23\u5efe\u{1fdf4}'});
+try {
+renderPassEncoder51.setStencilReference(627);
+} catch {}
+let arrayBuffer15 = buffer45.getMappedRange(584, 300);
+try {
+gpuCanvasContext1.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder294 = device0.createCommandEncoder({});
+let texture82 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder70 = commandEncoder294.beginComputePass();
+try {
+renderPassEncoder21.setScissorRect(111, 7, 4, 7);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(2, buffer4, 4_916, 9_781);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer34);
+} catch {}
+let commandEncoder295 = device2.createCommandEncoder();
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setViewport(77.9992261399455, 8.739057868564982, 9.76699525138458, 1.4229203854117791, 0.9546351113562503, 0.9866507714101634);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer47);
+} catch {}
+try {
+device2.queue.submit([commandBuffer150, commandBuffer126, commandBuffer109, commandBuffer161]);
+} catch {}
+let commandBuffer193 = commandEncoder282.finish({label: '\u4091\u{1fdbd}'});
+let renderBundle161 = renderBundleEncoder32.finish({label: '\u{1fa69}\ub0f5\u0dc8\u0023\ue15c\u{1f783}\u{1fb28}\u0c94\uce1f'});
+try {
+  await promise48;
+} catch {}
+let commandEncoder296 = device0.createCommandEncoder({label: '\u{1f78b}\u7dcb\u07d2\u2c3e\u60fd\u{1fd85}\ue146\u{1fa25}\u0869'});
+let computePassEncoder71 = commandEncoder296.beginComputePass({label: '\u{1feb0}\u296d'});
+let renderBundle162 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder27.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: 358.1, g: 340.0, b: -119.4, a: -283.8, });
+} catch {}
+try {
+device0.queue.submit([commandBuffer186, commandBuffer147]);
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+try {
+window.someLabel = device4.label;
+} catch {}
+try {
+device4.queue.writeBuffer(buffer43, 0, new DataView(new ArrayBuffer(21120)), 162, 420);
+} catch {}
+let pipelineLayout37 = device4.createPipelineLayout({label: '\u0197\u1f3c\u0b77\u7f7f\u{1fdf2}\u{1fed7}\u{1fb74}', bindGroupLayouts: [bindGroupLayout36]});
+let commandBuffer194 = commandEncoder287.finish();
+let texture83 = gpuCanvasContext9.getCurrentTexture();
+let renderBundle163 = renderBundleEncoder30.finish({label: '\uefae\u843f'});
+let commandEncoder297 = device3.createCommandEncoder({label: '\ude74\u0a83\u0b11\ufe49\u068a'});
+let commandBuffer195 = commandEncoder297.finish({label: '\u062e\ue0b3\u4d24\u3402'});
+let textureView71 = texture67.createView({label: '\u01ed\u08da\u05fe\u650a\u2ff3\u0648\u5af3\u0c96\uf2ce'});
+let pipeline20 = device3.createComputePipeline({
+  label: '\u6b4d\u{1f6a5}\uc90c\u0a2d',
+  layout: pipelineLayout29,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise47;
+} catch {}
+let commandEncoder298 = device4.createCommandEncoder({label: '\u{1f629}\u0c40\u{1f64d}\u0b36'});
+let commandBuffer196 = commandEncoder298.finish({label: '\ud34f\ud945\u1bb1\u003b\uab7b\u{1ff13}\uf8bb'});
+try {
+device4.queue.writeBuffer(buffer43, 3144, new Float32Array(3103), 577, 12);
+} catch {}
+let renderBundle164 = renderBundleEncoder31.finish({label: '\ucfa3\u{1fcc0}\u02b6\u3556\uf56c\u5d57'});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder299 = device0.createCommandEncoder();
+let commandBuffer197 = commandEncoder299.finish({label: '\u00c9\uca91'});
+let renderBundle165 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder49.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder54.setScissorRect(23, 2, 2, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(1, 79, 1, 229_959_232);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 5_112);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer0, 'uint32', 2_392, 1_045);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer4, 2_724, 3_359);
+} catch {}
+try {
+device0.queue.submit([commandBuffer190]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer198 = commandEncoder275.finish({label: '\ubf59\uc479\uadb4\uf4ed\u37a1\u{1f9e0}\u02d7'});
+let renderBundle166 = renderBundleEncoder31.finish({label: '\u{1fcd7}\u0a34\ua25a\u08fa\u{1ffc5}\ua472\u{1fdfa}\u{1f93c}\u566c'});
+document.body.prepend(img6);
+try {
+renderPassEncoder4.beginOcclusionQuery(4);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant({ r: 635.6, g: 984.4, b: -32.29, a: 707.4, });
+} catch {}
+try {
+renderPassEncoder4.draw(2, 98, 0, 522_185_272);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer35, 'uint16', 254, 137);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer36);
+} catch {}
+let bindGroupLayout43 = device2.createBindGroupLayout({
+  label: '\u2ba2\u00fd',
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 124,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 118, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 75, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 466, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 319,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 224, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 93, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 137,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 187, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 165,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 145,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 59, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 149,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer48 = device2.createBuffer({
+  size: 9637,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+commandEncoder290.copyBufferToBuffer(buffer47, 3716, buffer22, 8, 40);
+} catch {}
+document.body.prepend(video0);
+let pipelineLayout38 = device3.createPipelineLayout({label: '\u05d0\u0f32\u0f0b', bindGroupLayouts: [bindGroupLayout37, bindGroupLayout42]});
+let renderBundle167 = renderBundleEncoder29.finish({});
+let arrayBuffer16 = buffer45.getMappedRange(888, 2732);
+try {
+device3.queue.writeBuffer(buffer32, 80, new BigUint64Array(31396), 8383, 20);
+} catch {}
+let bindGroupLayout44 = device4.createBindGroupLayout({
+  label: '\ucab0\u43d1\u{1ff20}\u0cf3\u2008',
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 744,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {binding: 63, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 194, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 364, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder300 = device4.createCommandEncoder({label: '\ub2e8\u06a9\u0a43\u{1f724}\u28db\u6402\u449f\u{1f6f4}\u7c0f\u074f'});
+let commandEncoder301 = device2.createCommandEncoder({});
+let commandBuffer199 = commandEncoder290.finish({label: '\u3672\uad19\uab81\u{1fc5c}'});
+try {
+device2.queue.writeBuffer(buffer48, 3376, new Int16Array(2181), 829, 712);
+} catch {}
+document.body.prepend(video7);
+let buffer49 = device2.createBuffer({size: 3470, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup22, new Uint32Array(6), 0, 0);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+let commandEncoder302 = device2.createCommandEncoder({label: '\ucf06\ub173\ued84\ucbd7\u018c\u23df\u02d7\u0b9b'});
+let commandBuffer200 = commandEncoder295.finish({label: '\u8e6f\u{1fbc0}\u179b\u2c6e\u05e6\u2341\u0738\u{1fc07}\u341e\uefd5\u0186'});
+let sampler16 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.84,
+  lodMaxClamp: 84.60,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup26, new Uint32Array(506), 97, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup21, new Uint32Array(6106), 1711, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+commandEncoder302.resolveQuerySet(querySet43, 0, 0, buffer46, 5888);
+} catch {}
+try {
+device2.queue.submit([commandBuffer152]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer22, 44, new DataView(new ArrayBuffer(42719)), 289, 28);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup23, new Uint32Array(1923), 47, 0);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle167, renderBundle144]);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let texture84 = device2.createTexture({
+  label: '\ub852\ucdce\ucd27\u{1f8a2}\u49b5',
+  size: [15, 2, 73],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView72 = texture56.createView({label: '\u63a5\u0c1c\u{1fcc5}\u0b0f\u27a3\ufc24\u0bcb\u87e9\u000c\u0511'});
+try {
+renderPassEncoder53.setVertexBuffer(7, buffer22);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let commandEncoder303 = device2.createCommandEncoder({});
+let commandBuffer201 = commandEncoder303.finish({label: '\u{1fe23}\u{1f917}\u{1f61b}\u{1f999}'});
+let renderBundle168 = renderBundleEncoder26.finish({label: '\u0ed4\ue5c9\u2802\u8e57\u{1f692}'});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+commandEncoder301.copyBufferToBuffer(buffer47, 5192, buffer28, 12, 232);
+} catch {}
+let commandEncoder304 = device2.createCommandEncoder({label: '\u6eea\u70fc\u070a\u03f0\u{1fbf8}'});
+let commandBuffer202 = commandEncoder304.finish();
+let computePassEncoder72 = commandEncoder302.beginComputePass({});
+let renderBundle169 = renderBundleEncoder25.finish({label: '\uc60f\u102c\u4e10\u0387'});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer47, 772, 739);
+} catch {}
+try {
+commandEncoder301.resolveQuerySet(querySet42, 99, 6, buffer22, 256);
+} catch {}
+try {
+commandEncoder301.pushDebugGroup('\u0ee5');
+} catch {}
+try {
+computePassEncoder55.insertDebugMarker('\u{1f8f8}');
+} catch {}
+await gc();
+await gc();
+let commandEncoder305 = device3.createCommandEncoder({label: '\u{1fd5b}\u{1fb67}\u{1f96d}\u53d3\ud042\u0526\u070e'});
+let commandBuffer203 = commandEncoder305.finish({label: '\u08da\u2bf6\u{1f851}\uf548\u0b4f\u2aab'});
+let sampler17 = device3.createSampler({
+  label: '\uf151\u{1fe1e}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.68,
+  lodMaxClamp: 98.58,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder59.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup23, new Uint32Array(873), 215, 0);
+} catch {}
+try {
+renderPassEncoder50.setStencilReference(333);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(7, buffer42);
+} catch {}
+try {
+window.someLabel = bindGroup2.label;
+} catch {}
+video4.width = 2;
+let renderPassEncoder55 = commandEncoder301.beginRenderPass({
+  label: '\u{1fafe}\ua226\u{1f703}\u8838\u{1fb3f}\u{1ffbe}\u90d4\u9de5\u0414\u5688\u1129',
+  colorAttachments: [{
+  view: textureView58,
+  clearValue: { r: -553.7, g: -291.0, b: 401.9, a: -114.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+  await buffer49.mapAsync(GPUMapMode.READ, 0, 392);
+} catch {}
+await gc();
+let bindGroupLayout45 = device4.createBindGroupLayout({
+  label: '\u3c4b\uc04e\u2df4',
+  entries: [
+    {
+      binding: 42,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let computePassEncoder73 = commandEncoder300.beginComputePass({label: '\u8cbe\u{1f746}\u46d8\u1c19\u{1fa05}\u1578\u02af'});
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.submit([commandBuffer194]);
+} catch {}
+let imageData34 = new ImageData(20, 76);
+let querySet44 = device4.createQuerySet({label: '\ub007\u7ab4\u0c8a', type: 'occlusion', count: 19});
+let commandBuffer204 = commandEncoder300.finish({label: '\ubcfe\u655b\u{1fa27}\u9a48\u0ba9\uae50'});
+let texture85 = device4.createTexture({
+  label: '\u{1fc59}\ua87b\u4c58\u0214\u16c3\u{1f7af}\u23ba\u0aa1',
+  size: {width: 127},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let promise49 = device4.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout39 = device3.createPipelineLayout({
+  label: '\u{1f6e7}\u{1fb04}\u7de2\u63d3\ucb7d\u{1fd10}\u0b24\u1fa8\u906f\u5c50\u4b09',
+  bindGroupLayouts: [bindGroupLayout32],
+});
+let commandEncoder306 = device3.createCommandEncoder({label: '\u8d77\ua50c\ubba0\u30be'});
+try {
+computePassEncoder59.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup23, new Uint32Array(718), 26, 0);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(2, buffer42);
+} catch {}
+try {
+commandEncoder306.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 117, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder307 = device2.createCommandEncoder();
+let renderBundle170 = renderBundleEncoder26.finish({label: '\u{1f8f7}\u{1ff01}\u9d06\u{1fa98}\ubcf8\u23d1'});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(444);
+} catch {}
+try {
+commandEncoder307.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 46, y: 4, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 944 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1072 */
+  offset: 1072,
+  bytesPerRow: 1024,
+  buffer: buffer28,
+}, {width: 59, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.submit([commandBuffer202]);
+} catch {}
+let pipelineLayout40 = device4.createPipelineLayout({
+  label: '\u06b3\u17f4\uf12d\u6c3b\ua201\u82c0\u9a8a\u{1fe70}\u{1f662}\ub985',
+  bindGroupLayouts: [bindGroupLayout44],
+});
+try {
+device4.queue.writeBuffer(buffer43, 2092, new DataView(new ArrayBuffer(50696)), 41646, 724);
+} catch {}
+let bindGroup28 = device3.createBindGroup({
+  label: '\u595d\u0e14\u02af\u09ec\u7eb4\u07af\uf22b\u{1f8a6}\u7b28\ub431',
+  layout: bindGroupLayout33,
+  entries: [],
+});
+let buffer50 = device3.createBuffer({
+  label: '\u{1fc73}\u0910\u2f18',
+  size: 7663,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder308 = device3.createCommandEncoder();
+let commandBuffer205 = commandEncoder308.finish({label: '\u{1f6d3}\u4d79\u14ab\u0464\u7c2a\u{1fb08}'});
+await gc();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let pipelineLayout41 = device2.createPipelineLayout({label: '\ufbb5\u3618\u030a\u{1fe5d}\u{1fab0}\u{1f86b}', bindGroupLayouts: []});
+let commandBuffer206 = commandEncoder307.finish({label: '\uda4c\u03d8\u0e04\uf865\ud7dc\ua82f'});
+let commandBuffer207 = commandEncoder306.finish({label: '\u{1f74f}\ueda2'});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder46.pushDebugGroup('\u35e3');
+} catch {}
+let commandEncoder309 = device0.createCommandEncoder({label: '\ufb26\u089c\u9225\u03dd\u{1fc20}\ua3a4'});
+let renderPassEncoder56 = commandEncoder309.beginRenderPass({
+  label: '\u05a4\u0b60\u08bc\u{1f75d}\ub6f3\u37b8',
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 99,
+  clearValue: { r: -913.7, g: 213.6, b: -180.6, a: -856.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 398811350,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle8, renderBundle37, renderBundle124]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 3_756);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 1_228);
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync({
+  label: '\u{1fe99}\u0ed3\u2ca8\u04f6\u0283\ue63e\u{1fb9e}\u0273',
+  layout: pipelineLayout21,
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 648, attributes: []},
+      {arrayStride: 468, attributes: []},
+      {arrayStride: 116, stepMode: 'vertex', attributes: []},
+      {arrayStride: 388, stepMode: 'instance', attributes: []},
+      {arrayStride: 736, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 764, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 368,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x3', offset: 136, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+let video12 = await videoWithData();
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup23, new Uint32Array(911), 115, 0);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer42, 368, new BigUint64Array(3779), 531, 24);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let imageBitmap7 = await createImageBitmap(imageData23);
+let commandEncoder310 = device0.createCommandEncoder({});
+let computePassEncoder74 = commandEncoder310.beginComputePass();
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 124);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer4, 1_388, 10_110);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+  await promise49;
+} catch {}
+await gc();
+let offscreenCanvas6 = new OffscreenCanvas(790, 114);
+let bindGroup29 = device0.createBindGroup({label: '\u0b21\u026e', layout: bindGroupLayout20, entries: [{binding: 442, resource: sampler10}]});
+let renderBundle171 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder4.draw(9, 58, 3, 29_425_837);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer35, 164);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer35, 'uint16', 4, 238);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas6.getContext('webgpu');
+let commandEncoder311 = device3.createCommandEncoder();
+let renderPassEncoder57 = commandEncoder311.beginRenderPass({
+  label: '\u{1fe66}\u156a',
+  colorAttachments: [{
+  view: textureView62,
+  depthSlice: 24,
+  clearValue: { r: 82.28, g: 558.6, b: 6.164, a: -678.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet27,
+});
+let renderBundle172 = renderBundleEncoder29.finish();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+await gc();
+try {
+computePassEncoder65.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup28);
+} catch {}
+let commandEncoder312 = device3.createCommandEncoder({label: '\u3658\uf855\u0fe3'});
+try {
+renderPassEncoder46.executeBundles([renderBundle150]);
+} catch {}
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 73});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup8, new Uint32Array(1074), 144, 0);
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant({ r: -223.5, g: -583.6, b: 293.8, a: 849.4, });
+} catch {}
+try {
+renderPassEncoder4.draw(1, 239, 4, 1_094_865_045);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 1_820);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer4, 2_968, 5_342);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer1, 'uint16', 252, 4_407);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer36);
+} catch {}
+let promise50 = adapter5.requestAdapterInfo();
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 256, 3, 671_261_860);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 1_604);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer36);
+} catch {}
+try {
+computePassEncoder41.popDebugGroup();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder313 = device3.createCommandEncoder({label: '\u{1fcc7}\uf140\u07af'});
+let commandBuffer208 = commandEncoder313.finish({label: '\u2b21\u09c7\udd7b'});
+let texture86 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder52.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer45, 'uint16', 28, 205);
+} catch {}
+let commandEncoder314 = device3.createCommandEncoder({label: '\u879d\u02e5\u5c70\uec55'});
+let commandBuffer209 = commandEncoder314.finish({label: '\u{1f6d7}\ub0dd\u{1f765}'});
+let renderPassEncoder58 = commandEncoder312.beginRenderPass({
+  colorAttachments: [{view: textureView62, depthSlice: 21, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet27,
+});
+let renderBundle173 = renderBundleEncoder29.finish({label: '\u0465\u84b3\u38f0\u7a41\ud0f5\u9804\u0e57\u4c0f'});
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.insertDebugMarker('\u054b');
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device3, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device3.queue.submit([commandBuffer208]);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle147, renderBundle29, renderBundle109]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 500);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer35, 'uint32', 28, 334);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder315 = device2.createCommandEncoder();
+let commandBuffer210 = commandEncoder315.finish({label: '\u0fe6\u3c7a\u{1fd23}\u2bd8\ub19b'});
+let renderBundleEncoder33 = device2.createRenderBundleEncoder({label: '\u66c4\u611e\u51fc\u{1f6de}\u{1fde7}\u05a3\u9a05', colorFormats: ['rg16float']});
+await gc();
+try {
+computePassEncoder74.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline21);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let renderBundle174 = renderBundleEncoder31.finish({label: '\u013e\u6560'});
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+let buffer51 = device3.createBuffer({
+  label: '\ub8dc\u05da\u09ab',
+  size: 4496,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder46.executeBundles([renderBundle150, renderBundle158]);
+} catch {}
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+device4.queue.submit([]);
+} catch {}
+let promise51 = device4.queue.onSubmittedWorkDone();
+let commandEncoder316 = device4.createCommandEncoder({label: '\u035d\u028f\u07c9\u2a5f\u5161\u516c\u{1f759}\u0033'});
+let commandBuffer211 = commandEncoder316.finish({label: '\u02b7\ub953\ufae6\u{1f731}\u955d'});
+let texture87 = device4.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 80},
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device4.queue.writeBuffer(buffer43, 2716, new BigUint64Array(2459), 330, 112);
+} catch {}
+let buffer52 = device4.createBuffer({
+  label: '\u2bf5\u{1f831}\u40d9\uaf51\u9e6f\u08db\u1cd7\u2f95\u017f\u122a\u0b2e',
+  size: 9528,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder75 = commandEncoder274.beginComputePass();
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise50;
+} catch {}
+let commandEncoder317 = device2.createCommandEncoder({label: '\u16e6\uc482\u009c\u112a\u73cc'});
+let renderBundle175 = renderBundleEncoder25.finish({});
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup21, new Uint32Array(10000), 2018, 0);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer28, 744, new DataView(new ArrayBuffer(38348)), 18041, 120);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+  await promise51;
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer30, 0, 22);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroupLayout46 = device4.createBindGroupLayout({
+  label: '\u708f\u{1ff41}\uba0a',
+  entries: [
+    {
+      binding: 62,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 125,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 49, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 211,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 292,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 278,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 158, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 29, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 253,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 136,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 13293643, hasDynamicOffset: false },
+    },
+    {binding: 459, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 22, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 282,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 133, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 224,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 497,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 54712502, hasDynamicOffset: false },
+    },
+    {binding: 595, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 200,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 178, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 68, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 186,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 141, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 267,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 467,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 262,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 1063808, hasDynamicOffset: false },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 15, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 213,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 199,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 202,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 20, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 14, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 18110793, hasDynamicOffset: true },
+    },
+    {
+      binding: 367,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+try {
+device4.queue.submit([commandBuffer169]);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer43, 3484, new BigUint64Array(10006), 303, 32);
+} catch {}
+await gc();
+let imageData35 = new ImageData(16, 20);
+let offscreenCanvas7 = new OffscreenCanvas(1, 22);
+let imageData36 = new ImageData(76, 44);
+let commandEncoder318 = device3.createCommandEncoder();
+let commandBuffer212 = commandEncoder318.finish({});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup28, new Uint32Array(3813), 516, 0);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+document.body.prepend(video4);
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer23, 'uint32', 620, 1_760);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(3, buffer30, 12, 35);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let commandEncoder319 = device2.createCommandEncoder({});
+let querySet46 = device2.createQuerySet({label: '\ua02d\uef52\u4151', type: 'occlusion', count: 1360});
+let renderBundle176 = renderBundleEncoder25.finish();
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(1, buffer28, 488, 466);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer28, 'uint16', 242, 878);
+} catch {}
+try {
+commandEncoder319.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 640 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1760 */
+  offset: 1760,
+  bytesPerRow: 768,
+  rowsPerImage: 54,
+  buffer: buffer48,
+}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder319.resolveQuerySet(querySet28, 28, 1, buffer22, 0);
+} catch {}
+try {
+commandEncoder189.insertDebugMarker('\u52e9');
+} catch {}
+try {
+computePassEncoder58.setBindGroup(2, bindGroup28, new Uint32Array(4915), 45, 0);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(5, buffer51, 416, 171);
+} catch {}
+let bindGroupLayout47 = device3.createBindGroupLayout({
+  label: '\u0fe9\u01e1\ucfd7\u058f\u1ca1',
+  entries: [
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 283,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 208,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 181,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 697, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 169, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 191,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 233, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 487,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 215, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 64, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 225, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 712,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 170,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer53 = device3.createBuffer({size: 6090, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let textureView73 = texture67.createView({label: '\uf46d\uc008\u{1fc61}\u0c2a\u0013\u0ff6\ue7fb\ub72f\u{1ff1d}\uc3e3'});
+try {
+renderPassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder52.setScissorRect(213, 18, 9, 2);
+} catch {}
+document.body.prepend(img9);
+let commandEncoder320 = device4.createCommandEncoder();
+try {
+commandEncoder320.copyBufferToBuffer(buffer52, 1036, buffer43, 304, 1128);
+} catch {}
+try {
+commandEncoder320.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup0, new Uint32Array(2855), 136, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.draw(6, 10, 0, 116_556_845);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 344);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 3_876);
+} catch {}
+let computePassEncoder76 = commandEncoder320.beginComputePass({label: '\u00ba\u108e\u6b6e\u0719'});
+let commandEncoder321 = device2.createCommandEncoder({label: '\u{1fadb}\u0fda\u{1f95a}\ucfb8\ud836\u0743'});
+try {
+renderPassEncoder53.beginOcclusionQuery(196);
+} catch {}
+try {
+renderPassEncoder40.setViewport(96.34717245675729, 2.085100794218868, 1.103550655979088, 7.224699704665847, 0.543890050404746, 0.5877739287130707);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(3, buffer22, 104, 765);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup25, new Uint32Array(973), 407, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(2, 112, 11, 118_728_598);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 300);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 648);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer35, 0, 160);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup7, new Uint32Array(3645), 58, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 70, 1, 437_447_431);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer1, 'uint16', 8_250, 1_975);
+} catch {}
+try {
+window.someLabel = renderBundleEncoder8.label;
+} catch {}
+let textureView74 = texture54.createView({
+  label: '\u6037\ub652\u3926\u9929\ub11b\u0851\u{1fe6d}',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 3,
+});
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.draw(8, 292, 4, 1_943_197);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline21);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas7.getContext('webgpu');
+let commandEncoder322 = device0.createCommandEncoder({label: '\u{1f851}\u5f77\u6d6a\u0a7d\u{1f707}\u8bb5\u9090\u{1f999}\u6e6a\u571b'});
+let querySet47 = device0.createQuerySet({label: '\uf321\u99f9\u{1fe1a}', type: 'occlusion', count: 327});
+let renderPassEncoder59 = commandEncoder322.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 22,
+  clearValue: { r: 779.7, g: 522.9, b: -475.1, a: 650.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle177 = renderBundleEncoder28.finish({label: '\u817a\u0eb6\u8e37\u{1f967}\u{1f7dc}\uee94\u0113\u0751\u59b5'});
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder35.setViewport(96.03528170051814, 3.673507547585478, 2.7887127902214734, 6.2448231708116, 0.9311648014486033, 0.9636809637987278);
+} catch {}
+try {
+renderPassEncoder4.draw(1, 117, 11, 528_978_703);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 52);
+} catch {}
+await gc();
+try {
+device4.queue.submit([commandBuffer198, commandBuffer193]);
+} catch {}
+let commandEncoder323 = device0.createCommandEncoder({label: '\u{1fb40}\u0a2f\ub2b3\u{1fd5c}\u044c\u{1ffbe}\u{1f9ab}\u{1f8ae}\u733a'});
+let computePassEncoder77 = commandEncoder310.beginComputePass();
+let renderPassEncoder60 = commandEncoder323.beginRenderPass({
+  label: '\uab64\u{1fa95}\u47b8\u5ec2\u034c\u{1f72b}\u{1fdd1}\u586e\u1c18\uf1c3',
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 37,
+  clearValue: { r: -778.0, g: -88.31, b: -460.0, a: 157.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle178 = renderBundleEncoder28.finish();
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup8, new Uint32Array(810), 187, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 4_164);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 1_108);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup15, new Uint32Array(402), 126, 0);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline5);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 2372, new Int16Array(3433), 985);
+} catch {}
+let commandEncoder324 = device0.createCommandEncoder({label: '\u06f0\ufd31\u0900\u0c6f\uaceb\u4dc8\u0b31\u0413'});
+let commandBuffer213 = commandEncoder324.finish({});
+let texture88 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder69.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(28);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.draw(1, 61, 3, 365_779_875);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer1, 'uint16', 2_182, 329);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer34, 'uint32', 268, 1_791);
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 0, 204);
+} catch {}
+try {
+device0.queue.submit([commandBuffer119]);
+} catch {}
+let shaderModule15 = device4.createShaderModule({
+  code: `
+@group(0) @binding(63) var et28: texture_external;
+@group(0) @binding(47) var sam27: sampler;
+@group(0) @binding(34) var sam28: sampler;
+@group(0) @binding(364) var sam29: sampler_comparison;
+@group(0) @binding(744) var tex21: texture_depth_multisampled_2d;
+@group(0) @binding(94) var tex22: texture_2d_array<u32>;
+@group(0) @binding(194) var et29: texture_external;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_id) a0: vec3u) {
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var position: vec4f;
+  position = vec4f(0.07644, 0.1973, 0.02349, 0.1931);
+  return position;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec4i {
+  var out: vec4i;
+  _ = textureDimensions(et28);
+  _ = textureLoad(tex21, vec2i(), 0);
+  _ = textureLoad(et28, vec2u());
+  _ = textureLoad(tex22, vec2i(), 0, 0);
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder325 = device4.createCommandEncoder({label: '\u0b71\u8bd3\u176a\ua122\u0b1d\u5dd2\u{1fb3c}'});
+try {
+commandEncoder325.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 19},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 427, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let sampler18 = device3.createSampler({
+  label: '\ub3bf\u0da5\u{1fdd1}',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 41.82,
+  compare: 'always',
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup28, new Uint32Array(8), 1, 0);
+} catch {}
+document.body.prepend(video11);
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u0d96\u5675\ud927\u{1fd83}\ubcee\u0a41\u4996\u28e2\u{1f928}\uf2c1',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle179 = renderBundleEncoder21.finish({label: '\u0043\uc1a2\u0285'});
+let externalTexture33 = device0.importExternalTexture({
+  label: '\ub895\u08e4\u9e22\u{1fe06}\uc022\u002a\u0621\u6b3d\u668b\u0ad7',
+  source: videoFrame4,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder4.draw(1, 173, 18, 56_531_614);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 1_624);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(2, buffer35, 100, 51);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(4_294_967_295, undefined, 594_559_117, 18_746_510);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 84, new Int16Array(2456), 272, 60);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video13 = await videoWithData();
+let imageData37 = new ImageData(132, 16);
+try {
+adapter1.label = '\u1a05\u0583\u{1fb9e}\u0f72';
+} catch {}
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer42);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let promise52 = adapter0.requestAdapterInfo();
+try {
+renderPassEncoder4.drawIndirect(buffer1, 17_356);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer35, 'uint16', 102, 348);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer34, 'uint16', 4_144, 1_042);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(4, buffer34);
+} catch {}
+try {
+device0.queue.submit([commandBuffer132]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder326 = device2.createCommandEncoder({label: '\u{1fdcd}\uadc8\u6ba0\u4fd3\u0af7'});
+let commandBuffer214 = commandEncoder321.finish({label: '\u3a6a\u1013\u05e9\u08f8\u1e8c'});
+let computePassEncoder78 = commandEncoder326.beginComputePass({});
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder53.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(40, 1, 14, 3);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer47, 'uint16', 170, 594);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer47, 'uint16', 912, 1_129);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 2_788);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup12, new Uint32Array(358), 200, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer4, 1_392, 857);
+} catch {}
+document.body.prepend(video11);
+try {
+  await promise52;
+} catch {}
+let pipelineLayout42 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout8, bindGroupLayout17, bindGroupLayout21, bindGroupLayout13]});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup10, new Uint32Array(46), 35, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 3_052);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer36);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer110]);
+} catch {}
+let commandEncoder327 = device0.createCommandEncoder({label: '\u{1f9a4}\ucd26\u6a65\ud57a\u74eb\u37d4\u{1f7a9}'});
+let querySet48 = device0.createQuerySet({label: '\u009f\u5570\u3afb\u01a2\u274d', type: 'occlusion', count: 294});
+let renderPassEncoder61 = commandEncoder327.beginRenderPass({
+  label: '\u{1fb20}\ue151\ucf98\u9f04\u3cf4\u0edb\u{1fafa}',
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 257.7, g: 57.40, b: -52.09, a: -268.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer35, 64);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup9, new Uint32Array(1167), 64, 1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder328 = device2.createCommandEncoder({label: '\u4821\u68f3\u0119\u07f3\u{1fbe9}\ub1a7\u{1fb2c}\u8929\u6e9e'});
+let renderBundle180 = renderBundleEncoder25.finish({label: '\u6a9d\u{1fed2}\ua49f\u3184\ue9ac\u0b1c'});
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(1, buffer28, 0, 195);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup20, new Uint32Array(3988), 314, 0);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder329 = device2.createCommandEncoder({label: '\uc5ba\u{1f9a2}\u{1fb17}\uf7cc\u060b\u3425\u436a'});
+let commandBuffer215 = commandEncoder319.finish({label: '\uda28\ua224\u{1fc1e}\u55b4\u{1f726}\u{1f88d}\u{1fabe}\u{1fd1c}\u1762\u{1fc58}\u2321'});
+try {
+renderPassEncoder53.setScissorRect(22, 1, 4, 1);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer22);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+commandEncoder317.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 62, y: 3, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2208 widthInBlocks: 138 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 576 */
+  offset: 576,
+  bytesPerRow: 2304,
+  buffer: buffer30,
+}, {width: 138, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder60.insertDebugMarker('\u631c');
+} catch {}
+let commandEncoder330 = device3.createCommandEncoder({label: '\ua987\u03f2\u525e\u{1fac7}\u{1f843}\u840e'});
+let computePassEncoder79 = commandEncoder255.beginComputePass({label: '\u07e3\u52e0\u0935\u0542\u02c9'});
+let renderBundle181 = renderBundleEncoder29.finish({label: '\u06e0\u0092\u0416'});
+try {
+renderPassEncoder50.setViewport(419.52443318621357, 27.967839660818314, 113.52773220479509, 1.2595311277202783, 0.6222300117975067, 0.7482566059775666);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(7, buffer42, 8);
+} catch {}
+let externalTexture34 = device0.importExternalTexture({
+  label: '\u{1fb6f}\uabc7\uaf19\u1c82\u049a\u384d\u{1fd9b}\u9a98\ue353\ufff9\u0eb9',
+  source: videoFrame11,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer131]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 20, new Int16Array(96), 31, 0);
+} catch {}
+let commandEncoder331 = device4.createCommandEncoder({label: '\u0fac\u5151\ua05a\u04cb\u{1f752}'});
+let commandBuffer216 = commandEncoder325.finish({label: '\u040b\u{1ff6b}\u1f1e\u07c9\u05eb'});
+let textureView75 = texture87.createView({label: '\u0c08\u0398\u9fde\u3682\ub387\u89c5\ue290\u3bfb\u{1fb6d}\u{1ff24}'});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder331.clearBuffer(buffer43, 140, 220);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer24, 'uint32', 444, 3_090);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup22, new Uint32Array(3726), 245, 0);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer28, 'uint32', 192, 346);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas5);
+let bindGroupLayout48 = device0.createBindGroupLayout({entries: []});
+let commandEncoder332 = device0.createCommandEncoder();
+let commandBuffer217 = commandEncoder332.finish({label: '\u{1f9a7}\u0e4b\u57ab\u{1fa6f}\ub686\u0d98'});
+let texture89 = device0.createTexture({
+  label: '\u9208\u90a1\u0ab0\u09df\ue0d0\u4334\u{1ff55}\ue04f',
+  size: [70, 5, 26],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u4337\u93d7\u{1faa9}\ufada\u7dde\u{1fbc7}',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder27.setIndexBuffer(buffer1, 'uint16', 2_590, 1_510);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer35, 0, 45);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer34, 'uint32', 3_024, 894);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\u2a19');
+} catch {}
+let commandBuffer218 = commandEncoder317.finish({});
+let computePassEncoder80 = commandEncoder329.beginComputePass({label: '\u2a80\u{1fcd5}\u{1fdc0}\u{1fbef}\u1a68\u0589\u0e6f'});
+let renderPassEncoder62 = commandEncoder328.beginRenderPass({
+  label: '\u17f9\u8771\u{1f9a7}\u7eb7\ufe77\u0346\u{1fc93}\u739c',
+  colorAttachments: [{view: textureView58, loadOp: 'load', storeOp: 'discard'}],
+});
+let renderBundle182 = renderBundleEncoder24.finish({});
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setScissorRect(2, 2, 0, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer47, 'uint16', 3_832, 3_969);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(0, buffer28);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+video0.width = 38;
+let imageData38 = new ImageData(92, 40);
+let pipelineLayout43 = device3.createPipelineLayout({label: '\u4207\u{1fe61}\u0a04', bindGroupLayouts: [bindGroupLayout33]});
+let commandEncoder333 = device3.createCommandEncoder();
+let computePassEncoder81 = commandEncoder333.beginComputePass({label: '\u962b\u{1f865}\ue3a0\u{1f8c4}\u2252\u0336\u70cd'});
+try {
+renderPassEncoder57.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer45, 'uint16', 1_142, 3_344);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(7, buffer42, 112);
+} catch {}
+try {
+commandEncoder330.copyBufferToBuffer(buffer42, 168, buffer32, 632, 8);
+} catch {}
+try {
+renderPassEncoder51.pushDebugGroup('\u{1fc86}');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout49 = device2.createBindGroupLayout({label: '\u{1fef4}\ud955\u00a9\u{1fbd2}', entries: []});
+let buffer54 = device2.createBuffer({
+  label: '\u4eab\u{1f6f6}\u21de\u0e74\u5616\u728d\u{1fa34}\u0cb7\u3bdd\u0f23',
+  size: 5,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder334 = device2.createCommandEncoder({label: '\ue6e2\u85d7'});
+let computePassEncoder82 = commandEncoder334.beginComputePass({label: '\u0820\u2ab0\u{1fb2d}\u022e\u8161\u051d\u291e\u40b8\uf029'});
+let renderBundle183 = renderBundleEncoder33.finish();
+try {
+renderPassEncoder40.setVertexBuffer(3, undefined, 0, 985_213_981);
+} catch {}
+try {
+commandEncoder189.clearBuffer(buffer22);
+} catch {}
+let commandBuffer219 = commandEncoder331.finish({label: '\u01a0\u{1f9b2}\u{1fb1f}\ubee8'});
+let textureView76 = texture76.createView({label: '\u2ef0\u{1f797}\uf9cd'});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout50 = device3.createBindGroupLayout({entries: []});
+let commandEncoder335 = device3.createCommandEncoder({label: '\u{1f6a6}\u{1fd40}\u0fac\u0ffd\u{1fcfb}\u3325\u0816\u{1f604}\u0865\u3ce2\u{1f6aa}'});
+let renderPassEncoder63 = commandEncoder335.beginRenderPass({
+  label: '\u0246\u{1f8d0}\u000a',
+  colorAttachments: [{view: textureView62, depthSlice: 34, loadOp: 'clear', storeOp: 'discard'}],
+});
+let renderBundle184 = renderBundleEncoder29.finish({label: '\u{1f9b5}\udc5b\u0bbc\u56c4'});
+try {
+renderPassEncoder51.setVertexBuffer(7, buffer51, 0, 151);
+} catch {}
+let arrayBuffer17 = buffer45.getMappedRange(0, 148);
+try {
+commandEncoder330.copyBufferToBuffer(buffer42, 540, buffer50, 404, 112);
+} catch {}
+let bindGroupLayout51 = device2.createBindGroupLayout({
+  label: '\u09ab\u6852\u4759',
+  entries: [
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder336 = device2.createCommandEncoder();
+let renderPassEncoder64 = commandEncoder189.beginRenderPass({
+  label: '\u6da9\ue5bc\u{1f975}\uc4f1\u013f\u110d\uf55b\u{1fa60}\u05f9\ucd79',
+  colorAttachments: [{
+  view: textureView58,
+  clearValue: { r: 905.8, g: -64.73, b: 738.3, a: -73.58, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet42,
+});
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder336.copyBufferToBuffer(buffer48, 760, buffer49, 152, 348);
+} catch {}
+try {
+commandEncoder336.clearBuffer(buffer22);
+} catch {}
+let bindGroupLayout52 = device0.createBindGroupLayout({
+  label: '\u00b6\uf87f\u274d\u4c63\u{1f8fb}\u0402\u3ff4\u{1ffa2}\u09a3',
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 275,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 11, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 523, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 265,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 169, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 190, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 156,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 336, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 394,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 264,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 182,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 188,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 171,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 147,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 78721, hasDynamicOffset: true },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 140, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 98,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 129,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 52, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let bindGroup30 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 440, resource: {buffer: buffer35, offset: 512, size: 244}}],
+});
+let commandEncoder337 = device0.createCommandEncoder();
+let renderPassEncoder65 = commandEncoder337.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 123.1, g: 418.1, b: 255.2, a: -632.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 230720860,
+});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup9, [0]);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle47, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 41, 8, 92_126_904);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer35, 16);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(4_294_967_294, undefined, 0, 69_368_068);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer35, 'uint16', 206, 72);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer35);
+} catch {}
+let promise53 = device0.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(0, 0, 10, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(17, 187, 3, 70_454_630);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(4_294_967_295, undefined, 0, 691_978_208);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 2_742, 1_374);
+} catch {}
+let pipeline22 = await device0.createRenderPipelineAsync({
+  label: '\u{1f6d7}\u054a\u67b9\u95c9\u1648\u0dcb\u{1f63f}\u2ac3\uf758',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 379942531,
+    depthBias: -1913456921,
+    depthBiasSlopeScale: 458.1672653602301,
+    depthBiasClamp: 329.7122373479539,
+  },
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {arrayStride: 984, stepMode: 'instance', attributes: []},
+      {arrayStride: 324, attributes: []},
+      {arrayStride: 708, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 812, stepMode: 'instance', attributes: []},
+      {arrayStride: 428, stepMode: 'instance', attributes: []},
+      {arrayStride: 60, attributes: []},
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 32, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {},
+});
+try {
+  await promise53;
+} catch {}
+try {
+externalTexture21.label = '\u2d6e\ucea1\u{1fee0}\u0e72\ud5a2\u35ea\u01de';
+} catch {}
+let pipelineLayout44 = device2.createPipelineLayout({
+  label: '\u{1fbc5}\u0d9e\uf0ab\ua424\u{1ff10}\u9668\u39c6\u047b\u5692\uef7f',
+  bindGroupLayouts: [bindGroupLayout27],
+});
+let commandEncoder338 = device2.createCommandEncoder({label: '\u0693\u{1fffb}\u{1fd36}\u{1f6ae}\u00ff\u{1fcba}\u{1fd9c}'});
+let commandBuffer220 = commandEncoder336.finish({label: '\u{1f6d5}\ubf43\u1351\u0ec1\udd09\u0abd\u{1fd30}\u185a\u0c84'});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer46, 'uint32', 4_280, 864);
+} catch {}
+let computePassEncoder83 = commandEncoder338.beginComputePass({label: '\u04bd\ufdb8\u7beb\u{1f843}\u086b\u083c\u31a1\u0a54\u07c3\u{1fddc}\u093d'});
+let renderBundle185 = renderBundleEncoder26.finish({label: '\u{1f8c7}\u{1fbea}\u8416\u{1f66f}\u179e\u{1f74e}\u{1f794}'});
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer55 = device4.createBuffer({
+  size: 14666,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder339 = device4.createCommandEncoder({});
+let renderBundleEncoder37 = device4.createRenderBundleEncoder({label: '\u01bb\u7909\u{1fb49}', colorFormats: ['r8sint'], depthReadOnly: true});
+let renderBundle186 = renderBundleEncoder31.finish({label: '\u{1fddc}\u410a\u41dd\u{1f7fa}\u0546\u1e2d'});
+try {
+device4.queue.submit([commandBuffer216, commandBuffer219]);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let renderBundle187 = renderBundleEncoder37.finish({});
+let renderBundle188 = renderBundleEncoder4.finish({label: '\u8cb2\uc98c\u1b5c'});
+let sampler19 = device0.createSampler({
+  label: '\u31bd\u71a6\ued8d\u0212\u{1f87c}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 26.67,
+  lodMaxClamp: 54.29,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup25, new Uint32Array(70), 10, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 1_420);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder34.insertDebugMarker('\u{1f6a8}');
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder51.setStencilReference(2184);
+} catch {}
+try {
+device3.pushErrorScope('internal');
+} catch {}
+let commandEncoder340 = device3.createCommandEncoder({label: '\u06e6\ua5fb\u05e1\uc3c6\u04fe\ub3ed'});
+let renderPassEncoder66 = commandEncoder340.beginRenderPass({
+  label: '\u4e3b\u4148\u2071\u86d6',
+  colorAttachments: [{
+  view: textureView71,
+  depthSlice: 159,
+  clearValue: { r: -877.0, g: -464.5, b: -381.3, a: 143.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 250849610,
+});
+try {
+renderPassEncoder66.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup23, new Uint32Array(118), 29, 0);
+} catch {}
+try {
+renderPassEncoder52.setViewport(77.36335342119814, 90.51226883161127, 410.5469299601532, 1.8631446720569922, 0.2646865906940862, 0.809421548333103);
+} catch {}
+let commandEncoder341 = device0.createCommandEncoder({label: '\u9240\u{1f81b}\u3a0f\ubef2\u0016\u05ba\ua76d\u{1f9ec}\u{1f860}\u8b26'});
+try {
+renderPassEncoder36.executeBundles([renderBundle81, renderBundle111, renderBundle119, renderBundle16, renderBundle92, renderBundle45, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder4.draw(4, 178, 5, 135_113_760);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer34, 'uint32', 636, 1_340);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline5);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder341.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 84, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer221 = commandEncoder341.finish();
+try {
+renderPassEncoder33.executeBundles([renderBundle81, renderBundle165]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 3_376);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 7_148);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer1, 'uint32', 6_672, 102);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup16, [512]);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer0, 'uint16', 1_306, 192);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 46, y: 5, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(724), /* required buffer size: 724 */
+{offset: 724, bytesPerRow: 595}, {width: 141, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+let commandEncoder342 = device4.createCommandEncoder({});
+let commandBuffer222 = commandEncoder342.finish({label: '\u0244\u0f0f\u49af\u{1f624}\u0c12\u041c\u0048'});
+try {
+gpuCanvasContext2.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img6);
+let imageData39 = new ImageData(36, 48);
+let commandEncoder343 = device2.createCommandEncoder({label: '\u393e\ub532\u08c0'});
+let computePassEncoder84 = commandEncoder343.beginComputePass({});
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer46, 'uint16', 9_468, 2_366);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.draw(5, 26, 0, 2_580_062_350);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer0, 1_104, 735);
+} catch {}
+let commandEncoder344 = device3.createCommandEncoder();
+let texture90 = device3.createTexture({
+  label: '\u{1fdd3}\u08b9\u0c70',
+  size: [281, 48, 93],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let renderPassEncoder67 = commandEncoder330.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 90,
+  clearValue: { r: 337.7, g: -606.9, b: 584.0, a: 481.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder67.executeBundles([renderBundle158, renderBundle173]);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+commandEncoder344.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 15, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer42, 8, new Int16Array(17638), 3000, 92);
+} catch {}
+let promise54 = navigator.gpu.requestAdapter();
+let pipelineLayout45 = device4.createPipelineLayout({label: '\u18e7\u3984\u{1f846}\u047b\u0b85\u95c1\u0e21\u6aae\u940a', bindGroupLayouts: []});
+let buffer56 = device4.createBuffer({
+  label: '\u96b0\u0dbc\u5d32\u{1f6dd}\u391f\u8da6\u4590\u933e\u1872',
+  size: 1554,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandBuffer223 = commandEncoder339.finish({label: '\u4e67\ucc36\u728d\u030d\u0732\u0d06\u00aa\u5818\u20ef\u{1fb7b}\u0bb3'});
+try {
+device4.queue.submit([commandBuffer165]);
+} catch {}
+let renderBundle189 = renderBundleEncoder36.finish({label: '\u705a\u0e04\ua171\u0ac2\u4488\u1512\u8e11\ud1f4\u0d70\u{1f8f1}'});
+try {
+renderPassEncoder4.draw(1, 63, 0, 186_654_764);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup30, [0]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 1_192);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 268);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer1, 'uint16', 42, 5_896);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder35.insertDebugMarker('\ub096');
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 1_736);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline21);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder64.beginOcclusionQuery(393);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer54, 0, new DataView(new ArrayBuffer(37674)), 2703, 0);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas3.width = 800;
+let bindGroupLayout53 = device2.createBindGroupLayout({
+  label: '\u7f36\udb2e\u0cfc',
+  entries: [
+    {
+      binding: 63,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let renderBundle190 = renderBundleEncoder33.finish({label: '\u3ece\udd7c\uca6b\u{1f6c3}\ud14c'});
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer23, 'uint32', 3_104, 623);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(7, buffer22, 552, 72);
+} catch {}
+try {
+device2.queue.submit([commandBuffer163]);
+} catch {}
+let imageData40 = new ImageData(56, 28);
+let bindGroupLayout54 = device0.createBindGroupLayout({
+  label: '\u071c\u4472\u{1fa1d}\u08d6\ud53d\u3d5d\u{1fafc}\u4de4\u3492\u6335',
+  entries: [
+    {binding: 147, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 117, visibility: 0, sampler: { type: 'comparison' }},
+    {binding: 223, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 150,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 9175579, hasDynamicOffset: false },
+    },
+    {binding: 4, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 182, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 66,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 4901969, hasDynamicOffset: false },
+    },
+    {binding: 999, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 198, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 186,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let texture91 = device0.createTexture({
+  label: '\u1105\u0247\u04b1\u0dcd\u0352\u083e\u0404',
+  size: [90, 1, 10],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let commandEncoder345 = device4.createCommandEncoder({label: '\u8a1c\u458c\u73d2\u3716\u9d3e\u{1ff21}'});
+let commandBuffer224 = commandEncoder345.finish({label: '\u91ec\ud972\u7127\uce7d'});
+let textureView77 = texture87.createView({label: '\ub44f\uc017\u6aa2\u0445\u07f3\ucf1c'});
+let commandEncoder346 = device2.createCommandEncoder({label: '\u53f4\u0e20\udf2b\u40b9\ubb38\u51db\u2d2c\u{1fa45}'});
+let commandBuffer225 = commandEncoder346.finish({label: '\u{1f80b}\u615f\u{1fbd2}\u0fbf\u{1fce1}\u70a5\u{1fa63}'});
+try {
+renderPassEncoder40.setScissorRect(24, 0, 24, 3);
+} catch {}
+let externalTexture35 = device0.importExternalTexture({
+  label: '\u3c4b\u54de\u61bf\u03ab\u0860\u7fa3\u0357\u5bfe\u0e0e\u9e49\u0f4b',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(3, buffer35, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer1, 'uint32', 1_556, 2_618);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(5, buffer35, 84, 408);
+} catch {}
+let commandEncoder347 = device2.createCommandEncoder({label: '\u03ed\u{1f68b}\u5bf6\u{1fcb4}\u13d1\u6438\u{1f7d2}'});
+let commandBuffer226 = commandEncoder347.finish({label: '\u02bf\ua7bf\u{1fb40}\u1f43\u9d07\uef0f'});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup27, new Uint32Array(289), 90, 0);
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(3, bindGroup21);
+} catch {}
+let commandBuffer227 = commandEncoder174.finish({label: '\u2443\u26e6\u047e\ubbc6\u{1f9a4}\u{1fe16}\u0044\u423e'});
+let textureView78 = texture55.createView({label: '\u{1ff07}\u2301\u75e9\u55a7\uddba\u1f95\u7979\u5d35\u0150', aspect: 'all', baseMipLevel: 1});
+document.body.prepend(img0);
+let commandEncoder348 = device3.createCommandEncoder({label: '\u4cf0\ufac7\u{1feb8}\u9865\u0c3c\udc79'});
+try {
+commandEncoder344.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 32, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video4);
+let device5 = await adapter9.requestDevice({
+  label: '\u9caa\u234d\uda6d\uf0e5',
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxStorageTexturesPerShaderStage: 4,
+    maxStorageBuffersPerShaderStage: 8,
+    maxDynamicStorageBuffersPerPipelineLayout: 4,
+    maxUniformBufferBindingSize: 13656038,
+    maxStorageBufferBindingSize: 162330248,
+  },
+});
+let commandEncoder349 = device5.createCommandEncoder({label: '\u6068\u0bd1\u9a2a\u0bd9\u{1fff6}\ue299'});
+try {
+commandEncoder344.copyBufferToBuffer(buffer32, 16, buffer50, 392, 276);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+commandEncoder349.insertDebugMarker('\u6cdb');
+} catch {}
+document.body.prepend(video8);
+let renderPassEncoder68 = commandEncoder348.beginRenderPass({
+  label: '\u005d\ucf72\uec56\u4b2b\u8aeb\u18a9\ud0ea',
+  colorAttachments: [{
+  view: textureView73,
+  depthSlice: 126,
+  clearValue: { r: -200.4, g: 539.3, b: -30.60, a: -844.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder58.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder63.setViewport(414.55719385279286, 37.49946916877017, 127.0815472935244, 39.94843756590206, 0.1877449736909088, 0.5226500491652422);
+} catch {}
+try {
+renderPassEncoder51.popDebugGroup();
+} catch {}
+let pipeline23 = device3.createRenderPipeline({
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule14, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: false},
+});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer47, 'uint32', 852, 967);
+} catch {}
+try {
+device2.queue.submit([commandBuffer164, commandBuffer162, commandBuffer225]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 376, new Float32Array(21609), 7204, 76);
+} catch {}
+let pipelineLayout46 = device0.createPipelineLayout({label: '\u871c\uf6e6\u{1f7fb}\u537e\u2b2a\u0239\u{1f7fa}\ue4c7', bindGroupLayouts: []});
+try {
+computePassEncoder9.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder4.draw(2, 61, 2, 1_626_195_323);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer35, 32);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer36, 0, 2_696);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer1, 'uint16', 5_692, 6_725);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline21);
+} catch {}
+let arrayBuffer18 = buffer3.getMappedRange(2936, 0);
+try {
+device0.queue.submit([commandBuffer197]);
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder41.beginOcclusionQuery(31);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(4, buffer34, 0, 2_915);
+} catch {}
+let commandEncoder350 = device0.createCommandEncoder({label: '\uce87\u2a49\u029e\u4618\u858c'});
+let commandBuffer228 = commandEncoder350.finish({});
+let texture92 = device0.createTexture({
+  label: '\u0de9\u6d58\ua907\uaf15\uf169\u0b76\u06b6\u517f\u44f5\u{1f848}\ufa56',
+  size: [360, 1, 105],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u01be\u08df\u851d\u8b8a\u0892\u8808\u{1fc53}\u{1fc27}\u2184\u721a',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder77.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder4.draw(2, 162, 1, 99_214_388);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 16);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer1, 'uint32', 2_204, 3_488);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout47 = device3.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(2, bindGroup28, new Uint32Array(1371), 237, 0);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline23);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer167]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 30, y: 5, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(454), /* required buffer size: 454 */
+{offset: 6, bytesPerRow: 44}, {width: 2, height: 11, depthOrArrayLayers: 1});
+} catch {}
+let imageData41 = new ImageData(16, 24);
+let commandBuffer229 = commandEncoder344.finish({label: '\ubc32\ude65\u{1f7a2}\u5c12\u1f72'});
+let textureView79 = texture67.createView({label: '\u019f\u{1fda5}\u7faf\u234c\u01b9\u3c11\uab0b', dimension: '3d'});
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let imageData42 = new ImageData(36, 16);
+let bindGroupLayout55 = device0.createBindGroupLayout({
+  label: '\u0a2c\u0be0\u070d\u{1fc60}\u005a',
+  entries: [
+    {
+      binding: 69,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 6, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 340,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 239,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 227,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderBundle191 = renderBundleEncoder19.finish({label: '\ubd8e\u2f9c\u0521\u{1fc6d}\u{1f879}\u0e32\u{1fbf3}\u0f42\u0ad2\u59d9\u40ba'});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup30, [0]);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder41.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.draw(1, 58, 4, 48_869_154);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(5, buffer36, 0);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(0, buffer4);
+} catch {}
+let textureView80 = texture69.createView({label: '\u05f8\u0211\u2995\u07c8\u{1f794}\u12f3\uf2de\udd93\u0f42\u7c2d\u050f'});
+try {
+computePassEncoder58.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(1, buffer42, 0);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+renderPassEncoder46.popDebugGroup();
+} catch {}
+try {
+device3.queue.submit([commandBuffer192]);
+} catch {}
+document.body.prepend(canvas0);
+try {
+computePassEncoder68.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle130, renderBundle136]);
+} catch {}
+try {
+renderPassEncoder4.draw(4, 18, 12, 155_995_239);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 56);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup25, new Uint32Array(1523), 85, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 74, y: 7, z: 15},
+  aspect: 'all',
+}, new ArrayBuffer(1_890_075), /* required buffer size: 1_890_075 */
+{offset: 111, bytesPerRow: 543, rowsPerImage: 29}, {width: 81, height: 1, depthOrArrayLayers: 121});
+} catch {}
+let commandEncoder351 = device4.createCommandEncoder();
+try {
+gpuCanvasContext12.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder352 = device5.createCommandEncoder();
+let commandEncoder353 = device4.createCommandEncoder();
+let renderBundle192 = renderBundleEncoder32.finish({label: '\u{1f863}\u569a'});
+try {
+gpuCanvasContext6.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device4.queue.submit([commandBuffer196]);
+} catch {}
+let commandEncoder354 = device2.createCommandEncoder();
+let commandBuffer230 = commandEncoder354.finish({label: '\u{1f6f8}\u0a28\u08c3\ufc76\u0a91\u6f02\u2899'});
+let texture93 = device2.createTexture({
+  size: [80],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture36 = device2.importExternalTexture({label: '\u093e\ub971\u4584\u6c72\u0a89', source: videoFrame9, colorSpace: 'display-p3'});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer30, 'uint32', 120, 16);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(6, buffer22);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let buffer57 = device4.createBuffer({
+  label: '\ua596\u077e\u{1fd54}\u1620\u{1f6f9}\u6166\u{1f619}\u64a2',
+  size: 4009,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandBuffer231 = commandEncoder353.finish({label: '\uf22b\ucfa2\ua2fb'});
+document.body.prepend(video11);
+let texture94 = device0.createTexture({
+  size: {width: 560, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView81 = texture4.createView({
+  label: '\u{1f792}\u{1f683}\u5a35\u9ff9\u{1f846}\u34a7\u{1fff3}',
+  baseArrayLayer: 6,
+  arrayLayerCount: 5,
+});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle37, renderBundle92]);
+} catch {}
+try {
+renderPassEncoder4.draw(1, 200, 3, 588_445_418);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer34, 0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer121]);
+} catch {}
+document.body.prepend(video13);
+let commandEncoder355 = device3.createCommandEncoder({label: '\u0f1e\u0b05\ufbac\u{1f696}\ue83a\ub731\u{1f704}\u11ee\u06db\u{1f805}\u0eef'});
+let computePassEncoder85 = commandEncoder355.beginComputePass({});
+try {
+computePassEncoder81.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer50, 'uint32', 352, 2_049);
+} catch {}
+let commandEncoder356 = device2.createCommandEncoder({label: '\ud351\u5d62\u{1f769}\u04df\u04b2\u0947\ud9df\u00ae\u{1fe62}'});
+let textureView82 = texture55.createView({label: '\ubb2f\ua68a', aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer47, 'uint32', 3_144, 10_736);
+} catch {}
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder65.end();
+} catch {}
+try {
+renderPassEncoder60.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.draw(8, 100, 0, 658_855_018);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer35, 276);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer21, 2_348);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup30, new Uint32Array(2128), 447, 1);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder192.copyBufferToBuffer(buffer31, 420, buffer34, 1984, 964);
+} catch {}
+let commandBuffer232 = commandEncoder45.finish({label: '\u441e\u0cf8\ub422\ud620\u0834\u378d\u6fdd'});
+let texture95 = device0.createTexture({
+  label: '\u394b\uf045\u5489\ub6a8\ud9ab\u{1fa2f}\u{1f9b7}\u06fb',
+  size: {width: 180},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder4.draw(17, 168, 0, 804_368_950);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer35, 'uint16', 146, 210);
+} catch {}
+try {
+device0.queue.submit([commandBuffer172, commandBuffer28]);
+} catch {}
+let computePassEncoder86 = commandEncoder351.beginComputePass({label: '\u572c\uac92\u8f01\u73df\udce8\u{1fc12}'});
+video12.width = 124;
+let commandEncoder357 = device5.createCommandEncoder({});
+let commandBuffer233 = commandEncoder349.finish({label: '\u35bb\u888d\ub5ac\u40a0\uacb9'});
+let externalTexture37 = device5.importExternalTexture({source: video5, colorSpace: 'display-p3'});
+let commandEncoder358 = device2.createCommandEncoder({label: '\u0ecc\u6a20\u{1f94b}\u1c3a\u{1faaa}\u{1ffca}\u1ac7\u0362\u2737'});
+let textureView83 = texture72.createView({label: '\uf111\u674b\uc49e\u95e5'});
+let renderBundle193 = renderBundleEncoder24.finish({label: '\u5563\uf172\u7fe9\u9eb2\u29f0\u2ec7'});
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setBlendConstant({ r: -976.6, g: -145.7, b: -742.5, a: 227.0, });
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let arrayBuffer19 = buffer49.getMappedRange(24, 40);
+try {
+computePassEncoder59.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder52.setScissorRect(13, 1, 8, 6);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+renderPassEncoder52.pushDebugGroup('\uf575');
+} catch {}
+let commandBuffer234 = commandEncoder357.finish({label: '\u{1fdd7}\u{1fb15}\u78fb\u{1feda}\u0597\u70f7\u{1fdaa}'});
+let externalTexture38 = device5.importExternalTexture({label: '\ud8e1\ubae7\u{1fd36}\u0203\u{1f9a0}', source: video1, colorSpace: 'display-p3'});
+document.body.prepend(img11);
+let commandEncoder359 = device4.createCommandEncoder({label: '\u061a\u0c7b\u9077'});
+try {
+commandEncoder359.clearBuffer(buffer55, 680, 188);
+} catch {}
+let renderBundleEncoder39 = device5.createRenderBundleEncoder({colorFormats: ['rgba32uint'], depthReadOnly: true});
+try {
+renderBundleEncoder39.setVertexBuffer(4_294_967_294, undefined, 2_972_320_339, 381_462_284);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device5,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder360 = device5.createCommandEncoder({label: '\ua1b4\u8ded\u{1fd7d}\u6267\ubb27\u0409\u1af7\u01b9'});
+let computePassEncoder87 = commandEncoder352.beginComputePass({label: '\u0d16\u05d8\u2dcd\u0024'});
+let sampler20 = device5.createSampler({
+  label: '\u721b\u0542\u3f77\u{1fcc4}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 37.65,
+  lodMaxClamp: 76.37,
+  compare: 'always',
+});
+try {
+  await device5.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout56 = device5.createBindGroupLayout({label: '\u62b1\u99ca', entries: []});
+let commandEncoder361 = device5.createCommandEncoder({label: '\u701d\ufe6d\u5d76\ud3d6\u0d09\u{1f80e}\uc086\u{1fffc}'});
+let commandBuffer235 = commandEncoder360.finish({label: '\u{1f90d}\u0d8e\ub752\u2a66'});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let renderBundle194 = renderBundleEncoder29.finish();
+try {
+computePassEncoder79.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline23);
+} catch {}
+try {
+device3.queue.submit([]);
+} catch {}
+let promise55 = device3.queue.onSubmittedWorkDone();
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+let externalTexture39 = device3.importExternalTexture({label: '\u0415\u{1f803}\u081b', source: videoFrame4, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer32, 'uint32', 432, 95);
+} catch {}
+let arrayBuffer20 = buffer45.getMappedRange(224, 92);
+try {
+renderPassEncoder62.setIndexBuffer(buffer23, 'uint16', 18, 1_546);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(1, buffer46, 5_108, 9_578);
+} catch {}
+let promise56 = device2.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let texture96 = gpuCanvasContext12.getCurrentTexture();
+let commandBuffer236 = commandEncoder359.finish({});
+let textureView84 = texture85.createView({label: '\u{1fdb1}\uf6ad\uaa38\u1247\u70c5\u9de9\u068e'});
+let renderBundle195 = renderBundleEncoder30.finish({label: '\u{1fff2}\uacc9\u0eae\u5dce\u{1fd62}\u08df'});
+try {
+buffer56.unmap();
+} catch {}
+let promise57 = device4.queue.onSubmittedWorkDone();
+let commandEncoder362 = device0.createCommandEncoder({});
+let renderPassEncoder69 = commandEncoder192.beginRenderPass({
+  label: '\ufd80\ua4e9\ude43\u018a\u7464\u0e78\u07d8\u8801',
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -465.7, g: -429.2, b: -563.9, a: 691.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle196 = renderBundleEncoder17.finish();
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup30, [256]);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup18, new Uint32Array(1880), 16, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle120]);
+} catch {}
+try {
+computePassEncoder61.pushDebugGroup('\u5caf');
+} catch {}
+let commandEncoder363 = device3.createCommandEncoder();
+let commandBuffer237 = commandEncoder363.finish();
+let renderBundle197 = renderBundleEncoder40.finish({label: '\u0bfc\u7f98\u884a\ucb1f'});
+let externalTexture40 = device3.importExternalTexture({label: '\u{1f702}\u9528\u{1f824}', source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderPassEncoder46.setPipeline(pipeline23);
+} catch {}
+try {
+device3.queue.submit([commandBuffer179]);
+} catch {}
+let commandEncoder364 = device4.createCommandEncoder({});
+let texture97 = device4.createTexture({
+  label: '\u{1f6f3}\ue8d9\u{1fd79}\u9270',
+  size: {width: 127},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+try {
+  await promise57;
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let bindGroupLayout57 = device5.createBindGroupLayout({label: '\u06f6\u94fc\u7d65\u1e83', entries: []});
+let commandEncoder365 = device5.createCommandEncoder({label: '\u0df2\u4e31\ua488\u6809\u0254\udd5d\u0592\ub0b7\u718a\u{1f621}'});
+let renderBundle198 = renderBundleEncoder39.finish({label: '\u{1f9a1}\u{1fd77}'});
+let commandBuffer238 = commandEncoder365.finish({});
+try {
+computePassEncoder87.end();
+} catch {}
+try {
+  await promise56;
+} catch {}
+let bindGroupLayout58 = device5.createBindGroupLayout({
+  label: '\u{1f8ea}\u7e26\u{1f7d5}\u{1f745}\ubf56\u6bac\u4628\u69cb\u{1fa51}\u099d',
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 115,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 19156750, hasDynamicOffset: false },
+    },
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 217,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 3500206, hasDynamicOffset: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 156233548, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer58 = device5.createBuffer({size: 14662, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet49 = device5.createQuerySet({label: '\u6077\u0d93\u{1fcdf}\u{1fb4e}\u0422\u0bca', type: 'occlusion', count: 2205});
+let computePassEncoder88 = commandEncoder352.beginComputePass({label: '\u2293\u{1fd86}\u0a85\u42a2\u04e0\u020f\uc6b2\udf43\u103b'});
+let externalTexture41 = device5.importExternalTexture({
+  label: '\u9d3d\u{1f6f6}\ud349\u05ee\u709e\u54ce\uefd3\uf078\u2d96\u7be6',
+  source: video9,
+  colorSpace: 'srgb',
+});
+try {
+buffer58.unmap();
+} catch {}
+let buffer59 = device4.createBuffer({
+  label: '\u0b3e\uce91',
+  size: 16269,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder366 = device4.createCommandEncoder({label: '\ub63a\u0463\u01b9\u00b7\u0157\ua495\u00cf\ufbcd\u11da\u0850\u{1fc96}'});
+try {
+renderPassEncoder51.setPipeline(pipeline23);
+} catch {}
+try {
+adapter8.label = '\ude3d\ubdb4\u09a0\u08ae\u0778';
+} catch {}
+let computePassEncoder89 = commandEncoder361.beginComputePass({label: '\u{1f769}\u1c20\u0fce\u2b2c'});
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+try {
+externalTexture7.label = '\u01eb\u06af\u0db2\u3afb\u0319\u01eb';
+} catch {}
+let bindGroupLayout59 = device3.createBindGroupLayout({label: '\u557c\u707e\u05a6\u2d68\u{1fef5}\u6642\ueff3\u0a7e\u055e', entries: []});
+let renderBundleEncoder41 = device3.createRenderBundleEncoder({colorFormats: ['rgba8uint'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder79.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle158]);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer42, 'uint32', 36, 46);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(7, buffer42);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(4, buffer51, 0, 880);
+} catch {}
+let shaderModule16 = device2.createShaderModule({
+  label: '\u{1fa9e}\u20ae\u3c5d\u{1f97d}\u{1f8ba}',
+  code: `
+@group(0) @binding(73) var sam30: sampler;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+}
+
+struct S10 {
+  @location(9) f0: u32
+}
+struct VertexOutput0 {
+  @location(12) f45: vec4h,
+  @location(13) f46: vec3f,
+  @location(1) f47: f32,
+  @location(6) f48: vec4u,
+  @location(5) f49: vec2u,
+  @builtin(position) f50: vec4f
+}
+
+@vertex
+fn vertex0(@location(15) a0: u32, @location(13) a1: vec2h, @location(0) a2: vec3u, a3: S10) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f46 = vec3f(0.01831, 0.08548, 0.02309);
+  out.f48 = vec4u(219, 50, 87, 7);
+  out.f49 = vec2u(70, 35);
+  return out;
+}
+
+@fragment
+fn fragment0(@location(1) a0: f32, @location(13) a1: vec3f) -> @location(200) vec4u {
+  var out: vec4u;
+  out = vec4u(132, 150, 330, 83);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet50 = device2.createQuerySet({label: '\u005d\u01e2\u0a9b\u{1fd07}\u03a9\u920e', type: 'occlusion', count: 411});
+let commandBuffer239 = commandEncoder358.finish({});
+let textureView85 = texture56.createView({label: '\u{1fad0}\u4091\u02a1\u8024', dimension: '3d', baseArrayLayer: 0});
+let renderBundle199 = renderBundleEncoder33.finish({label: '\u6c04\uc61e\u84bd'});
+let externalTexture42 = device2.importExternalTexture({label: '\u{1fb84}\ue514\u13e8\ue907', source: video4, colorSpace: 'display-p3'});
+try {
+renderPassEncoder64.setVertexBuffer(2, buffer22);
+} catch {}
+let arrayBuffer21 = buffer49.getMappedRange(64, 36);
+try {
+commandEncoder356.copyBufferToBuffer(buffer47, 6316, buffer30, 16, 232);
+} catch {}
+try {
+commandEncoder356.clearBuffer(buffer30, 16, 188);
+} catch {}
+try {
+commandEncoder356.resolveQuerySet(querySet28, 13, 180, buffer33, 256);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let commandBuffer240 = commandEncoder356.finish({label: '\u98b1\u0416\u{1fc6e}\ud271\u{1fe9f}\u{1fb12}\ue306\u0748\u0c3c'});
+try {
+renderPassEncoder64.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder45.pushDebugGroup('\u0974');
+} catch {}
+let texture98 = device5.createTexture({
+  label: '\ua9dc\u09bd\u{1f947}\u9b2e',
+  size: [192],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler21 = device2.createSampler({
+  label: '\u0582\u{1f88f}\u{1fc9b}\u0ab9\ucddf\u1e33\u{1fa3a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 71.99,
+  lodMaxClamp: 86.30,
+  compare: 'always',
+});
+try {
+gpuCanvasContext1.configure({device: device2, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device2.queue.submit([commandBuffer240, commandBuffer206]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas2);
+await gc();
+let imageBitmap8 = await createImageBitmap(video12);
+try {
+computePassEncoder89.label = '\ud962\u013b\u{1f7c6}\u044f\u6909\u{1f688}\u5f52\ua8da\u6631\u721d\u4608';
+} catch {}
+let bindGroup31 = device5.createBindGroup({layout: bindGroupLayout57, entries: []});
+let commandEncoder367 = device5.createCommandEncoder();
+let texture99 = device5.createTexture({
+  label: '\ue17f\u{1f77d}\u{1fcef}\u{1f605}\ua125\u{1fcc5}\u{1f879}\u18b2\u03b9',
+  size: [158],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+try {
+computePassEncoder89.insertDebugMarker('\uf735');
+} catch {}
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+let bindGroupLayout60 = device5.createBindGroupLayout({
+  label: '\u86bc\u0071\u0f9b\u6a58\ue956\ude40\ub9c2\u0798\u9046\u0667',
+  entries: [
+    {binding: 148, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 128, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 358, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let renderBundle200 = renderBundleEncoder39.finish({label: '\u009d\u100f\u21a3'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let commandEncoder368 = device3.createCommandEncoder({});
+let commandBuffer241 = commandEncoder368.finish({label: '\u1757\u86ec\u0d54\u9516\u7cb3\u2318'});
+let externalTexture43 = device3.importExternalTexture({label: '\u159c\u3fd6\u4067', source: video6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder50.setScissorRect(119, 30, 46, 4);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer45, 'uint32', 1_464, 133);
+} catch {}
+try {
+  await buffer44.mapAsync(GPUMapMode.WRITE, 456, 20);
+} catch {}
+let renderBundle201 = renderBundleEncoder25.finish({});
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder369 = device0.createCommandEncoder({label: '\u{1fe3e}\u048b\u3f4a\u0f6f\uad83\u0e07\u4f7e\u{1fa61}\uc75c\u003b'});
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer1, 484);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer1, 3_052);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer34, 'uint32', 7_340, 1_393);
+} catch {}
+try {
+commandEncoder362.resolveQuerySet(querySet2, 3, 7, buffer4, 11264);
+} catch {}
+try {
+computePassEncoder9.pushDebugGroup('\u{1fa55}');
+} catch {}
+try {
+computePassEncoder9.popDebugGroup();
+} catch {}
+let imageData43 = new ImageData(64, 32);
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = externalTexture30.label;
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder53.setScissorRect(5, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer46, 'uint16', 2_498, 782);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer48, 3788, new BigUint64Array(55193), 2004, 136);
+} catch {}
+document.body.prepend(img1);
+video4.width = 66;
+let commandBuffer242 = commandEncoder367.finish({label: '\udc1d\u{1fd27}\ud001\u9c8b\u{1fabd}\u6f08\u0a10\u367c'});
+let externalTexture44 = device5.importExternalTexture({label: '\u0f0e\u{1fb4a}', source: video10, colorSpace: 'display-p3'});
+try {
+buffer58.unmap();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+adapter1.label = '\u73bb\u065c\uf210\u{1fb96}\u0746\ua58c\uaa33\u4395\u0028\u0920';
+} catch {}
+let commandEncoder370 = device4.createCommandEncoder({label: '\u{1f65d}\u0b7a'});
+let commandBuffer243 = commandEncoder366.finish();
+let computePassEncoder90 = commandEncoder370.beginComputePass({label: '\u0499\u909f\u{1f6cf}\u9762'});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder364.clearBuffer(buffer59, 3960, 3504);
+} catch {}
+let promise58 = device4.queue.onSubmittedWorkDone();
+try {
+  await promise55;
+} catch {}
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+let arrayBuffer22 = buffer49.getMappedRange(0, 0);
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandBuffer244 = commandEncoder274.finish({label: '\u0823\u0e20\u04ba\u7f7f\u08d4\u{1f6ec}\u324e\ua0a0\ueb69\u{1fd65}\u0771'});
+let renderBundleEncoder42 = device4.createRenderBundleEncoder({label: '\u0141\u8ca8', colorFormats: ['r8sint'], stencilReadOnly: true});
+let sampler22 = device4.createSampler({
+  label: '\u{1f6a3}\u0505\uf43d\u{1f9aa}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.51,
+  lodMaxClamp: 68.66,
+});
+let imageData44 = new ImageData(24, 108);
+let commandEncoder371 = device2.createCommandEncoder({label: '\u041d\u07e2\u5099\u0b34\u{1fefc}\ue213\u04a6\u9768\u3c96'});
+let computePassEncoder91 = commandEncoder371.beginComputePass();
+try {
+renderPassEncoder40.setVertexBuffer(3, buffer30, 380, 12);
+} catch {}
+let commandEncoder372 = device4.createCommandEncoder({label: '\u{1f64a}\u{1ff52}\u{1f872}\u{1fb0d}\u0405'});
+let commandBuffer245 = commandEncoder372.finish({label: '\ua562\u{1ff7b}'});
+try {
+buffer43.unmap();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame13.close();
+videoFrame14.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277928b-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277928b-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277928b.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277928b.html
@@ -1,0 +1,19479 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let promise0 = adapter0.requestDevice({
+  label: '\u0054\u99a7\u1786\u0dd3',
+  defaultQueue: {label: '\u4afb\ufc70'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 29554776, maxStorageBufferBindingSize: 138851781},
+});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter1.requestDevice({label: '\u{1fe86}\u{1fc8e}\uae16\u8b5a\u{1f671}\u0a37\u00e7\u0491\ufdc8\u{1ff2b}'});
+let commandEncoder0 = device0.createCommandEncoder();
+let commandEncoder1 = device0.createCommandEncoder({label: '\u0221\u0920\u0bcb'});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u0a4a\u0126\uba31'});
+let commandBuffer0 = commandEncoder1.finish({label: '\u1ff4\u0d86\u0732\u{1fbdd}\u05a0\u0173\u0d72\ue220\u0b0d'});
+let commandEncoder3 = device0.createCommandEncoder({label: '\uc4dd\u0810\u98dd\u{1fb23}\ub6d8\u0405\u0aa6\u0aca\u067f'});
+let commandBuffer1 = commandEncoder2.finish({label: '\u897b\u0de8\u8b8c\u44a3\u{1fec6}'});
+let texture0 = device0.createTexture({
+  label: '\u06d6\u3354\ud185\u{1fc76}',
+  size: [1, 120, 22],
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView0 = texture0.createView({label: '\ubc95\u0341\ue52b\ubb78\u0ce7\uf4e5\ua4b9\u0863'});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fc28}\uffe5\u02dc\u{1fcd5}\u0584\u002f\u4ce1\u2583\u13d6\u0977'});
+let commandBuffer2 = commandEncoder4.finish({label: '\uccdf\u{1f6f1}\u90ec\u85f8\u4de7\u3249\u{1fc61}\uc950'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+adapter1.label = '\u24e1\ue992\uec0b\u0da2\u9715\u0ae6\u09e4';
+} catch {}
+let buffer0 = device0.createBuffer({
+  size: 2963,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1f80f}\u07e9\u93e3\uc2d7\u{1f9b0}'});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u05ce\u3475\u0dab\udd23\u0123\uae17'});
+let textureView1 = texture0.createView({label: '\u44da\u040d\u09e1\u{1fcf9}\ua42f\u71a9\u23cd'});
+let textureView2 = texture0.createView({label: '\u2307\ude36\u0e5d\u39ee', baseMipLevel: 0, mipLevelCount: 1});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 308, new BigUint64Array(1771), 85, 40);
+} catch {}
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1ff9d}\u7a88\u3430\u{1fc42}'});
+let texture1 = device0.createTexture({
+  label: '\ua946\u{1f70e}\u{1fbff}\u5ca1',
+  size: [20, 10, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let commandBuffer3 = commandEncoder0.finish();
+let commandEncoder6 = device0.createCommandEncoder();
+let querySet0 = device0.createQuerySet({label: '\u04fb\ub394\u0ef4\uc66d\u04ac\uda0b\u0e60\u0d27', type: 'occlusion', count: 460});
+let computePassEncoder0 = commandEncoder3.beginComputePass({label: '\u38e3\u93ee\u{1ff7c}\u0bcf\uc3b3\u{1f7ae}\u9c83\u{1fd54}\u85bc'});
+let commandBuffer4 = commandEncoder6.finish({label: '\u{1fae9}\u0eba\u0493\uac63\u0f85\u6c92\u1c39\u6fc3\u99cb'});
+let texture2 = device0.createTexture({
+  label: '\ue27a\uc6c6\u082b\u42c9\ua82a\u5529\u{1fb16}\u0d3a\u2092\u3fd8',
+  size: [80, 40, 706],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle2 = renderBundleEncoder0.finish({});
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({label: '\u0985\ufa5e\u{1fca5}\u10f9\u03ae\u{1f7c9}\u5a8c\u916b\u1f06\u6706'});
+let computePassEncoder1 = commandEncoder7.beginComputePass();
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\ue26b\u1968\u9800\u{1f6ef}\u{1fb0e}\u2dfb', entries: []});
+let bindGroup0 = device0.createBindGroup({label: '\uc223\uce09', layout: bindGroupLayout0, entries: []});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u{1f7db}\u0ea9\u{1f699}\u0d62\u6aab\u{1fc00}\u12d5'});
+let adapter2 = await navigator.gpu.requestAdapter();
+let imageData0 = new ImageData(44, 40);
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let bindGroup1 = device0.createBindGroup({label: '\ua4a9\u06ae\u7b1f\u165c\u85c8', layout: bindGroupLayout0, entries: []});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1fb8e}\u{1f97b}\ucd20\u060b\u06ff'});
+let commandBuffer5 = commandEncoder9.finish({});
+let renderBundle3 = renderBundleEncoder0.finish();
+let computePassEncoder2 = commandEncoder8.beginComputePass();
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1792, new Float32Array(1943), 699, 48);
+} catch {}
+await gc();
+let commandBuffer6 = commandEncoder5.finish({label: '\u0ac0\u9221\u{1fc72}\uc81f\u99ed'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u8ee5\u0288\udd6b\uc314\ubde9\u6fd2\u0dfa\u5b44\u8e73\u852c\u002d',
+  colorFormats: ['r8unorm'],
+});
+let renderBundle4 = renderBundleEncoder1.finish({label: '\u48ac\u01a4\u{1f78d}\ua6fd\u52c8\u00d5\u6245'});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 2382});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(331), 54, 0);
+} catch {}
+try {
+renderBundle0.label = '\u3259\u359e\u3f8e\u08a2';
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\udd52\u{1f82c}\u0e7c\u08cb\u41b3\uc7a8\u{1fe4d}\ub1da\u0532\u04b1\u{1f9e7}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1ff55}\u{1fd99}\u22ab\u{1f876}\u9dcc\u2ccc\uc4c0'});
+let commandBuffer7 = commandEncoder10.finish({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(581), 254, 0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(3, bindGroup1, new Uint32Array(1562), 413, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let imageData1 = new ImageData(4, 120);
+let bindGroup2 = device0.createBindGroup({layout: bindGroupLayout0, entries: []});
+let textureView3 = texture1.createView({
+  label: '\u743b\ud19b\u01ad\u3814\ua8bb\u068e\uf5ce',
+  dimension: '2d-array',
+  format: 'r8unorm',
+  baseMipLevel: 1,
+});
+let commandEncoder11 = device0.createCommandEncoder({label: '\u6286\u0c1b\u0b2c\u31b3\ub97c\u0fe2\u138f\u{1fd01}\ubae8\ucbae'});
+let computePassEncoder3 = commandEncoder11.beginComputePass({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({label: '\u9ad3\u5d64\u003b\u65a2\u7567\u73a8', colorFormats: ['r8unorm'], depthReadOnly: true});
+let renderBundle5 = renderBundleEncoder0.finish({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+commandBuffer6.label = '\uea74\u{1f7f7}\ud3bb\u6d8d\u526a\u{1f9f7}';
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder();
+let textureView4 = texture0.createView({label: '\u{1f838}\u0823\udcc4\ub2dc\u0a84\u056d\u025a\u{1f94c}\u1738\u053f\u07da'});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(742), 141, 0);
+} catch {}
+let commandBuffer8 = commandEncoder12.finish({label: '\udc27\u38c2\u{1f983}\uf934\u0fea\u{1f8d2}\uec7c\u3c40\u{1f8f8}\u{1f95e}'});
+let texture3 = device0.createTexture({
+  label: '\u3775\ue9e8\u{1f98a}\u{1fc99}\u06a6\u{1f8fb}\ub344\u7c5f\u512f',
+  size: {width: 2, height: 240, depthOrArrayLayers: 27},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle6 = renderBundleEncoder1.finish({});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 92, 1_757);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0]});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u422d\u0429\u{1fced}\uc820\u07e9\u0d8e\u8ce3'});
+let computePassEncoder4 = commandEncoder13.beginComputePass({label: '\u0a36\ucc54\u{1f70a}\u510e'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\ub7c9\ued1a\u0dcb\u{1f775}\u0708\u050b\u9175\u{1fae9}',
+  colorFormats: ['r8unorm'],
+  stencilReadOnly: false,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 20, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(31), /* required buffer size: 31 */
+{offset: 31, bytesPerRow: 174}, {width: 0, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter2.label = '\u02b3\u04e7\u4a65\u{1f86e}\u{1f80d}\u3266\uc10a';
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\ub2fb\ue10d\u6f08\ucfb2\u0bc6\ud1c9\u0dd6\u57c0'});
+try {
+device0.queue.submit([commandBuffer6, commandBuffer8]);
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder();
+let commandBuffer9 = commandEncoder15.finish({label: '\ua2c4\uf01a\ubf4f\u8c17\u{1ff7f}\u5d6a\u28ce\u0ad9'});
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 1_628, 341);
+} catch {}
+let commandBuffer10 = commandEncoder14.finish({label: '\u547b\uc899\u21c6\u9918\uf005\u01b9\ud032\u09fc\u5cd7\u1842'});
+let renderBundle7 = renderBundleEncoder0.finish({label: '\u{1f6d1}\u88c9\u0ff4\u9b6f\u030d\u8406\u{1fdf7}\u0c93'});
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, undefined, 0, 371_738_705);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet2 = device0.createQuerySet({label: '\u0575\u0c72\u55b1\u7554', type: 'occlusion', count: 517});
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5, undefined, 81_169_124, 95_446_752);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 108, 255);
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u{1f7e6}\u087a\u4296\u6a11\u63ea\u9a2e\u{1f67a}\u1788',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let commandEncoder16 = device0.createCommandEncoder({label: '\u001f\u7f77\uadbd\u{1fed0}\ud646\u01c8\u053e\u0983'});
+let commandBuffer11 = commandEncoder16.finish({label: '\u37e6\u0f6b\u0cc6'});
+let textureView5 = texture2.createView({
+  label: '\ubb87\u0bb3\u07df\u0d43\u3090\ubf36\u831e\ucc2f\u803d\u0132',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 864, 973);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let commandEncoder17 = device0.createCommandEncoder({label: '\u35f1\ub5c0\u0545\u3001\u74b7\u0048\u15fb\u5d45\uc344'});
+let commandBuffer12 = commandEncoder17.finish({});
+let textureView6 = texture3.createView({baseMipLevel: 1});
+let renderBundle8 = renderBundleEncoder2.finish({label: '\u{1fb36}\u5d18\u0f68\uf637\u684e'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 746, 5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas0 = document.createElement('canvas');
+let querySet3 = device0.createQuerySet({label: '\u00ad\u88c4\uae92\u794d\u00af\u04f0\u39dc\u5d50\u{1f678}', type: 'occlusion', count: 175});
+let texture4 = device0.createTexture({
+  label: '\udacd\u3ac2\u1bf5',
+  size: [1, 30, 119],
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder0 = commandEncoder13.beginRenderPass({
+  label: '\ua7e4\u{1fb0d}',
+  colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 160, 714);
+} catch {}
+let commandBuffer13 = commandEncoder3.finish({label: '\u{1f78f}\u0377\ue233\u7fc5\u0670'});
+let textureView7 = texture2.createView({
+  label: '\u{1fa08}\u9efb\u7389\u{1f9db}\ued21\u{1f8af}\u05b7\u949f\u0af4',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+try {
+adapter0.label = '\u0fc6\ud1fa\u07e2';
+} catch {}
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(3219), 1399, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 1_504, 270);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 200, new Float32Array(52928), 9613, 688);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let commandEncoder18 = device0.createCommandEncoder({label: '\u05d0\u06ae\u{1fa52}\u31fc\u032a\u{1f811}\u{1f69f}\uc047'});
+let texture5 = device0.createTexture({
+  label: '\u2276\uc3e0\u2fdd\u82f1',
+  size: [1],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView8 = texture5.createView({label: '\u{1f71c}\u52c2\ud73b\u{1fb89}\u040b\u0d59\u294e\u704b'});
+try {
+commandEncoder18.clearBuffer(buffer0, 668, 248);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let buffer1 = device0.createBuffer({
+  label: '\u0195\u03e4\ubd4c\ub873\u{1ff51}\ucf35\uf6e9\u237a\u509d\udf9a\u8167',
+  size: 2461,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder19 = device0.createCommandEncoder({label: '\uff04\u6136\u5cf0\uf9ad\ua062'});
+let renderPassEncoder1 = commandEncoder19.beginRenderPass({
+  label: '\u798a\u0408\u{1f75e}\u2bcd\u14e3\u0888\u34d1\u0223\u03ab\u13f5',
+  colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 121918021,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle2]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 40, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(95), /* required buffer size: 95 */
+{offset: 84, bytesPerRow: 1}, {width: 0, height: 12, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let commandBuffer14 = commandEncoder18.finish({label: '\u0115\u054f\u2876'});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let device1 = await promise0;
+let canvas1 = document.createElement('canvas');
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer1, 316);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 1_364, 560);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker('\u4712');
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let commandEncoder20 = device1.createCommandEncoder();
+let commandBuffer15 = commandEncoder20.finish({label: '\ue86e\u{1f736}\u0e28\u04a2\u0eb3\u008a\u06fd\u3bc2\u88d2'});
+let commandEncoder21 = device0.createCommandEncoder();
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.63,
+  lodMaxClamp: 93.93,
+});
+try {
+renderPassEncoder1.setViewport(0.88288066270368, 3.7545889198275573, 1.051823856268352, 0.7148098829017893, 0.5346215895110551, 0.9537008289979814);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 662, 46);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder();
+let commandBuffer16 = commandEncoder22.finish({label: '\u82ee\ubdab\u6046\ucd0f'});
+let renderPassEncoder2 = commandEncoder21.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 318.9, g: 889.6, b: 526.7, a: -730.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint16', 1_152, 50);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+let commandBuffer17 = commandEncoder11.finish({label: '\u07dd\u{1fe0e}\u0e31\uba67\u4114\ubaee\u0465'});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(671), 100, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer1, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 100, 223);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle9 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer1, 0);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let computePassEncoder5 = commandEncoder23.beginComputePass();
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle8, renderBundle4, renderBundle7, renderBundle1, renderBundle0]);
+} catch {}
+let renderBundleEncoder4 = device1.createRenderBundleEncoder({label: '\u0165\u0c18\u6285\u3f04', colorFormats: ['rgb10a2uint']});
+let commandEncoder24 = device1.createCommandEncoder({label: '\u9674\u88ee\u{1ff39}\u0105\u6df7\u10ab\u853b'});
+let commandBuffer18 = commandEncoder24.finish({label: '\ud481\uc962\u{1f833}\u9137'});
+let renderBundle10 = renderBundleEncoder4.finish({label: '\u7083\u6c4c\u0885\u4eae\u{1fc07}\u{1f66e}\u06db\u04d0\u{1f9a1}\u{1f7ec}\u{1fd65}'});
+let sampler1 = device1.createSampler({
+  label: '\u{1feb0}\u03fa\ub140\u06ee\u{1f7be}\u000e',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.74,
+  lodMaxClamp: 75.64,
+});
+let commandEncoder25 = device1.createCommandEncoder({label: '\u{1fcad}\u74f1\u{1f8a7}\u08c9\u{1fa34}\ucabe\u04b0\u0ffc\u072c\u03c5'});
+let commandBuffer19 = commandEncoder25.finish({label: '\u1e4d\uf3cd\u{1fdfa}\u9f12'});
+let textureView9 = texture0.createView({label: '\u{1f893}\uc0fa\u258d\u9abb\u0d30\uc05c\u{1f717}\u0c4c'});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3, new Uint32Array(927), 36, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9]);
+} catch {}
+canvas1.height = 71;
+let buffer2 = device0.createBuffer({
+  label: '\u{1f819}\u26d4\u016c\u88d7\uaa3e\ubd30\u{1fe19}\u06c1\u7d1c\u1f72\u3fdd',
+  size: 443,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let renderBundle11 = renderBundleEncoder0.finish({label: '\uf890\u0c1b\u090d\u{1faaa}\u0733\u{1fd00}\uec21\u0921'});
+try {
+computePassEncoder1.pushDebugGroup('\u8809');
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+let buffer3 = device0.createBuffer({
+  size: 17514,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1fd2e}\u01b7\u{1fb6a}\uf0e6\ub701\ucca8\u6dbf\ucf69\u8917\u0ad7\u57ca'});
+let textureView10 = texture0.createView({label: '\u{1fd59}\uaa7f\u0ed8\ucb3f\u35eb\ub291\u5c9f\u438f\u1d34\u0b82', dimension: '3d'});
+let computePassEncoder6 = commandEncoder26.beginComputePass({label: '\u0495\u189b\u6407'});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder({label: '\u{1fcf4}\u0408\u{1f8ef}\u01c3'});
+let querySet4 = device1.createQuerySet({label: '\u28e4\u3fd2\ue0f3\u{1f926}\uaef7\u54de\u3151', type: 'occlusion', count: 587});
+let computePassEncoder7 = commandEncoder27.beginComputePass({label: '\u8a83\u7720\uf7cb\u0451'});
+let bindGroup4 = device0.createBindGroup({label: '\u{1fa1f}\u{1fad1}\ud5e1\u6395\u{1f7d5}\u4329\ub145', layout: bindGroupLayout0, entries: []});
+let renderBundle12 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -601.1, g: -797.4, b: 934.2, a: -615.0, });
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4, new Uint32Array(523), 1, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u0c81');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture6 = gpuCanvasContext0.getCurrentTexture();
+canvas0.width = 87;
+let commandEncoder28 = device1.createCommandEncoder();
+let computePassEncoder8 = commandEncoder28.beginComputePass({label: '\u{1fcfc}\ub711\u0493\ua365\u8ffd\u15a0\u0877\u0459\u{1f889}\u7dc1\u02b4'});
+let renderBundle13 = renderBundleEncoder4.finish({label: '\u{1fbd7}\u0918\u3e1d\u0865\u03b4\u0612\u8c47\u07d0\u{1ff19}'});
+try {
+device1.queue.submit([commandBuffer19, commandBuffer18]);
+} catch {}
+let renderBundle14 = renderBundleEncoder4.finish({label: '\u74b1\u{1fe08}\ub73a\u9a0e\u0947\u5681'});
+let commandEncoder29 = device1.createCommandEncoder({label: '\u{1f791}\u{1fb5e}\u{1f81e}'});
+let renderBundle15 = renderBundleEncoder4.finish();
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u3bdd\u0ed3\u859a\u7d82\u0146\u{1f790}\u0449\u89db\u7f85\u088a',
+  bindGroupLayouts: [bindGroupLayout0],
+});
+let commandEncoder30 = device0.createCommandEncoder({label: '\uab32\uff7b\ud930'});
+let renderPassEncoder3 = commandEncoder30.beginRenderPass({
+  label: '\u08c9\u0185\ub4b6\uadea\ub244',
+  colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup1, new Uint32Array(1232), 35, 0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer3, 0, 7_407);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet0, 5, 4, buffer2, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder();
+let texture7 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle16 = renderBundleEncoder2.finish({label: '\u2bb1\u06d8\ucdd8\u0fbe'});
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer1, 0, 501);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer2, 12, buffer3, 2068, 36);
+} catch {}
+let commandBuffer20 = commandEncoder32.finish({label: '\ubb56\u3347\u0be3\u781a'});
+let renderPassEncoder4 = commandEncoder31.beginRenderPass({
+  label: '\u8d1e\u59ac\u234f\u1141\u09bb\u{1fc44}\u0082\ue390\u43b4',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 391.7, g: -684.0, b: -755.9, a: 608.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle17 = renderBundleEncoder3.finish({label: '\u78d2\u1368\u8d69\u6938\u0d80'});
+let promise2 = device0.queue.onSubmittedWorkDone();
+let commandEncoder33 = device1.createCommandEncoder({label: '\u0216\u0908\u{1f672}\uce3e\uf980\u0411\u0449\u4739\u0940\u{1fa0b}\u0dca'});
+let renderBundle18 = renderBundleEncoder4.finish();
+let buffer4 = device0.createBuffer({
+  label: '\u0214\ua6f1\u{1fd11}\ua2ef',
+  size: 7877,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer3, 0, 3_086);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5, commandBuffer10]);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer2, 'uint16', 162, 10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14, commandBuffer2]);
+} catch {}
+let computePassEncoder9 = commandEncoder33.beginComputePass({label: '\ua383\ua9cd\u{1f905}\u{1f7ef}\u{1fff1}\u07c0\u91c4\u{1f77d}'});
+let renderBundle19 = renderBundleEncoder4.finish({});
+try {
+  await promise2;
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({label: '\u{1f9c0}\u{1faeb}\u00fc\uf300\u8436\ub1d1\u0bc4\u0153\u836d'});
+let commandBuffer21 = commandEncoder34.finish({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer2, 'uint32', 176, 99);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+try {
+renderBundle3.label = '\u0b3a\u063d\u151f\ubbd7';
+} catch {}
+let renderBundle20 = renderBundleEncoder0.finish();
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(134), 45, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer3, 'uint16', 1_236, 407);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let commandEncoder35 = device0.createCommandEncoder();
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint16', 250, 163);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 42, y: 2, z: 80},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 76, z: 4},
+  aspect: 'all',
+},
+{width: 0, height: 7, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer3, 1384, 2136);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let querySet5 = device0.createQuerySet({label: '\u6074\u0fe5\u40db\uf3bb\uaa43', type: 'occlusion', count: 42});
+let commandBuffer22 = commandEncoder35.finish({label: '\ufac4\u4dc6\u0f40\u9aea\uada9\u8b80\u7354\u6754'});
+let texture8 = device0.createTexture({
+  label: '\u0e0c\u{1f9e7}\u076f\ub7e8\u0738\u75e8\u2504',
+  size: [10, 5, 88],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer2, 0, 102);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 36, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(96_155), /* required buffer size: 96_155 */
+{offset: 85, bytesPerRow: 93, rowsPerImage: 223}, {width: 1, height: 142, depthOrArrayLayers: 5});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder36 = device1.createCommandEncoder({label: '\uc3c2\ua78d'});
+let commandBuffer23 = commandEncoder36.finish({});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandBuffer24 = commandEncoder29.finish({label: '\u832a\uc496\u628d\u1ad9\u6303\u0e38\u06a3\u2264\uedd4\u04c6\u2299'});
+let renderBundle21 = renderBundleEncoder4.finish({label: '\u{1f8e7}\u0f70\u0901\ub5dd\ue758\u7c23'});
+let renderBundle22 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 52, 195);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer3, 0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({label: '\u0b8a\u9229', bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0]});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u{1fa5b}\u{1f9a3}\u696c\ub265\u69de\u0a8a\ud242'});
+let commandBuffer25 = commandEncoder37.finish({});
+let sampler2 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.56,
+  lodMaxClamp: 41.97,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(664), 14, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer3, 'uint32', 696, 3_923);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 3788, new Int16Array(15370), 858, 360);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let renderPassEncoder5 = commandEncoder38.beginRenderPass({
+  label: '\u{1fdb8}\u0a6f\u7ec2\u1a2a\u9305\u{1fd6a}\u1973',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -241.8, g: -408.6, b: 816.1, a: -892.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\uba2f');
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\ubc89\ua77f\u8e0c\u03f0\u{1fc3a}\u0e76\u0a85\u23ee\u{1f791}\ucbca'});
+let renderPassEncoder6 = commandEncoder39.beginRenderPass({
+  label: '\ua820\u02a6\u8f49\u0c80\u{1f894}\ua673\ua17e\u9f54\u{1fd0e}\u097e\u{1f93f}',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -138.1, g: -237.0, b: -246.4, a: 558.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u4fd0\u{1f67c}'});
+let commandBuffer26 = commandEncoder40.finish({label: '\u0097\u78f9\u4ca2\u0334'});
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 340, new DataView(new ArrayBuffer(3184)), 596, 88);
+} catch {}
+try {
+adapter1.label = '\u2d38\u06b5\u{1f997}\u02c3\u{1f66d}\u08e4\udca9\ua3fa\u0a86';
+} catch {}
+try {
+device0.label = '\u0536\u6a3d\u{1fcd3}\u5280\u0b3b\u{1ffe7}\u1b6f\ue45a';
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({label: '\u{1f869}\ude67\u497c\u{1f65d}\u750a\u0e62'});
+let renderPassEncoder7 = commandEncoder41.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 867.5, g: 428.6, b: -410.1, a: 403.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 641064319,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer3, 'uint32', 780, 3_879);
+} catch {}
+let texture9 = device1.createTexture({size: [44, 7, 47], dimension: '3d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+device1.queue.submit([commandBuffer15]);
+} catch {}
+canvas0.width = 1888;
+let commandEncoder42 = device1.createCommandEncoder({label: '\u009b\u2105\ub355\u0534\u{1f6cc}\u0105'});
+let computePassEncoder10 = commandEncoder42.beginComputePass({label: '\uce82\u28bf\u09d8'});
+let querySet6 = device1.createQuerySet({label: '\uf187\u43df\u095f\u26d9', type: 'occlusion', count: 12});
+let sampler3 = device1.createSampler({
+  label: '\u90c0\uebfc\u{1fc4d}\u{1f9c4}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.77,
+  lodMaxClamp: 65.86,
+  compare: 'not-equal',
+});
+let texture10 = device1.createTexture({
+  label: '\u{1fc02}\ud398\uc362',
+  size: [180],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let commandEncoder43 = device1.createCommandEncoder({label: '\u029d\u{1f7c9}\u4110\u01ca\u27dc\u09ab'});
+let computePassEncoder11 = commandEncoder43.beginComputePass({label: '\u0534\u2107\u08f2\u0ecc\u{1fd01}'});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle12, renderBundle2]);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u081b\ud30e',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let buffer5 = device0.createBuffer({size: 9085, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer3, 904);
+} catch {}
+let renderBundle23 = renderBundleEncoder0.finish({label: '\uf49f\u{1f79c}\u957e\u002b\u0a65\u0069\ub0c4\u88d9\u0027\ud591'});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let renderBundle24 = renderBundleEncoder4.finish({});
+let bindGroupLayout1 = device1.createBindGroupLayout({
+  label: '\u4e83\uea7c',
+  entries: [{binding: 159, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }}],
+});
+let commandEncoder44 = device1.createCommandEncoder({label: '\u19b1\u0df2\u{1f6fb}\u42ba\u051f\udd70\u12e2\u0c72'});
+let commandBuffer27 = commandEncoder44.finish();
+let renderBundle25 = renderBundleEncoder4.finish({label: '\u{1fd2f}\u{1f623}'});
+let commandEncoder45 = device1.createCommandEncoder();
+let commandBuffer28 = commandEncoder45.finish({});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder46 = device1.createCommandEncoder({label: '\uf581\u97d5\u5eae\u8b59\u0666'});
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1f61c}\u{1fdcf}\u1ce3\u7fea\ucdd0\ufd07\u{1ff34}\u{1fb00}'});
+let renderPassEncoder8 = commandEncoder47.beginRenderPass({
+  label: '\u023f\u2511\u2302',
+  colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 515245820,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 8284, new Int16Array(1178), 580, 80);
+} catch {}
+let pipelineLayout5 = device1.createPipelineLayout({
+  label: '\u{1fe69}\u0033\u02d9\u0ec6',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout1],
+});
+let commandEncoder48 = device1.createCommandEncoder();
+let renderBundle26 = renderBundleEncoder4.finish();
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData2 = new ImageData(16, 68);
+try {
+renderPassEncoder7.setIndexBuffer(buffer2, 'uint16', 152, 32);
+} catch {}
+try {
+device0.queue.submit([commandBuffer25, commandBuffer20]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder49 = device1.createCommandEncoder({label: '\ua004\u{1fefb}\u092b\u6a54\u{1fc1e}\u59ab\ube4e'});
+let buffer6 = device1.createBuffer({
+  label: '\u{1f67c}\ufb5b\u{1f80d}',
+  size: 15620,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle27 = renderBundleEncoder4.finish();
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u2520\ud106\u{1f700}\u{1ff91}\u16f7\ucf11\uf014\u0da2',
+  entries: [
+    {
+      binding: 397,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 260, new Int16Array(40), 1, 4);
+} catch {}
+let commandEncoder50 = device1.createCommandEncoder({label: '\ucc75\u{1ff06}\u8577\u805b'});
+let commandBuffer29 = commandEncoder50.finish({label: '\u04c8\u{1f6ba}\u0b1e\uea7f\u0a09\u0ea5\uedbc\u0750\u36e1\u0ea6'});
+let computePassEncoder12 = commandEncoder48.beginComputePass({label: '\u02c2\u{1f9c3}'});
+try {
+device0.queue.label = '\u00cc\uc244';
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({label: '\u0f51\ucd5d\u{1fdd6}\u0967\u8f80\u{1f657}\u{1fe90}\uab1a\u15c5\u8b17', entries: []});
+let renderBundle28 = renderBundleEncoder1.finish({label: '\u7993\u0036\u004b\u6458\u{1feb2}\uc45a\u0593'});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer1);
+} catch {}
+await gc();
+let commandEncoder51 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({label: '\u{1f99e}\u714a\u0ee8\u0bd5\u00a0\u4baa', type: 'occlusion', count: 70});
+let renderPassEncoder9 = commandEncoder51.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 212.6, g: -585.1, b: -292.6, a: -441.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer2, 148);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17, commandBuffer22]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1416, new Int16Array(14789), 505, 1076);
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({label: '\ufb2b\u013b\u9f06\uc08c\u0b0d\u2404'});
+let textureView11 = texture5.createView({label: '\u15a6\uc7f0\ud0bf\u8438', arrayLayerCount: 1});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5687 */
+  offset: 5687,
+  bytesPerRow: 0,
+  buffer: buffer5,
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 7, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer0, 292, 108);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder53 = device1.createCommandEncoder();
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 5192, new Int16Array(20871), 1784, 1700);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let img0 = await imageWithData(27, 33, '#48417ea0', '#ad292cf1');
+let texture11 = device1.createTexture({
+  label: '\u0769\u00ef\u0206',
+  size: {width: 22},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle29 = renderBundleEncoder4.finish();
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout6 = device1.createPipelineLayout({label: '\u{1fb04}\u05fb\u7951\u063d\u91ac\u4e06\u02e0\ueb95', bindGroupLayouts: [bindGroupLayout1]});
+let commandEncoder54 = device1.createCommandEncoder({label: '\u{1f768}\u6611\ue0ef\u0689\u0835\ue9f7\ud50b\uc66c\u61c5\u06e3\u{1ff39}'});
+let commandBuffer30 = commandEncoder54.finish({label: '\ued9c\u{1fa92}'});
+let renderBundle30 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder9.pushDebugGroup('\u{1ffa2}');
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\ue0db\u{1fee9}\u0ea5\u6c05\u955a\u606c\ua895\ub4a7\u{1f61e}\ue7a9',
+  entries: [
+    {binding: 160, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer7 = device0.createBuffer({
+  label: '\u0c01\u49e5\u{1f95e}',
+  size: 3211,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder55 = device0.createCommandEncoder();
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer2, 24, 99);
+} catch {}
+let renderPassEncoder10 = commandEncoder55.beginRenderPass({
+  label: '\u1bf0\u1deb\uc714\u{1fbea}\u{1fa8f}\u65a0\u823b\u0312\u87b7',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 520.2, g: 975.3, b: -695.3, a: -442.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let renderBundle31 = renderBundleEncoder0.finish({});
+let sampler4 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.82,
+  lodMaxClamp: 49.89,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer3, 4_084);
+} catch {}
+let shaderModule0 = device1.createShaderModule({
+  label: '\u{1f701}\u{1fbfb}\u{1fe30}\u2977\u0a0f',
+  code: `@group(1) @binding(159) var sam1: sampler;
+@group(0) @binding(159) var sam0: sampler;
+@group(2) @binding(159) var sam2: sampler;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+_ = sam1;
+_ = sam0;
+_ = sam2;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let promise4 = device1.queue.onSubmittedWorkDone();
+let commandEncoder56 = device1.createCommandEncoder({label: '\u009b\u493d\u{1fb3f}\u4fe2'});
+let commandBuffer31 = commandEncoder53.finish({label: '\u07dd\ufcde\u46a2\u1e20\u6d74'});
+let textureView12 = texture9.createView({label: '\u0c54\u3ebf\u28f4', format: 'rgb10a2uint'});
+let renderBundle32 = renderBundleEncoder4.finish({label: '\uc8d1\u45e7\u{1f9f5}\u{1fe48}\ubf49\u8ad5\uae80\u{1fc96}\ub38b\u{1fb42}'});
+try {
+buffer6.unmap();
+} catch {}
+try {
+computePassEncoder9.popDebugGroup();
+} catch {}
+let commandEncoder57 = device1.createCommandEncoder({label: '\u0217\u4a1d'});
+let renderBundleEncoder5 = device1.createRenderBundleEncoder({label: '\u046e\uf243\u0829\u71ee\uc429\u{1faa5}', colorFormats: ['rgb10a2uint']});
+try {
+device1.queue.submit([commandBuffer28]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 3456, new DataView(new ArrayBuffer(5329)), 807, 556);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({label: '\u09ff\u{1fc2e}\uf712\u3a04\u3f02\u0a51\uc84a\u0de8\u{1f94a}'});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(318), 179, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet1, 334, 113, buffer4, 0);
+} catch {}
+try {
+adapter2.label = '\u06ab\u0f8a';
+} catch {}
+let shaderModule1 = device1.createShaderModule({
+  label: '\u0323\u{1fa3c}\u{1fbef}\u0d09\u684a\u7d96\u04bb\uf6dc\u{1f6d5}\u{1fad7}\u{1f874}',
+  code: `@group(0) @binding(159) var sam3: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(2) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+_ = sam3;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f1: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: f32, @location(15) a1: vec2<f16>, @location(9) a2: vec2<i32>) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup5 = device1.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 159, resource: sampler1}]});
+let renderBundle33 = renderBundleEncoder4.finish({label: '\ud566\u0446\u6456\uacb4\u21d4'});
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({label: '\u9404\u7a4f\u{1fc64}\uf309', entries: []});
+let buffer8 = device0.createBuffer({
+  label: '\u0ec0\u0830\u0cce\u{1f9ce}\ua7ed\u{1f805}\u681a\u{1fdf9}\u51e0\u0533',
+  size: 3720,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u02a7\u82b4\ube35\u8386\u0309\ue6e6'});
+let commandBuffer32 = commandEncoder52.finish({label: '\u0c54\u1d76\u{1fd3a}\u4c6b\u5d84\u7407\ub5b8\ub994\u{1f66a}\u643b'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer3, 0, 8_605);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 40, y: 6, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 5, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 1160, new Int16Array(25918), 2246, 56);
+} catch {}
+let commandBuffer33 = commandEncoder46.finish({label: '\u21ea\u0460\u385b\u0c86\u{1f8b5}\u0039\u0c1b\u1f0c\ud029\u07cd\uef08'});
+let texture12 = device1.createTexture({size: [2160], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let renderBundle34 = renderBundleEncoder4.finish({label: '\u03b5\u431f'});
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup5, new Uint32Array(2661), 189, 0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(1, buffer6, 388);
+} catch {}
+let commandBuffer34 = commandEncoder56.finish({});
+let computePassEncoder13 = commandEncoder49.beginComputePass();
+let renderBundle35 = renderBundleEncoder5.finish({label: '\ud3d5\u{1fe7c}\u2621\u099b\u{1ffe5}\u0510\ua852\u3045\u08f6\u0802'});
+try {
+device1.queue.writeBuffer(buffer6, 4976, new DataView(new ArrayBuffer(39623)), 713, 1376);
+} catch {}
+let video0 = await videoWithData();
+let imageBitmap0 = await createImageBitmap(canvas0);
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer8, 772, 901);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let commandEncoder60 = device1.createCommandEncoder({label: '\u87ef\u{1f658}\u0706\uf84f\uc0c1\u491e\u{1fb57}\ua678\u09c3'});
+let querySet8 = device1.createQuerySet({label: '\u7437\u3713\u39a7\u{1f6dc}\u{1fe6b}', type: 'occlusion', count: 546});
+let texture13 = device1.createTexture({
+  label: '\u70e9\u{1fd37}\u0f0a\u{1fb3a}\u81c3',
+  size: {width: 180, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder6 = device1.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: false});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline0 = device1.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule1, constants: {}}});
+let commandBuffer35 = commandEncoder59.finish({label: '\u0249\u4992\ucc22\u3b92'});
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 23, z: 2},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 3332, new Float32Array(964), 17, 352);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let computePassEncoder14 = commandEncoder57.beginComputePass({label: '\u{1fde8}\u58c0'});
+let renderBundleEncoder7 = device1.createRenderBundleEncoder({
+  label: '\u6e1a\u0532\u83c2\u{1fe87}\u8491\u9bb9\u04b4\ua259\u{1ffbc}\uf275',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+document.body.prepend(video0);
+let commandEncoder61 = device0.createCommandEncoder();
+let textureView13 = texture5.createView({label: '\u{1fe45}\u0a52\u9c5a\u01f5\u865f\u7320', baseMipLevel: 0});
+try {
+renderPassEncoder0.executeBundles([renderBundle28, renderBundle22, renderBundle28, renderBundle31]);
+} catch {}
+let computePassEncoder15 = commandEncoder60.beginComputePass({label: '\u09d9\u5fbd\u9612\u{1fdce}\u0bdb\u0da3\ufc81\u0076'});
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker('\u014e');
+} catch {}
+try {
+device1.queue.submit([commandBuffer34, commandBuffer29]);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\ueb1d\u0538\u088a\uce4f\u3e30\u1dd9\u{1fb65}\u0532\u057c'});
+let texture14 = device0.createTexture({
+  size: [1, 30, 191],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle36 = renderBundleEncoder2.finish({label: '\u8ac2\u4bab\u{1fc66}\u{1fc24}\u39d0\u{1f8bc}\u0d09\ucfe8\u{1f9a3}\u{1f8a0}\ud726'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+let buffer9 = device0.createBuffer({
+  label: '\u0645\u090c\u4522\u08df\u{1fe66}\u6933',
+  size: 16829,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer36 = commandEncoder26.finish({label: '\uf8d6\u{1fd63}'});
+canvas1.height = 224;
+let buffer10 = device1.createBuffer({size: 2159, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder63 = device1.createCommandEncoder({label: '\u0034\u0732\u0c8a\uc539\u0742\ue7df\u59c9\u09c0\u9e86\uaff6'});
+let texture15 = device1.createTexture({size: [1206], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder63.insertDebugMarker('\ud164');
+} catch {}
+let commandBuffer37 = commandEncoder63.finish({label: '\u2934\u{1fa51}\u29dc\uad8b\uee27\uacbc\u1633\u20f0\u09ab\ua28c\u4491'});
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer6, 0, 652);
+} catch {}
+try {
+device1.queue.submit([commandBuffer33, commandBuffer24]);
+} catch {}
+let commandEncoder64 = device1.createCommandEncoder();
+let sampler5 = device1.createSampler({
+  label: '\u07b1\u9e22\u0220\u{1f9cf}\u{1f6be}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.997,
+  lodMaxClamp: 66.57,
+  maxAnisotropy: 1,
+});
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let imageBitmap1 = await createImageBitmap(img0);
+let commandEncoder65 = device0.createCommandEncoder({label: '\uf937\u1baa\u618b\u358a\uf695\u5925\u2298\u6165'});
+let renderPassEncoder11 = commandEncoder65.beginRenderPass({colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundle37 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(1107), 313, 0);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let textureView14 = texture10.createView({mipLevelCount: 1});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(2653), 119, 0);
+} catch {}
+let pipeline1 = device1.createComputePipeline({
+  label: '\u76df\u{1f8ed}\u414d\u{1f8b0}\u0e2b',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1},
+});
+let videoFrame0 = new VideoFrame(canvas0, {timestamp: 0});
+let commandBuffer38 = commandEncoder62.finish({label: '\u0892\u3737\u0748'});
+let renderPassEncoder12 = commandEncoder58.beginRenderPass({
+  label: '\u593d\u08c5\u0981\u521b\u29c6',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -880.3, g: -181.6, b: 549.5, a: 286.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup1, new Uint32Array(239), 1, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer0, 'uint16', 2, 36);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\ub826');
+} catch {}
+try {
+device0.queue.submit([commandBuffer16, commandBuffer38]);
+} catch {}
+await gc();
+let canvas4 = document.createElement('canvas');
+let commandEncoder66 = device1.createCommandEncoder({});
+let renderBundle38 = renderBundleEncoder7.finish({});
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 137, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3, buffer6, 2_808, 442);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\u4841');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroupLayout6 = device1.createBindGroupLayout({label: '\u8b5c\u0beb\u{1f620}\u9fc4\u1a2a\u8657', entries: []});
+let commandEncoder67 = device1.createCommandEncoder({});
+let commandBuffer39 = commandEncoder67.finish({label: '\u1f78\u020a\u10fc\u{1fd73}\u{1f808}\u15a5\u0128\u22dc'});
+let texture16 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+let commandBuffer40 = commandEncoder61.finish({label: '\u05c2\u0763\u{1f8fa}\u4549\u{1f988}\ua4ea\u{1fc45}\u5629'});
+try {
+renderPassEncoder5.executeBundles([renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, undefined, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 15, depthOrArrayLayers: 95}
+*/
+{
+  source: video0,
+  origin: { x: 7, y: 2 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView15 = texture13.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer6, 6_900);
+} catch {}
+try {
+commandEncoder64.clearBuffer(buffer6);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let commandEncoder68 = device0.createCommandEncoder();
+let computePassEncoder16 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let pipeline2 = device1.createComputePipeline({
+  label: '\u3fab\u{1fc3c}\u{1fef9}\u6f52',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, constants: {}},
+});
+let buffer11 = device0.createBuffer({
+  label: '\u{1f8f6}\u6ae6\ub8f3\u{1fb86}\u6491\u5edf\u2896\u4132\u93b3\uf0e9',
+  size: 11892,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture17 = device0.createTexture({
+  size: [10, 5, 1],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup2, new Uint32Array(5619), 14, 0);
+} catch {}
+document.body.prepend(video0);
+let canvas5 = document.createElement('canvas');
+try {
+device0.label = '\u9c5b\u0590\u934c\u{1ffd7}\u0b2a\u035c\u11ec\ua7d5';
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u5150\u0d68\u{1fdf8}\u03f5\u13d5\u3d04\u{1fe12}\ue680\u097a\ufd3d\ucb12',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2],
+});
+let texture18 = device0.createTexture({
+  label: '\u69af\ua88a',
+  size: {width: 1, height: 30, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint32', 1_476, 608);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer2);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder69 = device1.createCommandEncoder({label: '\uaeb1\u039f\uee39\u6407\u{1f9af}\u0467\u{1fc16}\u0b74\ufea9\u{1fc35}'});
+let renderBundleEncoder8 = device1.createRenderBundleEncoder({label: '\u06df\u1131\u3a6e', colorFormats: ['rgb10a2uint']});
+let externalTexture0 = device1.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({label: '\u58f0\u0ab5\ub064\u022e\ua90e\uee7a\uef32\u3bbf\u5db9', colorFormats: ['r8unorm']});
+let renderBundle39 = renderBundleEncoder0.finish({label: '\u00b6\u0f30\u28e7\u1ba2\u0c98\u0805\u9991\u0697\u{1f634}\u8155\u{1f94c}'});
+try {
+renderPassEncoder11.setIndexBuffer(buffer0, 'uint16', 24, 1_427);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer3, 'uint32', 768, 3_999);
+} catch {}
+let textureView16 = texture17.createView({
+  label: '\u3ec8\u0b60\u2159\u1e46\u499b\u0ad4\ua757',
+  format: 'r8unorm',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup3, new Uint32Array(136), 22, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer1, 0, 738);
+} catch {}
+let commandEncoder70 = device1.createCommandEncoder({label: '\u2eed\u{1f8dd}\u1e43'});
+let computePassEncoder17 = commandEncoder66.beginComputePass({label: '\u82d2\udce4\u{1ff1f}\u4261'});
+let renderPassEncoder13 = commandEncoder69.beginRenderPass({
+  label: '\ue698\u03a1\u0c98',
+  colorAttachments: [{view: textureView15, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 778961260,
+});
+try {
+device1.queue.submit([commandBuffer31, commandBuffer27]);
+} catch {}
+canvas0.width = 83;
+let texture19 = device0.createTexture({
+  label: '\ue4c5\u8219\ub27e\u5e8a\u04ea\u06d4\u0a4b\u{1fae1}\u{1fab9}\u1405\u{1fd35}',
+  size: {width: 40},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup2, new Uint32Array(4068), 265, 0);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(514);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 416, new BigUint64Array(14844), 1573, 60);
+} catch {}
+let computePassEncoder18 = commandEncoder64.beginComputePass({label: '\u{1fc9f}\u2e94\u0497\u1589\u4a15\u442b\u07fa\uf1a4'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+let commandEncoder71 = device1.createCommandEncoder({label: '\u7415\u{1f6aa}\u4a9d\u642f\u0e85\u5635\u6b98'});
+let renderPassEncoder14 = commandEncoder71.beginRenderPass({
+  label: '\u4e24\ub4c7\u3441\u{1f94a}\u2d6a\uaf32\u0d6a',
+  colorAttachments: [{view: textureView15, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 788334450,
+});
+let renderBundle40 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer6, 4_136);
+} catch {}
+try {
+commandEncoder49.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 10, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48 */
+  offset: 48,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder72 = device1.createCommandEncoder({label: '\u{1fb96}\u9ad5\u7be0\ub660\u{1f716}\u047a\u{1f912}\ub67a'});
+let textureView17 = texture9.createView({label: '\u02e1\u2742\u042c\u{1fb61}\u{1f7ba}\u038a\u{1fd1e}\u0cf2', baseArrayLayer: 0});
+let computePassEncoder19 = commandEncoder49.beginComputePass({label: '\u{1fc51}\u{1fb64}\u0655\ua990\u0da5\u0db7\ud2a2'});
+let renderPassEncoder15 = commandEncoder72.beginRenderPass({
+  label: '\u6694\u07c0\u3701\u0307\u079a\u0fcc\u01e2',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 406.0, g: -796.6, b: -983.5, a: -994.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 24300489,
+});
+try {
+renderPassEncoder15.setVertexBuffer(1, undefined, 101_848_409);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1543, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline3 = device1.createComputePipeline({
+  label: '\uc64e\u{1fd83}\u8199\u15c7\u453c\u0d59\u{1fa18}\u0972',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, constants: {}},
+});
+let pipeline4 = device1.createRenderPipeline({
+  label: '\u1263\u{1f628}\u{1f743}\u38ec\u6123\u03ee\ub6c5',
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: [{format: 'rgb10a2uint'}]},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw'},
+});
+let bindGroup6 = device1.createBindGroup({layout: bindGroupLayout6, entries: []});
+let commandBuffer41 = commandEncoder70.finish({label: '\ua0c5\ufbf1\ud61d\u469e\u0f2b\u{1f70a}'});
+let texture20 = device1.createTexture({
+  label: '\u{1f744}\ucc69\u516b\u{1fd27}\u05df\ude75',
+  size: {width: 270, height: 1, depthOrArrayLayers: 55},
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup5, new Uint32Array(2446), 490, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer6, 4_128);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let canvas6 = document.createElement('canvas');
+let renderBundle41 = renderBundleEncoder4.finish({label: '\u{1fcc3}\u{1f800}'});
+try {
+renderPassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer6, 2_920);
+} catch {}
+try {
+device1.label = '\u{1fe73}\u2596\u59af\u4ec7\u08cb\u{1f82a}\u{1fd1c}\u8ed4';
+} catch {}
+let sampler6 = device1.createSampler({
+  label: '\u{1fba2}\u{1feab}\u0ee5\u03b8\u1333',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.92,
+  lodMaxClamp: 89.70,
+  compare: 'always',
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup5, new Uint32Array(1434), 347, 0);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1128, new BigUint64Array(10342), 1412, 48);
+} catch {}
+let commandEncoder73 = device1.createCommandEncoder();
+let renderPassEncoder16 = commandEncoder73.beginRenderPass({
+  label: '\u7a80\u4c77\u0c69\u{1fc90}\ua507\u95dc\u443e\u{1fd31}\u2933',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 551.5, g: -72.82, b: 879.4, a: -285.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(98);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+device1.queue.submit([commandBuffer30]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(446, 130);
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 322});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup1, new Uint32Array(553), 49, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(726), 54, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 628, new DataView(new ArrayBuffer(1817)), 90, 264);
+} catch {}
+document.body.prepend(img0);
+await gc();
+let commandEncoder74 = device1.createCommandEncoder({label: '\u9099\u0f5b\u{1fafc}\ufd13\u6909\udcf1'});
+let commandBuffer42 = commandEncoder74.finish();
+let externalTexture1 = device1.importExternalTexture({label: '\u8138\u0321\u26cf', source: videoFrame0, colorSpace: 'srgb'});
+try {
+device1.queue.writeBuffer(buffer6, 264, new Float32Array(988));
+} catch {}
+let imageData3 = new ImageData(32, 16);
+let renderBundle42 = renderBundleEncoder4.finish({label: '\u8d68\ud827\ue799\ud816'});
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: -967.9, g: -574.6, b: 734.7, a: 927.7, });
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer6, 0, 896);
+} catch {}
+let img1 = await imageWithData(67, 173, '#89e345b8', '#b5fa7870');
+let commandEncoder75 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({label: '\ue32b\u30ec\uafb2\ue633\u033c\u0538\u6934\u{1fc0f}\u0d74', type: 'occlusion', count: 1899});
+let commandBuffer43 = commandEncoder75.finish({label: '\u05f9\u6339'});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup1, new Uint32Array(4415), 2111, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup3, new Uint32Array(127), 16, 0);
+} catch {}
+try {
+externalTexture1.label = '\u62a4\udcbb\u04f8\u08fe\u{1f6b7}\u6bc6';
+} catch {}
+let texture21 = device1.createTexture({size: [44], sampleCount: 1, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let externalTexture2 = device1.importExternalTexture({label: '\ue394\u7383', source: video0});
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup6, new Uint32Array(1849), 32, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer6);
+} catch {}
+canvas0.width = 12;
+let commandEncoder76 = device1.createCommandEncoder({});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup6, new Uint32Array(1808), 21, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup6, new Uint32Array(125), 7, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer6, 0);
+} catch {}
+let pipeline5 = device1.createRenderPipeline({
+  label: '\ufc0b\u6a56\u0278\u0474\u0155\uef90',
+  layout: pipelineLayout6,
+  multisample: {count: 1},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {arrayStride: 72, stepMode: 'instance', attributes: []},
+      {arrayStride: 716, stepMode: 'instance', attributes: []},
+      {arrayStride: 552, attributes: []},
+      {arrayStride: 28, stepMode: 'instance', attributes: []},
+      {arrayStride: 32, stepMode: 'instance', attributes: []},
+      {arrayStride: 300, attributes: []},
+      {arrayStride: 288, attributes: []},
+      {
+        arrayStride: 108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 0, shaderLocation: 15},
+          {format: 'sint8x4', offset: 0, shaderLocation: 9},
+          {format: 'float32x2', offset: 16, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', unclippedDepth: true},
+});
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let buffer12 = device1.createBuffer({
+  size: 16468,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandBuffer44 = commandEncoder76.finish();
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(159);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer6, 0, 3_123);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1440, new Float32Array(24757), 2459, 228);
+} catch {}
+canvas5.width = 476;
+let renderBundle43 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: 857.2, g: -307.7, b: -951.2, a: -270.9, });
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer44]);
+} catch {}
+let commandEncoder77 = device1.createCommandEncoder({label: '\u46e3\u3738\ub889\ud3cf\u{1f786}\u2c54\u{1f779}\u{1f9f9}'});
+let textureView18 = texture20.createView({
+  label: '\u26e9\ue465\u07e9\u0231\u0ba9\ubc2e',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 8,
+});
+let renderPassEncoder17 = commandEncoder77.beginRenderPass({
+  label: '\u{1f80c}\ufa4f\ucaac\u0aa9\u8f2d\u38db\u{1fdf0}\uca0e\u0cdd\u0183',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -978.1, g: 167.8, b: 158.3, a: 698.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 729465076,
+});
+let renderBundle44 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup6, new Uint32Array(2434), 428, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 9496, new Float32Array(24259), 692, 320);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(28, 125);
+let texture22 = device1.createTexture({
+  label: '\u{1fa6f}\u4c2c\u{1f9fa}\u{1fe24}\u{1f633}\u7c57',
+  size: {width: 176},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer0 = buffer12.getMappedRange(3112);
+let renderBundle45 = renderBundleEncoder9.finish();
+let externalTexture3 = device0.importExternalTexture({label: '\ua4c6\u0167\u15f9\u052f\u7141\u02ee', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder2.executeBundles([renderBundle36, renderBundle20, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4152, new BigUint64Array(6171), 999, 76);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, undefined, 0, 326_445_633);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup6);
+} catch {}
+let pipelineLayout8 = device1.createPipelineLayout({label: '\u3a8b\u0ca4\u17f7', bindGroupLayouts: []});
+let commandEncoder78 = device1.createCommandEncoder({label: '\u0455\uabf9\u{1fa0f}\u0186\u{1fbc0}'});
+let renderBundle46 = renderBundleEncoder6.finish({label: '\ud86f\u391b\u{1fa23}\u0ce3\u0cf0\u4905\u916e\u3c09'});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer6, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker('\u1997');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 3024, new DataView(new ArrayBuffer(17704)), 553, 1008);
+} catch {}
+let querySet11 = device1.createQuerySet({
+  label: '\u0dd9\u69af\u0b00\u{1f63c}\u773f\u0a69\ub986\ua337\ue1b5\u0e83\u090a',
+  type: 'occlusion',
+  count: 1044,
+});
+let renderBundleEncoder10 = device1.createRenderBundleEncoder({
+  label: '\u7e66\u0509\u0bc2\u{1f996}\u276c\u08d5\u4051',
+  colorFormats: ['rgb10a2uint'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup6);
+} catch {}
+let commandEncoder79 = device1.createCommandEncoder({label: '\u02d2\u{1fd56}\ue285\uf8be\u0f3f\u{1ff53}\u07e9\u0d9a\u{1ffd3}\ub903\u8140'});
+let textureView19 = texture15.createView({aspect: 'all', baseMipLevel: 0});
+let renderPassEncoder18 = commandEncoder79.beginRenderPass({
+  label: '\u{1fcaa}\u{1fc91}\u7b0b\u076a\u5315\u0b94\ucb82\u0303\u0c32\u0879',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 60.86, g: 396.4, b: 348.0, a: 285.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline5);
+} catch {}
+await gc();
+try {
+device0.label = '\u0b29\u4d1e\ub6f8\uc31e\u0453\ua5e9';
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({label: '\u{1fe9a}\ua2fe\u34e4\u5bf7\u045c'});
+let computePassEncoder20 = commandEncoder80.beginComputePass({label: '\u4ab3\u{1f614}'});
+try {
+renderPassEncoder2.executeBundles([renderBundle8, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer3, 1_096, 5_611);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u0cfd');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 22, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(111_107), /* required buffer size: 111_107 */
+{offset: 63, bytesPerRow: 284, rowsPerImage: 128}, {width: 0, height: 8, depthOrArrayLayers: 4});
+} catch {}
+await gc();
+let canvas7 = document.createElement('canvas');
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer2);
+} catch {}
+let gpuCanvasContext5 = canvas6.getContext('webgpu');
+await gc();
+let commandEncoder81 = device0.createCommandEncoder();
+let computePassEncoder21 = commandEncoder81.beginComputePass();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer11, 0, 1_467);
+} catch {}
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\uea4a\u033b\u19ad\u6ae9\u68c6\u0714\u0a32\uda06\u5731\ud3fc\u11b0',
+  colorFormats: ['r8unorm'],
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 191}
+*/
+{
+  source: video0,
+  origin: { x: 3, y: 2 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext6 = canvas7.getContext('webgpu');
+try {
+computePassEncoder21.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer1, 212);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint32', 100, 3);
+} catch {}
+let buffer13 = device1.createBuffer({
+  label: '\u322f\ua924\ude18\u1a62\uc9a6\u6c54\u0927\u{1febd}',
+  size: 9802,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandBuffer45 = commandEncoder78.finish({label: '\u{1fafb}\u8b9d\u{1f627}\ud7b8\u07b5\u{1ffb3}'});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup5, new Uint32Array(275), 4, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle25, renderBundle29, renderBundle33, renderBundle42, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer13, 'uint16', 5_630, 237);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 3980, new DataView(new ArrayBuffer(41401)), 873, 2640);
+} catch {}
+let commandEncoder82 = device1.createCommandEncoder({});
+let texture23 = device1.createTexture({
+  size: [301],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup5, new Uint32Array(679), 127, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder82.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 11, y: 21, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 452 */
+  offset: 452,
+  buffer: buffer13,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer39]);
+} catch {}
+let commandEncoder83 = device1.createCommandEncoder({label: '\u0d8d\u419c'});
+let renderPassEncoder19 = commandEncoder83.beginRenderPass({
+  label: '\uf524\u903e\u0819\u810b\ubd21\u04ee\u{1f68d}\u{1f7cf}\ud80f',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 761.9, g: -328.8, b: 241.8, a: 533.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer13, 'uint32', 2_304, 485);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer6);
+} catch {}
+let renderPassEncoder20 = commandEncoder82.beginRenderPass({
+  label: '\u630c\u0bfc\u0bae\u01e2\u0a0b\ue6d5\u0a9f\u059e\u0c24\u9dca',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 181.0, g: 136.6, b: 225.7, a: -869.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle47 = renderBundleEncoder10.finish({label: '\u4f2f\u2d68\u{1f9cd}\u{1fb24}\u02ae\u9d23\u{1f666}\u6eef\u9388\u30d1'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(66.44354293437053, 35.90731109018992, 72.11069878994292, 2.8860735362695618, 0.7048688189451819, 0.9931548137648707);
+} catch {}
+let textureView20 = texture22.createView({label: '\uc2a1\u{1ffb0}\u0765\ue76e\u9794', mipLevelCount: 1});
+try {
+renderPassEncoder18.setIndexBuffer(buffer13, 'uint32', 108, 3_838);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1420, new Int16Array(12514), 66, 1640);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint32', 796, 2_955);
+} catch {}
+let commandEncoder84 = device1.createCommandEncoder({label: '\u0068\ued5b\u0f1d\u421a\ucee3'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(369), 6, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer13, 'uint32', 392, 991);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas1.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder18.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer6, 1_032);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer13, 'uint32', 1_424, 2_292);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\ue235');
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter();
+let commandEncoder85 = device0.createCommandEncoder({label: '\u7bb5\u{1f9f1}\u0ee8\u0c8a\u0369\u{1f791}\u15e9\u0ead\u584e\u0ce7\u995b'});
+let renderPassEncoder21 = commandEncoder85.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -947.6, g: -616.5, b: 901.7, a: -633.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 74113266,
+});
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint16', 556, 1_367);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, undefined, 0);
+} catch {}
+let bindGroupLayout7 = device1.createBindGroupLayout({entries: []});
+let commandEncoder86 = device1.createCommandEncoder({label: '\u48f6\u8353\u0655\u00c5\uf691\u017e\uf5ab\u{1f82c}\u6063\u08fd\uc7bb'});
+let commandBuffer46 = commandEncoder84.finish({label: '\u64f8\ua46a'});
+let computePassEncoder22 = commandEncoder86.beginComputePass({label: '\u25a6\u{1ff70}\u{1f917}\u{1fbe7}\u0160\u06e0\u0ee1'});
+let renderBundleEncoder12 = device1.createRenderBundleEncoder({label: '\u2029\u5bfc\u0c41\u477b\u047c\u0f0b', colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+renderPassEncoder14.setIndexBuffer(buffer13, 'uint32', 328, 2_887);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer13, 'uint16', 2_140, 588);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer6, 1_808, 1_200);
+} catch {}
+try {
+renderPassEncoder18.pushDebugGroup('\u0613');
+} catch {}
+let imageData4 = new ImageData(8, 64);
+let texture24 = device1.createTexture({
+  label: '\ub60d\u4840\uadfc',
+  size: {width: 176, height: 30, depthOrArrayLayers: 190},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder13 = device1.createRenderBundleEncoder({label: '\u002e\u335d', colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder14.beginOcclusionQuery(522);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1316, new DataView(new ArrayBuffer(4319)), 450, 364);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u{1fb32}\ufa82\ua265\u32da\u94da\u497a', bindGroupLayouts: [bindGroupLayout3]});
+let buffer14 = device0.createBuffer({size: 45456, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: true});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(4, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3503);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup2, new Uint32Array(1681), 416, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer3, 'uint32', 3_916, 63);
+} catch {}
+video0.width = 46;
+let commandEncoder87 = device0.createCommandEncoder({label: '\ubd4e\uafdb\u{1f7b8}\u{1ff95}\u0292\u{1fe93}'});
+let commandBuffer47 = commandEncoder87.finish({label: '\u2d45\u26cd\u8bda\u{1ffaf}\u0a6a\u0b6f\u00e8\u2bd7\uc450\uf0bb\uc38f'});
+try {
+renderPassEncoder8.setBlendConstant({ r: 361.7, g: 110.4, b: -245.1, a: 783.8, });
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint32', 96, 20);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer1, 44);
+} catch {}
+let renderBundle48 = renderBundleEncoder11.finish({label: '\ud152\u{1fd81}\u0d0b\ud401\u{1fe50}\u051d\u7714\u06bf\u{1fa5e}\ucc76\u2992'});
+try {
+renderPassEncoder7.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer0, 'uint16', 490, 355);
+} catch {}
+let pipelineLayout10 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout1]});
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer13, 'uint32', 728, 1_129);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 468, new Int16Array(12031), 2608, 1776);
+} catch {}
+let buffer15 = device1.createBuffer({label: '\u9e5e\ua452\u7401', size: 32181, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder88 = device1.createCommandEncoder();
+let commandBuffer48 = commandEncoder88.finish({label: '\uea24\u60d0\ua70f\u9b5e\u088d\u053d\u0a03\u0e65'});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setViewport(19.4295917330577, 3.5353447433260765, 82.99217520539321, 0.4215688746026347, 0.1454571575600372, 0.15067146770865614);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer1 = buffer12.getMappedRange(64, 680);
+try {
+device1.queue.writeBuffer(buffer15, 14956, new Float32Array(6087), 1468, 2468);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup5, new Uint32Array(1570), 104, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(144.1497812240428, 36.58525308232163, 12.171884503931283, 2.4795688404111846, 0.7969037893734052, 0.8681493209137262);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint16', 2_326, 604);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let renderBundle49 = renderBundleEncoder3.finish({});
+try {
+device0.queue.submit([commandBuffer47]);
+} catch {}
+try {
+adapter2.label = '\u{1faf0}\u5aee\u7ff5\u{1fd39}\ufffb\udd1c\u6aba\ub798\u{1fd8d}';
+} catch {}
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({label: '\u73a5\u{1fd03}', colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint16', 378, 118);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer6, 624);
+} catch {}
+let texture25 = device0.createTexture({
+  label: '\u0661\uac7b\u02a5\u01af\u{1f650}\ubcef\u0609\u84f5',
+  size: [1, 30, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle50 = renderBundleEncoder1.finish();
+try {
+computePassEncoder21.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0, new Uint32Array(176), 3, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 0, 151);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+let commandEncoder89 = device1.createCommandEncoder();
+let commandBuffer49 = commandEncoder89.finish({label: '\uedd0\u0d2a\u262f\u35f6\u0f63\u0062'});
+let renderBundle51 = renderBundleEncoder8.finish();
+try {
+computePassEncoder22.end();
+} catch {}
+let arrayBuffer2 = buffer12.getMappedRange(1128, 100);
+try {
+device1.queue.submit([commandBuffer37, commandBuffer41]);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+await gc();
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer2, 'uint16', 92, 17);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer4, 0, 640);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u{1fd47}');
+} catch {}
+let img2 = await imageWithData(70, 152, '#2214c15f', '#ff196fd0');
+let imageData5 = new ImageData(12, 8);
+let bindGroup7 = device1.createBindGroup({
+  label: '\u2e09\u{1ffcb}\u{1ff28}\u514e\u{1f894}\u{1ff97}\u6f34\u{1f930}\uf098\u{1f836}\u{1fcfb}',
+  layout: bindGroupLayout7,
+  entries: [],
+});
+let pipelineLayout11 = device1.createPipelineLayout({
+  label: '\u16aa\udc29\u6621\u{1fd40}\u7256',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout7, bindGroupLayout7],
+});
+let renderPassEncoder22 = commandEncoder86.beginRenderPass({
+  label: '\u177b\ud6b1\ufb3b\uf7d9\u6f81\u95ff\u82e5\u7638',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -375.2, g: 139.6, b: 939.0, a: 549.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 6979533,
+});
+try {
+renderPassEncoder18.executeBundles([renderBundle51]);
+} catch {}
+try {
+renderPassEncoder18.setViewport(2.1540790078116356, 38.36087543608356, 157.2658074658528, 1.082594494189663, 0.06555646606219068, 0.8502185233904848);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer13, 'uint32', 604, 1_926);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer13, 'uint32', 1_240, 1_319);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas0.getContext('webgpu');
+await gc();
+let commandEncoder90 = device1.createCommandEncoder({label: '\ue1f2\u{1f87f}\uc0ea\ub9a8\u0a7d\u291b'});
+let renderPassEncoder23 = commandEncoder90.beginRenderPass({
+  label: '\u3e19\u0672\u{1fa35}\u{1fce7}\u71f2\u054c',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 664.5, g: 268.5, b: -209.3, a: -26.93, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle52 = renderBundleEncoder13.finish({label: '\u0138\u0b7f\u047c\u06fd\u5ded\u76b3\u030e'});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle52, renderBundle34, renderBundle21, renderBundle51]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup6);
+} catch {}
+let pipeline6 = await device1.createComputePipelineAsync({
+  label: '\u3573\u0ed1\u88f9\u3e5e\u057e\u2412\ub49b',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, constants: {}},
+});
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\u0026\u04ab\u0e3e\u6c45\ue17b\u2854\u9b72\u5498\u7b8a\u06ec\u{1fb4f}',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout7],
+});
+let texture26 = device1.createTexture({
+  label: '\u676c\u{1fb56}\u01ca\u0b23\u018a\u{1faee}\u47b0\ue8a3\ue587',
+  size: [603, 1, 7],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup7, new Uint32Array(1274), 294, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer13, 'uint16', 1_110, 863);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer13, 'uint32', 1_068, 2_092);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+window.someLabel = renderPassEncoder4.label;
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder();
+let commandBuffer50 = commandEncoder8.finish();
+let renderPassEncoder24 = commandEncoder91.beginRenderPass({
+  label: '\u{1fe32}\u75db\ubeef\u28a8\u6c4a\u866c',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 769.8, g: -168.4, b: 429.0, a: -857.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+renderPassEncoder24.setViewport(9.755678679162203, 4.9212504575884335, 0.14987036589403516, 0.06774776803659828, 0.24178599229379538, 0.8255259244020021);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup4, new Uint32Array(2386), 83, 0);
+} catch {}
+try {
+commandBuffer28.label = '\u7c3b\u0703';
+} catch {}
+let commandEncoder92 = device1.createCommandEncoder({label: '\u9737\ub92b\u96ac\u2f72\u47ad\u9e24\uceb7\u0539\u8a19\u{1fb16}\ue63f'});
+let texture27 = device1.createTexture({
+  size: [180, 40, 72],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView21 = texture24.createView({label: '\u79d4\u{1f968}\u913d', dimension: '3d', aspect: 'all'});
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle18, renderBundle21, renderBundle35]);
+} catch {}
+try {
+renderPassEncoder20.setViewport(176.15850151668684, 12.664382269650144, 3.775136530539708, 2.5257715558102047, 0.6331257760961817, 0.6824054285840059);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer6, 7_356);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint32', 716, 1_322);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline5);
+} catch {}
+let commandEncoder93 = device1.createCommandEncoder({label: '\u{1f7bd}\u0602\u46ad\u03d1\u0c74\ue604\ue568\u0d43\u0deb\u{1fb44}'});
+let renderPassEncoder25 = commandEncoder92.beginRenderPass({
+  label: '\u70ca\u{1ff48}\ua0ec\u32f4\u{1f68e}\u{1fc62}\u56a2\u{1f937}',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 15,
+  clearValue: { r: 601.2, g: -90.81, b: -766.5, a: -70.36, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle53 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup5, new Uint32Array(6), 0, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup6, new Uint32Array(2461), 285, 0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 12, y: 15, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1_612_261), /* required buffer size: 1_612_261 */
+{offset: 277, bytesPerRow: 230, rowsPerImage: 292}, {width: 36, height: 1, depthOrArrayLayers: 25});
+} catch {}
+let commandEncoder94 = device1.createCommandEncoder();
+let commandBuffer51 = commandEncoder93.finish({label: '\u002b\u6464\u2015\u023f\ud5f1\u0807\u{1f9b7}\u{1faa7}\u{1fe67}\u{1f7e3}\u7df7'});
+let computePassEncoder23 = commandEncoder48.beginComputePass({label: '\u335b\u33ad\u2027\ueb1f\u196a\u{1fe88}\u{1fda9}\u0fa0\u83b2'});
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup7, new Uint32Array(1460), 22, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle53, renderBundle51]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer13, 'uint16', 3_290, 809);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer6, 1_744, 2_775);
+} catch {}
+try {
+renderPassEncoder18.popDebugGroup();
+} catch {}
+try {
+commandEncoder94.insertDebugMarker('\u088f');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer15, 168, new Int16Array(11140), 260, 2620);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({label: '\u85cf\ubfcf\u{1ffae}'});
+let commandBuffer52 = commandEncoder95.finish({label: '\u34a9\u0f89\u{1fdd8}\u0267\u8f78\u4cae\u5abf'});
+let renderBundle54 = renderBundleEncoder0.finish();
+try {
+renderPassEncoder11.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer3, 'uint16', 6_390, 400);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer11, 0, 1_479);
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({label: '\u20fe\u23d7\u{1ff75}\u73d1\u09ce\u9a4e\u{1f9eb}\uf1a3\u5165\u5c4e\u0a2a'});
+let commandBuffer53 = commandEncoder96.finish({label: '\uff0a\u09ba\uc05a\u{1fa28}\u0a52\u{1f8a6}\u04be'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u0d6d\u1ff4\u3769\u7599\u542e',
+  colorFormats: ['r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder15.setIndexBuffer(buffer2, 'uint32', 80, 45);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 191}
+*/
+{
+  source: canvas5,
+  origin: { x: 19, y: 2 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let sampler7 = device0.createSampler({
+  label: '\u88c3\u0700\ub906\u{1fe8e}\ud7f1\u47df',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.76,
+  lodMaxClamp: 84.71,
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer11, 'uint16', 1_592, 1_796);
+} catch {}
+let video1 = await videoWithData();
+try {
+window.someLabel = pipelineLayout10.label;
+} catch {}
+let querySet12 = device1.createQuerySet({
+  label: '\u01e3\u{1faca}\u0e4c\u{1f731}\u3c04\u0b7e\u3f50\u0b2c\u{1fe8d}\uf22f',
+  type: 'occlusion',
+  count: 899,
+});
+let externalTexture4 = device1.importExternalTexture({label: '\ucbc4\u{1f858}\ua997\u75cf\u04ab\u{1ffa6}', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer13, 'uint32', 100, 1_479);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup7, new Uint32Array(2740), 533, 0);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline4);
+} catch {}
+let bindGroupLayout8 = device1.createBindGroupLayout({
+  label: '\ue9fc\ub8a7\ud376\u{1f8e0}\u087c\ua7b4',
+  entries: [
+    {binding: 79, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 115,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder97 = device1.createCommandEncoder();
+let renderPassEncoder26 = commandEncoder94.beginRenderPass({
+  label: '\u3925\u0bac\u010c\u9d27\u{1f992}\u{1fa8f}\u4635\u869a\u9160\u{1ff76}\u78ce',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 21,
+  clearValue: { r: 888.0, g: -381.7, b: -516.6, a: 78.28, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle55 = renderBundleEncoder13.finish();
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline5);
+} catch {}
+let renderPassEncoder27 = commandEncoder27.beginRenderPass({
+  label: '\u{1fe27}\u4b62',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 115,
+  clearValue: { r: 504.7, g: 340.4, b: 760.3, a: -807.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+let renderBundleEncoder16 = device1.createRenderBundleEncoder({label: '\u8370\u69da\ub0ad', colorFormats: ['r8sint']});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup7, new Uint32Array(1463), 98, 0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer6, 1_088, 1_307);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u0793');
+} catch {}
+let commandEncoder98 = device1.createCommandEncoder({label: '\uc39c\u460c\u0dc3\u{1faae}\uffc1\u7b3f\u0e28'});
+let computePassEncoder24 = commandEncoder97.beginComputePass({label: '\uae07\u038a\u0632\u{1f9aa}\u0926\uabc6\u{1faa6}\u6f45'});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(1, 3, 75, 2);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer13, 'uint16', 2, 5_057);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let querySet13 = device1.createQuerySet({label: '\u{1f99a}\u{1fda7}\u2c53', type: 'occlusion', count: 387});
+try {
+computePassEncoder18.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint32', 1_296, 314);
+} catch {}
+try {
+commandEncoder98.copyBufferToBuffer(buffer6, 792, buffer15, 2616, 2788);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle32, renderBundle42, renderBundle26, renderBundle42]);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint16', 870, 272);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let renderBundle56 = renderBundleEncoder5.finish({label: '\ue22c\u7f75\u{1fafa}\u{1fc66}\u07e1\u{1ff15}\u{1fddc}'});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle42]);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -539.0, g: -599.6, b: -893.3, a: -832.3, });
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup7, new Uint32Array(1075), 32, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer6, 1_452, 5_437);
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer15, 9812, 2396);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline7 = device1.createRenderPipeline({
+  label: '\uddbf\u05fd\u0dd7\u0211\uce7f\u2198',
+  layout: pipelineLayout6,
+  multisample: {count: 1, mask: 0x19ff7b91},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 196, stepMode: 'vertex', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 644, attributes: []},
+      {arrayStride: 504, attributes: []},
+      {arrayStride: 656, attributes: [{format: 'sint16x2', offset: 48, shaderLocation: 9}]},
+      {arrayStride: 104, stepMode: 'instance', attributes: []},
+      {arrayStride: 2048, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 244, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let img3 = await imageWithData(8, 51, '#49945bad', '#5da83239');
+let bindGroupLayout9 = device1.createBindGroupLayout({label: '\u6da9\u8eac\u{1f9f4}\u09cd', entries: []});
+let commandEncoder99 = device1.createCommandEncoder();
+let renderPassEncoder28 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 108,
+  clearValue: { r: -129.0, g: -951.4, b: -374.5, a: 805.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 3, 1);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint16', 2_012, 1_391);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let imageData6 = new ImageData(20, 32);
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u{1f65f}\u6d2a\u{1fa1a}\u0e13',
+  entries: [
+    {
+      binding: 112,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(274);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup0, new Uint32Array(897), 188, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 108, new Int16Array(4771), 1093, 4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup0, new Uint32Array(2390), 258, 0);
+} catch {}
+let textureView22 = texture4.createView({label: '\u6436\u{1ff8f}\u{1f9a6}\u{1fdbd}\u{1ffe5}\u0499\u1e61\u8da5\u90d8\u0520', format: 'r8unorm'});
+try {
+renderPassEncoder21.executeBundles([renderBundle6, renderBundle17]);
+} catch {}
+let commandEncoder100 = device1.createCommandEncoder();
+let commandBuffer54 = commandEncoder100.finish({label: '\u2005\uc720\u02a5\u4445\u{1ff07}\u0796\u{1f753}'});
+let sampler8 = device1.createSampler({
+  label: '\u09ed\u0b4f\u328c\u{1f748}\u0817\u{1fb58}\u{1fc00}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.58,
+  lodMaxClamp: 39.37,
+  maxAnisotropy: 2,
+});
+let externalTexture5 = device1.importExternalTexture({
+  label: '\uf7ef\u0a16\u296c\u0b87\u8911\u444b\u0c67\uc302\u{1fc5a}\u09d1\u02b0',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup5, new Uint32Array(3019), 117, 0);
+} catch {}
+let arrayBuffer3 = buffer12.getMappedRange(1232, 536);
+try {
+commandEncoder98.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 33, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = await device1.createComputePipelineAsync({
+  label: '\u{1fcbb}\ue641\u{1fd61}\u0501\u0d10\u0025\u055b\u01af\u{1f60c}\u01a6\u608e',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1, constants: {}},
+});
+let commandBuffer55 = commandEncoder98.finish({label: '\u{1f6e7}\u7520\ua8bb\uf497'});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle34]);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer6, 0, 1_423);
+} catch {}
+let arrayBuffer4 = buffer12.getMappedRange(0, 0);
+try {
+buffer6.unmap();
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 708);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+canvas0.height = 1453;
+let videoFrame1 = new VideoFrame(img2, {timestamp: 0});
+let commandEncoder101 = device1.createCommandEncoder();
+let computePassEncoder25 = commandEncoder101.beginComputePass({label: '\u881d\ue6ea\u01e6\u0f17\u2971\ub0fd'});
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint32', 1_460, 908);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer6);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.READ, 2432, 6488);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 13},
+  aspect: 'all',
+}, new ArrayBuffer(302), /* required buffer size: 302 */
+{offset: 302, bytesPerRow: 263}, {width: 52, height: 5, depthOrArrayLayers: 0});
+} catch {}
+canvas4.height = 1660;
+let commandEncoder102 = device0.createCommandEncoder({});
+let texture28 = device0.createTexture({
+  label: '\u3e78\uf271\u0a38\u476b\u06e2\u0e91\u{1fd7d}\u0509\u4e40\u06da\u0169',
+  size: [80, 40, 706],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle57 = renderBundleEncoder0.finish({label: '\uc3c3\ue26a\u0206\u{1f78b}\uad49\u{1fe93}\ue595'});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup0, new Uint32Array(620), 29, 0);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\u401a');
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u0266');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandBuffer56 = commandEncoder97.finish({label: '\u{1fb31}\u06f3\u8bc6\u246c\u{1fb30}\u185f\u07fc\ua297\u0c78'});
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint32', 1_980, 2_465);
+} catch {}
+try {
+device1.queue.submit([commandBuffer45]);
+} catch {}
+canvas4.height = 614;
+let computePassEncoder26 = commandEncoder102.beginComputePass();
+let imageBitmap2 = await createImageBitmap(imageData2);
+let renderBundle58 = renderBundleEncoder13.finish({label: '\u821e\u092f\u5f7b'});
+try {
+renderPassEncoder20.setIndexBuffer(buffer13, 'uint16', 2_090, 231);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint32', 12, 1_026);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let renderBundle59 = renderBundleEncoder8.finish({label: '\u6d21\u{1fbc9}\u0107\u0dd4'});
+let externalTexture6 = device1.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint16', 166, 4_345);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer6, 0, 6_514);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer11, 1_452, 52);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer0, 'uint32', 132, 236);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer7, 0, 498);
+} catch {}
+try {
+device0.queue.submit([commandBuffer26]);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(242, 151);
+let commandEncoder103 = device1.createCommandEncoder({});
+let computePassEncoder27 = commandEncoder103.beginComputePass({});
+let renderPassEncoder29 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 5,
+  clearValue: { r: 383.7, g: 409.1, b: 875.6, a: -390.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 232928026,
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup6, new Uint32Array(2614), 48, 0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup5, new Uint32Array(1165), 18, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer6, 0, 3_305);
+} catch {}
+try {
+gpuCanvasContext9.configure({device: device1, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+try {
+  await promise5;
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({label: '\u0521\u0b9e\u1df2\u{1fe0f}\u4745\u001e\u0e05\u0c15\u0aac', entries: []});
+let textureView23 = texture3.createView({label: '\u9cea\u4361\uaf0c\u4454\u0e9b\u6108\u0108\u0cc3', mipLevelCount: 1});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u5942\u033e\u{1f724}\u{1facb}\ub77c\u7129\u080e',
+  colorFormats: ['r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle60 = renderBundleEncoder17.finish({label: '\u03c9\u{1ff1f}\ub9ae\u8981\u{1fc51}\u{1fccd}\u5d74\ufcfd\ud84d\u06d7'});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder104 = device1.createCommandEncoder({});
+let computePassEncoder28 = commandEncoder104.beginComputePass({label: '\uc2a4\u16b4'});
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint16', 178, 1_035);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+let commandEncoder105 = device0.createCommandEncoder({label: '\u9a6b\u8968\u4055\u{1f959}\u84c8\u{1f6ec}'});
+let renderPassEncoder30 = commandEncoder105.beginRenderPass({
+  label: '\u75ff\ubd2b\u8519\udf8f\u0af3\u007d\ua2ae',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -163.8, g: -479.4, b: 132.2, a: 955.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle61 = renderBundleEncoder9.finish({label: '\u{1fa4c}\u{1fe4c}\ud583\udb48\ua9ab\u094b\u{1fe77}\u36ed'});
+try {
+renderPassEncoder30.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer5, 'uint32', 2_756, 110);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer1, 140, 316);
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({label: '\u0f43\u948e\uc9f9\uc8a4\u467d\u074b\u{1f963}\u4b23\u{1f807}\u2dcf'});
+let commandBuffer57 = commandEncoder106.finish({label: '\u{1fbec}\u3792\u0273\u{1f6eb}\u9ec8\u3ad1\u{1f78a}\u3941\u08bc\u{1fb6e}\ub1ae'});
+let computePassEncoder29 = commandEncoder80.beginComputePass({label: '\u{1fc5e}\u0058\u2bd2'});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u72eb\u0907\u883a\u{1faec}\ue8a4\u{1fdf1}\ubb10\u{1f7da}',
+  colorFormats: ['r8unorm'],
+  stencilReadOnly: true,
+});
+let externalTexture7 = device0.importExternalTexture({label: '\ua938\u3336\u7125\u1156\uf00e\uf1f9\u{1f6b4}\u027a\u{1f906}\u{1fec9}', source: videoFrame0});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer11, 'uint32', 960, 7_871);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer0, 'uint16', 1_590, 653);
+} catch {}
+let arrayBuffer5 = buffer14.getMappedRange(13720, 4284);
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer32]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView24 = texture8.createView({
+  label: '\u044a\uf168\u032d\u{1fd34}\u0425\u{1f870}\ufdd9\u0ad5\u0b4a',
+  dimension: '3d',
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder7.setBlendConstant({ r: 351.2, g: 464.8, b: 101.8, a: 743.3, });
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(7, buffer3, 14_328, 427);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 191}
+*/
+{
+  source: imageData0,
+  origin: { x: 14, y: 1 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout13 = device1.createPipelineLayout({
+  label: '\ub69d\u0fca\u3445\u071e\u2bf6\u{1faf4}\u001d\u1386\u0dcb',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout9, bindGroupLayout1, bindGroupLayout6],
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline4);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas2.getContext('webgpu');
+await gc();
+let textureView25 = texture15.createView({label: '\u2e3a\u02c3\u409a\u{1feb6}', baseMipLevel: 0});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({label: '\u04b1\u74f8\u0ee7', colorFormats: ['rgb10a2uint']});
+let renderBundle62 = renderBundleEncoder10.finish({label: '\u38ab\u{1f981}\u{1ffcd}\u01a7\u80f2\u{1fb0b}\ud544'});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle56, renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+device1.queue.submit([commandBuffer42]);
+} catch {}
+let promise6 = device1.queue.onSubmittedWorkDone();
+let commandEncoder107 = device1.createCommandEncoder({label: '\u5a29\u03f3\u81a9\u12ea\u63ae\uf19f\u9973\u0738\u01c3\u{1fbe6}'});
+let textureView26 = texture23.createView({label: '\u9b8d\u8614\u9c75\u{1f885}\u5cf6\u0221\u3e57\u{1fa93}\u06ca', arrayLayerCount: 1});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup6, new Uint32Array(1688), 44, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer13, 'uint32', 2_736, 605);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(1, buffer6, 5_496, 236);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let shaderModule2 = device1.createShaderModule({
+  label: '\u0c3a\u01ad\u{1f72c}\ucfc3\ua442\ucf1d',
+  code: `@group(0) @binding(159) var sam4: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+
+
+@fragment
+fn fragment0(@location(7) a0: f32, @location(13) a1: vec2<i32>, @builtin(sample_index) a2: u32) -> @location(200) vec4<u32> {
+var r: vec4f;
+_ = sam4;
+return vec4<u32>();
+}
+
+struct VertexOutput0 {
+  @location(7) f2: f32,
+  @builtin(position) f3: vec4<f32>,
+  @location(13) f4: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f16>) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\ub13a\u0f9d\u0e46\u045b',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout1, bindGroupLayout9, bindGroupLayout9],
+});
+let commandEncoder108 = device1.createCommandEncoder({label: '\uab3b\u{1ffec}\u1df0\u{1ffa0}\u959f\u87ce\u60a8\u{1fe62}\u3773\u{1fa3c}'});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle33, renderBundle24]);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer10, 304, buffer13, 400, 416);
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({label: '\ub0f8\ufb58\u6f26\ua06b\u0bb8\u38be\uc745'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(0, bindGroup2, new Uint32Array(4351), 70, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer11, 0, 318);
+} catch {}
+let arrayBuffer6 = buffer14.getMappedRange(18008, 2748);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise6;
+} catch {}
+let buffer16 = device1.createBuffer({
+  label: '\u{1fa4c}\u0a6b\u0f83\ub74e\u24ed',
+  size: 30654,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder110 = device1.createCommandEncoder({label: '\u41ce\u562e\u4081\u06a7\u{1f69d}\u{1fd94}\u06d7\u5428'});
+let commandBuffer58 = commandEncoder48.finish();
+let texture29 = device1.createTexture({size: [1206], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let renderPassEncoder31 = commandEncoder108.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 90,
+  clearValue: { r: -5.187, g: 142.7, b: -186.5, a: -883.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({
+  label: '\u0b89\u0f93\uc641\u0270\u6133\u94e8\u918e\ud7e8',
+  colorFormats: ['r8sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup5, new Uint32Array(331), 63, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup7, new Uint32Array(1108), 27, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle21, renderBundle29]);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer16, 0, 778);
+} catch {}
+try {
+device1.queue.submit([commandBuffer51, commandBuffer48]);
+} catch {}
+try {
+adapter1.label = '\u0776\u1772\ucaa9';
+} catch {}
+let commandBuffer59 = commandEncoder109.finish({label: '\ua6ba\ua4ad\uc701\ucc05\u00f4\u94f1\u84be\u0eb4'});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup1, new Uint32Array(2947), 101, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle60, renderBundle8]);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let commandEncoder111 = device1.createCommandEncoder({label: '\u0b11\uda6e\ufdc1\u81d9\u25cf\u{1fe48}'});
+let commandBuffer60 = commandEncoder110.finish({label: '\ufd0c\u720f\u{1f8f9}\u{1fbe5}\u64d4\u2bd3\ub903\u0763\udc59'});
+let texture30 = device1.createTexture({
+  label: '\u5be8\uf22c\u612b\u{1ff0d}\uea08\ud943\ub621\uf0a8\uf724',
+  size: [176, 30, 190],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder30 = commandEncoder107.beginComputePass({});
+let renderPassEncoder32 = commandEncoder111.beginRenderPass({
+  label: '\ua669\u1d2f\u0ab7',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -745.9, g: 748.6, b: 689.4, a: -249.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup7, new Uint32Array(927), 162, 0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+adapter0.label = '\u87f9\u{1fd33}\u{1f854}\u2fb8\u9dd7\u{1fd98}\u0711';
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({label: '\u04cb\u684c\u{1fc33}\ua8e3\u0ba9\u{1fe81}\ue254\u0915\u45ce\uacfc'});
+try {
+renderPassEncoder7.setViewport(9.958537432832893, 0.1564360729751274, 0.007770646056028523, 2.3911185111477553, 0.3634757500982331, 0.7313388981807778);
+} catch {}
+try {
+renderPassEncoder20.setViewport(2.2440784836215744, 3.536614443810291, 131.60957425850643, 19.12243686190562, 0.2988317339085621, 0.9359045698457795);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 13, y: 1, z: 22},
+  aspect: 'all',
+}, new ArrayBuffer(27_786), /* required buffer size: 27_786 */
+{offset: 258, bytesPerRow: 68, rowsPerImage: 202}, {width: 14, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({label: '\u{1fca7}\u{1fcb1}\ub9f5'});
+let textureView27 = texture5.createView({
+  label: '\ufc55\u0567\ue92f\u216f\u8445\u818a\u{1fd97}\u3a44\uf749\ub255',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder7.setViewport(0.8226415189470881, 0.8327952029223712, 3.4768584833376623, 3.801681075845067, 0.928583770860002, 0.9310993492611225);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer11, 'uint32', 2_896, 674);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer4, 0, 243);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer2, 144, buffer11, 444, 20);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 11},
+  aspect: 'all',
+}, new ArrayBuffer(2_309_724), /* required buffer size: 2_309_724 */
+{offset: 450, bytesPerRow: 214, rowsPerImage: 116}, {width: 0, height: 4, depthOrArrayLayers: 94});
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let commandEncoder114 = device0.createCommandEncoder({label: '\u044a\u218d\u{1fd1c}\u0f1c\u{1fc86}\ua921\u6442\ua014\u7574\u04da'});
+let commandBuffer61 = commandEncoder112.finish();
+try {
+renderPassEncoder30.executeBundles([renderBundle9, renderBundle11, renderBundle54]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer7, 0, 5);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer11, 'uint32', 11_168, 245);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer2, 0, 40);
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(buffer9, 5956, buffer5, 508, 812);
+} catch {}
+document.body.prepend(img1);
+let commandEncoder115 = device1.createCommandEncoder({});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(2, buffer16, 14_200);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer13, 'uint16', 2_064, 1_628);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u0e2c');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandBuffer62 = commandEncoder113.finish();
+let textureView28 = texture18.createView({
+  label: '\u836f\u{1f6cd}\u211d\u{1fa39}\ud71e\u758d\u{1fb40}\u{1fb20}',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+let computePassEncoder31 = commandEncoder114.beginComputePass({label: '\u5d40\u0446\u63ce\u08d8\ua087\uaae3\ue998\u{1ff31}\u4ee4\u704b'});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(0, 0, 2, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer59]);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({label: '\u9d38\u098a\u7e07\u{1fb25}\u{1ff06}\u8c3b\u{1f82a}\u7faf\ua57f\u0452'});
+let renderPassEncoder33 = commandEncoder116.beginRenderPass({
+  label: '\uff29\u096d\u0e82',
+  colorAttachments: [{view: textureView28, loadOp: 'clear', storeOp: 'discard'}],
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder8.setViewport(6.978191251653415, 3.623600724889271, 0.23503712240892616, 1.2505383875596245, 0.8133635793908294, 0.9423283377523894);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer11, 'uint16', 3_542, 263);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet7, 1, 11, buffer14, 16384);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 11, y: 29 },
+  flipY: true,
+}, {
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer63 = commandEncoder115.finish({label: '\u0bd8\u{1ff18}\u9b83\u{1fb3d}\u0593\u7ccd\u{1fdae}\u8923'});
+let renderBundle63 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer6, 0, 4_804);
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder({label: '\u{1fb1d}\u5ea1\u0295\u9cec\uc6eb\u{1fef6}\u245e'});
+let commandBuffer64 = commandEncoder117.finish();
+let renderPassEncoder34 = commandEncoder7.beginRenderPass({
+  label: '\u82bb\ufe19\u0aa6\u0a65\udb96\ucbde',
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -665.3, g: 816.1, b: 843.8, a: -32.49, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+});
+let sampler9 = device0.createSampler({
+  label: '\ue78c\ude88\u3652\u0b56\u{1f947}\u{1fb4a}\u026b\u0d2f\uaf9c\u2c21\u0497',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.96,
+  lodMaxClamp: 44.48,
+  compare: 'never',
+});
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup3, new Uint32Array(1689), 137, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer11, 'uint32', 616, 2_573);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder118 = device1.createCommandEncoder({label: '\u4440\u{1f63f}\u88c1'});
+let commandBuffer65 = commandEncoder118.finish();
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(442);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(2, buffer16, 1_996);
+} catch {}
+let shaderModule3 = device1.createShaderModule({
+  label: '\uf09a\u5349\u6400\u23b0\ub5c5\u342b',
+  code: `@group(2) @binding(159) var sam5: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(sample_mask) f1: u32,
+  @location(3) f2: vec2<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+_ = sam5;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f5: vec4<f32>,
+  @location(11) f6: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: i32, @location(12) a1: vec4<u32>, @location(15) a2: vec2<i32>, @location(10) a3: vec4<u32>) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout15 = device1.createPipelineLayout({label: '\ucf7b\u0372\u11b1\u0376', bindGroupLayouts: []});
+let renderBundle64 = renderBundleEncoder14.finish({label: '\u{1fd8c}\u1896\u{1fa54}\u7dd5\u9b81\u0630'});
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(2, buffer16);
+} catch {}
+document.body.prepend(canvas5);
+let commandEncoder119 = device1.createCommandEncoder({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer16, 4_332);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer13, 'uint32', 2_352, 254);
+} catch {}
+try {
+commandEncoder119.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 28, y: 17, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 10, y: 3, z: 56},
+  aspect: 'all',
+},
+{width: 25, height: 2, depthOrArrayLayers: 12});
+} catch {}
+try {
+commandEncoder119.resolveQuerySet(querySet6, 5, 0, buffer16, 3072);
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({
+  label: '\u2402\u79a0\u{1f6ba}\uc430\u9f01',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout3, bindGroupLayout5, bindGroupLayout3],
+});
+let commandEncoder120 = device0.createCommandEncoder({label: '\uf9ca\u42da\u4450\u48a5\u0507\ue3fe\u{1fc96}\u599b\u{1fb01}\u2c03'});
+let computePassEncoder32 = commandEncoder120.beginComputePass({label: '\ue330\ub3dd\u027e\u0676\u5a66'});
+let renderBundle65 = renderBundleEncoder2.finish();
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup3, new Uint32Array(3570), 1345, 0);
+} catch {}
+let bindGroup8 = device1.createBindGroup({
+  label: '\udf9c\u12a5\u405e\u235f\u4a1d\u93df\u{1ff1c}\u252f',
+  layout: bindGroupLayout8,
+  entries: [{binding: 79, resource: externalTexture2}, {binding: 115, resource: textureView18}],
+});
+let commandBuffer66 = commandEncoder119.finish({label: '\ucdf4\u{1fcf4}\uaecc'});
+try {
+renderBundleEncoder20.setIndexBuffer(buffer13, 'uint16', 312, 872);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let renderBundle66 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup6, new Uint32Array(3849), 905, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle26, renderBundle21, renderBundle33, renderBundle47, renderBundle55, renderBundle64]);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(1941);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer6, 588);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer16);
+} catch {}
+let pipeline9 = device1.createRenderPipeline({
+  label: '\u5031\u7330\u{1f733}\u01a8\u8ba7\u7f92',
+  layout: pipelineLayout11,
+  multisample: {mask: 0xcf01209a},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', passOp: 'decrement-clamp'},
+    stencilReadMask: 114586076,
+    depthBias: -1067041828,
+  },
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {arrayStride: 120, stepMode: 'instance', attributes: []},
+      {arrayStride: 136, attributes: []},
+      {arrayStride: 48, attributes: []},
+      {arrayStride: 456, stepMode: 'instance', attributes: []},
+      {arrayStride: 296, attributes: []},
+      {arrayStride: 276, stepMode: 'instance', attributes: []},
+      {arrayStride: 324, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 140,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 8, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+video0.height = 43;
+let imageBitmap3 = await createImageBitmap(videoFrame1);
+let commandEncoder121 = device1.createCommandEncoder({label: '\ufb15\ucc42\u05e4\u062c\u60e1\u02af\u38f9\u{1f6b7}'});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer6, 6_492, 747);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer6, 104, buffer13, 1360, 1684);
+} catch {}
+let bindGroup9 = device1.createBindGroup({layout: bindGroupLayout9, entries: []});
+let renderPassEncoder35 = commandEncoder49.beginRenderPass({
+  label: '\u03af\u8e64',
+  colorAttachments: [{view: textureView21, depthSlice: 31, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 410156426,
+});
+let renderBundle67 = renderBundleEncoder6.finish();
+try {
+computePassEncoder28.setBindGroup(3, bindGroup5, new Uint32Array(354), 119, 0);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(851);
+} catch {}
+try {
+renderPassEncoder31.setViewport(161.04849661392493, 15.470199678313422, 4.75217470004471, 1.6374705574645345, 0.6619467125359905, 0.8443732156058709);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer13, 'uint32', 460, 1_027);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer16);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer13, 'uint16', 782, 4_253);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder122 = device1.createCommandEncoder();
+let commandBuffer67 = commandEncoder101.finish({label: '\u06dc\u86fb\ua21a\ucb24\uaf20\u4393\ucc7d'});
+let externalTexture8 = device1.importExternalTexture({label: '\u17b6\u834f\u9fcc\u0506', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint16', 3_490, 2_190);
+} catch {}
+let commandBuffer68 = commandEncoder81.finish();
+let texture31 = device0.createTexture({
+  label: '\ue4f1\u929a\u0c7c\u0da4\u{1f933}\u0bec\u62f0',
+  size: {width: 40, height: 20, depthOrArrayLayers: 18},
+  mipLevelCount: 3,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let textureView29 = texture18.createView({label: '\u{1fc1a}\uc9c6\u02fa\u06e5\ua4db', dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup2, new Uint32Array(5530), 1772, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer2, 'uint16', 126, 27);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer8);
+} catch {}
+let commandBuffer69 = commandEncoder60.finish({label: '\u0efe\u{1fa4d}\u4639\u6d9c\u{1fbef}\u5fed\u44dc\u468d\u3232\u3dd4\u00bc'});
+let computePassEncoder33 = commandEncoder122.beginComputePass({label: '\u0c04\u{1ff60}\uca0e\u{1f885}\u0f19\u8903\u{1f60f}\u2e7a\u6838\ua88a\u{1f7c8}'});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  label: '\u3a67\u0e02\u{1fa8f}\u104b\u3aaa\u015b\u07b2\u4c5e\u0411\u{1fe45}',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup6, new Uint32Array(3641), 724, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer16, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint32', 3_040, 381);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 17, y: 16, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.submit([commandBuffer56, commandBuffer49]);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u08e3\u{1fa7d}\u{1f635}\u02fb',
+  code: `@group(0) @binding(160) var et0: texture_external;
+@group(0) @binding(62) var tex0: texture_2d<f32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et0, vec2u());
+r += textureLoad(tex0, vec2u(), 0);
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+r += textureLoad(tex0, vec2u(), 0);
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f32>, @location(15) a1: vec3<i32>, @location(4) a2: vec4<f32>) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture32 = device0.createTexture({
+  label: '\uc1f3\u1fa2\u{1fbe9}\u{1fe1b}\u861d\u3917\u8d9b\ud7d5',
+  size: [2],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler10 = device0.createSampler({
+  label: '\u9380\u02e9\uca30\u{1f6a3}\u2d30',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 83.44,
+  lodMaxClamp: 93.54,
+});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup4, new Uint32Array(7858), 2091, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle49]);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup0);
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({label: '\u{1f863}\u0dd6\u008a\u9b1a\u{1f8b4}\u0733'});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup1, new Uint32Array(3765), 73, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer2, 0, 15);
+} catch {}
+let commandBuffer70 = commandEncoder121.finish({label: '\uedee\u{1fa74}\u0034\u3c32'});
+let texture33 = device1.createTexture({
+  size: [2160],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer13, 'uint16', 52, 3_129);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer6, 1_260, 1_800);
+} catch {}
+try {
+  await promise9;
+} catch {}
+try {
+adapter2.label = '\u748f\u455b\u{1f60d}\u{1fa53}\u04ab\u7cb9';
+} catch {}
+let commandBuffer71 = commandEncoder123.finish({label: '\u{1f6d8}\u0207\u{1fcd7}'});
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer2);
+} catch {}
+try {
+  await promise8;
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer3, 'uint16', 4_806, 464);
+} catch {}
+try {
+device0.queue.submit([commandBuffer64]);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup1, new Uint32Array(1019), 22, 0);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 336, 105);
+} catch {}
+try {
+commandEncoder120.copyBufferToBuffer(buffer5, 1396, buffer11, 368, 1172);
+} catch {}
+let imageData7 = new ImageData(60, 104);
+let texture34 = device0.createTexture({
+  label: '\u0817\uf557',
+  size: {width: 20},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder34 = commandEncoder120.beginComputePass({label: '\u09f0\u06cc\u{1f60d}\u{1f8d9}\u{1ff3f}\uaaa2\u{1ff58}'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer7, 60, 146);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer2);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet9, 5, 12, buffer2, 0);
+} catch {}
+let buffer17 = device1.createBuffer({
+  label: '\u0160\ub973\u3c5e\uca37\ubb63\u{1fc20}\u845d\u3f3e\u{1f610}\u5831\u{1fa6a}',
+  size: 13920,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer16, 4_180);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer13, 'uint16', 684, 327);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer16, 0, 1_239);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.prepend(video0);
+let textureView30 = texture11.createView({label: '\u771a\u0806\u0506\u{1fd45}\ucb1d\u8251', arrayLayerCount: 1});
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer13, 'uint16', 5_698, 167);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(5, buffer6, 1_536, 629);
+} catch {}
+try {
+device1.queue.submit([commandBuffer23, commandBuffer54]);
+} catch {}
+let commandEncoder124 = device0.createCommandEncoder({label: '\u347b\udc38\u{1f963}\u08c8'});
+let textureView31 = texture31.createView({
+  label: '\u0e44\u589b\u{1f744}\ud06e\ub921\u0b83\u0caa\u{1ff01}',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 2,
+});
+let renderPassEncoder36 = commandEncoder124.beginRenderPass({
+  label: '\uca80\u9e60',
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 79,
+  clearValue: { r: -632.1, g: 373.3, b: -452.2, a: -80.29, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 485136364,
+});
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer3, 'uint32', 416, 3_914);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup8, new Uint32Array(1330), 570, 0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup6);
+} catch {}
+let renderBundle68 = renderBundleEncoder21.finish({});
+try {
+renderPassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer17, 1_908, 3_143);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer16, 0);
+} catch {}
+try {
+adapter1.label = '\ue731\u{1f67a}\u0f59\uca55\u67ea\u6377\u1f71\u022a\u0e01';
+} catch {}
+let commandEncoder125 = device1.createCommandEncoder({});
+let querySet14 = device1.createQuerySet({label: '\u9e31\u{1ff48}\u5be7\u{1fcdf}\u0d51', type: 'occlusion', count: 408});
+let renderPassEncoder37 = commandEncoder125.beginRenderPass({
+  label: '\u{1f700}\u144d\u7ed1\u7bfd\u2288',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 20,
+  clearValue: { r: 979.6, g: -819.5, b: 487.7, a: 63.26, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 888090553,
+});
+let renderBundle69 = renderBundleEncoder14.finish();
+try {
+computePassEncoder33.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup7, new Uint32Array(210), 63, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder12.insertDebugMarker('\u0697');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 3108, new DataView(new ArrayBuffer(1346)), 333, 44);
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({label: '\ub68a\ucd10\u0fe4\u9d75\u{1f810}\u004e\u{1f94e}'});
+let texture35 = gpuCanvasContext6.getCurrentTexture();
+let textureView32 = texture31.createView({label: '\ub6a4\u{1fb0f}', dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 3});
+let renderPassEncoder38 = commandEncoder120.beginRenderPass({
+  label: '\u7bb8\ub0b9\u{1fc9f}\u{1ff6f}\ud66a\uc3fa\u30e8\u5f6a\u0555',
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: 710.1, g: 385.6, b: -999.9, a: -939.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle65, renderBundle50]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 6_716, 249);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer1, 104);
+} catch {}
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\udfd1\ua1a8\u8288\u7256\u{1faad}\u0fda\u{1fa77}\u674c',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout1],
+});
+let commandEncoder127 = device1.createCommandEncoder();
+let commandBuffer72 = commandEncoder127.finish({label: '\u2890\u{1fcab}\u85d4\ua3e0\u0e50\ud93e\u0089'});
+let textureView33 = texture20.createView({
+  label: '\u573d\u4bad\u0816\u{1f923}\u0a11\u0f87',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer6, 0, 3_426);
+} catch {}
+try {
+device1.queue.submit([commandBuffer67, commandBuffer70]);
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({label: '\u0cf1\ubb6e\u8285\u0544\ua960\u1605\u0a54\u5409\u1d2a'});
+let computePassEncoder35 = commandEncoder68.beginComputePass({label: '\u{1f7f1}\u089a\u5759\uc9ba\u0d82\u041f'});
+let renderPassEncoder39 = commandEncoder126.beginRenderPass({
+  label: '\u{1f700}\u3806\u5634',
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -217.0, g: -98.67, b: 580.6, a: -931.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle70 = renderBundleEncoder11.finish();
+let renderPassEncoder40 = commandEncoder128.beginRenderPass({
+  label: '\u6715\ube3a\u{1fb68}',
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -611.6, g: -19.73, b: -155.9, a: 61.61, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer8, 0, 26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 812, new Float32Array(3232), 1061, 352);
+} catch {}
+let renderBundle71 = renderBundleEncoder15.finish({label: '\u5ac4\ufeae\uec7b\uec15'});
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup4);
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u0130\ub339', bindGroupLayouts: [bindGroupLayout2, bindGroupLayout3, bindGroupLayout3]});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup0, new Uint32Array(5160), 1896, 0);
+} catch {}
+try {
+renderPassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer5, 'uint32', 448, 1_665);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup0, new Uint32Array(1213), 133, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder129 = device1.createCommandEncoder();
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({label: '\u6a49\u3828', colorFormats: ['r8sint'], depthReadOnly: true, stencilReadOnly: true});
+let bindGroupLayout12 = device1.createBindGroupLayout({
+  label: '\u{1fe1a}\u0907\u02a2\u0377\ud1cc\u0a12\u{1f9ce}\u0a49\u01fe\u3d58',
+  entries: [
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder130 = device1.createCommandEncoder({label: '\u{1f84c}\u0da5\ua767\u{1fb5b}\u0f54\u0e50\u{1fd07}\u3002\u{1fc0d}'});
+let commandBuffer73 = commandEncoder130.finish({label: '\u4694\u01be'});
+let renderBundle72 = renderBundleEncoder20.finish({label: '\ue41a\u0541\u0f85'});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup9, new Uint32Array(339), 24, 0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer16, 9_808, 2_435);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageData6);
+let textureView34 = texture32.createView({label: '\u0f4d\u7b0b\u0047\u0ba0\ufb72\u57c6\u9faa\ua482\u0af3\u04ab'});
+let renderBundle73 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(4.173708486260116, 1.383509557341112, 4.338654850791429, 2.322449504194918, 0.9608938831908557, 0.98925915525807);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer5, 'uint32', 1_316, 713);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.prepend(video0);
+try {
+window.someLabel = device1.label;
+} catch {}
+let commandEncoder131 = device1.createCommandEncoder({label: '\u951f\ub036\u{1fcf9}\u0261\u03ef\u0093\u00d8'});
+try {
+renderPassEncoder20.setIndexBuffer(buffer13, 'uint16', 2_798, 336);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer6, 0, 323);
+} catch {}
+try {
+commandEncoder131.copyBufferToBuffer(buffer6, 2844, buffer16, 6552, 6212);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer11, 'uint32', 1_972, 739);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(video0);
+let commandEncoder132 = device0.createCommandEncoder();
+let texture36 = gpuCanvasContext2.getCurrentTexture();
+let renderPassEncoder41 = commandEncoder132.beginRenderPass({
+  label: '\u4206\ua540\u1fd2\u18b9\u00b5\uaf7f\u079b\u250b\u660c',
+  colorAttachments: [{view: textureView3, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet5,
+});
+let externalTexture9 = device0.importExternalTexture({
+  label: '\u{1fbbb}\u3849\u0c7d\u69eb\u{1fa55}\u4bee\u{1f68c}\ue024\u{1fadd}',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder10.beginOcclusionQuery(1330);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer7, 0, 28);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer3, 2_056, 4_461);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer52, commandBuffer61]);
+} catch {}
+let commandBuffer74 = commandEncoder129.finish({label: '\u0be0\u9e33\u0087\u873b\u{1f82d}\u1a26\u09be\u0c00\uef28\ue3d8'});
+let renderBundle74 = renderBundleEncoder13.finish({label: '\u0b7d\u02f7\ud83a\u2800\u{1fd61}\u2579\uf13e'});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder11.dispatchWorkgroupsIndirect(buffer6, 7_600);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle34, renderBundle66, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer13, 'uint16', 1_150, 3_760);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 876, new DataView(new ArrayBuffer(6720)), 489, 912);
+} catch {}
+let buffer18 = device1.createBuffer({
+  label: '\u4d06\u3488',
+  size: 38854,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let commandEncoder133 = device1.createCommandEncoder({label: '\u{1ffe5}\u289b\u9235\u0813\uf5c9\u0954\ude9e\u{1fc60}\u8a16\u210c'});
+let commandBuffer75 = commandEncoder131.finish({label: '\u2fd9\u6b87\u5306\u{1fa6d}\udf13\ub04b\u8886\u{1fd45}\uf3e8\ua23e\u01f6'});
+let computePassEncoder36 = commandEncoder133.beginComputePass({label: '\u0e02\u9310\u0bd1\u5b61\uf087\ub45e\u0fda\u{1f7c9}'});
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer18, 'uint16', 3_880, 2_876);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4_294_967_294, undefined, 1_244_041_110, 863_808_540);
+} catch {}
+try {
+device1.queue.submit([commandBuffer72, commandBuffer63]);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout11, entries: []});
+let renderBundle75 = renderBundleEncoder0.finish({label: '\u0066\u{1f6c9}\u0abb\u77c5\ube44\u0bef'});
+let promise10 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u0a90\uf7ee\u0c29',
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let sampler11 = device0.createSampler({
+  label: '\ucd70\u7633\u0353',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.70,
+  lodMaxClamp: 76.59,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder36.setScissorRect(2, 0, 0, 0);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img3);
+canvas4.height = 237;
+let bindGroup11 = device1.createBindGroup({
+  label: '\u0c31\ubdb8\u2305\u0429\u0f6b\u00fd',
+  layout: bindGroupLayout1,
+  entries: [{binding: 159, resource: sampler8}],
+});
+let pipelineLayout19 = device1.createPipelineLayout({
+  label: '\u2ba8\u78b2\u0a82\u{1f6bb}\u{1fbb6}\u192b',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout9],
+});
+let buffer19 = device1.createBuffer({size: 40015, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+try {
+renderBundleEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+  await promise10;
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer18, 'uint32', 1_100, 1_579);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer6, 1_328, 156);
+} catch {}
+try {
+computePassEncoder27.insertDebugMarker('\u9a88');
+} catch {}
+let buffer20 = device0.createBuffer({
+  label: '\u2deb\u{1f92f}\u0778\ue137\u97e7\u80c8',
+  size: 5242,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle76 = renderBundleEncoder17.finish({label: '\u03e4\u5fb7\u04be\uddd2\u{1f989}\u7c97\u0111\ud573\u73e9\u599b'});
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer11);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer5, 'uint16', 964, 705);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer4);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder134 = device1.createCommandEncoder({label: '\ub18f\u{1ff7d}\u785c\u6c42\uc10f\u{1f96e}\u35ba\u8548\u0455\u9ed6\u0cdf'});
+let commandBuffer76 = commandEncoder134.finish({label: '\u{1ffdb}\ueff1\u3692\u076f\u{1f864}\ub1eb'});
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer6, 0, 388);
+} catch {}
+try {
+window.someLabel = renderPassEncoder2.label;
+} catch {}
+try {
+computePassEncoder29.setBindGroup(3, bindGroup10, new Uint32Array(918), 3, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer2, 'uint16', 12, 112);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer1, 100);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer8, 0, 79);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\uec38');
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandEncoder135 = device0.createCommandEncoder({label: '\ufdae\u3282\u0dee\u5233\ue40f\u0b47\u8143\uc54e'});
+let renderPassEncoder42 = commandEncoder135.beginRenderPass({
+  label: '\u{1fd16}\ub445\ufdba\u04bf',
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 60,
+  clearValue: { r: -495.1, g: 78.29, b: -951.7, a: 56.77, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer3, 'uint16', 1_130, 19);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 2732, new Float32Array(13354), 994, 216);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 15, depthOrArrayLayers: 95}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 84, y: 15 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 52},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer17, 0, 322);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer17, 0, 2_968);
+} catch {}
+let device2 = await adapter3.requestDevice({
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxVertexBufferArrayStride: 2048,
+    maxUniformBufferBindingSize: 2468712,
+    maxStorageBufferBindingSize: 160011343,
+    maxUniformBuffersPerShaderStage: 12,
+    maxInterStageShaderVariables: 16,
+    maxInterStageShaderComponents: 64,
+  },
+});
+try {
+  await promise11;
+} catch {}
+let externalTexture10 = device2.importExternalTexture({label: '\u0d79\u7cf0\u{1f904}\u2adf', source: videoFrame0});
+let commandEncoder136 = device2.createCommandEncoder({label: '\u79ba\u5b19\uf58b\u000d'});
+let commandBuffer77 = commandEncoder136.finish({});
+let commandEncoder137 = device2.createCommandEncoder();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+commandBuffer2.label = '\u724d\u36d8\ua8a8\u5111\u{1fdb3}\u9db4\u9b47';
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({label: '\u0cdb\ub0e5\u413f\u057e\u2420\u5861\u0998\u073a\u1b9d\u543c'});
+let commandBuffer78 = commandEncoder138.finish({label: '\u0159\u0194\u0bfd\u0ee7\u{1f972}\u5056\u0f70'});
+let texture37 = device0.createTexture({
+  label: '\u0ad1\u{1f825}\u685a',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle39, renderBundle28]);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer3, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer7, 752, 100);
+} catch {}
+try {
+computePassEncoder31.insertDebugMarker('\u2ae0');
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint32', 20, 442);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.WRITE, 2880, 2584);
+} catch {}
+let renderBundle77 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer20, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer4, 508, 1_429);
+} catch {}
+await gc();
+let commandEncoder139 = device1.createCommandEncoder();
+let commandBuffer79 = commandEncoder139.finish({label: '\udd50\u274b\u13f8\u{1fbc6}\u1a29'});
+let texture38 = device1.createTexture({
+  size: [44],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup5, new Uint32Array(2380), 19, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle14, renderBundle25, renderBundle53, renderBundle38, renderBundle24, renderBundle41, renderBundle59]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer13, 'uint16', 1_666, 3_111);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer17);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(3, buffer16, 2_084, 4_722);
+} catch {}
+let bindGroup12 = device0.createBindGroup({label: '\u021a\ub140', layout: bindGroupLayout5, entries: []});
+let buffer21 = device0.createBuffer({
+  label: '\u{1f651}\uffed\u{1f8ad}\udf93\u050a\u8ad9\u91a6',
+  size: 3573,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+});
+let externalTexture11 = device0.importExternalTexture({
+  label: '\ub0a5\u0098\u{1ff54}\u0329\ufa11\u0de9\u079e\u0a78\u052f',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder34.executeBundles([renderBundle22, renderBundle16, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer5, 'uint16', 3_738, 607);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+document.body.prepend(canvas6);
+let imageData8 = new ImageData(60, 60);
+let renderBundle78 = renderBundleEncoder12.finish();
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+device1.queue.submit([commandBuffer75]);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer16, 0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+commandEncoder57.insertDebugMarker('\u0918');
+} catch {}
+let pipeline10 = await device1.createRenderPipelineAsync({
+  label: '\u93ea\u{1fc54}\u{1fb0d}\u2f52\u01a0\u06f9\u3970\u434b\u7530\u48ce\u0022',
+  layout: pipelineLayout6,
+  multisample: {mask: 0x172d8b0b},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 886666936,
+    stencilWriteMask: 2151835535,
+    depthBias: -1018601813,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {arrayStride: 272, stepMode: 'instance', attributes: []},
+      {arrayStride: 220, stepMode: 'instance', attributes: []},
+      {arrayStride: 164, attributes: []},
+      {arrayStride: 76, stepMode: 'instance', attributes: []},
+      {arrayStride: 16, stepMode: 'instance', attributes: []},
+      {arrayStride: 376, stepMode: 'vertex', attributes: []},
+      {arrayStride: 792, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 64,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 28, shaderLocation: 2},
+          {format: 'sint16x2', offset: 8, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+offscreenCanvas2.height = 974;
+try {
+device0.label = '\u7cb2\u9a7f\ud098\uc4b3\u0d7e\ub1aa\u{1f97f}\ue17e\u0342\u0c25\u032c';
+} catch {}
+try {
+window.someLabel = commandBuffer21.label;
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  label: '\u0238\u0afe\u04be\u{1f900}\u{1f60d}\ua8f2\u0a1e\uc3c3\ua8f2\ua0c6\u{1fde2}',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup2, new Uint32Array(4038), 663, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer8);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer4, 2_180, 318);
+} catch {}
+let texture39 = gpuCanvasContext7.getCurrentTexture();
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle23, renderBundle70, renderBundle49]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(7, buffer8, 556);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 756, 1_148);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u{1f87f}');
+} catch {}
+try {
+window.someLabel = commandEncoder137.label;
+} catch {}
+let commandBuffer80 = commandEncoder137.finish({label: '\u0076\u7a53\u8732\u{1f876}\u039d'});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageBitmap5 = await createImageBitmap(canvas7);
+let commandEncoder140 = device0.createCommandEncoder();
+let renderPassEncoder43 = commandEncoder140.beginRenderPass({
+  label: '\u0aa2\u52fe\uaa2c\u6a59\u9e1a\u969b\u2056\u0ee5',
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 30,
+  clearValue: { r: 373.5, g: 308.1, b: -11.31, a: 368.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+});
+let renderBundle79 = renderBundleEncoder11.finish({label: '\u03bf\u4c34\u{1f81a}\uc858'});
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup12, new Uint32Array(9044), 870, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer11, 'uint32', 32, 115);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame2 = new VideoFrame(canvas1, {timestamp: 0});
+let commandBuffer81 = commandEncoder57.finish({label: '\u87b6\u{1f870}\uf7ec\u0b79\ubaa4\u{1f9ec}\u32ac'});
+let renderBundleEncoder23 = device1.createRenderBundleEncoder({label: '\u62e8\u45c6', colorFormats: ['r8sint'], stencilReadOnly: false});
+try {
+renderPassEncoder14.beginOcclusionQuery(182);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+video0.width = 71;
+let commandEncoder141 = device2.createCommandEncoder({});
+let sampler12 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 51.93,
+});
+try {
+window.someLabel = commandEncoder137.label;
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer80, commandBuffer77]);
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder();
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer5, 'uint16', 740, 298);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer8, 0, 38);
+} catch {}
+try {
+commandEncoder142.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 21},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 8, new Float32Array(12786), 1228, 308);
+} catch {}
+try {
+adapter1.label = '\u{1faca}\u4b52\u3b2c\u09ae\u{1fdc0}\u1de2\u0845\u12a9\ud98e\u3a91\u351d';
+} catch {}
+let textureView35 = texture20.createView({
+  label: '\u433e\uda27\u4d8c\u3dee\u{1f9e5}',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 5,
+});
+try {
+computePassEncoder30.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5, new Uint32Array(1470), 158, 0);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u{1fda2}\u005e',
+  entries: [
+    {
+      binding: 20,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 28, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+  ],
+});
+let renderPassEncoder44 = commandEncoder142.beginRenderPass({
+  label: '\u{1f836}\uba04',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -448.9, g: -468.6, b: 777.8, a: 102.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 451051034,
+});
+let renderBundle80 = renderBundleEncoder3.finish({});
+try {
+device0.queue.submit([commandBuffer50, commandBuffer71]);
+} catch {}
+let commandBuffer82 = commandEncoder141.finish({label: '\u0e17\u02c7\u{1fc0a}\u{1fa1f}\u1617\u952b\ue1b7'});
+let promise12 = device2.queue.onSubmittedWorkDone();
+try {
+externalTexture4.label = '\u{1fa93}\u03aa\u0d83\ubb81\u9fb2\u{1fbac}\u{1f944}\u201c\u26e3\u96f2';
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer18, 'uint16', 12_856, 1_584);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 184);
+} catch {}
+try {
+device1.queue.submit([commandBuffer79]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 46, y: 2, z: 71},
+  aspect: 'all',
+}, new ArrayBuffer(9_196), /* required buffer size: 9_196 */
+{offset: 290, bytesPerRow: 150, rowsPerImage: 2}, {width: 14, height: 2, depthOrArrayLayers: 30});
+} catch {}
+let buffer22 = device0.createBuffer({
+  label: '\u{1fe16}\ua16d\u0d15\uebc5\ud6ac\u859b\u422b\u34d2\u0414\uce10\u0933',
+  size: 26360,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder143 = device0.createCommandEncoder({label: '\u0681\uadee\u{1f882}\u{1fd4b}\u0e0f\u0a83\u34d8\u{1f9ea}\u2575\u027e'});
+let texture40 = device0.createTexture({
+  size: {width: 80, height: 40, depthOrArrayLayers: 706},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder45 = commandEncoder143.beginRenderPass({
+  label: '\u{1fd4c}\u{1f68a}\u02e9\u3108',
+  colorAttachments: [{view: textureView29, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 344827961,
+});
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup10, new Uint32Array(1202), 125, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup14 = device0.createBindGroup({label: '\u{1fe8a}\u0670\u0c98\u2773\u{1f97b}\u0053\u{1f9a9}', layout: bindGroupLayout3, entries: []});
+let commandEncoder144 = device0.createCommandEncoder();
+let querySet15 = device0.createQuerySet({
+  label: '\u326f\u5718\u2f28\uea6a\u2e0f\ud511\udab3\u75cc\ufcda\u8a1e\u0c6a',
+  type: 'occlusion',
+  count: 1171,
+});
+let texture41 = device0.createTexture({
+  size: {width: 80},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder46 = commandEncoder144.beginRenderPass({
+  label: '\u{1f789}\uaaab\u34c3\u4065',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 518.1, g: -223.5, b: -279.4, a: 892.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder11.executeBundles([renderBundle49]);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer2, 'uint32', 200, 28);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\u07f6');
+} catch {}
+let imageData9 = new ImageData(32, 20);
+let imageData10 = new ImageData(40, 80);
+let commandEncoder145 = device1.createCommandEncoder();
+let computePassEncoder37 = commandEncoder145.beginComputePass({label: '\u17fc\u0afa\ue3dc\u35ab'});
+let externalTexture12 = device1.importExternalTexture({label: '\u2401\ubd97\u5162\u3e12\u04a1\u7611\u2714\uf5f2\uc432\u8b3d\u091e', source: video1});
+try {
+computePassEncoder11.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer13, 'uint16', 50, 1_364);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(2, buffer17, 192, 1_945);
+} catch {}
+let renderBundleEncoder24 = device2.createRenderBundleEncoder({label: '\u044a\u04c2\ud8ba\ua200', colorFormats: ['bgra8unorm'], sampleCount: 4, stencilReadOnly: true});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup8);
+} catch {}
+let pipeline11 = await device1.createComputePipelineAsync({
+  label: '\u01fd\u0791\ue7ea',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule3, constants: {}},
+});
+let commandEncoder146 = device1.createCommandEncoder({});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup5);
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder();
+let querySet16 = device0.createQuerySet({
+  label: '\u0bf7\uca8f\u0582\ub513\ucf5b\u{1f9cd}\u558c\u05c3\uce01\u0ef9',
+  type: 'occlusion',
+  count: 21,
+});
+let renderPassEncoder47 = commandEncoder147.beginRenderPass({
+  label: '\u{1fb66}\u7afb\u{1faec}',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -271.7, g: -179.1, b: -920.5, a: -740.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 32885450,
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup10, new Uint32Array(5921), 1706, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 3_420, 332);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer11, 0, 2_199);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16', 1_014, 288);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 40, depthOrArrayLayers: 706}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 18, y: 5 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 281},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let commandEncoder148 = device1.createCommandEncoder({label: '\u3082\u0132\ua64a\u0d5f\u{1f97e}\u09b3\u{1fdf6}\u0254'});
+try {
+renderPassEncoder29.setIndexBuffer(buffer13, 'uint32', 160, 287);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer13, 'uint16', 208, 2_554);
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 43, y: 13, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 326, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder({label: '\u{1f702}\u0d1f\u9393\u88a1\u5de5\u{1f86c}\uba83\ue2d6\u{1ff25}\u3bc0\u0251'});
+let commandBuffer83 = commandEncoder149.finish();
+let textureView36 = texture37.createView({label: '\uabf6\u9ccf\u418a\u{1fa82}\u2d22\ube32\ue7a9\u7c38'});
+let renderBundle81 = renderBundleEncoder17.finish({label: '\u{1f8a8}\u051c\u{1f9a3}\u{1f918}'});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderPassEncoder8.setIndexBuffer(buffer22, 'uint16', 1_262, 4_840);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(5, buffer20, 1_184, 1_761);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder150 = device2.createCommandEncoder({label: '\u2056\u0344'});
+let commandBuffer84 = commandEncoder150.finish({label: '\ua835\u0ae4\u0f3a\u0dec\uc85c\ue3e5\u{1fd60}\u0456\u6a91\uac60\u5059'});
+let imageData11 = new ImageData(20, 8);
+let bindGroupLayout15 = device2.createBindGroupLayout({
+  label: '\u0bb2\u06f0\u68a2\u08be\u{1f75d}\u{1fbd9}\u{1f963}\u{1f890}\u7652\u0ef4\u8810',
+  entries: [
+    {
+      binding: 507,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout20 = device2.createPipelineLayout({label: '\uc039\uc338\u{1fce4}\uca13', bindGroupLayouts: [bindGroupLayout15]});
+let commandEncoder151 = device0.createCommandEncoder({label: '\u396f\u20a6'});
+let renderPassEncoder48 = commandEncoder151.beginRenderPass({
+  label: '\ua79b\udfd6',
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 20,
+  clearValue: { r: -831.9, g: 737.0, b: 219.0, a: -272.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 434508370,
+});
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer3, 0);
+} catch {}
+let shaderModule5 = device2.createShaderModule({
+  label: '\ub6c6\u{1f847}\u0cb3\u0fdb\u06ed\u052a\uff30',
+  code: `@group(0) @binding(507) var<storage, read_write> buffer23: u32;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+buffer23 += bitcast<u32>(r.x);
+}
+
+
+
+@fragment
+fn fragment0() -> @location(200) vec4<f32> {
+var r: vec4f;
+buffer23 += bitcast<u32>(r.x);
+return vec4<f32>();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(11) a1: u32) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let commandEncoder152 = device2.createCommandEncoder({label: '\u{1fa55}\ubcb6\u956d\u0762'});
+let commandBuffer85 = commandEncoder152.finish({label: '\ua86a\u03b2\u{1f6d6}\ue2ad\u{1ffc0}'});
+try {
+renderBundleEncoder24.setVertexBuffer(4, undefined, 0);
+} catch {}
+let commandEncoder153 = device1.createCommandEncoder({});
+let commandBuffer86 = commandEncoder153.finish({label: '\u96af\u1e11\u94f3'});
+let textureView37 = texture9.createView({label: '\uf327\u5cef\u{1fa17}\u0620\ued88\ud8d4\u79f4\u05c8\u4cac', baseMipLevel: 0});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup6, new Uint32Array(132), 18, 0);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer18, 'uint16', 5_722, 7_885);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder148.resolveQuerySet(querySet6, 2, 2, buffer12, 2560);
+} catch {}
+let promise13 = device1.createRenderPipelineAsync({
+  label: '\u22cc\u0559',
+  layout: pipelineLayout11,
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgb10a2uint'}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 690047636,
+    stencilWriteMask: 2937117614,
+    depthBias: -1049552909,
+    depthBiasSlopeScale: 275.5950222274388,
+    depthBiasClamp: -30.65190739677378,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 52, attributes: []},
+      {arrayStride: 268, attributes: []},
+      {arrayStride: 236, stepMode: 'vertex', attributes: []},
+      {arrayStride: 388, attributes: []},
+      {arrayStride: 776, stepMode: 'instance', attributes: []},
+      {arrayStride: 440, stepMode: 'instance', attributes: []},
+      {arrayStride: 224, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 48, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let renderBundle82 = renderBundleEncoder9.finish({label: '\u089a\u0045\u0128\uf811\u054a\u{1fca5}\u{1ff5f}\u5b62\u0e23\u09a6'});
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup0, new Uint32Array(1449), 813, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer22, 'uint32', 756, 574);
+} catch {}
+let commandBuffer87 = commandEncoder146.finish();
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle19]);
+} catch {}
+try {
+commandEncoder148.clearBuffer(buffer15, 5964, 5084);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 452, new Int16Array(10786), 3290);
+} catch {}
+let commandEncoder154 = device2.createCommandEncoder({label: '\u2286\u{1f6c2}\u0a59\u037d\ude28\u0544\u08e2\u0877\u201f\uc851'});
+let renderBundle83 = renderBundleEncoder24.finish();
+let commandEncoder155 = device2.createCommandEncoder({label: '\uc03f\u085c\u047e\u9a3d\u0c69\u{1f9e7}\uc97f\u0b0f\u0ab0'});
+let sampler13 = device2.createSampler({
+  label: '\u4d1a\ude55\uf104\u0c78\u8a0f\u073a\ub125\ue81b',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.11,
+  lodMaxClamp: 99.66,
+  maxAnisotropy: 1,
+});
+let commandEncoder156 = device2.createCommandEncoder();
+let commandBuffer88 = commandEncoder155.finish({});
+let computePassEncoder38 = commandEncoder156.beginComputePass();
+let renderBundle84 = renderBundleEncoder24.finish({label: '\u{1f9e1}\u40da\u0daf\ueb43\u0d8e\u{1fdcc}'});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+let pipeline12 = await device2.createRenderPipelineAsync({
+  label: '\u02c2\ub068\u09a9',
+  layout: pipelineLayout20,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {arrayStride: 676, stepMode: 'instance', attributes: []},
+      {arrayStride: 16, stepMode: 'instance', attributes: []},
+      {arrayStride: 360, stepMode: 'instance', attributes: []},
+      {arrayStride: 348, attributes: []},
+      {arrayStride: 908, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 204, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 292,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 92, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: false},
+});
+let commandEncoder157 = device2.createCommandEncoder({});
+let sampler14 = device2.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 34.59,
+  lodMaxClamp: 42.22,
+});
+let computePassEncoder39 = commandEncoder148.beginComputePass();
+try {
+computePassEncoder28.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 76, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let querySet17 = device0.createQuerySet({label: '\u338c\u1703\u343f\u5e92\u1ada\u2a47', type: 'occlusion', count: 440});
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.WRITE, 3048, 712);
+} catch {}
+try {
+device0.queue.submit([commandBuffer36]);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder158 = device0.createCommandEncoder({label: '\u585e\ue018\ub9c2'});
+let commandBuffer89 = commandEncoder158.finish({label: '\ufc25\u1407\u00ef'});
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer1, 388);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer2, 'uint16', 28, 31);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer7, 340, 463);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+video1.height = 11;
+try {
+adapter0.label = '\u6708\u0acd\u{1faf2}\uf139\u{1f91b}\u2e65\u{1f646}\u3e59\u035d\u030e\u0a94';
+} catch {}
+let renderBundle85 = renderBundleEncoder0.finish({label: '\u0b9c\u1b52\u{1f665}\ucc80\u0fb5\u07a0\u91d9\u{1f7d8}'});
+try {
+renderPassEncoder36.executeBundles([renderBundle36]);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer22, 'uint16', 10_124, 215);
+} catch {}
+try {
+device0.queue.submit([commandBuffer83]);
+} catch {}
+let commandEncoder159 = device2.createCommandEncoder({label: '\u008e\u04df\ua564\ua44b\u9341\u8566\u{1f720}\u05af\u8dfd\u334d\u039d'});
+canvas0.height = 356;
+let canvas8 = document.createElement('canvas');
+let commandEncoder160 = device1.createCommandEncoder({label: '\u6cda\uaa86\u73c0\u0f2f\u06c5\ua02c'});
+let commandBuffer90 = commandEncoder160.finish({label: '\uc578\u5452\u7df0'});
+try {
+computePassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer18, 'uint32', 1_936, 7_969);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer13, 'uint32', 1_764, 2_012);
+} catch {}
+try {
+device1.queue.submit([commandBuffer55, commandBuffer65]);
+} catch {}
+let gpuCanvasContext11 = canvas8.getContext('webgpu');
+let commandEncoder161 = device0.createCommandEncoder({});
+let commandBuffer91 = commandEncoder161.finish({label: '\u6eec\ua69f\u{1fdc8}\u734c\u{1fe8d}\u37cd\u2eaf\u0ac2\ud51c'});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup13, new Uint32Array(2718), 504, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup4, new Uint32Array(723), 22, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 109, y: 5 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout21 = device1.createPipelineLayout({
+  label: '\u2986\u980c\u{1fe13}\u00f4\u214d\u090e\u{1f753}\udf2e',
+  bindGroupLayouts: [bindGroupLayout12],
+});
+let textureView38 = texture27.createView({label: '\uf5e9\u17dc\u0553\u1abf', aspect: 'all', baseMipLevel: 1, baseArrayLayer: 10});
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup7, new Uint32Array(632), 212, 0);
+} catch {}
+let commandEncoder162 = device0.createCommandEncoder();
+let renderPassEncoder49 = commandEncoder162.beginRenderPass({
+  label: '\u3077\u5261\ucfa4\u0929\u{1f8c9}\u10ae\uc3ee\u0f95',
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: -648.5, g: -43.33, b: -513.9, a: 25.41, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle86 = renderBundleEncoder11.finish({label: '\ud340\ue3e8\ua912\u{1f809}\u{1fee4}'});
+try {
+renderPassEncoder48.setVertexBuffer(3, buffer11, 132, 1_285);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer22, 'uint16', 4_700, 9_849);
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder({});
+let commandBuffer92 = commandEncoder163.finish({label: '\u{1f7bd}\u2b6b\u9a08\ue50f'});
+let texture42 = device0.createTexture({
+  label: '\u6c27\u3074\ue63e\ucfb3\u3c0c\u{1fea7}\u6dc6\u81cf',
+  size: [1, 120, 3],
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle87 = renderBundleEncoder1.finish();
+let commandEncoder164 = device1.createCommandEncoder({label: '\ub901\u3a9b'});
+let commandBuffer93 = commandEncoder164.finish({});
+let renderBundle88 = renderBundleEncoder6.finish();
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer16);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(1, buffer16, 1_700, 4_414);
+} catch {}
+let video2 = await videoWithData();
+let bindGroup15 = device1.createBindGroup({
+  label: '\u32a0\u19b7\ufaeb\u0a72\u09a7\uebc0\u8859\u{1f798}\u019c\u1e0c',
+  layout: bindGroupLayout7,
+  entries: [],
+});
+let textureView39 = texture11.createView({dimension: '1d'});
+try {
+renderPassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup8);
+} catch {}
+let commandEncoder165 = device0.createCommandEncoder({label: '\ud70f\u86e1\u034a\u52d7\u0c94'});
+let commandBuffer94 = commandEncoder165.finish({label: '\ue777\u{1fd93}\ueef5\u39c9\u{1ff44}\u{1ff42}\u90ac\ubf16\uae67'});
+try {
+renderBundleEncoder18.setIndexBuffer(buffer2, 'uint32', 172, 54);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView40 = texture19.createView({label: '\ueba0\ufe7e\uabdd\u6d50\ufa59\u3b4e\u07a2\u3d6c\u{1f718}'});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup1, new Uint32Array(2358), 891, 0);
+} catch {}
+try {
+renderPassEncoder48.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 948, 1_267);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer7, 0, 123);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer8, 388, 555);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 11},
+  aspect: 'all',
+}, new ArrayBuffer(454_766), /* required buffer size: 454_766 */
+{offset: 46, bytesPerRow: 232, rowsPerImage: 245}, {width: 0, height: 1, depthOrArrayLayers: 9});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 7, y: 11 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder47.setViewport(2.9800975511101035, 3.32941388957337, 4.437046331899411, 1.5904036002008726, 0.772858948517813, 0.8089391226395674);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer20);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer11, 'uint32', 108, 7_766);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer40, commandBuffer53]);
+} catch {}
+let imageData12 = new ImageData(8, 40);
+let textureView41 = texture14.createView({baseMipLevel: 1});
+let renderBundle89 = renderBundleEncoder15.finish({label: '\u2df8\u0b79\u9813'});
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer7, 52, 176);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer5, 'uint32', 4_064, 267);
+} catch {}
+let arrayBuffer7 = buffer9.getMappedRange(3048, 64);
+let texture43 = gpuCanvasContext8.getCurrentTexture();
+try {
+computePassEncoder31.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderBundle7.label = '\u0cf4\u{1fb86}\u{1fed8}\u430d\u00e0\uef0d\u762b\u{1feb3}\u56b3\u8971';
+} catch {}
+let bindGroup16 = device0.createBindGroup({label: '\u23ec\u05fb', layout: bindGroupLayout5, entries: []});
+let renderBundle90 = renderBundleEncoder2.finish({label: '\u4ccb\u2949\u{1f84f}'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup13, new Uint32Array(219), 11, 0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer1, 116, 132);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let texture44 = device0.createTexture({
+  label: '\uc8bb\uc284\u{1fcff}\u7343\u0c16\ucaf4',
+  size: {width: 1, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup12, new Uint32Array(1815), 185, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer22, 'uint32', 4_296, 255);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer20, 592);
+} catch {}
+document.body.prepend(img3);
+let commandEncoder166 = device0.createCommandEncoder({label: '\u24fe\u50c3\uf56a\u{1f756}\u5da1\u0b29\u{1f976}\u735f\u{1f7ad}\uc002\ub36d'});
+let computePassEncoder40 = commandEncoder166.beginComputePass({label: '\uf022\udb35\u3151\uecf2\u{1fca4}\u{1f616}\u07ca\u{1f6cc}\u08a5'});
+try {
+renderPassEncoder21.setViewport(6.285180986710559, 4.260916370571506, 3.040140319553641, 0.19872308673807712, 0.03909651993699881, 0.3503766909056457);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 212, new BigUint64Array(11520), 1803, 16);
+} catch {}
+let commandEncoder167 = device2.createCommandEncoder({});
+await gc();
+let commandBuffer95 = commandEncoder157.finish({label: '\u9aa7\u993d\u{1f90c}\u0e2f\ube63\u0efb\u0bad\u{1f693}'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline13 = await device2.createComputePipelineAsync({
+  label: '\u{1fe89}\u{1fabe}\u{1f721}\u055a\u1959\u62ac\u{1ff8b}',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule5, constants: {}},
+});
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer18, 'uint32', 7_736, 2_534);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(5, buffer6);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device1, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+try {
+device1.queue.submit([commandBuffer74]);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let commandBuffer96 = commandEncoder154.finish({label: '\u19eb\u8de9'});
+let renderBundle91 = renderBundleEncoder24.finish({label: '\u0856\u29ee\u09cb\u9d23'});
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise15 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise15;
+} catch {}
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer6, 4_620);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup11, new Uint32Array(2698), 404, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer6, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer18, 'uint16', 3_576, 12_390);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4_294_967_295, undefined, 188_836_787, 147_260_420);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer7, 0, 90);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup12);
+} catch {}
+await gc();
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(4, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder44.setViewport(4.871324302474554, 1.6793468183620064, 4.983433093706287, 1.260938836479231, 0.20423203009023783, 0.44181854143937604);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+document.body.prepend(video0);
+let renderBundle92 = renderBundleEncoder22.finish({label: '\u81a5\u{1fe77}\ue754\ua40d\u02a4\u00b2\u{1fadb}\u1e98\u6622\u096d'});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup15, []);
+} catch {}
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 1692, new Float32Array(12282), 96, 620);
+} catch {}
+let promise16 = device1.queue.onSubmittedWorkDone();
+let commandEncoder168 = device0.createCommandEncoder({label: '\uc486\ud9e2\ud1a0\uf783\uebee\u39b8\ue115\u0f24'});
+let renderBundle93 = renderBundleEncoder3.finish({});
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup12, new Uint32Array(7), 0, 0);
+} catch {}
+try {
+commandEncoder168.resolveQuerySet(querySet7, 14, 13, buffer22, 768);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder({label: '\ubf57\u{1fa4c}'});
+let renderBundle94 = renderBundleEncoder18.finish({label: '\ucedb\u0da4\u7339\u124c\u0071\uc621'});
+try {
+renderPassEncoder49.executeBundles([renderBundle87]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(40_325), /* required buffer size: 40_325 */
+{offset: 213, bytesPerRow: 184, rowsPerImage: 55}, {width: 0, height: 54, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder170 = device2.createCommandEncoder({label: '\u{1fdcc}\ub49b\u03b6\u2c25\u0ce2'});
+let commandBuffer97 = commandEncoder167.finish({});
+let computePassEncoder41 = commandEncoder156.beginComputePass();
+try {
+computePassEncoder41.setPipeline(pipeline13);
+} catch {}
+let commandEncoder171 = device0.createCommandEncoder({label: '\u0004\u35de\u020e'});
+let commandBuffer98 = commandEncoder171.finish({label: '\u8311\u725c\u0ceb\u0f1b\u{1fcb1}\u5479\u7f05\ucdf9\u72ba\u{1fc92}'});
+let renderPassEncoder50 = commandEncoder168.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  clearValue: { r: 630.0, g: -331.2, b: 813.2, a: -46.15, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle95 = renderBundleEncoder3.finish({label: '\ub7e6\u011d\uc66c\u79af\u0f1f\u{1f959}\u9827\u8fe5\u097f'});
+try {
+renderPassEncoder41.beginOcclusionQuery(41);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+commandEncoder169.copyBufferToBuffer(buffer5, 36, buffer4, 1816, 1076);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise16;
+} catch {}
+let commandEncoder172 = device2.createCommandEncoder({});
+let texture45 = device2.createTexture({size: {width: 1}, dimension: '1d', format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+let commandEncoder173 = device2.createCommandEncoder();
+let computePassEncoder42 = commandEncoder159.beginComputePass();
+let renderBundle96 = renderBundleEncoder24.finish();
+document.body.prepend(canvas7);
+video2.width = 19;
+let commandEncoder174 = device1.createCommandEncoder({label: '\ue608\u576c\ua77b\uc2ce'});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+computePassEncoder11.dispatchWorkgroups(2, 2, 1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle67]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer13, 'uint16', 4_726, 389);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4_294_967_295, undefined, 0, 590_129_839);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+commandEncoder133.resolveQuerySet(querySet12, 124, 88, buffer17, 1792);
+} catch {}
+await gc();
+let commandBuffer99 = commandEncoder169.finish({label: '\u{1fe71}\ub3e2\u0463\u0ece'});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(83);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer22, 'uint32', 2_440, 6_733);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 191}
+*/
+{
+  source: imageData11,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder175 = device1.createCommandEncoder({label: '\ub03a\ud215\ubc16\ue9ef\u02a9\u7eff\u152e'});
+try {
+renderPassEncoder27.setIndexBuffer(buffer13, 'uint16', 64, 1_259);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer13, 'uint32', 328, 478);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer17, 0, 802);
+} catch {}
+try {
+device1.queue.submit([commandBuffer81]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer15, 4224, new Float32Array(8761), 3755, 1680);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder176 = device0.createCommandEncoder();
+let externalTexture14 = device0.importExternalTexture({label: '\u{1fa3b}\u019a\uc60c\u0b57', source: videoFrame2});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup1, new Uint32Array(2676), 131, 0);
+} catch {}
+try {
+computePassEncoder26.end();
+} catch {}
+let querySet18 = device1.createQuerySet({label: '\u8ec3\u{1fbfa}\u7ca9\u{1f82c}\ue8a9\ua184\u031d\u0328\u021e', type: 'occlusion', count: 1402});
+let textureView42 = texture10.createView({label: '\u{1fec5}\u996d\u19d3\u2c1d\u{1fcbe}\u96a3\u45ba'});
+let renderBundle97 = renderBundleEncoder7.finish({label: '\u6db2\u{1fff5}\u174f\u0e49'});
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer13, 'uint32', 2_664, 1_445);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint32', 820, 1_275);
+} catch {}
+let arrayBuffer8 = buffer17.getMappedRange(0, 3656);
+try {
+device1.queue.writeBuffer(buffer15, 384, new BigUint64Array(2700), 1736, 44);
+} catch {}
+let computePassEncoder43 = commandEncoder176.beginComputePass();
+let renderPassEncoder51 = commandEncoder102.beginRenderPass({
+  label: '\u9395\u2991\u758d\u0187',
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 63,
+  clearValue: { r: 373.2, g: -627.6, b: 705.9, a: 238.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder41.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle31, renderBundle82]);
+} catch {}
+let arrayBuffer9 = buffer8.getMappedRange(0, 1088);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let computePassEncoder44 = commandEncoder170.beginComputePass({label: '\u{1fd8d}\uf22f\u0a5f\u07d0\u04f5'});
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder();
+let commandBuffer100 = commandEncoder177.finish({label: '\u{1f863}\ub5db\u32af'});
+let renderBundle98 = renderBundleEncoder17.finish({label: '\u0175\u{1fcf3}\ue1c0\u{1fbb0}'});
+try {
+renderPassEncoder5.executeBundles([renderBundle79]);
+} catch {}
+document.body.prepend(img1);
+let bindGroupLayout17 = device2.createBindGroupLayout({
+  label: '\u0900\u8f36\u081c\u{1fd67}\uc251\u{1fcfb}\uda64\u{1f8d1}',
+  entries: [
+    {
+      binding: 215,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder178 = device2.createCommandEncoder({label: '\u{1f7c2}\ub639\u08a8\u9162'});
+try {
+  await promise17;
+} catch {}
+let commandEncoder179 = device2.createCommandEncoder({label: '\ua9ac\u8ffe\uf597\uead1\uf3a2'});
+try {
+computePassEncoder42.setPipeline(pipeline13);
+} catch {}
+try {
+device2.queue.submit([commandBuffer96]);
+} catch {}
+let commandEncoder180 = device1.createCommandEncoder();
+let renderPassEncoder52 = commandEncoder180.beginRenderPass({
+  label: '\u067b\u{1f75c}\u0bf6\u9476\u0295\u{1f835}\u{1fe44}',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -842.2, g: 108.4, b: -270.2, a: -300.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup11, new Uint32Array(255), 48, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer18, 'uint16', 13_172, 1_846);
+} catch {}
+try {
+commandEncoder175.resolveQuerySet(querySet12, 87, 44, buffer12, 512);
+} catch {}
+try {
+commandEncoder174.insertDebugMarker('\u708f');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 1148, new Float32Array(5734), 1172, 44);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout22 = device1.createPipelineLayout({
+  label: '\ue167\u0a89\u6402\ub818\u0cfe\u{1fdb1}',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout6, bindGroupLayout7, bindGroupLayout12],
+});
+let texture46 = device1.createTexture({
+  size: [270, 1, 199],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder45 = commandEncoder133.beginComputePass({label: '\u{1fb8f}\uaa5f\u0e67\u4330\u27a4\u1d57\u160a\u0956\u{1f749}\u0f98'});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup5, new Uint32Array(2531), 326, 0);
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer18, 'uint32', 2_600, 21_651);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(1, buffer16, 552);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let bindGroup17 = device1.createBindGroup({layout: bindGroupLayout7, entries: []});
+let commandBuffer101 = commandEncoder175.finish({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup8, new Uint32Array(3768), 1073, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle44, renderBundle29, renderBundle68, renderBundle63, renderBundle66]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer13, 'uint16', 1_724, 180);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer16, 6_956, 237);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer18, 'uint32', 28_816, 394);
+} catch {}
+try {
+device1.queue.submit([commandBuffer66]);
+} catch {}
+let promise18 = adapter3.requestAdapterInfo();
+let commandBuffer102 = commandEncoder174.finish();
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(6, buffer16, 376, 12);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder181 = device1.createCommandEncoder();
+let commandBuffer103 = commandEncoder181.finish({});
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder52.pushDebugGroup('\u7272');
+} catch {}
+try {
+window.someLabel = externalTexture11.label;
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle61]);
+} catch {}
+let arrayBuffer10 = buffer8.getMappedRange(1088, 172);
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+canvas2.width = 266;
+let video3 = await videoWithData();
+let pipelineLayout23 = device0.createPipelineLayout({
+  label: '\u0681\u2c69\u02b4\u{1f885}',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout10, bindGroupLayout4],
+});
+let texture47 = device0.createTexture({
+  label: '\u07c4\u{1f99f}\u27bd\u0856\uc5ff\u{1f6a7}\u07a5\u1aff\udb73',
+  size: {width: 40, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup10, new Uint32Array(1859), 751, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup13, []);
+} catch {}
+let commandBuffer104 = commandEncoder179.finish({label: '\u{1f85f}\u8efe\ube2d\u0861'});
+let renderBundle99 = renderBundleEncoder24.finish();
+let pipeline14 = device2.createComputePipeline({
+  label: '\u576a\u54fc\u087b\uff49\u{1ff76}\ubb98\u169e\u051a\u36ad\u6f10',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let textureView43 = texture23.createView({label: '\ueefb\u1a3b\u{1fbb9}\u4fc0\u4132\u{1f782}\u{1fa27}\u{1ffd0}\u0895\u8fc1'});
+let renderBundle100 = renderBundleEncoder26.finish({label: '\uee1d\u8662\ufbbe\ua04a\u{1ff12}\u4cf5'});
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup8, new Uint32Array(2557), 78, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer18, 'uint32', 4_860, 396);
+} catch {}
+try {
+device1.queue.submit([commandBuffer90]);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer3, 'uint16', 140, 1_658);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let textureView44 = texture28.createView({label: '\u031a\u{1f887}\uecd3\ub697\u9bcd', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle101 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(1826);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(6, buffer1, 0, 137);
+} catch {}
+try {
+device0.queue.submit([commandBuffer98, commandBuffer100]);
+} catch {}
+let bindGroupLayout18 = device1.createBindGroupLayout({
+  label: '\u1478\u562e\u1467\u{1fc40}\u{1fa4a}',
+  entries: [
+    {
+      binding: 105,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture48 = device1.createTexture({
+  label: '\u{1fd5a}\u5ca0\ubd83\u0156\u0787\u{1fc60}\u3185\uc055\u07ef',
+  size: {width: 270, height: 1, depthOrArrayLayers: 50},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle53]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer6, 0, 2_368);
+} catch {}
+try {
+renderPassEncoder52.popDebugGroup();
+} catch {}
+try {
+device1.queue.submit([commandBuffer102, commandBuffer103, commandBuffer87]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder182 = device1.createCommandEncoder({label: '\u62d5\ue580\u{1fc04}\u0191\u7d5b\u400f\u0168\ua8a4\u01b1\u04fd'});
+let commandBuffer105 = commandEncoder182.finish({label: '\u{1fa68}\u{1fa82}\u0c2f\u{1f6d6}\uf84e'});
+try {
+renderPassEncoder28.executeBundles([renderBundle38]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer13, 'uint32', 1_964, 779);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline15 = device1.createComputePipeline({layout: pipelineLayout13, compute: {module: shaderModule3, constants: {}}});
+await gc();
+let promise19 = navigator.gpu.requestAdapter({});
+let bindGroupLayout19 = device1.createBindGroupLayout({entries: [{binding: 166, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}]});
+let renderBundle102 = renderBundleEncoder12.finish({label: '\u2493\ub205\u7571\uabca\ufaaa'});
+try {
+computePassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer13, 'uint32', 952, 1_718);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(1, buffer17);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+  await promise18;
+} catch {}
+document.body.prepend(canvas4);
+let bindGroup18 = device1.createBindGroup({label: '\u91f1\u0d57\uc8ba\u{1fcab}\u4ab8', layout: bindGroupLayout9, entries: []});
+let textureView45 = texture13.createView({
+  label: '\u0508\u5403\u0a58\u{1fc00}\u0f20\u54ef\u1fe2\u003d\ueef5\u08a9\u{1fbc4}',
+  format: 'rgb10a2uint',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint32', 300, 184);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(4, buffer16);
+} catch {}
+let promise20 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise20;
+} catch {}
+let commandEncoder183 = device0.createCommandEncoder({label: '\u{1f93c}\u8b9c\u612f\u639e\u5977\u513b\ubc06'});
+document.body.prepend(img1);
+let commandEncoder184 = device0.createCommandEncoder({label: '\ua377\uce8d\u3789\u15c8\u98b6\uc109\u971c\u71a6\uaf8d\u0d0a\u8acf'});
+let commandBuffer106 = commandEncoder184.finish({label: '\uc1f7\u4ec8\u05e5\u9f53\u61eb\u8bc6\uf0ed\u5b9d\u0d9e\u0993'});
+try {
+renderPassEncoder43.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+commandEncoder183.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer107 = commandEncoder183.finish();
+let textureView46 = texture32.createView({label: '\u49ce\uf55e\ub521\u0874\ued65\u03e6\ua19b\u00f7\u{1fe2f}\u8ca6', baseMipLevel: 0});
+try {
+renderPassEncoder49.setViewport(6.784844725649441, 4.248548835226752, 1.1158825455190517, 0.43443489344484404, 0.03145443130427905, 0.876846437827621);
+} catch {}
+try {
+device0.queue.submit([commandBuffer89]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 191}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 160, y: 22 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder185 = device1.createCommandEncoder({label: '\u08d0\u{1fe96}\u{1f6bc}\u0459\u0389'});
+let texture49 = device1.createTexture({
+  label: '\u8d57\u0545\u{1fbca}\u{1fc5c}\u4ebd\u36e5\u8138\u0ce2\u5b7a\u52bb\uab9d',
+  size: {width: 360, height: 80, depthOrArrayLayers: 424},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder14.setScissorRect(33, 2, 101, 7);
+} catch {}
+try {
+commandEncoder185.copyBufferToBuffer(buffer19, 1920, buffer6, 2096, 1608);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 72, new Int16Array(10668), 420, 556);
+} catch {}
+let commandEncoder186 = device0.createCommandEncoder({label: '\ua8ed\ua4a9\u1b2d\u6fc1\u{1f795}\u0d35\u0fd2\uac9d\ua148'});
+let commandBuffer108 = commandEncoder186.finish({label: '\u8725\ua76d\u{1fad2}\uec07\u{1fb03}\u6a1a'});
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer7, 1_488);
+} catch {}
+await gc();
+try {
+window.someLabel = device2.label;
+} catch {}
+let querySet19 = device2.createQuerySet({label: '\u{1fe32}\u0043\ua119\u0f22', type: 'occlusion', count: 415});
+let textureView47 = texture45.createView({label: '\u{1f86c}\u0dce\u298d\u17aa'});
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline14);
+} catch {}
+let commandEncoder187 = device1.createCommandEncoder({});
+let commandBuffer109 = commandEncoder185.finish({});
+let renderPassEncoder53 = commandEncoder187.beginRenderPass({
+  label: '\u0007\uc744\ud08d\u{1f6c1}\u0b26\u{1f659}',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 88.52, g: 574.2, b: 335.2, a: -863.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle103 = renderBundleEncoder14.finish({label: '\u2936\ua2e9\u0f0d'});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle78]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(515);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer16, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 13580, new Float32Array(18108), 7788, 20);
+} catch {}
+try {
+window.someLabel = commandBuffer4.label;
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup13, new Uint32Array(1216), 30, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer22, 'uint16', 2_064, 1_130);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData13 = new ImageData(124, 4);
+let texture50 = device2.createTexture({
+  size: {width: 1, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 10, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(45), /* required buffer size: 45 */
+{offset: 45, bytesPerRow: 196}, {width: 0, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup3, new Uint32Array(3237), 1293, 0);
+} catch {}
+offscreenCanvas2.height = 6;
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder41.setViewport(1.4666700752818695, 3.9935166743915835, 3.9398506328218987, 0.936258349939201, 0.4212595411132769, 0.45774999680050343);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(2, buffer7);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout13, bindGroupLayout2]});
+let commandEncoder188 = device0.createCommandEncoder();
+let renderPassEncoder54 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 24,
+  clearValue: { r: -233.9, g: 650.3, b: 462.0, a: 599.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 128366547,
+});
+try {
+renderPassEncoder38.end();
+} catch {}
+let arrayBuffer11 = buffer8.getMappedRange(1264, 156);
+let renderBundle104 = renderBundleEncoder15.finish({label: '\ua3f0\u{1ff5d}\u08ae\u{1f71f}\u{1fda3}\u07e5\u469a\uecc1\u{1fd13}\u1a39'});
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer3, 0);
+} catch {}
+document.body.prepend(canvas7);
+try {
+computePassEncoder28.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: 544.1, g: -562.5, b: 283.0, a: -856.7, });
+} catch {}
+let arrayBuffer12 = buffer12.getMappedRange(744, 76);
+let imageData14 = new ImageData(76, 36);
+let pipelineLayout25 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout17, bindGroupLayout17, bindGroupLayout17]});
+let texture51 = gpuCanvasContext11.getCurrentTexture();
+try {
+computePassEncoder41.setPipeline(pipeline14);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+await gc();
+let renderBundleEncoder28 = device1.createRenderBundleEncoder({label: '\u08f8\u1f5b\u0a58\uac03\u7eb0\u794c', colorFormats: ['r8sint'], stencilReadOnly: true});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(3, buffer17);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer18, 'uint16', 852, 1_392);
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let commandEncoder189 = device2.createCommandEncoder();
+let commandBuffer110 = commandEncoder178.finish({label: '\u1332\u5997'});
+let computePassEncoder46 = commandEncoder173.beginComputePass();
+try {
+computePassEncoder46.setPipeline(pipeline14);
+} catch {}
+let querySet20 = device2.createQuerySet({type: 'occlusion', count: 235});
+let commandBuffer111 = commandEncoder159.finish({label: '\u0374\u8ba0\ub05e\u2429\u{1ff87}'});
+try {
+computePassEncoder44.setPipeline(pipeline14);
+} catch {}
+let texture52 = device1.createTexture({
+  label: '\u2d65\u007b\u0540\u013c\u{1f814}\u560b\u{1ffa4}\uc910\u{1fc72}',
+  size: [88, 15, 95],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder39.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer6, 724, 81);
+} catch {}
+let commandBuffer112 = commandEncoder172.finish({});
+let textureView48 = texture45.createView({label: '\u7ab0\u0e3e\u01bd\u{1f8d1}\ue9a2\ue806\ueb8c\u33a2', baseArrayLayer: 0});
+let pipeline16 = device2.createComputePipeline({layout: pipelineLayout20, compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}}});
+let textureView49 = texture50.createView({
+  label: '\u0228\ue4a2\u0d14\u61ad\u{1fc46}\u{1f7b0}\u095b\u961e\u061a\u05da',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 2,
+});
+let bindGroupLayout20 = device1.createBindGroupLayout({label: '\ue59b\u23c4\u72fd', entries: []});
+let commandEncoder190 = device1.createCommandEncoder();
+let querySet21 = device1.createQuerySet({type: 'occlusion', count: 457});
+let renderBundle105 = renderBundleEncoder23.finish();
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer18, 'uint32', 2_352, 17_435);
+} catch {}
+try {
+device1.queue.submit([commandBuffer86]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 1000, new Float32Array(17361), 2081, 304);
+} catch {}
+await gc();
+let videoFrame3 = new VideoFrame(canvas7, {timestamp: 0});
+let computePassEncoder47 = commandEncoder189.beginComputePass({});
+let offscreenCanvas3 = new OffscreenCanvas(175, 102);
+let video4 = await videoWithData();
+let imageData15 = new ImageData(32, 4);
+let commandEncoder191 = device0.createCommandEncoder({label: '\u549e\u0ff9\u5cb8\uf38c\u{1f8c0}\u1f70\u{1fc9c}'});
+let commandBuffer113 = commandEncoder191.finish({});
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup10);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas3.getContext('webgpu');
+let commandEncoder192 = device2.createCommandEncoder({label: '\u{1fb97}\u0e9b\u991c\u{1fd69}\u6c07\u9c5c\u3943\u0781'});
+let renderBundle106 = renderBundleEncoder24.finish();
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 32, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView50 = texture45.createView({label: '\ubf5e\uc9cf\uf0bc\ud81b'});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline16);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({label: '\u{1f6b8}\u{1fa04}\u{1fb25}\u2520\ub809\ua204', entries: []});
+let commandEncoder193 = device0.createCommandEncoder({label: '\u04a1\u00a3\u{1fc85}\u8aa9\u12f0'});
+let sampler15 = device0.createSampler({
+  label: '\u68d9\ue4f6\u0fb7\u{1fd37}\u442b\u8cbb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.394,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer11, 'uint16', 1_702, 78);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer106, commandBuffer91]);
+} catch {}
+let textureView51 = texture45.createView({label: '\u090d\u06eb\u{1f935}\u6d8d\u0e74'});
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let renderBundle107 = renderBundleEncoder22.finish();
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer16);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer13, 'uint32', 60, 775);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer16, 1016, 16828);
+} catch {}
+let bindGroup19 = device0.createBindGroup({label: '\u0812\u5b8b\u0fbc\u9798\u1b4e\u2326\ubb75', layout: bindGroupLayout0, entries: []});
+let commandBuffer114 = commandEncoder193.finish({label: '\u5fa1\u65f2\uf989\uf5af\u67e1\u7c07'});
+let renderBundle108 = renderBundleEncoder9.finish();
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup13, new Uint32Array(447), 52, 0);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([renderBundle36, renderBundle71, renderBundle9, renderBundle70, renderBundle61, renderBundle22, renderBundle101, renderBundle49, renderBundle11, renderBundle8]);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+adapter2.label = '\u{1fd57}\u941a\u0386\ue42e\ub4f0\u097d\u14e6';
+} catch {}
+let buffer24 = device1.createBuffer({
+  label: '\u{1fe3a}\ufbde',
+  size: 33516,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandBuffer115 = commandEncoder190.finish({label: '\u8e72\u173c\ubc3d\u18ac\u0e61\u0678\u9df8\u0aba\u07a8\u05ad\ueac6'});
+try {
+renderPassEncoder16.setIndexBuffer(buffer24, 'uint16', 3_056, 15_985);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(1, buffer24);
+} catch {}
+try {
+renderPassEncoder27.insertDebugMarker('\u{1ff73}');
+} catch {}
+let commandEncoder194 = device2.createCommandEncoder({});
+let computePassEncoder48 = commandEncoder192.beginComputePass({label: '\u28bc\u9750\u{1f6da}\u0b9c\u39fc\u{1ff4f}\u7c3b\u{1f81f}\u{1f9c9}\udf2f\u03db'});
+let renderBundle109 = renderBundleEncoder24.finish();
+try {
+device2.pushErrorScope('validation');
+} catch {}
+let promise21 = device2.queue.onSubmittedWorkDone();
+let textureView52 = texture11.createView({label: '\u{1f873}\u0ba7\u{1fd4c}\u4640\u02dd\u0272'});
+let renderBundle110 = renderBundleEncoder21.finish({label: '\u0d1e\u4c4b\uc6f4\uf0a4\u5333'});
+try {
+computePassEncoder18.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup18);
+} catch {}
+let arrayBuffer13 = buffer17.getMappedRange(4256, 5448);
+let renderBundle111 = renderBundleEncoder1.finish({label: '\u8dd3\u4103\uc35f\uc11b\ua634\u{1fd35}\u0dcb\ud540\u0d82\u061d'});
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let video5 = await videoWithData();
+let buffer25 = device1.createBuffer({
+  label: '\ue435\u0bda\u{1f8cf}\u{1fbc0}',
+  size: 6032,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup8, new Uint32Array(1209), 45, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer109]);
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder();
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer2, 'uint32', 44, 57);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer22, 'uint32', 108, 1_144);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(2, buffer8, 268);
+} catch {}
+try {
+externalTexture4.label = '\u770d\u{1f6b4}\u078e\u1708\u5fe9\u212c\u0bd1\u{1fa52}\u79ae';
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer25, 'uint16', 280, 2_946);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer25, 2_404, 912);
+} catch {}
+try {
+device1.queue.submit([commandBuffer46, commandBuffer58]);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer6, 84);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer18, 'uint32', 20_020, 7_426);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup7);
+} catch {}
+canvas3.height = 275;
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle69, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer24, 5_424);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData16 = new ImageData(8, 24);
+let commandBuffer116 = commandEncoder194.finish({label: '\uc251\u6bc0\u7ea9\ub7dd\uce1b\ueca5\u8147\ubc86'});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 201, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(289), /* required buffer size: 289 */
+{offset: 289, bytesPerRow: 186}, {width: 0, height: 105, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let commandEncoder196 = device0.createCommandEncoder();
+let renderPassEncoder55 = commandEncoder195.beginRenderPass({
+  label: '\ud3e2\u4ca1\u0c4b\u{1f824}\u{1fe7b}\u{1f9fc}\u{1f7bc}',
+  colorAttachments: [{view: textureView3, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(2, bindGroup1, new Uint32Array(903), 105, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.setViewport(7.156675407209562, 3.798951908353125, 0.8256738245950801, 0.4255021076339037, 0.7646343087922137, 0.8466547089353951);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(7, buffer20, 0, 244);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder196.clearBuffer(buffer21, 524, 484);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(65_038), /* required buffer size: 65_038 */
+{offset: 334, bytesPerRow: 24, rowsPerImage: 298}, {width: 0, height: 15, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder197 = device1.createCommandEncoder({label: '\u44cc\u{1f7a1}\u0f79\u01cc\ud3f5\u{1f68a}\u{1f8ad}\u0089\u9b6b\u0001\u0b60'});
+let commandBuffer117 = commandEncoder122.finish({label: '\u0aa9\u0b25\u5cf4\uc1f9\u422d\uf781\u06ff\u0980\ue842\u{1ff1a}'});
+let texture53 = device1.createTexture({
+  label: '\u{1f6e0}\u01c0\u6d41\uf392\ub8bf\ua7a5\u4b05\u8ecd',
+  size: [2160],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder49 = commandEncoder197.beginComputePass({label: '\u0f37\u0a28\u{1ffe9}\u0e11'});
+try {
+renderPassEncoder23.executeBundles([renderBundle14, renderBundle63, renderBundle14, renderBundle26, renderBundle59]);
+} catch {}
+try {
+renderPassEncoder52.setViewport(104.8478935730786, 14.236474144860939, 64.06848445467452, 21.992402479504474, 0.6225648893773532, 0.8034209986012524);
+} catch {}
+try {
+renderPassEncoder19.draw(7, 0, 921_330_983, 1);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer6, 12_840);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2, buffer25, 0, 517);
+} catch {}
+canvas5.height = 174;
+let shaderModule6 = device0.createShaderModule({
+  label: '\ud247\u7f34\u0887\u9178\u0215\u{1f728}\u50b2\u4605\u0744\u8811',
+  code: `@group(1) @binding(112) var st0: texture_storage_2d<r32uint, write>;
+@group(2) @binding(62) var tex1: texture_2d<f32>;
+@group(2) @binding(160) var et1: texture_external;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+textureStore(st0, vec2u(), bitcast<vec4u>(r));
+r += textureLoad(tex1, vec2u(), 0);
+r += textureLoad(et1, vec2u());
+}
+
+
+
+@fragment
+fn fragment0() -> @location(200) f32 {
+var r: vec4f;
+textureStore(st0, vec2u(), bitcast<vec4u>(r));
+r += textureLoad(tex1, vec2u(), 0);
+return f32();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: f32, @location(15) a1: vec3<f16>, @location(1) a2: vec4<f16>, @location(9) a3: vec3<i32>, @builtin(instance_index) a4: u32, @location(10) a5: vec2<u32>, @builtin(vertex_index) a6: u32) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer3, 0);
+} catch {}
+try {
+commandEncoder196.clearBuffer(buffer3, 10676, 188);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let commandBuffer118 = commandEncoder189.finish({label: '\u5927\u854e\u{1ffe5}\u32fe\u01cd\uf43e\u{1fdc9}\u{1f90e}\u9451\u{1fdc7}\u5d86'});
+try {
+computePassEncoder41.end();
+} catch {}
+let img4 = await imageWithData(20, 86, '#f651c4c0', '#9144addf');
+let commandEncoder198 = device0.createCommandEncoder({label: '\u9d13\u54a5'});
+let renderPassEncoder56 = commandEncoder166.beginRenderPass({
+  label: '\u0a19\u8680\u86a2\u0b93\udbeb\u7458\uc633\u0d0a\u5dd1',
+  colorAttachments: [{view: textureView16, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet7,
+});
+let renderBundle112 = renderBundleEncoder17.finish({});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder44.beginOcclusionQuery(297);
+} catch {}
+try {
+renderPassEncoder44.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer3, 'uint16', 988, 2_368);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 7, y: 12 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture54 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder48.setPipeline(pipeline13);
+} catch {}
+try {
+device2.queue.submit([commandBuffer84]);
+} catch {}
+let pipeline17 = await device2.createComputePipelineAsync({
+  label: '\u{1f605}\u{1fc2e}',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule5, constants: {}},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup20 = device0.createBindGroup({layout: bindGroupLayout11, entries: []});
+let renderPassEncoder57 = commandEncoder198.beginRenderPass({
+  label: '\u3a80\u025f\ue577',
+  colorAttachments: [{view: textureView44, depthSlice: 76, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+renderBundleEncoder27.setIndexBuffer(buffer5, 'uint16', 104, 1_410);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer68, commandBuffer35]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+let imageData17 = new ImageData(48, 116);
+let buffer26 = device1.createBuffer({
+  size: 28160,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder199 = device1.createCommandEncoder({});
+try {
+computePassEncoder28.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+device1.queue.submit([commandBuffer69]);
+} catch {}
+let querySet22 = device0.createQuerySet({label: '\u7b85\u06d5\u4762\uc5cf\u024f\uc08f', type: 'occlusion', count: 349});
+let texture55 = gpuCanvasContext1.getCurrentTexture();
+let renderPassEncoder58 = commandEncoder196.beginRenderPass({
+  label: '\u0a17\u1f21\uc150\u{1f6c0}\u0717\u66ef\u04c4\u{1fc39}\u1474\u0ea3',
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: -307.4, g: 562.2, b: -381.5, a: -549.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder51.executeBundles([renderBundle7, renderBundle93]);
+} catch {}
+try {
+adapter2.label = '\u41f2\ua234\u06fd\u7506\u47b3\u6ba5\u0250\u{1f7f1}\u0612\u{1fddd}\u550c';
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup5, new Uint32Array(3058), 86, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint16', 294, 1_028);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(65, 28);
+let commandBuffer119 = commandEncoder199.finish({label: '\uef41\u0929\u0377\uae05\u87a1\u0f39\u273b\u0dde\u0a4a\u{1fbc0}\u1100'});
+let texture56 = device1.createTexture({
+  label: '\u37f3\u04e4\u0346\u5ba7',
+  size: {width: 603},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle38, renderBundle32, renderBundle18, renderBundle58]);
+} catch {}
+try {
+renderPassEncoder19.draw(62, 1, 16_566_259, 4);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer24, 7_456);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let commandEncoder200 = device0.createCommandEncoder({label: '\u2e4f\u0069\ue049\u0720\ua8db\u59a2\u01c1\u{1f8e3}'});
+let renderPassEncoder59 = commandEncoder200.beginRenderPass({
+  label: '\u{1fa24}\u1361\u{1f80f}\u{1fa6c}\u88c0\ufcec\u002a\uc5a5\ud86e\u04cb',
+  colorAttachments: [{view: textureView44, depthSlice: 90, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 593822424,
+});
+let renderBundle113 = renderBundleEncoder17.finish({label: '\u4146\ue8b6\u9ab6\ub028\udadb\u434e\ua397\u6140\u344c'});
+try {
+renderBundleEncoder27.setIndexBuffer(buffer3, 'uint16', 3_044, 1_837);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer8, 0, 528);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let commandBuffer120 = commandEncoder173.finish({label: '\u7aac\u04ba'});
+let texture57 = device2.createTexture({
+  label: '\ucdd6\u4856',
+  size: {width: 1, height: 120, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView53 = texture57.createView({label: '\u{1fdfe}\u24b4\u8ad8\u1e83'});
+let computePassEncoder50 = commandEncoder156.beginComputePass({label: '\uf9b0\u4582\u4cfc\u6b0f\u011f\ucb9f\u09d6\u{1fcbc}\u3aac\u02fc'});
+try {
+computePassEncoder50.setPipeline(pipeline13);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 14, y: 1 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer121 = commandEncoder148.finish({label: '\u89a9\u{1f692}\udcdf\u042d'});
+let texture58 = device1.createTexture({
+  size: [180, 40, 212],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder35.executeBundles([renderBundle74]);
+} catch {}
+try {
+renderPassEncoder19.draw(53, 1, 952_394_438);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer24, 9_216);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+let shaderModule7 = device1.createShaderModule({
+  label: '\u{1fc20}\u04d0\u{1fc0a}\u{1fc5a}\u1c54\u{1f602}\ua11b\u{1fd6d}\u0a2c\u8bab\u0da6',
+  code: `@group(1) @binding(159) var sam6: sampler;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+_ = sam6;
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder201 = device1.createCommandEncoder();
+let commandBuffer122 = commandEncoder201.finish({label: '\u{1fbb3}\u0898\u{1fe39}'});
+let texture59 = device1.createTexture({
+  size: [603],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle42, renderBundle32, renderBundle69]);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer25, 0, 2_006);
+} catch {}
+video3.height = 92;
+let pipelineLayout26 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout7, bindGroupLayout18]});
+let externalTexture15 = device1.importExternalTexture({label: '\u0779\u00dc\u8ad1\u053b\u{1fd33}\u0a74\u0bb4', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder37.setVertexBuffer(3, buffer17, 0, 4_198);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle5, renderBundle8, renderBundle101]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(1.8411751802015985, 1.2344853947545982, 3.6653744968797706, 1.6979220495707867, 0.17696114020773712, 0.17880295641373423);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+document.body.prepend(img2);
+try {
+canvas9.getContext('webgl');
+} catch {}
+let commandEncoder202 = device2.createCommandEncoder();
+let renderBundle114 = renderBundleEncoder24.finish();
+try {
+computePassEncoder50.setPipeline(pipeline13);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline13);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 27, y: 31 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture60 = device2.createTexture({
+  label: '\u03af\u4dbb\u{1fede}\u0e5e\ua8c9\u{1fba3}\u7ff6\u330d\u07be',
+  size: [1, 480, 1],
+  sampleCount: 4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder51 = commandEncoder202.beginComputePass({label: '\u{1f7f4}\u1c79\u024d\ubfdb'});
+let offscreenCanvas5 = new OffscreenCanvas(534, 203);
+let bindGroupLayout22 = device2.createBindGroupLayout({
+  entries: [{binding: 535, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let textureView54 = texture57.createView({label: '\u1e1d\u7715\u{1fdc3}\u{1fb4d}\u{1f6ee}\u0043\u{1f6f5}', dimension: '2d'});
+let renderBundle115 = renderBundleEncoder24.finish({label: '\u04e1\u{1f699}\u9441\u6da4\u04f4\u8845\u0c5d\ufb48'});
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(141), /* required buffer size: 141 */
+{offset: 141, bytesPerRow: 206, rowsPerImage: 30}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(520, 98);
+let imageBitmap6 = await createImageBitmap(imageData3);
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+video2.width = 1;
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer26, 'uint32', 4_228, 2_938);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+device1.queue.submit([commandBuffer105]);
+} catch {}
+let textureView55 = texture10.createView({label: '\u24fc\u7fb3\u28a1\u3b4b\u0fc0'});
+try {
+computePassEncoder17.dispatchWorkgroupsIndirect(buffer24, 2_524);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 2144, new DataView(new ArrayBuffer(25765)), 1537, 584);
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas4.getContext('webgpu');
+let gpuCanvasContext14 = offscreenCanvas6.getContext('webgpu');
+let renderBundleEncoder29 = device1.createRenderBundleEncoder({label: '\ue3c8\uec2f', colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle116 = renderBundleEncoder8.finish({label: '\u{1f996}\u490d\u9f4d\ue55d\ub94a'});
+try {
+computePassEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer13, 'uint32', 428, 270);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(7, buffer24, 5_880);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+computePassEncoder11.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: 403.2, g: 452.4, b: 721.6, a: 482.8, });
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline13);
+} catch {}
+try {
+device2.queue.submit([commandBuffer110]);
+} catch {}
+let commandEncoder203 = device2.createCommandEncoder({label: '\u0f6d\u{1fb7e}\ubbf0\ufee4\u5636\u0d58\u04d3\u{1f944}\u0911\u8164'});
+let commandBuffer123 = commandEncoder203.finish({label: '\uc05f\u{1fe62}\u{1f68e}\uc68a\u{1fbb0}\u0d53'});
+let computePassEncoder52 = commandEncoder170.beginComputePass({label: '\u1849\u2254\u93d5\u{1fc11}'});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+device2.queue.submit([commandBuffer88]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(186), /* required buffer size: 186 */
+{offset: 186, bytesPerRow: 181}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule8 = device1.createShaderModule({
+  label: '\u{1fdda}\u06ca\u{1f662}\ufbcd\ubfe2\ubd46',
+  code: `@group(1) @binding(159) var sam7: sampler;
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> @location(200) vec4<f32> {
+var r: vec4f;
+_ = sam7;
+return vec4<f32>();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f7: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder204 = device1.createCommandEncoder({label: '\u{1f74a}\u53f1\uf25d\u{1f69a}\u{1f620}\u2d27\u3b26\u8723\ud2e2'});
+let commandBuffer124 = commandEncoder204.finish({label: '\u9636\ue530\u{1fe76}\udc62\u4d9a\uf22e'});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(1, bindGroup7, new Uint32Array(21), 6, 0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(171.86549643624974, 7.509543905002762, 3.735006719566777, 32.44677198945472, 0.5924859251077945, 0.6490528297202993);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline14);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+document.body.prepend(img1);
+let commandEncoder205 = device2.createCommandEncoder({label: '\u{1ff10}\u08d1\u197f\uf2c2\u1a6c\uc631\u44fe\ua155\u{1fb17}\ufa16'});
+let commandBuffer125 = commandEncoder205.finish({label: '\u0484\u0d9a\u3ab1\u0e40\u0b2d\u6b35\u0537\ufc3d\uefd2\ue410\u679a'});
+let renderBundle117 = renderBundleEncoder24.finish({label: '\ud72f\u{1f9a8}\u02e6\u0c6e'});
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 3,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(111), /* required buffer size: 111 */
+{offset: 111, bytesPerRow: 50}, {width: 0, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u42a7\u4950\u{1fe0c}\u{1fb83}\u05ca\u0156\u39d9\uc852\u1ceb';
+} catch {}
+canvas3.height = 1254;
+let commandEncoder206 = device1.createCommandEncoder({label: '\u0519\u{1fee9}\u8931\u{1f99f}\u0f9a\u29b3'});
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle47]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer18, 'uint16', 82, 10_469);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer24, 0, 11_413);
+} catch {}
+try {
+commandEncoder206.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 25},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let bindGroup21 = device1.createBindGroup({
+  label: '\ubbf5\u{1ffc5}\u0bb2\u19ef\u3406\u6af6\u70d6\u116d\ue3ef\u0aab',
+  layout: bindGroupLayout6,
+  entries: [],
+});
+let commandEncoder207 = device1.createCommandEncoder({label: '\u2c4a\u9e22\u38b7\u07b8\u75fa'});
+try {
+computePassEncoder30.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle46]);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer17, 4_676);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer24, 'uint32', 3_680, 738);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas5.getContext('webgpu');
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandBuffer126 = commandEncoder207.finish();
+let renderPassEncoder60 = commandEncoder206.beginRenderPass({
+  label: '\u{1f71b}\u{1faf1}\uf7c7\u8202\u8982\u{1f62b}',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: -591.2, g: -783.5, b: 851.6, a: 163.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup15, new Uint32Array(3249), 1655, 0);
+} catch {}
+try {
+renderPassEncoder45.label = '\u4809\u5134\u0410\u0148\u0a9c\u066b';
+} catch {}
+await gc();
+let shaderModule9 = device2.createShaderModule({
+  label: '\u0617\u3bfc\u3331\ucb7f\u057b\u{1f6f8}\u{1fab3}\ub25d\uc801\u5ebe\ue1a2',
+  code: `@group(1) @binding(215) var sam9: sampler;
+@group(0) @binding(215) var sam8: sampler;
+@group(2) @binding(215) var sam10: sampler;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+_ = sam9;
+_ = sam8;
+_ = sam10;
+}
+
+
+
+@fragment
+fn fragment0() -> @location(200) vec4<f32> {
+var r: vec4f;
+_ = sam9;
+_ = sam8;
+_ = sam10;
+return vec4<f32>();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f8: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+var r: vec4f;
+_ = sam9;
+_ = sam8;
+_ = sam10;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup22 = device2.createBindGroup({
+  label: '\u05ce\u7d32\u{1fb6f}\u{1fb27}\u040d',
+  layout: bindGroupLayout17,
+  entries: [{binding: 215, resource: sampler14}],
+});
+let commandEncoder208 = device2.createCommandEncoder({label: '\u000d\u03c4\u2e2b\uf7fe\ub22d\u9a3b\u24d7\u440d\ueafe\ud446'});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup22, new Uint32Array(2589), 0, 0);
+} catch {}
+await gc();
+let commandBuffer127 = commandEncoder208.finish();
+let textureView56 = texture45.createView({label: '\u05af\uc25e\u2c9d\u818c\u7a85\u80a3\u{1f9e2}', mipLevelCount: 1});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder209 = device1.createCommandEncoder({label: '\u2b01\u3a1b\u3e35\uccdf'});
+let renderPassEncoder61 = commandEncoder209.beginRenderPass({
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 29.28, g: -276.7, b: 710.7, a: 250.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup18, new Uint32Array(2008), 450, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer24, 'uint16', 7_568, 5_601);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer13, 'uint32', 2_044, 1_714);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let texture61 = device2.createTexture({
+  size: [1, 240, 373],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle118 = renderBundleEncoder24.finish({label: '\ubec6\u0926\u673b\u{1f771}\u0a97'});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup22);
+} catch {}
+let pipeline18 = device2.createComputePipeline({
+  label: '\u4c6b\u{1fbd5}\u9e24\u7580\u{1fdd9}',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule9, constants: {}},
+});
+let commandEncoder210 = device1.createCommandEncoder({label: '\u015f\u06bd\uc366\ub730\u094d'});
+let computePassEncoder53 = commandEncoder210.beginComputePass({});
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({label: '\u{1f64e}\ufb45\ufb06\u99b7\ue2bb\u{1fe36}', colorFormats: ['rg8unorm']});
+try {
+computePassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer26, 'uint32', 1_132, 14_293);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer17, 248, 1_109);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u09a5');
+} catch {}
+let textureView57 = texture9.createView({label: '\u01b7\u7fb0\u57f2\u07b0\udcba', arrayLayerCount: 1});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup7, new Uint32Array(2911), 31, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle58]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer26, 'uint16', 14_318, 1_292);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup17, new Uint32Array(93), 52, 0);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer25, 'uint32', 856, 444);
+} catch {}
+let bindGroupLayout23 = device2.createBindGroupLayout({
+  label: '\u626d\u1cc3\u0af8\uc9aa\u7ab9\u0e6b\u4417\u5058\u0588\u710e\u4b77',
+  entries: [{binding: 391, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }}],
+});
+let buffer27 = device2.createBuffer({
+  label: '\ub255\u9f80\u{1fecf}\u{1fa75}',
+  size: 72,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup22);
+} catch {}
+let bindGroup23 = device2.createBindGroup({
+  label: '\u{1fef6}\u250e\u{1f897}\u0e1b\u{1f88b}',
+  layout: bindGroupLayout17,
+  entries: [{binding: 215, resource: sampler13}],
+});
+await gc();
+let bindGroupLayout24 = device1.createBindGroupLayout({
+  label: '\ua0f2\uc212\u9e39\u{1f7e0}\u8a11\uf97d\u{1fea8}',
+  entries: [
+    {
+      binding: 504,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 255,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 1212744, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder211 = device1.createCommandEncoder({label: '\u0fd5\ub135\u1152\ub9ef\ue4f5\u0469'});
+let computePassEncoder54 = commandEncoder211.beginComputePass({label: '\u{1f7c9}\uaf7a\u547f\u01d7'});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer26, 'uint32', 28_160);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(0, buffer6, 0, 1_093);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup11);
+} catch {}
+let textureView58 = texture45.createView({label: '\u{1fab6}\u{1f6f7}\u608b\u3d05'});
+let renderBundleEncoder31 = device2.createRenderBundleEncoder({
+  label: '\u08b7\udb6a\ud79a\u{1f950}',
+  colorFormats: ['bgra8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder31.setVertexBuffer(4_294_967_295, undefined, 86_028_186, 53_384_089);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(450), /* required buffer size: 450 */
+{offset: 450, bytesPerRow: 270}, {width: 0, height: 101, depthOrArrayLayers: 0});
+} catch {}
+let pipeline19 = device2.createComputePipeline({
+  label: '\u43cf\u{1f782}\u{1fe7e}',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule5, constants: {}},
+});
+let pipeline20 = device2.createRenderPipeline({
+  label: '\uc6c1\u{1fcee}\u5712',
+  layout: pipelineLayout20,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 4026336689,
+  },
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 804, stepMode: 'instance', attributes: []},
+      {arrayStride: 2048, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 316, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 48, stepMode: 'instance', attributes: []},
+      {arrayStride: 80, attributes: [{format: 'uint32x3', offset: 44, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let externalTexture16 = device2.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+await gc();
+let buffer28 = device2.createBuffer({
+  label: '\ud005\u4b0b\u98f5\u{1f7f7}\u163a\u52d7\u326b\u0636\uf4ee',
+  size: 64047,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandBuffer128 = commandEncoder192.finish();
+let externalTexture17 = device2.importExternalTexture({
+  label: '\u{1fa93}\udf05\ub823\u{1f840}\ub0b9\ucb0c\uf1e1\u0981\u{1fbdd}\u{1faab}',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder50.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup22);
+} catch {}
+let pipelineLayout27 = device1.createPipelineLayout({label: '\u{1fa88}\u09c4\uf44c\u080e', bindGroupLayouts: [bindGroupLayout19, bindGroupLayout7]});
+let commandEncoder212 = device1.createCommandEncoder();
+let computePassEncoder55 = commandEncoder212.beginComputePass({label: '\ua1f8\ua0d6\ue818\u{1f8a0}\u085d\u{1f8a5}\u{1f72d}\uabf6\u{1f673}\u0d82'});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup8, new Uint32Array(312), 8, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(1, buffer6, 80);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup21, []);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer13, 'uint32', 756, 2_486);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 4496, new Int16Array(1882), 226, 836);
+} catch {}
+let commandEncoder213 = device2.createCommandEncoder({label: '\u{1fde5}\u{1fa94}\u5a9b\u086e\u18df\u{1fc4a}\u2283\u888d'});
+let computePassEncoder56 = commandEncoder213.beginComputePass({label: '\u{1f9de}\ub5c9\u3c70\ue17e'});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.WRITE, 8, 0);
+} catch {}
+try {
+commandEncoder170.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 111, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder214 = device1.createCommandEncoder({label: '\u{1fd1c}\u1bae\u64f1\u4623'});
+let commandBuffer129 = commandEncoder214.finish();
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(6, buffer6, 0, 10_031);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer13, 'uint32', 1_416, 842);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(2, buffer6);
+} catch {}
+video2.width = 158;
+let bindGroupLayout25 = device2.createBindGroupLayout({entries: []});
+let commandEncoder215 = device2.createCommandEncoder({label: '\u3c2c\u3736\ucb48\u0f5c\u{1fe22}\u5644\u3d41\u{1fc3f}\u8106'});
+let commandBuffer130 = commandEncoder215.finish({label: '\u069f\u0f6e\ueda1\u{1f861}\u{1f91c}'});
+let computePassEncoder57 = commandEncoder170.beginComputePass();
+let renderBundle119 = renderBundleEncoder31.finish();
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+device2.queue.submit([commandBuffer123, commandBuffer128]);
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+document.body.prepend(canvas2);
+await gc();
+let buffer29 = device1.createBuffer({
+  size: 14016,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder216 = device1.createCommandEncoder({label: '\ua949\u{1ff32}'});
+let querySet23 = device1.createQuerySet({label: '\u{1f6b8}\u1102\u8ead\u0113\ub4c3\u6750\uc698\u8d2a', type: 'occlusion', count: 175});
+let texture62 = device1.createTexture({
+  label: '\u{1fa6e}\u0988\u7c7e',
+  size: {width: 540, height: 1, depthOrArrayLayers: 6},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder58 = commandEncoder216.beginComputePass({label: '\u{1fa43}\u0fc2\u04d2'});
+let renderBundle120 = renderBundleEncoder20.finish({label: '\u0d3f\u487a\u6ba7\u64b6\u04e2\ub12f\u36c2\uaafd'});
+let sampler16 = device1.createSampler({
+  label: '\u0c00\uf817\u0e27\ua82e\u085c',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 77.15,
+  lodMaxClamp: 81.89,
+});
+try {
+renderBundleEncoder29.setIndexBuffer(buffer13, 'uint32', 272, 3_601);
+} catch {}
+try {
+device1.queue.submit([commandBuffer122]);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder217 = device1.createCommandEncoder({label: '\u0e79\uaf47\u{1fc84}\u{1fe9b}'});
+let commandBuffer131 = commandEncoder217.finish({});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup9, new Uint32Array(2031), 153, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle47, renderBundle116]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(124);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer25, 408);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder218 = device2.createCommandEncoder({label: '\u{1f841}\u0161'});
+try {
+buffer27.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 23, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(170), /* required buffer size: 170 */
+{offset: 170, rowsPerImage: 132}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas2.width = 911;
+let commandEncoder219 = device2.createCommandEncoder({label: '\u134b\u0f78\u0ed7\u2701\u8327\udfcb\u0438\u0e3a'});
+let commandBuffer132 = commandEncoder219.finish({});
+let renderPassEncoder62 = commandEncoder218.beginRenderPass({
+  label: '\u0b29\u{1f623}\u2528\u1afa\u0874\u096f',
+  colorAttachments: [{view: textureView53, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 634837467,
+});
+try {
+computePassEncoder51.pushDebugGroup('\u02d2');
+} catch {}
+try {
+renderPassEncoder62.insertDebugMarker('\u8057');
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+canvas3.height = 211;
+let texture63 = device1.createTexture({
+  label: '\ua792\ua71e\u3e81',
+  size: [360, 80, 424],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder55.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle51]);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer26, 'uint16', 2_906, 238);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup9, new Uint32Array(2428), 514, 0);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer25, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer16, 0, 3_875);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer29, 'uint32', 40, 1_949);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer60, commandBuffer117]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 90, height: 20, depthOrArrayLayers: 106}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 62 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 3, y: 1, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+canvas7.height = 491;
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let pipelineLayout28 = device1.createPipelineLayout({
+  label: '\u{1fb0a}\u8907\u08ba\uedae\u{1f89e}\u0cc7\u0fa1\uf089\u{1fcd4}',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout9, bindGroupLayout24, bindGroupLayout6],
+});
+let commandEncoder220 = device1.createCommandEncoder({label: '\ua3e3\ub5f7\u7bc4'});
+let commandBuffer133 = commandEncoder220.finish({label: '\u00f9\u{1f628}\u8b9d\u318d\u988e\u04f9\u031a\uac4a\u7bdd'});
+let texture64 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder53.setBindGroup(3, bindGroup17, new Uint32Array(654), 230, 0);
+} catch {}
+try {
+computePassEncoder17.dispatchWorkgroups(1, 2, 1);
+} catch {}
+try {
+computePassEncoder17.dispatchWorkgroupsIndirect(buffer16, 2_384);
+} catch {}
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let promise22 = device1.queue.onSubmittedWorkDone();
+let commandEncoder221 = device2.createCommandEncoder({label: '\u{1f7a9}\u064e\u00d2\u1b40\u{1fab2}'});
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 35, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(155), /* required buffer size: 155 */
+{offset: 155, bytesPerRow: 196}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let pipeline21 = device2.createComputePipeline({
+  label: '\u{1f60f}\u0669\u3906\u0440\uea1f\ue440\u4c51',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule9, constants: {}},
+});
+try {
+  await promise22;
+} catch {}
+offscreenCanvas3.height = 1445;
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandBuffer134 = commandEncoder221.finish({label: '\u0b65\u0a80\u08db\u4cd3\u7ff7\uad6f\u3ed2\u0e97\u{1f959}\u0433\u0d70'});
+let textureView59 = texture45.createView({});
+try {
+computePassEncoder57.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder62.setViewport(0.7636281512556644, 36.04839931583906, 0.09253339878899232, 54.405106805836, 0.5589878983300062, 0.9709690483943321);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(7, undefined);
+} catch {}
+offscreenCanvas2.width = 1774;
+try {
+adapter2.label = '\ueb22\u{1f932}\u0389';
+} catch {}
+let commandEncoder222 = device2.createCommandEncoder({label: '\u00b5\u383a'});
+let commandBuffer135 = commandEncoder222.finish({label: '\u0c59\u9ef3\uae60\u{1f960}\ud558\u2b31'});
+try {
+device2.queue.submit([commandBuffer82]);
+} catch {}
+let pipeline22 = device2.createRenderPipeline({
+  label: '\uf813\u{1f788}\uc79b\ud61d\u6980\u{1fc49}',
+  layout: pipelineLayout25,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 3742717586,
+    stencilWriteMask: 2828374421,
+    depthBias: 251814161,
+    depthBiasSlopeScale: 708.2466391527233,
+  },
+  vertex: {module: shaderModule9, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'front'},
+});
+let commandEncoder223 = device1.createCommandEncoder({label: '\u0eb6\u{1f8d3}\u00c3'});
+let commandBuffer136 = commandEncoder211.finish({});
+let renderPassEncoder63 = commandEncoder223.beginRenderPass({
+  label: '\u{1fb83}\u9c1e\u1c77\u{1f73e}\ud409\u0649',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: -852.2, g: 945.1, b: -905.2, a: 492.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder10.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer26, 'uint16', 3_706, 4_978);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup7, new Uint32Array(568), 124, 0);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(6, buffer25, 604, 353);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 360, height: 80, depthOrArrayLayers: 424}
+*/
+{
+  source: imageData16,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 63, y: 12, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout26 = device1.createBindGroupLayout({label: '\u{1fcb7}\u{1ffcd}\u{1fe6e}\u50ea\u80c6\ub721\u9cda\u7568\u{1fd99}\u0448\uc315', entries: []});
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(5, buffer6, 0, 3_266);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer131]);
+} catch {}
+try {
+renderPassEncoder62.setScissorRect(0, 20, 0, 17);
+} catch {}
+try {
+device2.queue.submit([commandBuffer95]);
+} catch {}
+try {
+computePassEncoder17.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 76);
+} catch {}
+try {
+device1.queue.submit([commandBuffer115, commandBuffer93, commandBuffer124]);
+} catch {}
+let commandEncoder224 = device2.createCommandEncoder({label: '\u5ea0\u{1f7b8}\u9b69\u0aea\u{1fc0d}\u{1fdbc}'});
+let commandBuffer137 = commandEncoder224.finish({});
+try {
+computePassEncoder51.setPipeline(pipeline13);
+} catch {}
+document.body.prepend(video5);
+let texture65 = device1.createTexture({
+  label: '\u{1f7c9}\uf727\u974b\u{1fccf}\u20e0\u32e9\u{1ff5e}',
+  size: [1080],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder23.executeBundles([renderBundle110]);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup18, new Uint32Array(532), 60, 0);
+} catch {}
+let imageData18 = new ImageData(200, 24);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let bindGroupLayout27 = device1.createBindGroupLayout({label: '\u005c\u{1fc0c}\u0435\u7e86\u4acd\uba3d\u{1fc0f}\u06c2\u{1fa4e}\u5c93\ue122', entries: []});
+try {
+renderPassEncoder61.setIndexBuffer(buffer18, 'uint32', 8_396, 312);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(5, buffer6, 0, 525);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer24, 'uint32', 3_660, 3_281);
+} catch {}
+let promise23 = device1.queue.onSubmittedWorkDone();
+let pipeline23 = device1.createRenderPipeline({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 84, attributes: []},
+      {arrayStride: 436, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 24, stepMode: 'vertex', attributes: []},
+      {arrayStride: 64, stepMode: 'instance', attributes: []},
+      {arrayStride: 344, attributes: []},
+      {arrayStride: 468, stepMode: 'instance', attributes: []},
+      {arrayStride: 328, attributes: [{format: 'unorm8x4', offset: 32, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let commandEncoder225 = device1.createCommandEncoder({});
+let renderPassEncoder64 = commandEncoder225.beginRenderPass({
+  label: '\udb59\ub8d7\u1086\u0494\u3b11',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 445.9, g: -550.6, b: 44.16, a: 991.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder17.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer29, 'uint32', 3_412, 2_800);
+} catch {}
+try {
+device1.queue.submit([commandBuffer129]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 10, y: 2, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(1_142_462), /* required buffer size: 1_142_462 */
+{offset: 62, bytesPerRow: 241, rowsPerImage: 296}, {width: 15, height: 5, depthOrArrayLayers: 17});
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+let imageData19 = new ImageData(112, 4);
+let bindGroup24 = device1.createBindGroup({label: '\u069a\u8df1\udd25\uc10d\ueb60', layout: bindGroupLayout27, entries: []});
+try {
+renderPassEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker('\u47dc');
+} catch {}
+try {
+device1.queue.submit([commandBuffer73, commandBuffer126, commandBuffer136, commandBuffer119]);
+} catch {}
+let bindGroup25 = device2.createBindGroup({label: '\u03ef\u2470', layout: bindGroupLayout25, entries: []});
+let commandEncoder226 = device2.createCommandEncoder({label: '\u0ced\u823e\u760f'});
+let commandBuffer138 = commandEncoder226.finish({});
+try {
+computePassEncoder57.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle83, renderBundle117, renderBundle109, renderBundle109, renderBundle99, renderBundle83, renderBundle118, renderBundle119, renderBundle114, renderBundle114]);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer127]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 74, y: 41 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 165, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 60, depthOrArrayLayers: 0});
+} catch {}
+let promise25 = device2.createRenderPipelineAsync({
+  label: '\u2e10\u9f77\u{1fe48}\u1081\u07b7\u9b63\u41a8\uf0df\u07d0\u9c64\u02b7',
+  layout: pipelineLayout20,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {module: shaderModule5, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm'}]},
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {arrayStride: 20, stepMode: 'instance', attributes: []},
+      {arrayStride: 344, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 32, attributes: []},
+      {arrayStride: 136, attributes: []},
+      {arrayStride: 96, attributes: []},
+      {arrayStride: 500, attributes: []},
+      {arrayStride: 428, attributes: [{format: 'uint32', offset: 72, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let renderBundle121 = renderBundleEncoder6.finish({label: '\uafee\u0c37\u74f5\u{1f76d}\u7d3e'});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let renderBundle122 = renderBundleEncoder12.finish({label: '\uc568\u{1ffb4}\u3eea'});
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer6, 5_684, 128);
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.READ, 0, 19984);
+} catch {}
+video5.height = 3;
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\u{1f889}\ud5b5\u01a3\u0de2\u9b7d\u04f5\u00cd',
+  entries: [
+    {
+      binding: 18,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder227 = device1.createCommandEncoder();
+let commandBuffer139 = commandEncoder227.finish({label: '\u0ae3\u{1fe15}\u0c67\u6891\u{1fc0c}\u936b\u8b64\u5e31\ud18f\u{1f8bb}'});
+let textureView60 = texture48.createView({
+  label: '\u4abe\ua956\u86a6\u{1ffbe}\u0ef0\uf3a7\u76a6',
+  format: 'rg8unorm',
+  baseMipLevel: 2,
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder28.setStencilReference(2845);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint16', 1_064, 306);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 45, height: 10, depthOrArrayLayers: 53}
+*/
+{
+  source: canvas1,
+  origin: { x: 65, y: 17 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let videoFrame4 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let commandEncoder228 = device2.createCommandEncoder({label: '\u101e\uc179\u0a98\u{1f63d}\u6324'});
+let computePassEncoder59 = commandEncoder228.beginComputePass({label: '\u38b4\u4092\u6b44\ua8b3\ud6d2\u0348\u65e5\u0d4d\u20f9\u0d85\ua65c'});
+let externalTexture18 = device2.importExternalTexture({label: '\ue463\u0bad\uc308', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+device2.queue.submit([commandBuffer125, commandBuffer120]);
+} catch {}
+let videoFrame5 = new VideoFrame(video2, {timestamp: 0});
+let commandEncoder229 = device2.createCommandEncoder();
+let texture66 = gpuCanvasContext9.getCurrentTexture();
+let renderPassEncoder65 = commandEncoder229.beginRenderPass({
+  label: '\u08c5\u{1f9b8}\uc875\u0811\uc338\u{1f7be}\ub2b7\u{1fa4c}\u85e8\u07d7',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: -289.3, g: -673.1, b: 651.9, a: 115.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet20,
+});
+let externalTexture19 = device2.importExternalTexture({label: '\u92c0\ucd9a\u{1faa4}', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder59.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+let commandEncoder230 = device2.createCommandEncoder({label: '\u9ec3\u5e96\u13a5\uf098\u0725'});
+let commandBuffer140 = commandEncoder230.finish();
+let texture67 = device2.createTexture({
+  label: '\ud79f\ub928',
+  size: {width: 12},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder231 = device2.createCommandEncoder({label: '\u617c\ud833\u0b70\ub100\u7721\u1850\ueae5\u0822\u54be\ue6f3'});
+let commandBuffer141 = commandEncoder231.finish({label: '\u7866\u05fe\ua0ad\ub33d\u3eec\u0649\u4993\u022a\u0619'});
+try {
+computePassEncoder56.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup23, new Uint32Array(2359), 572, 0);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle115, renderBundle119, renderBundle91, renderBundle109, renderBundle109, renderBundle118]);
+} catch {}
+try {
+renderPassEncoder65.setViewport(0.9333225801701136, 24.25302698608149, 0.040181424894635415, 27.778231259994538, 0.696723632965864, 0.9550135282040844);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(0, undefined);
+} catch {}
+let pipeline24 = await device2.createComputePipelineAsync({layout: pipelineLayout20, compute: {module: shaderModule5, constants: {}}});
+offscreenCanvas2.width = 1805;
+try {
+computePassEncoder50.setBindGroup(2, bindGroup25, new Uint32Array(2547), 145, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup22);
+} catch {}
+await gc();
+let buffer30 = device2.createBuffer({
+  label: '\u6888\u02ea\uf49e\uf5bc\ub486\u{1f870}',
+  size: 25476,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder232 = device2.createCommandEncoder({label: '\u08a0\u{1fd15}\u9ab0'});
+let querySet24 = device2.createQuerySet({
+  label: '\u020a\u8963\u03bf\u2327\ua4e0\u0d6f\u0cb9\u6f65\u{1fcb5}\u0812\u{1f906}',
+  type: 'occlusion',
+  count: 88,
+});
+let commandBuffer142 = commandEncoder232.finish({label: '\udfe2\u0186\ua4ec\u0959\u0aa1'});
+let renderBundle123 = renderBundleEncoder31.finish({label: '\u4196\u85d2'});
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+try {
+  await promise24;
+} catch {}
+let commandEncoder233 = device2.createCommandEncoder({});
+let commandBuffer143 = commandEncoder233.finish({label: '\uffee\u0242\u148f\u893f\u18b5\u{1fa6a}\u66ee\u{1fd3b}'});
+try {
+computePassEncoder56.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle114, renderBundle106, renderBundle109]);
+} catch {}
+try {
+renderPassEncoder65.setScissorRect(0, 5, 0, 16);
+} catch {}
+let arrayBuffer14 = buffer27.getMappedRange(0, 0);
+let commandEncoder234 = device1.createCommandEncoder({label: '\udfd3\u01a0\u040a\u{1f690}\u{1f7c9}\u1a48'});
+let commandBuffer144 = commandEncoder234.finish({label: '\u6659\u998c\u025a\u330e\u55b4\ue9ff\u{1fdfc}\u551c'});
+let textureView61 = texture21.createView({});
+let renderBundle124 = renderBundleEncoder8.finish({label: '\u0610\u{1fb24}\u7293\u452a\uef37\u528a\u0286\u{1fa0e}\u0c78\u{1f6f5}'});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(1, bindGroup8, new Uint32Array(365), 16, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer24, 0, 2_665);
+} catch {}
+let commandEncoder235 = device2.createCommandEncoder({label: '\u07bc\u4d90\u2bdd\u19f9\u0c3e\u0767\u0d44\u3192\u894a\u{1fc09}\u{1ffa9}'});
+let commandBuffer145 = commandEncoder235.finish({label: '\u006e\u02c6\u1b51\u0610'});
+let texture68 = device2.createTexture({
+  label: '\u{1f65a}\u{1fc40}\u0a70\u{1fa6e}\u09cf\u05f6',
+  size: {width: 12, height: 60, depthOrArrayLayers: 218},
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder32 = device2.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], sampleCount: 4, depthReadOnly: false, stencilReadOnly: true});
+let renderBundle125 = renderBundleEncoder32.finish({label: '\u03a7\u{1f836}\u{1f725}\u{1fdb8}\u03d7\uce98\u088a'});
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup25, new Uint32Array(1016), 160, 0);
+} catch {}
+try {
+renderPassEncoder62.setScissorRect(0, 57, 0, 4);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4_294_967_294, undefined, 994_452_961, 664_489_572);
+} catch {}
+canvas7.width = 239;
+try {
+device0.queue.label = '\u08f9\u09af\uf4a7\u0e3e\u{1fa56}\ud91f\u{1fd91}\u0881\u1278\uec3b';
+} catch {}
+let commandEncoder236 = device2.createCommandEncoder();
+let commandBuffer146 = commandEncoder236.finish({label: '\u6ad8\u{1f9f9}\uaee9\u0128\u0f5f\u9117\u{1fa04}\ub4b5\u50f5\u31d1'});
+let renderBundle126 = renderBundleEncoder31.finish({});
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder237 = device1.createCommandEncoder({});
+try {
+computePassEncoder18.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer25, 'uint32', 2_128, 147);
+} catch {}
+try {
+commandEncoder237.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let externalTexture20 = device2.importExternalTexture({label: '\u{1fa4a}\u53b6\u33f3\u0341\u074e\ude52\u{1fc1d}\u4ce7\u412f\u156e', source: videoFrame1});
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+offscreenCanvas1.height = 1730;
+try {
+computePassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup15, new Uint32Array(601), 56, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(6, buffer25, 0, 2_358);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer29, 'uint16', 650, 4_657);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(4, buffer17, 0, 2_541);
+} catch {}
+try {
+commandEncoder237.resolveQuerySet(querySet21, 29, 36, buffer13, 768);
+} catch {}
+let querySet25 = device1.createQuerySet({label: '\u8240\u110e\u4e00\u55c8', type: 'occlusion', count: 292});
+let texture69 = device1.createTexture({
+  label: '\uf796\u31cb\u480a\u5186\u003b\u0dd1\u{1f96a}\u09e7\ud55b',
+  size: {width: 22},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({label: '\u{1ff8d}\u02c4\u0ff3\u{1fadd}\u01c2', colorFormats: ['rg8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(952);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer13, 'uint16', 820, 160);
+} catch {}
+try {
+commandEncoder210.copyBufferToBuffer(buffer29, 7124, buffer16, 7236, 1024);
+} catch {}
+try {
+device1.queue.submit([commandBuffer139]);
+} catch {}
+let renderBundle127 = renderBundleEncoder24.finish({label: '\ue07b\ud936'});
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder65.insertDebugMarker('\u7bba');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 89, y: 1 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = device2.createComputePipeline({layout: pipelineLayout25, compute: {module: shaderModule9, constants: {}}});
+canvas9.width = 706;
+try {
+adapter1.label = '\u0c87\u71d6\u0f5a\u568b\u{1f89c}\u0448';
+} catch {}
+let bindGroupLayout29 = device2.createBindGroupLayout({
+  label: '\u87bf\ua460\u06d3\u4825\uf663\u048c\ued53\u0538\u3d52\u{1f980}\u9b95',
+  entries: [
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder238 = device2.createCommandEncoder({});
+let texture70 = device2.createTexture({
+  label: '\u514f\u4b24\u8ec2\u1bd5\uaf52\u{1f951}',
+  size: [12, 60, 37],
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder66 = commandEncoder228.beginRenderPass({colorAttachments: [{view: textureView53, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder62.setBindGroup(1, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+try {
+device2.queue.submit([commandBuffer146]);
+} catch {}
+document.body.prepend(img4);
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let bindGroup26 = device2.createBindGroup({
+  label: '\u06f5\u5311\u0dc7\uc3ff\u019c\u0c3d\u5f8c\u771f\ua092\u6b8e',
+  layout: bindGroupLayout23,
+  entries: [{binding: 391, resource: sampler14}],
+});
+let commandBuffer147 = commandEncoder238.finish({label: '\ue2e4\u09bb'});
+try {
+computePassEncoder51.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(2, bindGroup26, new Uint32Array(460), 41, 0);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle115]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData16,
+  origin: { x: 1, y: 23 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise23;
+} catch {}
+let bindGroup27 = device1.createBindGroup({label: '\u0b51\u62a2\u0dbd\u0c48', layout: bindGroupLayout6, entries: []});
+let commandEncoder239 = device1.createCommandEncoder({label: '\uf1e8\ua50c\uc023\ua989\u7f01\ud0fa\u{1fa1f}\u8650'});
+let renderPassEncoder67 = commandEncoder210.beginRenderPass({
+  label: '\u{1fe08}\uf745',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -551.3, g: -508.1, b: -764.4, a: 176.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+});
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 1964, new BigUint64Array(2357), 1322, 704);
+} catch {}
+let commandBuffer148 = commandEncoder237.finish({label: '\u{1fe3d}\u615b\ua88d\udd1e'});
+let renderPassEncoder68 = commandEncoder239.beginRenderPass({
+  label: '\u269d\uc0e1\u249e\u97d5\u30f0\u2005\u665e',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 61,
+  clearValue: { r: 37.13, g: 269.9, b: -824.4, a: 807.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler17 = device1.createSampler({
+  label: '\uecfa\u1f27\u0817',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.35,
+  lodMaxClamp: 58.51,
+});
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer24, 'uint16', 5_134, 21);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let promise26 = navigator.gpu.requestAdapter({});
+let commandEncoder240 = device2.createCommandEncoder({label: '\u0288\u086e\u0e54'});
+let texture71 = device2.createTexture({
+  label: '\u09e4\u0269\u3d3e\u{1fd61}\u3b90\u5075\u2d52\u02ee\ud626\u0229',
+  size: {width: 3, height: 15, depthOrArrayLayers: 8},
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder60 = commandEncoder240.beginComputePass();
+try {
+computePassEncoder51.setBindGroup(3, bindGroup22, new Uint32Array(1303), 66, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline12);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+video3.height = 16;
+let texture72 = device1.createTexture({
+  label: '\u{1fc63}\u1929\u059f',
+  size: [360, 80, 10],
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView62 = texture22.createView({label: '\u{1fb3b}\u68ce\u225c\u0e96\u3127\u4ce8'});
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder60.setBlendConstant({ r: 242.2, g: 17.47, b: -419.9, a: -361.5, });
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer25, 'uint32', 1_160, 330);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 572, new DataView(new ArrayBuffer(5917)), 1160, 1352);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 9, y: 5, z: 53},
+  aspect: 'all',
+}, new ArrayBuffer(1_177_785), /* required buffer size: 1_177_785 */
+{offset: 77, bytesPerRow: 94, rowsPerImage: 298}, {width: 38, height: 13, depthOrArrayLayers: 43});
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+canvas9.width = 75;
+await gc();
+let bindGroupLayout30 = device2.createBindGroupLayout({
+  label: '\u3244\u4c67\u083a\ud414\u60eb',
+  entries: [{binding: 22, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let commandEncoder241 = device2.createCommandEncoder({});
+let commandBuffer149 = commandEncoder241.finish();
+try {
+computePassEncoder51.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer30, 12_672, 1_023);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder66.end();
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer30);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+offscreenCanvas6.width = 806;
+let querySet26 = device2.createQuerySet({label: '\u816f\u0a8e', type: 'occlusion', count: 1263});
+let renderBundle128 = renderBundleEncoder24.finish({label: '\u22f1\u8885'});
+let externalTexture21 = device2.importExternalTexture({label: '\u0457\u25a4\u0574\u05b8\u039b\u0710\u{1f8bd}\ua30b', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer15 = buffer27.getMappedRange(8, 4);
+let commandEncoder242 = device2.createCommandEncoder();
+let texture73 = device2.createTexture({
+  label: '\u057b\u033d\uc5f4\u{1ffe3}',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer30, 'uint32', 3_224, 829);
+} catch {}
+try {
+computePassEncoder51.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(79_833), /* required buffer size: 79_833 */
+{offset: 33, bytesPerRow: 120, rowsPerImage: 109}, {width: 0, height: 12, depthOrArrayLayers: 7});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 60, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 3,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer31 = device1.createBuffer({
+  label: '\u0897\u9287\ubbb2',
+  size: 2100,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let texture74 = device1.createTexture({
+  label: '\u05df\u0fd3\u31fe',
+  size: [90, 20, 1],
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup8, new Uint32Array(191), 42, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder68.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer13, 'uint16', 1_706, 1_573);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup17, new Uint32Array(197), 45, 0);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer26, 'uint16', 10_530, 972);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 5140, new BigUint64Array(327));
+} catch {}
+let commandEncoder243 = device2.createCommandEncoder({label: '\u7487\u0998\u0a54\u9c15\uc4de\u{1fd85}'});
+let computePassEncoder61 = commandEncoder170.beginComputePass();
+let renderPassEncoder69 = commandEncoder243.beginRenderPass({
+  label: '\uf690\u3be5\u0f9e\u6283\u4ecc\ua0a8\u{1fd30}',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: 534.7, g: 462.3, b: -162.3, a: -485.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet19,
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup26, new Uint32Array(4044), 236, 0);
+} catch {}
+try {
+renderPassEncoder62.setScissorRect(0, 16, 0, 6);
+} catch {}
+try {
+renderPassEncoder65.setViewport(0.22662149928512643, 30.578473505099094, 0.2567243282277846, 51.67729357386073, 0.28147654646877174, 0.8016439615296869);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(5, buffer30, 1_572);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 60, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 23, y: 4 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 3,
+  origin: {x: 0, y: 17, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData20 = new ImageData(100, 8);
+let textureView63 = texture30.createView({label: '\u022c\uc805\u07f9\u{1ff15}\u4222', baseMipLevel: 1});
+let renderBundleEncoder34 = device1.createRenderBundleEncoder({label: '\u0df4\uae9c', colorFormats: ['r8sint'], stencilReadOnly: true});
+try {
+computePassEncoder17.dispatchWorkgroupsIndirect(buffer6, 720);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(3, bindGroup15, new Uint32Array(556), 119, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(101.44581509876438, 28.83839531886897, 66.61619241671359, 5.339183052176545, 0.9013567421030786, 0.995084328088624);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer6, 4_316, 1_709);
+} catch {}
+let commandEncoder244 = device1.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder244.beginComputePass({label: '\u2f4d\u952f\ue78c\u0605\u0fa3\uab77\u0dfd'});
+let renderBundle129 = renderBundleEncoder30.finish({});
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(4, buffer17, 0);
+} catch {}
+try {
+renderPassEncoder53.insertDebugMarker('\u0136');
+} catch {}
+let commandBuffer150 = commandEncoder242.finish({});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(6, buffer30, 160, 3_115);
+} catch {}
+let commandEncoder245 = device2.createCommandEncoder({});
+let renderPassEncoder70 = commandEncoder213.beginRenderPass({
+  label: '\u05c5\uafcc\u{1fc89}\u7ba3\u06d5\ubf26\u{1fa43}\u057b',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: 887.6, g: 181.5, b: 607.7, a: 485.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 239739330,
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer30, 'uint16', 5_306, 1_558);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(4_294_967_294, undefined, 0, 382_034_979);
+} catch {}
+try {
+device2.queue.submit([commandBuffer130, commandBuffer104]);
+} catch {}
+try {
+adapter0.label = '\uf59a\u007d\u0420\u4656\u0d15\u3250\uae5e\u00ad';
+} catch {}
+let commandEncoder246 = device2.createCommandEncoder();
+let commandBuffer151 = commandEncoder246.finish({label: '\u0e7a\u02e4\u{1f73b}\ud9a1\u3dc7'});
+let renderBundle130 = renderBundleEncoder31.finish({label: '\u0ce4\ubd8a\u{1fe2d}\u{1fa72}\u00a4\u0343\u0b98\u{1ffda}\u{1f9c5}\u02e8\u98b3'});
+let sampler18 = device2.createSampler({
+  label: '\u{1fd85}\u{1ffcb}\u{1fa49}\ueb3c\u08e7\u01e3\u0d09\u131d\u0aa7\u2f1b',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.21,
+  lodMaxClamp: 69.61,
+  maxAnisotropy: 12,
+});
+let commandEncoder247 = device2.createCommandEncoder({label: '\u07a6\u{1fe67}\u{1fdca}'});
+let querySet27 = device2.createQuerySet({
+  label: '\u{1fff1}\u683f\u{1fa40}\u{1f915}\uf6de\u{1f97f}\u3484\u0917\uc83c\u0045\u81a1',
+  type: 'occlusion',
+  count: 373,
+});
+try {
+computePassEncoder61.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+commandEncoder245.insertDebugMarker('\u{1fdf2}');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(405_207), /* required buffer size: 405_207 */
+{offset: 159, bytesPerRow: 168, rowsPerImage: 219}, {width: 0, height: 3, depthOrArrayLayers: 12});
+} catch {}
+let commandEncoder248 = device1.createCommandEncoder();
+let renderPassEncoder71 = commandEncoder248.beginRenderPass({
+  label: '\u685c\ub954\u0c77\u{1fcbe}\u{1fe2b}\u0aaa\u{1f647}\u{1fa41}',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 105,
+  clearValue: { r: 549.5, g: 391.5, b: -538.0, a: -769.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 3114891,
+});
+try {
+renderPassEncoder67.beginOcclusionQuery(186);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup24, new Uint32Array(2159), 74, 0);
+} catch {}
+try {
+renderBundle123.label = '\u0dc7\u0701\udf3a\u0412\u0aa2';
+} catch {}
+let commandBuffer152 = commandEncoder245.finish({label: '\u7cde\uc151\u0d33\ub7e0\u56a6\u09a2\u05c8\u88ac\u6ba3\u1543'});
+try {
+renderPassEncoder70.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+try {
+device2.queue.submit([commandBuffer137, commandBuffer152, commandBuffer112]);
+} catch {}
+let video6 = await videoWithData();
+let commandEncoder249 = device1.createCommandEncoder();
+let commandBuffer153 = commandEncoder249.finish({label: '\uaae7\u9a3e\uca69\u{1fd2e}\u{1fbaa}\u0be0'});
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(8);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer31, 'uint32', 712, 105);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+externalTexture17.label = '\u{1ff77}\u0f08\u2e38\u0c88\u0916\u00f9\uf908\u8f28\u{1fe76}\u{1feea}';
+} catch {}
+let commandBuffer154 = commandEncoder247.finish({label: '\u{1fab9}\u{1f635}\u{1faab}\u4431\uaa47\u0abd\ua228\u{1fc36}\u885d\u8ce8'});
+try {
+computePassEncoder50.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+renderPassEncoder62.pushDebugGroup('\u0ee0');
+} catch {}
+try {
+device2.queue.submit([commandBuffer143, commandBuffer141, commandBuffer150]);
+} catch {}
+let buffer32 = device2.createBuffer({
+  label: '\u0170\u711f\u8a46\u5262\u73c3\u00b1\uad10\ud5ff',
+  size: 920,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture75 = device2.createTexture({
+  label: '\u0c09\u0fff\u1736\u74bf\u9a67\ua531\u09f4\u8d3b\u8f2f\u{1fe4d}',
+  size: {width: 1, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder51.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer30, 'uint32', 1_144, 7_118);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+let commandEncoder250 = device1.createCommandEncoder();
+let commandBuffer155 = commandEncoder250.finish({label: '\u0bf1\u2e40\u0fa8\uc638\u00ba\u2d68\uf8bc\u{1f6ac}\u0644'});
+let texture76 = gpuCanvasContext8.getCurrentTexture();
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle51]);
+} catch {}
+try {
+device1.queue.submit([commandBuffer133]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 180, height: 40, depthOrArrayLayers: 212}
+*/
+{
+  source: video3,
+  origin: { x: 5, y: 6 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 28, y: 2, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+canvas0.width = 875;
+let buffer33 = device2.createBuffer({
+  label: '\u{1fc24}\u03e0\u001e\u{1fa42}\u0c58\u02dd\u0332',
+  size: 3526,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder251 = device2.createCommandEncoder({label: '\uc47b\u0d97'});
+let commandBuffer156 = commandEncoder251.finish({});
+try {
+renderPassEncoder70.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(6, undefined, 845_476_866);
+} catch {}
+let arrayBuffer16 = buffer27.getMappedRange(16, 0);
+try {
+device2.queue.submit([commandBuffer138, commandBuffer140]);
+} catch {}
+await gc();
+let renderBundle131 = renderBundleEncoder32.finish({label: '\u8948\u{1f7af}\u0abf\u3e95\u{1f890}\u{1f63c}\u073a\uc2b9'});
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder70.setViewport(0.08645981642959644, 73.23683493301294, 0.7782473440585315, 43.5114082876694, 0.9962234625789127, 0.9964062564576608);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer33, 'uint16', 350, 123);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer32, 0, 777);
+} catch {}
+let imageData21 = new ImageData(8, 24);
+let texture77 = device1.createTexture({
+  label: '\ud3d7\ufe81\uc384\u0d1e',
+  size: [180, 40, 1],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setViewport(40.294234321115695, 32.190777198978466, 79.40982140537415, 3.1643561163663216, 0.26839908780538424, 0.32372428941967535);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer25);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer31, 'uint16', 126, 1_865);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(0, buffer17);
+} catch {}
+try {
+device1.queue.submit([commandBuffer144]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 180, height: 40, depthOrArrayLayers: 212}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 2, y: 27 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 36, y: 1, z: 58},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let commandEncoder252 = device2.createCommandEncoder({label: '\u86b8\u{1fce5}\ue0e6\u4ea3\u9dfc\u3e8e\u0c54'});
+let commandBuffer157 = commandEncoder252.finish();
+try {
+renderPassEncoder69.setIndexBuffer(buffer30, 'uint32', 2_564, 11_285);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 30, depthOrArrayLayers: 37}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 170, y: 13 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder253 = device2.createCommandEncoder({label: '\u{1fa68}\uc202\u{1f8f4}\u6008\u{1f80d}\ue058\u812b\u8769'});
+let renderPassEncoder72 = commandEncoder253.beginRenderPass({
+  label: '\u0873\u098d',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: -445.3, g: -772.7, b: 44.19, a: -861.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet20,
+});
+try {
+renderPassEncoder69.setBindGroup(0, bindGroup23, new Uint32Array(1553), 686, 0);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(5, buffer33, 0);
+} catch {}
+try {
+renderPassEncoder62.popDebugGroup();
+} catch {}
+let commandEncoder254 = device2.createCommandEncoder();
+let querySet28 = device2.createQuerySet({type: 'occlusion', count: 1310});
+let commandBuffer158 = commandEncoder254.finish();
+let renderBundle132 = renderBundleEncoder31.finish({label: '\uc627\u{1ff4b}\uaade\uf71f\u0c6a\u{1fa7f}\u{1f7f1}\u0df3\u{1f8fa}\u8ce5'});
+try {
+renderPassEncoder72.executeBundles([renderBundle106]);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer29, 'uint32', 1_820, 1_169);
+} catch {}
+let renderBundle133 = renderBundleEncoder7.finish({label: '\u2224\u0d84\u7e33\u{1fbce}\u{1fb6a}\u08d3'});
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle78, renderBundle64, renderBundle110]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer6, 0, 5_966);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder255 = device2.createCommandEncoder({label: '\uc17b\u{1fd55}\u5ee4\uf8fd\u0ebe\u0985\u4361\u{1fa5b}\u61bc'});
+try {
+computePassEncoder61.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle131, renderBundle99, renderBundle118, renderBundle128]);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer30, 'uint32', 4_480, 820);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline12);
+} catch {}
+let textureView64 = texture69.createView({label: '\u{1f663}\u0247\u0ec4\u127b\ufcc7\uba1b\ucc4d\u96b0'});
+try {
+computePassEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer29, 'uint16', 5_910, 542);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer26, 'uint32', 3_012, 4_731);
+} catch {}
+let imageData22 = new ImageData(48, 88);
+let promise27 = adapter0.requestAdapterInfo();
+let commandEncoder256 = device2.createCommandEncoder();
+let commandBuffer159 = commandEncoder256.finish({label: '\u072d\uf54f\u0cbb\u{1fdf3}\u0e86\ue32b\ueaa6\u067e\ucf1c\u{1f76d}\u9226'});
+let renderPassEncoder73 = commandEncoder255.beginRenderPass({
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: -359.0, g: 332.4, b: -999.4, a: -901.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet24,
+});
+try {
+computePassEncoder50.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 149, y: 11 },
+  flipY: false,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 76, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 41, depthOrArrayLayers: 0});
+} catch {}
+let querySet29 = device2.createQuerySet({label: '\uf014\u885c\uf4aa\u6151\u00cd\u0c35\u4bb4\uf4df\u0756', type: 'occlusion', count: 302});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle132, renderBundle126, renderBundle99, renderBundle99]);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer33, 'uint16', 392, 598);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(2, buffer33);
+} catch {}
+try {
+renderPassEncoder62.pushDebugGroup('\u07fc');
+} catch {}
+try {
+device2.queue.submit([commandBuffer158, commandBuffer118, commandBuffer135, commandBuffer145, commandBuffer157]);
+} catch {}
+let pipeline26 = await promise25;
+let shaderModule10 = device1.createShaderModule({
+  label: '\u0da6\u{1fcd3}\u{1f892}\u2e46\u31b8\u078b\ufeea',
+  code: `@group(0) @binding(79) var et2: texture_external;
+@group(0) @binding(115) var tex2: texture_2d<f32>;
+@group(1) @binding(159) var sam11: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et2, vec2u());
+r += textureLoad(tex2, vec2u(), 0);
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(7) f1: vec4<u32>,
+  @location(4) f2: f32,
+  @location(5) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+r += textureLoad(et2, vec2u());
+r += textureLoad(tex2, vec2u(), 0);
+_ = sam11;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f9: vec4<i32>,
+  @location(8) f10: vec4<i32>,
+  @location(0) f11: vec4<u32>,
+  @builtin(position) f12: vec4<f32>,
+  @location(15) f13: f32
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, @location(1) a1: f32, @location(3) a2: vec3<i32>, @location(8) a3: vec4<u32>, @location(12) a4: i32) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder257 = device1.createCommandEncoder();
+let commandBuffer160 = commandEncoder257.finish({});
+let texture78 = device1.createTexture({
+  label: '\u74ce\ufa0d\udfba\u0ccc\u09f9\u{1f9a1}\u94c5\u40ac\uf863',
+  size: {width: 22, height: 3, depthOrArrayLayers: 23},
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer31, 'uint32', 200, 615);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+renderBundleEncoder19.insertDebugMarker('\u7e13');
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder67.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer13, 'uint32', 188, 633);
+} catch {}
+offscreenCanvas3.height = 590;
+let bindGroup28 = device2.createBindGroup({
+  label: '\u7159\u{1fec0}\u03f5\u01c4\ub45a\u{1fcaf}\ud2f9\u0b48\u2515\u{1fa95}\uc907',
+  layout: bindGroupLayout15,
+  entries: [{binding: 507, resource: {buffer: buffer33, offset: 2048, size: 28}}],
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder62.setViewport(0.4402761856356273, 73.668659985518, 0.45605739021355757, 42.816527058449694, 0.06408802944865477, 0.15253790042795246);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer30, 'uint16', 1_844, 1_159);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer17 = buffer32.getMappedRange();
+try {
+renderPassEncoder62.popDebugGroup();
+} catch {}
+let pipeline27 = await device2.createComputePipelineAsync({
+  label: '\u00c7\ud731\u0416\u{1f91f}\u6a76\u{1fb5f}\u94c8\u{1ff8d}\u0756\u94ba',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule9, constants: {}},
+});
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+await gc();
+try {
+  await promise27;
+} catch {}
+let commandEncoder258 = device2.createCommandEncoder({});
+let commandBuffer161 = commandEncoder258.finish({});
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer30, 'uint32', 15_320, 1_346);
+} catch {}
+try {
+device2.queue.submit([commandBuffer159]);
+} catch {}
+let video7 = await videoWithData();
+let computePassEncoder63 = commandEncoder156.beginComputePass({label: '\u156c\ucfc1\u629d\u4cf3\u3480\uea7c\u735b\u02f4\u{1feaf}'});
+try {
+renderPassEncoder62.executeBundles([renderBundle83]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(65_225), /* required buffer size: 65_225 */
+{offset: 29, bytesPerRow: 232, rowsPerImage: 54}, {width: 1, height: 12, depthOrArrayLayers: 6});
+} catch {}
+try {
+adapter1.label = '\u0703\u28d2';
+} catch {}
+let bindGroupLayout31 = device1.createBindGroupLayout({
+  label: '\u080c\u0c65\u88a5\u5d5c\u{1f94f}\u1db1\u{1fba8}\ue716\u{1fd50}\u006c\u05d5',
+  entries: [
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {binding: 174, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let renderBundle134 = renderBundleEncoder5.finish({label: '\ua39a\u{1fc43}\u0e0c\u{1f6d7}\u{1f64c}'});
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+let arrayBuffer18 = buffer17.getMappedRange(3656, 108);
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 45, height: 10, depthOrArrayLayers: 53}
+*/
+{
+  source: imageData11,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 3,
+  origin: {x: 23, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup29 = device1.createBindGroup({label: '\ud6cc\ua81d\ufc3d', layout: bindGroupLayout1, entries: [{binding: 159, resource: sampler17}]});
+let renderBundle135 = renderBundleEncoder21.finish({label: '\u{1fe98}\u3563\u0798\u{1f8a6}\ufbd3\u7835\u058c\u1c8b\ua3b6'});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup8, new Uint32Array(787), 32, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer18, 'uint32', 5_916, 7_259);
+} catch {}
+canvas1.width = 911;
+let commandEncoder259 = device1.createCommandEncoder();
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer13, 'uint16', 0, 536);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer25, 0, 1_821);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer29, 1312, new Float32Array(6511), 1151, 1464);
+} catch {}
+canvas4.width = 1106;
+let imageData23 = new ImageData(80, 28);
+let bindGroup30 = device2.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 507, resource: {buffer: buffer28, offset: 12288, size: 18548}}],
+});
+let commandEncoder260 = device2.createCommandEncoder();
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup28, new Uint32Array(516), 1, 0);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandBuffer82.label = '\ue2a6\ua6ab\u7da1\uc121\u{1f9c6}';
+} catch {}
+let commandEncoder261 = device2.createCommandEncoder({label: '\u07f3\uaada\u075e'});
+let commandBuffer162 = commandEncoder261.finish({});
+try {
+renderPassEncoder72.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder260.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 37},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 25});
+} catch {}
+try {
+renderPassEncoder69.pushDebugGroup('\u6262');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 74, y: 7 },
+  flipY: true,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 30, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let pipelineLayout29 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout22, bindGroupLayout25]});
+let buffer34 = device2.createBuffer({size: 16972, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder262 = device2.createCommandEncoder({});
+let commandBuffer163 = commandEncoder262.finish({label: '\u01ae\u0575\u1f2c\udd47'});
+let texture79 = device2.createTexture({
+  label: '\u1d3f\uf6d7\u{1fee3}\ua868\u{1f837}',
+  size: {width: 1, height: 120, depthOrArrayLayers: 773},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder64 = commandEncoder260.beginComputePass({label: '\u012a\ue687\u6e58\u0521\u04ff\uf535\uc37a\u0042\u{1f713}'});
+let renderPassEncoder74 = commandEncoder240.beginRenderPass({
+  label: '\u40de\uab44\u308e',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: 923.2, g: 707.3, b: 97.86, a: 517.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle136 = renderBundleEncoder32.finish({label: '\u{1fa8c}\u57cb\u{1feff}\u84d1\u6e76\u00d5\u0299'});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup30, new Uint32Array(2198), 137, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder73.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle127, renderBundle130]);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(4, buffer33, 0, 117);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 23, y: 0 },
+  flipY: true,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 113, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder263 = device1.createCommandEncoder({label: '\u0ba0\u25a2'});
+try {
+renderPassEncoder60.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer29, 'uint32', 5_200, 765);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise28 = device1.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+let commandEncoder264 = device2.createCommandEncoder({label: '\u0b4a\u5405\uc649\u1e9c\u{1f74b}\uaaf6\u2418\u8532\uf52d'});
+let commandBuffer164 = commandEncoder264.finish({label: '\u{1f9c6}\u86ab\u{1f779}\u{1fc3a}\u{1ff9b}\u06f6'});
+try {
+renderPassEncoder74.setIndexBuffer(buffer33, 'uint16', 408, 288);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let pipelineLayout30 = device2.createPipelineLayout({
+  label: '\u{1f9d2}\u9f05\ud836\u{1fae2}\u1e2f\u{1fa67}\uf5cc\u0f56',
+  bindGroupLayouts: [bindGroupLayout29, bindGroupLayout30, bindGroupLayout25],
+});
+let commandEncoder265 = device2.createCommandEncoder();
+let commandBuffer165 = commandEncoder265.finish({label: '\u{1fca2}\u6939\u{1fcbd}\ub0d2\udb19\u0a71\uc166\u071f\u0d22'});
+let externalTexture22 = device2.importExternalTexture({
+  label: '\u385b\u9e3c\u09ac\u6184\u06cd\udc66\u07f4\ub8b6\u{1f660}\u56bf\uf90e',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder63.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle119]);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer30, 'uint16', 5_024, 4_649);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline26);
+} catch {}
+let renderBundle137 = renderBundleEncoder24.finish({label: '\ub0d7\u30b4\u35d7\u{1fa44}\u0618'});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder73.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder70.executeBundles([]);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer163, commandBuffer154]);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let shaderModule11 = device1.createShaderModule({
+  label: '\u016e\u{1f613}\ucc5a\u{1f942}\u413a\u07ac\ufd6d\uc0a4\u{1f656}\u03cf\u{1ffe1}',
+  code: `@group(1) @binding(159) var sam12: sampler;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct S0 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec2<i32>,
+  @location(6) f1: vec4<f32>,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S0) -> FragmentOutput0 {
+var r: vec4f;
+_ = sam12;
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: vec3<u32>, @location(4) a1: u32, @location(7) a2: vec4<u32>) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout32 = device1.createBindGroupLayout({
+  label: '\u0511\u0a6b\u00c0\uc668',
+  entries: [
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer166 = commandEncoder263.finish({label: '\u3013\u7dd3\ue23b\u8a5e\u7b86'});
+let computePassEncoder65 = commandEncoder259.beginComputePass({label: '\ua0ba\ud48d'});
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup5, new Uint32Array(1245), 508, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer25);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer25, 'uint16', 14, 844);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(1, undefined, 0, 440_743_057);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5);
+} catch {}
+let arrayBuffer19 = buffer17.getMappedRange(3768, 8);
+try {
+buffer12.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer160, commandBuffer155]);
+} catch {}
+let bindGroupLayout33 = device2.createBindGroupLayout({
+  label: '\u8f1c\uf84a\u688f\u4686\ubdf0\uadc9\u{1fd78}\u0df3\u1164\u0779\u025c',
+  entries: [
+    {
+      binding: 334,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let renderBundle138 = renderBundleEncoder31.finish({label: '\uaebf\u544f\ucbaa\u60e8\u0c25'});
+try {
+renderPassEncoder69.beginOcclusionQuery(387);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer134, commandBuffer161]);
+} catch {}
+canvas8.width = 220;
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer26, 'uint16', 22, 11_765);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(0, buffer25);
+} catch {}
+let arrayBuffer20 = buffer17.getMappedRange(9704, 12);
+try {
+gpuCanvasContext15.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise29 = adapter2.requestAdapterInfo();
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 259,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder266 = device1.createCommandEncoder();
+let commandBuffer167 = commandEncoder266.finish({label: '\u0dff\u{1f6b1}'});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(5, buffer24);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 100 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6312 */
+  offset: 6312,
+  bytesPerRow: 256,
+  buffer: buffer29,
+}, {
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 7},
+  aspect: 'all',
+}, {width: 25, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder267 = device1.createCommandEncoder({label: '\u6902\u9b8a\u27f9\u8906\u{1fd4d}'});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(4, buffer16, 0, 7_509);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device1, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer29, 2552, new DataView(new ArrayBuffer(21097)), 7036, 2296);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 180, height: 40, depthOrArrayLayers: 212}
+*/
+{
+  source: img2,
+  origin: { x: 14, y: 24 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 84, y: 4, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder65.beginOcclusionQuery(121);
+} catch {}
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(6, buffer32, 464, 65);
+} catch {}
+try {
+device2.queue.submit([commandBuffer147]);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let commandEncoder268 = device1.createCommandEncoder({label: '\u049a\u0694\u8490\u0707\u1773\u{1ffa6}\ub066\ue061'});
+let commandBuffer168 = commandEncoder267.finish({label: '\u011b\u0724\u7f29\u{1fad3}\u06bd\u10e6'});
+let sampler19 = device1.createSampler({
+  label: '\ue6ce\u0969',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 83.32,
+  lodMaxClamp: 84.84,
+});
+try {
+computePassEncoder17.dispatchWorkgroups(1, 1, 1);
+} catch {}
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 7,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 105159039, hasDynamicOffset: false },
+    },
+    {
+      binding: 159,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let computePassEncoder66 = commandEncoder64.beginComputePass({});
+try {
+computePassEncoder17.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(1, buffer6, 0, 682);
+} catch {}
+try {
+adapter3.label = '\u4c6c\ud440\u0b6b\u9ba1\ud598\u{1f6d9}';
+} catch {}
+let shaderModule12 = device1.createShaderModule({
+  code: `@group(2) @binding(159) var sam15: sampler;
+@group(0) @binding(159) var sam13: sampler;
+@group(1) @binding(159) var sam14: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(2) f0: f32,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+_ = sam15;
+_ = sam13;
+_ = sam14;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f14: vec4<f16>,
+  @builtin(position) f15: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(1) a1: vec4<i32>, @builtin(instance_index) a2: u32) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture80 = device1.createTexture({
+  size: {width: 603},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder67.beginOcclusionQuery(254);
+} catch {}
+try {
+renderPassEncoder67.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer24);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+document.body.prepend(video0);
+let commandEncoder269 = device2.createCommandEncoder({label: '\u{1f77a}\u{1f769}\u851a\u{1fee4}\u{1f770}\u0a4f\uc93e\u{1fdcb}\u0eaa\u0e19'});
+let commandBuffer169 = commandEncoder269.finish({label: '\u02ee\u75d7'});
+let texture81 = device2.createTexture({
+  size: {width: 12, height: 60, depthOrArrayLayers: 218},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView65 = texture75.createView({dimension: '2d-array'});
+let renderBundle139 = renderBundleEncoder31.finish({label: '\u{1f7a6}\uf6d2\u{1fffd}\u23b8\u0246\u3a8e\uf6c7\u952a\ud444\u07d1'});
+let commandEncoder270 = device2.createCommandEncoder();
+let commandBuffer170 = commandEncoder270.finish({label: '\u825f\uea65\u{1fad9}\u4bc3\ud107'});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup26, new Uint32Array(2289), 512, 0);
+} catch {}
+try {
+renderPassEncoder69.endOcclusionQuery();
+} catch {}
+let arrayBuffer21 = buffer32.getMappedRange(920, 0);
+let imageData24 = new ImageData(8, 4);
+let commandEncoder271 = device2.createCommandEncoder();
+let texture82 = device2.createTexture({
+  label: '\u{1fce7}\u0a7e',
+  size: [3],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder75 = commandEncoder271.beginRenderPass({
+  label: '\u9a61\u99eb\ucd7b\u1bbc\uffbd\u67d1\ubea8\ua6a3\u{1f95f}\ucf30',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: 81.07, g: -420.6, b: -999.6, a: -277.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder72.setViewport(0.2575751390838754, 21.111853148911372, 0.36386584312735376, 84.89679949939243, 0.8862122262818252, 0.9721825693555992);
+} catch {}
+try {
+renderPassEncoder69.popDebugGroup();
+} catch {}
+try {
+window.someLabel = externalTexture7.label;
+} catch {}
+video5.height = 6;
+let bindGroupLayout36 = device1.createBindGroupLayout({entries: []});
+let pipelineLayout31 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12, bindGroupLayout8, bindGroupLayout18]});
+let commandEncoder272 = device1.createCommandEncoder({label: '\u0658\u17d2\u6288\u2412\u0b6d\u038d\u13ac'});
+let commandBuffer171 = commandEncoder268.finish({label: '\u0964\u0b5c'});
+let renderPassEncoder76 = commandEncoder272.beginRenderPass({
+  label: '\u6830\u341c\u391f',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: -428.7, g: 755.9, b: 832.7, a: 132.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 142790882,
+});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder({
+  label: '\u{1fd8e}\u9e6f\uc13b\u0ed5\u7a09\u99f2\u07b8\u0af9\u06d3\ud511',
+  colorFormats: ['rg8unorm'],
+  stencilReadOnly: false,
+});
+let externalTexture23 = device1.importExternalTexture({
+  label: '\uda79\u6804\ub085\u8c5d\u1c8a\u08f3\u1366\uc763\u1681\u{1f614}',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder10.dispatchWorkgroupsIndirect(buffer6, 14_304);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle103, renderBundle42]);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer29, 'uint16', 1_324, 737);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer17, 3_496, 94);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+  await promise29;
+} catch {}
+let commandEncoder273 = device1.createCommandEncoder({});
+try {
+renderPassEncoder60.setVertexBuffer(1, buffer25);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(4, buffer25, 272);
+} catch {}
+await gc();
+await gc();
+let commandEncoder274 = device1.createCommandEncoder({label: '\u02ab\u{1fcf8}\u3e98\u02d0\uda43\u{1f7ea}\u855e'});
+let renderBundle140 = renderBundleEncoder19.finish({label: '\u{1fa76}\u95ee\uc9df'});
+try {
+renderPassEncoder19.executeBundles([renderBundle134, renderBundle63, renderBundle140, renderBundle116, renderBundle69]);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer13, 'uint16', 856, 1_290);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer31, 'uint32', 324, 1_471);
+} catch {}
+try {
+commandEncoder274.resolveQuerySet(querySet18, 78, 567, buffer12, 2560);
+} catch {}
+let imageData25 = new ImageData(64, 20);
+let querySet30 = device2.createQuerySet({label: '\u417a\ue1aa\ub93a\uf73f\u{1f758}\ub03d', type: 'occlusion', count: 190});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup23, new Uint32Array(432), 2, 0);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder62.setViewport(0.13995439493812334, 83.93491581269231, 0.4601844608955678, 4.50112269364257, 0.47122539265667474, 0.9342674557128938);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer30, 'uint16', 5_504, 6_404);
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder275 = device2.createCommandEncoder({label: '\u06a5\u3222\u{1fb43}\u{1f82c}\u0a74'});
+let commandBuffer172 = commandEncoder275.finish({label: '\u{1ffda}\u00e8\ube8b\u0ff5\u{1fb7c}\u{1f644}'});
+try {
+renderPassEncoder69.setIndexBuffer(buffer30, 'uint16', 6_006, 393);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+canvas5.height = 553;
+let renderPassEncoder77 = commandEncoder273.beginRenderPass({
+  label: '\u68c4\u6af8\u{1fcbe}\u90bb\u1a7b\u293f\u06a6\u00c8\u0a80\ue954\u1c56',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -89.75, g: -908.1, b: -195.3, a: -74.04, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet18,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup5, new Uint32Array(2739), 313, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup18, new Uint32Array(1973), 1166, 0);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer18, 'uint32', 344, 6_618);
+} catch {}
+let pipelineLayout32 = device2.createPipelineLayout({label: '\u09ce\uf773\u05d9', bindGroupLayouts: [bindGroupLayout17, bindGroupLayout22]});
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline26);
+} catch {}
+try {
+device2.queue.submit([commandBuffer85]);
+} catch {}
+let bindGroupLayout37 = device1.createBindGroupLayout({
+  label: '\u{1f766}\udf15\u0aa1',
+  entries: [
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder276 = device1.createCommandEncoder({});
+let commandBuffer173 = commandEncoder276.finish();
+let externalTexture24 = device1.importExternalTexture({label: '\u849c\ud6c3\u{1f79a}\u0180\u{1fde7}\u{1ffdf}', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder17.dispatchWorkgroups(1, 3, 1);
+} catch {}
+try {
+renderPassEncoder53.setBlendConstant({ r: -359.2, g: 495.4, b: 650.7, a: -907.4, });
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup24, new Uint32Array(3583), 328, 0);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(2, buffer16, 0, 4_685);
+} catch {}
+document.body.prepend(video1);
+try {
+computePassEncoder62.label = '\u2f26\ua925\u2bc6';
+} catch {}
+let commandEncoder277 = device1.createCommandEncoder({label: '\u0720\u7dfd'});
+let commandBuffer174 = commandEncoder277.finish({label: '\u2dd0\uede5\ua385\u1ffd'});
+try {
+computePassEncoder10.dispatchWorkgroups(3, 1, 1);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer26, 'uint16', 2_648, 6_323);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer17);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+commandEncoder274.clearBuffer(buffer31);
+} catch {}
+await gc();
+let commandEncoder278 = device1.createCommandEncoder({label: '\u2480\u05c1\u{1fbfd}\u6dad\u{1fffc}\u27e2\u57bb\u98d9\u{1ffdf}\u050a\u{1fda7}'});
+let commandBuffer175 = commandEncoder278.finish({label: '\u074c\u0ce6\ucdc1\u4732\u097d\u{1f985}\u0ec0\u61db\u7d9d\u589a\ue3cc'});
+let computePassEncoder67 = commandEncoder274.beginComputePass({label: '\u3f76\uf780\uaf38\u0c16'});
+try {
+computePassEncoder10.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer24, 'uint32', 1_076, 9_652);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(7, buffer24);
+} catch {}
+let promise30 = adapter1.requestAdapterInfo();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let promise31 = navigator.gpu.requestAdapter({});
+let shaderModule13 = device1.createShaderModule({
+  label: '\u7f15\u2ad3',
+  code: `@group(0) @binding(159) var sam16: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+_ = sam16;
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(11) f0: vec3<u32>,
+  @location(9) f1: i32,
+  @location(5) f2: f32,
+  @location(10) f3: vec3<f32>
+}
+
+@vertex
+fn vertex0(a0: S1) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let buffer35 = device1.createBuffer({
+  label: '\ud7aa\ufdb7\u0254\uf618\u7d9e\u0296\u2359\u0c3e\u4251\u060f\u0d8f',
+  size: 19439,
+  usage: GPUBufferUsage.MAP_WRITE,
+});
+let renderBundle141 = renderBundleEncoder28.finish({label: '\u0756\u{1f99d}\u9b2f\u{1f75d}'});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer25, 'uint32', 60, 871);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup7, new Uint32Array(984), 56, 0);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+document.body.prepend(canvas6);
+let commandEncoder279 = device1.createCommandEncoder({});
+let commandBuffer176 = commandEncoder279.finish();
+try {
+computePassEncoder17.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(1, 2, 1);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(7, undefined);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let promise32 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(canvas2);
+let promise33 = adapter2.requestAdapterInfo();
+let pipelineLayout33 = device2.createPipelineLayout({
+  label: '\u{1f7b6}\u{1f7c1}\u3ebb\u4fa4\u0402\uf0b5\u30c1\u13a6\u1a54',
+  bindGroupLayouts: [bindGroupLayout25],
+});
+try {
+renderPassEncoder73.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 236, new DataView(new ArrayBuffer(2911)), 248, 60);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+await gc();
+try {
+computePassEncoder66.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle26]);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer31, 'uint32', 20, 109);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer25, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer148]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 14, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(54), /* required buffer size: 54 */
+{offset: 54, bytesPerRow: 63}, {width: 5, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder280 = device2.createCommandEncoder({label: '\u{1fbfc}\u{1fdb4}\u0764\uc24e'});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup26, new Uint32Array(2532), 607, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+let arrayBuffer22 = buffer27.getMappedRange(24, 0);
+try {
+commandEncoder280.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 652 */
+  offset: 652,
+  buffer: buffer34,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 212, new BigUint64Array(1608), 161, 64);
+} catch {}
+let renderBundleEncoder36 = device2.createRenderBundleEncoder({
+  label: '\u{1fba6}\u08cc\u004e\u{1fa11}\u0b6a\u0e5b\ub4d2\u{1f707}',
+  colorFormats: ['bgra8unorm'],
+  sampleCount: 4,
+});
+let renderBundle142 = renderBundleEncoder31.finish({});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 60, depthOrArrayLayers: 37}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 18, y: 20 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 32, depthOrArrayLayers: 0});
+} catch {}
+let imageData26 = new ImageData(32, 12);
+let texture83 = device2.createTexture({
+  size: [2, 960, 1],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder78 = commandEncoder280.beginRenderPass({
+  label: '\u2fc6\u606a\u01cf',
+  colorAttachments: [{view: textureView53, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 89119008,
+});
+try {
+renderPassEncoder73.end();
+} catch {}
+try {
+renderPassEncoder65.beginOcclusionQuery(198);
+} catch {}
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer32, 0, 10);
+} catch {}
+let querySet31 = device2.createQuerySet({label: '\u74e0\ue285\u7905\u{1f667}', type: 'occlusion', count: 976});
+let texture84 = device2.createTexture({
+  label: '\u0aea\u9685\ub3c7',
+  size: [3, 15, 54],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup26, new Uint32Array(746), 32, 0);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(1, bindGroup30, []);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle142, renderBundle118]);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 100, new Float32Array(1815));
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 66},
+  aspect: 'all',
+}, new ArrayBuffer(511_833), /* required buffer size: 511_833 */
+{offset: 75, bytesPerRow: 243, rowsPerImage: 52}, {width: 0, height: 27, depthOrArrayLayers: 41});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder281 = device1.createCommandEncoder({label: '\u6332\u0a0a\u1f88\u78b9\u4d34\ub9b4\uea3b\u5772\u87b7\u0114'});
+let commandBuffer177 = commandEncoder281.finish({label: '\uaa55\u{1f9e3}'});
+try {
+renderPassEncoder67.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer26, 'uint32', 2_892, 8_726);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise34 = device1.createRenderPipelineAsync({
+  label: '\u7587\u0ce4\u00ed\u0a4b\u30a8\u51a9\ua37f',
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0xf98565b},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule11,
+    buffers: [
+      {arrayStride: 240, attributes: []},
+      {arrayStride: 36, stepMode: 'instance', attributes: []},
+      {arrayStride: 16, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 320, shaderLocation: 7}],
+      },
+      {arrayStride: 220, stepMode: 'instance', attributes: []},
+      {arrayStride: 292, attributes: []},
+      {arrayStride: 328, attributes: []},
+      {
+        arrayStride: 248,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 24, shaderLocation: 5},
+          {format: 'uint16x4', offset: 40, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise33;
+} catch {}
+video5.height = 86;
+try {
+computePassEncoder61.setPipeline(pipeline13);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 360, new Float32Array(17278), 3050, 308);
+} catch {}
+let commandEncoder282 = device1.createCommandEncoder();
+let externalTexture25 = device1.importExternalTexture({label: '\u0bec\u5794\ue410\u05e9', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder28.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 192, new Int16Array(5200), 517, 3524);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({});
+let commandEncoder283 = device2.createCommandEncoder({label: '\u8598\u5c13\u5356\u0578\ub7f3\u1277\u040b'});
+let renderPassEncoder79 = commandEncoder283.beginRenderPass({
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: -342.7, g: 459.5, b: 743.6, a: 384.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet29,
+  maxDrawCount: 165869185,
+});
+try {
+renderPassEncoder62.executeBundles([renderBundle139]);
+} catch {}
+try {
+renderPassEncoder65.setStencilReference(4065);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer30, 'uint32', 1_700, 2_276);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer30, 'uint16', 3_350, 9_713);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline12);
+} catch {}
+document.body.prepend(video4);
+canvas0.height = 1;
+let renderBundleEncoder37 = device2.createRenderBundleEncoder({
+  label: '\u7330\u0840',
+  colorFormats: ['bgra8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle143 = renderBundleEncoder32.finish({label: '\u{1fc6e}\u0697\u0d4f\u08c4\u{1f741}\ue874\udf1a\u{1f732}\u0363'});
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint32', 296, 287);
+} catch {}
+let imageData27 = new ImageData(12, 4);
+let commandEncoder284 = device1.createCommandEncoder({});
+let commandBuffer178 = commandEncoder284.finish({label: '\u6b55\ud3e5\u780a\u0842\u{1fa02}'});
+let texture85 = device1.createTexture({
+  label: '\u0b1d\u5b40\u{1fe01}\u6df5\u7455\u7e45\u0f85',
+  size: {width: 270, height: 1, depthOrArrayLayers: 547},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder68 = commandEncoder282.beginComputePass();
+try {
+renderPassEncoder53.executeBundles([renderBundle46, renderBundle110, renderBundle103, renderBundle121, renderBundle42]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer13, 'uint16', 1_508, 966);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+canvas0.height = 658;
+try {
+pipeline25.label = '\u{1fdbf}\u{1f945}\u{1fcb8}\u6a7e\u389a\u47c1';
+} catch {}
+try {
+computePassEncoder64.dispatchWorkgroups(2, 1, 1);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle91]);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer33, 'uint16', 688, 787);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint16', 1_514, 362);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline12);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+renderBundleEncoder36.insertDebugMarker('\u{1ff4f}');
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder69.end();
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint32', 52, 134);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(3, buffer32, 108);
+} catch {}
+try {
+renderBundleEncoder36.insertDebugMarker('\u6780');
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let promise35 = device2.createComputePipelineAsync({
+  label: '\u0aeb\u9bdb\u965a',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule9, constants: {}},
+});
+try {
+pipelineLayout29.label = '\ua2f3\u62f0';
+} catch {}
+let commandEncoder285 = device2.createCommandEncoder({});
+let commandBuffer179 = commandEncoder285.finish({label: '\u65ae\u{1ff56}\u6db6\u0c88\u0c08\u0277\uc93b\u0ea4\u{1fb32}\u0a24'});
+try {
+renderPassEncoder75.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder70.setViewport(0.2837227028856807, 3.863390527203703, 0.03573159784582884, 107.95054226117954, 0.24218765539718168, 0.36643805406575164);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(6, buffer30, 0, 2_448);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 40},
+  aspect: 'all',
+}, new ArrayBuffer(221_925), /* required buffer size: 221_925 */
+{offset: 542, bytesPerRow: 275, rowsPerImage: 23}, {width: 2, height: 1, depthOrArrayLayers: 36});
+} catch {}
+document.body.prepend(video3);
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer31, 'uint16', 210, 227);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(7, buffer25);
+} catch {}
+let arrayBuffer23 = buffer26.getMappedRange();
+try {
+commandEncoder282.clearBuffer(buffer15, 1264, 1044);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let commandEncoder286 = device1.createCommandEncoder({label: '\u7f07\u517a\u2be9\uc461\u{1ffa3}\ub30e\ucd1a\u0721\ud3b7\ufded'});
+let texture86 = device1.createTexture({
+  label: '\u6a2a\u0a02\u0f0b\u31e2',
+  size: [88],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder68.setPipeline(pipeline4);
+} catch {}
+let promise36 = adapter4.requestAdapterInfo();
+let textureView66 = texture67.createView({label: '\u23b5\u061b', dimension: '1d', baseMipLevel: 0});
+let renderBundle144 = renderBundleEncoder32.finish();
+try {
+computePassEncoder51.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer30, 'uint32', 3_456, 1_047);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData26,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 96, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder287 = device2.createCommandEncoder({label: '\u{1fda4}\u2702\u5877\ua1a2\u3b27\u{1ff4c}\u5bf9\u8e3d'});
+let commandBuffer180 = commandEncoder287.finish({});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup22, new Uint32Array(3408), 433, 0);
+} catch {}
+try {
+computePassEncoder64.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(3, bindGroup23, new Uint32Array(7522), 5585, 0);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(3, buffer30, 0, 7_126);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer30, 'uint32', 5_508, 1_751);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4_294_967_295, undefined, 1_378_418_143, 1_060_671_189);
+} catch {}
+let bindGroupLayout38 = device2.createBindGroupLayout({
+  label: '\uc491\u0d29\ufac7',
+  entries: [
+    {
+      binding: 122,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder288 = device2.createCommandEncoder({label: '\udfe0\u3ad9\u45c0\u{1f94b}\u{1fc1d}\u40c7\u0aa0\u0b6e\u3856'});
+try {
+computePassEncoder63.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle114]);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(3, buffer32);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer30, 'uint16', 8_482, 2_655);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 924, new Float32Array(4868), 594, 772);
+} catch {}
+await gc();
+let commandEncoder289 = device2.createCommandEncoder({label: '\u0d10\ua506\u5996\u1fc1\udfae\u{1f63c}\u{1f777}'});
+let textureView67 = texture60.createView({label: '\ue704\u80ba\uf921\u0295\u010e\uc9a4\ubff4\u{1f8f7}\u2651\u0bdd\u{1fdcc}'});
+let renderBundle145 = renderBundleEncoder24.finish();
+try {
+computePassEncoder63.dispatchWorkgroups(2, 4, 1);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer30, 'uint32', 932, 4_437);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(5, buffer32, 0, 15);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 12, new Int16Array(673), 139, 164);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 1,
+  origin: {x: 0, y: 20, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(281_098), /* required buffer size: 281_098 */
+{offset: 30, bytesPerRow: 116, rowsPerImage: 115}, {width: 0, height: 9, depthOrArrayLayers: 22});
+} catch {}
+offscreenCanvas6.height = 1753;
+let promise37 = adapter3.requestAdapterInfo();
+let commandEncoder290 = device1.createCommandEncoder({label: '\u{1f64f}\u{1f956}\u8108\u0027\u55fe'});
+let commandBuffer181 = commandEncoder286.finish({label: '\u223c\u00a5\ua6c4\u0688\u5fee\u0f23\u01c0'});
+let renderBundle146 = renderBundleEncoder4.finish();
+try {
+computePassEncoder67.setBindGroup(3, bindGroup17, new Uint32Array(7303), 289, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle140]);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer24, 'uint32', 10_132, 5_006);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 5924, new DataView(new ArrayBuffer(12305)), 6090, 528);
+} catch {}
+let pipelineLayout34 = device2.createPipelineLayout({
+  label: '\u3d91\u{1f938}\u1b34',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout15, bindGroupLayout22, bindGroupLayout30],
+});
+let commandEncoder291 = device2.createCommandEncoder({label: '\u0777\u3a3f\u{1fe5b}'});
+let computePassEncoder69 = commandEncoder288.beginComputePass({});
+try {
+computePassEncoder64.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle123, renderBundle115, renderBundle145, renderBundle126]);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer32);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline26);
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u0c49');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 452, new BigUint64Array(5476), 496, 100);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+textureView14.label = '\u06a2\u0159\u12ef\uc3c3\u080b';
+} catch {}
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer29, 'uint32', 2_664, 235);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+  await promise37;
+} catch {}
+canvas5.width = 1301;
+try {
+computePassEncoder66.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setBlendConstant({ r: 51.24, g: 894.3, b: -632.4, a: -468.8, });
+} catch {}
+try {
+renderPassEncoder29.setViewport(2.3576768847064304, 27.00990705469398, 133.5389815701351, 2.2869592787607376, 0.6066543790030456, 0.9423577229428923);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer26, 'uint32', 27_720, 22);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer13, 'uint16', 146, 2_847);
+} catch {}
+let commandEncoder292 = device2.createCommandEncoder({});
+let commandBuffer182 = commandEncoder291.finish({label: '\u85fa\ua953\u{1fe85}\u0bf0\u{1fdf0}\u53e8\u{1fbd5}\uf0ed\u0441\u0de8'});
+let texture87 = device2.createTexture({
+  label: '\u0686\u00cc\u7a0e\u2f6b\uc924\u051e',
+  size: [1, 240, 1],
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder78.executeBundles([renderBundle142]);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(4, buffer32, 120);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(1, buffer30, 6_744, 647);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 29, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData28 = new ImageData(28, 40);
+let computePassEncoder70 = commandEncoder290.beginComputePass({label: '\u00ad\u{1f6ed}\u016e\uab11\u021c'});
+let renderPassEncoder80 = commandEncoder282.beginRenderPass({
+  label: '\ue8e7\uc241\u0393',
+  colorAttachments: [{view: textureView21, depthSlice: 17, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 140588788,
+});
+let renderBundle147 = renderBundleEncoder30.finish({label: '\ubd00\u239d\u4ba1\u0f9d\u9ad9\uf1c0\u8ca9\u8ce5'});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 3, 2);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(7, buffer6, 0);
+} catch {}
+let externalTexture26 = device1.importExternalTexture({label: '\ub53f\u019e\u71ca\ue3d3', source: video6, colorSpace: 'display-p3'});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup24, new Uint32Array(238), 33, 0);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(3, bindGroup6, new Uint32Array(2756), 143, 0);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer24, 'uint32', 1_744, 7_784);
+} catch {}
+try {
+commandEncoder145.copyTextureToBuffer({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 648 widthInBlocks: 162 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 60 */
+  offset: 60,
+  bytesPerRow: 768,
+  buffer: buffer13,
+}, {width: 162, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer183 = commandEncoder145.finish();
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder19.setViewport(93.55024620710078, 39.640495103794784, 86.2357773970157, 0.07592823706235781, 0.2964769915481653, 0.4277796197127108);
+} catch {}
+let renderPassEncoder81 = commandEncoder289.beginRenderPass({
+  label: '\u{1fdd8}\u8108\u04ba\u{1f90b}\u4f4d\u{1f857}\ubb5c',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: 731.2, g: -162.4, b: 652.1, a: -300.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 102436633,
+});
+try {
+renderPassEncoder75.setIndexBuffer(buffer33, 'uint32', 676, 174);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(7, buffer30);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(0, bindGroup30, new Uint32Array(1420), 41, 0);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint32', 772, 755);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer32, 0, 230);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 1444, new BigUint64Array(33498), 6998, 1940);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 11},
+  aspect: 'all',
+}, new ArrayBuffer(126_534), /* required buffer size: 126_534 */
+{offset: 510, bytesPerRow: 59, rowsPerImage: 142}, {width: 0, height: 7, depthOrArrayLayers: 16});
+} catch {}
+let textureView68 = texture50.createView({label: '\u0fef\u7f9b\u0c18\ufdfc\u0265', baseMipLevel: 3, mipLevelCount: 1});
+let renderPassEncoder82 = commandEncoder292.beginRenderPass({
+  label: '\u1362\u{1f8c1}\u{1f694}\u{1ffa6}\u899a\u0570\udb2c\uc0ce',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: -618.1, g: -620.0, b: -161.5, a: 59.50, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle148 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder63.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle84, renderBundle132, renderBundle130, renderBundle126]);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+await gc();
+let pipelineLayout35 = device1.createPipelineLayout({
+  label: '\u067b\u024b\u{1faea}\udd61\u9fa7',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout12, bindGroupLayout18],
+});
+let buffer36 = device1.createBuffer({
+  label: '\u25db\u{1ff04}\ueaf5\u6d8e',
+  size: 8648,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer184 = commandEncoder274.finish({});
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup5, new Uint32Array(718), 160, 0);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(4, buffer6, 0, 1_680);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise38 = device1.createRenderPipelineAsync({
+  label: '\u06c4\u6c18\uccc3',
+  layout: pipelineLayout13,
+  fragment: {module: shaderModule3, entryPoint: 'fragment0', constants: {}, targets: [{format: 'r8sint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 4108569411,
+    stencilWriteMask: 2060271614,
+    depthBiasSlopeScale: 733.6276413711485,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1112,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 20, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 48, shaderLocation: 15}],
+      },
+      {arrayStride: 200, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'sint32x2', offset: 580, shaderLocation: 5}]},
+      {arrayStride: 196, stepMode: 'instance', attributes: []},
+      {arrayStride: 468, stepMode: 'instance', attributes: []},
+      {arrayStride: 76, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'uint8x4', offset: 380, shaderLocation: 12}]},
+    ],
+  },
+});
+try {
+  await promise32;
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder293 = device2.createCommandEncoder();
+let renderBundle149 = renderBundleEncoder24.finish({label: '\u{1ff71}\u0617\u{1fc3c}\u3fcd\ue493\ufa00\u{1f971}\u4dd9\u8dff\u{1f703}\uf572'});
+try {
+renderPassEncoder70.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+commandEncoder293.resolveQuerySet(querySet31, 69, 52, buffer28, 15360);
+} catch {}
+let commandEncoder294 = device2.createCommandEncoder({label: '\u6b02\u0914\uff29\u9b62\u195e\u{1f8ec}\u35d3\u0bbc\u9c43\u8247'});
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 116, new Float32Array(7624), 624, 84);
+} catch {}
+let promise39 = device2.queue.onSubmittedWorkDone();
+let imageData29 = new ImageData(16, 36);
+let commandBuffer185 = commandEncoder293.finish();
+let texture88 = device2.createTexture({
+  label: '\u{1fce6}\u{1f9af}\ub078',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder83 = commandEncoder294.beginRenderPass({
+  label: '\u9d9a\uae9a\u281e\ubc50\ud040\udc53\u835b\u7392\u{1fb06}\uf1b9',
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: -968.8, g: 968.0, b: -720.7, a: -957.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder51.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(4, buffer30, 0, 2_629);
+} catch {}
+document.body.prepend(canvas7);
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup24, new Uint32Array(213), 104, 0);
+} catch {}
+try {
+computePassEncoder63.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer30, 'uint16', 2_120, 3_315);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint16', 598, 13);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(1, buffer32, 172, 25);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 66},
+  aspect: 'all',
+}, new ArrayBuffer(183_617), /* required buffer size: 183_617 */
+{offset: 473, bytesPerRow: 118, rowsPerImage: 191}, {width: 2, height: 25, depthOrArrayLayers: 9});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let imageData30 = new ImageData(16, 8);
+offscreenCanvas4.height = 110;
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1, 2);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(1, bindGroup27, new Uint32Array(1940), 40, 0);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(1, buffer16, 0, 3_610);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer26, 'uint16', 4_006, 454);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let arrayBuffer24 = buffer17.getMappedRange(3776, 12);
+try {
+device1.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 3,
+  origin: {x: 2, y: 1, z: 18},
+  aspect: 'all',
+}, new ArrayBuffer(31_594), /* required buffer size: 31_594 */
+{offset: 60, bytesPerRow: 303, rowsPerImage: 52}, {width: 11, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 1, depthOrArrayLayers: 547}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 81, y: 33 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 64, y: 0, z: 104},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule14 = device2.createShaderModule({
+  code: `@group(0) @binding(507) var<storage, read_write> buffer37: u32;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+buffer37 += bitcast<u32>(r.x);
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+buffer37 += bitcast<u32>(r.x);
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(2) f0: vec4<u32>,
+  @location(6) f1: f32,
+  @location(1) f2: vec4<f16>
+}
+struct VertexOutput0 {
+  @builtin(position) f16: vec4<f32>,
+  @location(8) f17: vec2<i32>,
+  @location(15) f18: vec3<i32>
+}
+
+@vertex
+fn vertex0(a0: S2) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder63.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder83.setStencilReference(716);
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer33, 'uint32', 2_368, 224);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint16', 776, 813);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer32, 60, 66);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder295 = device2.createCommandEncoder({label: '\u8975\u{1fbbc}\u{1f891}\u{1fcae}\u328a\u3775'});
+let computePassEncoder71 = commandEncoder295.beginComputePass({label: '\u0b9d\u4c4b'});
+let externalTexture27 = device2.importExternalTexture({label: '\u{1f8c7}\u{1ffc9}\u0639\ua83b', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder81.setViewport(0.7630210765374195, 461.429630784804, 0.19249766559752796, 4.0273686013604655, 0.5137468834948379, 0.6522911047385774);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint16', 478, 74);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+  await buffer34.mapAsync(GPUMapMode.READ, 3208);
+} catch {}
+let commandEncoder296 = device1.createCommandEncoder({});
+let renderPassEncoder84 = commandEncoder296.beginRenderPass({
+  label: '\u0ecb\u09f1',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 141,
+  clearValue: { r: -738.0, g: -412.7, b: 388.0, a: 340.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 176202000,
+});
+let externalTexture28 = device1.importExternalTexture({
+  label: '\ub9e7\u07bd\u0724\ua9a7\u5e9f\ub782\udd7d\ua779\u3b11\u35ed',
+  source: video2,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer13, 'uint32', 3_128, 811);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 912, new Int16Array(4465), 83, 1196);
+} catch {}
+let renderBundle150 = renderBundleEncoder20.finish({label: '\uc323\u896c\u0fa5\u51f3\u{1f83f}'});
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: 71.56, g: 405.5, b: 672.9, a: -166.6, });
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer25, 'uint16', 1_772, 393);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer26, 'uint32', 1_008, 11_900);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker('\u05c9');
+} catch {}
+let bindGroupLayout39 = device2.createBindGroupLayout({entries: []});
+let commandEncoder297 = device2.createCommandEncoder({label: '\uc2db\u4600\u5258\u0088'});
+let commandBuffer186 = commandEncoder297.finish();
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup26, []);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer32, 4);
+} catch {}
+try {
+computePassEncoder63.insertDebugMarker('\ud81d');
+} catch {}
+canvas8.width = 111;
+let imageData31 = new ImageData(4, 8);
+try {
+renderPassEncoder77.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder80.end();
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup15, new Uint32Array(1600), 124, 0);
+} catch {}
+try {
+renderPassEncoder29.pushDebugGroup('\uba58');
+} catch {}
+try {
+device1.queue.submit([commandBuffer177, commandBuffer183]);
+} catch {}
+canvas3.width = 17;
+let externalTexture29 = device1.importExternalTexture({
+  label: '\u{1fa52}\u269e\u{1ffda}\u{1fcc6}\ufbb0\u{1fab0}\u0bb0\u9179',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder17.dispatchWorkgroupsIndirect(buffer31, 768);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder64.setScissorRect(4, 1, 2, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer36, 'uint16', 1_660, 893);
+} catch {}
+try {
+renderPassEncoder29.popDebugGroup();
+} catch {}
+await gc();
+let videoFrame6 = new VideoFrame(canvas7, {timestamp: 0});
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({
+  label: '\ue9d0\u{1f8c5}\u079e\u{1f9eb}\uaeba\uee79\ud246\u0bac\u0fbf',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup6, new Uint32Array(2171), 996, 0);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle135, renderBundle134]);
+} catch {}
+let commandEncoder298 = device2.createCommandEncoder({label: '\u{1fd0c}\u{1f976}'});
+let renderBundle151 = renderBundleEncoder37.finish();
+try {
+renderPassEncoder75.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup26, new Uint32Array(3030), 491, 0);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let promise40 = device2.queue.onSubmittedWorkDone();
+let buffer38 = device1.createBuffer({
+  label: '\u4fe5\u{1fc79}\uf8c0\u0241\u766c',
+  size: 12716,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder299 = device1.createCommandEncoder();
+let commandBuffer187 = commandEncoder299.finish({label: '\u0c74\u{1f6cf}\u{1f6b3}\u{1f929}'});
+let renderBundle152 = renderBundleEncoder35.finish({label: '\u{1fe77}\u1775'});
+try {
+renderPassEncoder68.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle124]);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer18, 'uint32', 4_412, 8_584);
+} catch {}
+try {
+  await promise40;
+} catch {}
+try {
+computePassEncoder65.setBindGroup(3, bindGroup7, new Uint32Array(3017), 256, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer24, 'uint32', 1_256, 10_327);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup17, new Uint32Array(3964), 816, 0);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+let commandEncoder300 = device2.createCommandEncoder({label: '\u{1fa1f}\u58fe'});
+let texture89 = gpuCanvasContext9.getCurrentTexture();
+let computePassEncoder72 = commandEncoder298.beginComputePass({label: '\u397f\u09c0\u8e09\u3443\u7377\u3350\u{1f81d}'});
+try {
+renderBundleEncoder36.setIndexBuffer(buffer30, 'uint16', 94, 5_146);
+} catch {}
+try {
+commandEncoder300.copyBufferToBuffer(buffer28, 63832, buffer33, 2004, 56);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 1396, new DataView(new ArrayBuffer(1795)), 495, 40);
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup30, new Uint32Array(512), 7, 0);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+  await promise39;
+} catch {}
+let computePassEncoder73 = commandEncoder300.beginComputePass({label: '\ue285\u1563'});
+let renderBundle153 = renderBundleEncoder31.finish({label: '\u33d5\u04e8\u58a8\u0911\u8196\u6ed9\u9eb5\u16fe\u3d06'});
+let externalTexture30 = device2.importExternalTexture({
+  label: '\ud19c\u5422\u5fb1\u{1f963}\u7ade\u8eb3\u{1f80a}\uc0de\u{1ffbf}\u0de8',
+  source: video6,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder83.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer162, commandBuffer164]);
+} catch {}
+canvas8.width = 4911;
+let shaderModule15 = device2.createShaderModule({
+  label: '\u07dd\u1ed9\u0c91\uce59',
+  code: `@group(0) @binding(507) var<storage, read_write> buffer39: u32;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+buffer39 += bitcast<u32>(r.x);
+}
+
+struct FragmentOutput0 {
+  @location(4) f0: i32,
+  @location(0) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec4<f32>, @location(11) a1: f32, @location(5) a2: f16) -> FragmentOutput0 {
+var r: vec4f;
+buffer39 += bitcast<u32>(r.x);
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(3) f0: vec3<f32>,
+  @location(5) f1: vec3<f32>,
+  @location(11) f2: vec4<f32>
+}
+struct VertexOutput0 {
+  @builtin(position) f19: vec4<f32>,
+  @location(6) f20: f32,
+  @location(5) f21: f16,
+  @location(11) f22: f32,
+  @location(10) f23: vec3<f16>,
+  @location(1) f24: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<f32>, @location(7) a1: vec4<f32>, @location(15) a2: vec2<f16>, @location(8) a3: vec2<f16>, @location(6) a4: vec3<i32>, a5: S3) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder301 = device2.createCommandEncoder({});
+let renderPassEncoder85 = commandEncoder301.beginRenderPass({
+  label: '\ua9f8\u0350\ue7ef\u0c7e\u{1fe56}\udd09\u0009\u1b02\uf84b',
+  colorAttachments: [{
+  view: textureView67,
+  resolveTarget: textureView65,
+  clearValue: { r: 711.4, g: -98.42, b: -475.0, a: 534.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline12);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let querySet32 = device2.createQuerySet({label: '\ud78a\uf630', type: 'occlusion', count: 285});
+try {
+computePassEncoder72.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup25, new Uint32Array(893), 496, 0);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(2, buffer32, 324, 35);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer32, 0, 562);
+} catch {}
+let arrayBuffer25 = buffer34.getMappedRange(4096, 0);
+try {
+device2.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 3,
+  origin: {x: 0, y: 16, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(721_845), /* required buffer size: 721_845 */
+{offset: 39, bytesPerRow: 118, rowsPerImage: 278}, {width: 0, height: 2, depthOrArrayLayers: 23});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 20, y: 86 },
+  flipY: true,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas5.height = 604;
+let shaderModule16 = device1.createShaderModule({
+  label: '\ucd82\u{1f703}\u09db',
+  code: `@group(0) @binding(115) var tex3: texture_2d<f32>;
+@group(2) @binding(62) var<storage, read> buffer40: u32;
+@group(2) @binding(255) var et4: texture_external;
+@group(2) @binding(504) var sam17: sampler;
+@group(0) @binding(79) var et3: texture_external;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(tex3, vec2u(), 0);
+r += bitcast<f32>(buffer40);
+r += textureLoad(et4, vec2u());
+_ = sam17;
+r += textureLoad(et3, vec2u());
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<u32>,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+r += textureLoad(tex3, vec2u(), 0);
+r += bitcast<f32>(buffer40);
+r += textureLoad(et4, vec2u());
+_ = sam17;
+r += textureLoad(et3, vec2u());
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f25: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<f32>) -> VertexOutput0 {
+var r: vec4f;
+r += bitcast<f32>(buffer40);
+r += textureLoad(et4, vec2u());
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer24, 'uint32', 5_988, 9_537);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer16, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 916, new Float32Array(9029), 915, 208);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let buffer41 = device2.createBuffer({
+  size: 11746,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder65.beginOcclusionQuery(172);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup23, new Uint32Array(380), 82, 0);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline12);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+await gc();
+try {
+renderPassEncoder83.setVertexBuffer(4, buffer33, 1_200, 21);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+try {
+device2.queue.submit([commandBuffer186, commandBuffer111, commandBuffer172]);
+} catch {}
+let shaderModule17 = device2.createShaderModule({
+  label: '\u{1fe09}\u6dda\u9276\u7f48',
+  code: `@group(2) @binding(215) var sam20: sampler;
+@group(1) @binding(215) var sam19: sampler;
+@group(0) @binding(215) var sam18: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+_ = sam20;
+_ = sam19;
+_ = sam18;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec4<u32>) -> FragmentOutput0 {
+var r: vec4f;
+_ = sam20;
+_ = sam19;
+_ = sam18;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f26: vec4<f32>,
+  @location(9) f27: vec4<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+var r: vec4f;
+_ = sam20;
+_ = sam19;
+_ = sam18;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture90 = device2.createTexture({
+  label: '\u{1f632}\u3494\u0b71\ud723\u{1fb4a}',
+  size: [3, 15, 1],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder39 = device2.createRenderBundleEncoder({label: '\u{1fc86}\u{1fcfe}\u0576\uab9f\u{1fb9b}\u3999\ucc37', colorFormats: ['r8unorm']});
+try {
+renderPassEncoder83.end();
+} catch {}
+try {
+renderPassEncoder75.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer41, 'uint32', 552, 1_540);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(6, buffer30, 0, 2_177);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let promise41 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let pipelineLayout36 = device1.createPipelineLayout({label: '\uceb6\u4a92\u92e8\u{1f862}', bindGroupLayouts: [bindGroupLayout18, bindGroupLayout34]});
+let renderBundle154 = renderBundleEncoder10.finish({label: '\u2249\u{1f71e}\u3332\u{1f6ff}'});
+try {
+computePassEncoder10.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer18, 'uint32', 15_384, 836);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup5, new Uint32Array(1274), 206, 0);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(2, buffer33, 36, 824);
+} catch {}
+let commandEncoder302 = device1.createCommandEncoder();
+let querySet33 = device1.createQuerySet({
+  label: '\u0563\u0832\u73c3\u{1fd14}\u89b9\u24d8\u9df1\u{1feeb}\u0f8c\u0912',
+  type: 'occlusion',
+  count: 1897,
+});
+let renderPassEncoder86 = commandEncoder302.beginRenderPass({
+  label: '\u{1fec4}\u09a0\u0083\u{1fde9}\u076b\u642a\ub52e\u0b4d\u5b59\u6aac\u{1fb2e}',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 942.3, g: 194.7, b: -298.1, a: 191.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 126075685,
+});
+let renderBundleEncoder40 = device1.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+renderPassEncoder71.setIndexBuffer(buffer38, 'uint16', 2_420, 391);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder10.dispatchWorkgroups(2, 1, 1);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(7, buffer17, 708);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer173]);
+} catch {}
+try {
+  await promise30;
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let texture91 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup26, new Uint32Array(6063), 1616, 0);
+} catch {}
+try {
+device2.queue.submit([commandBuffer116]);
+} catch {}
+let commandEncoder303 = device2.createCommandEncoder({label: '\u0ec7\u{1fab8}\ube13\u0128\u{1fd79}\u82c2\u0f43'});
+let commandBuffer188 = commandEncoder303.finish({label: '\uda75\u1f3e'});
+let renderBundle155 = renderBundleEncoder39.finish({label: '\ub82b\u{1fcee}\u9142\u03cb\u{1fd05}\ua243'});
+try {
+renderPassEncoder62.setVertexBuffer(5, buffer41, 0, 1_684);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer41, 'uint16', 1_328, 1_497);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer33);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 42, y: 47 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let buffer42 = device1.createBuffer({
+  label: '\u410d\u69cc\u0d63\u9866\u{1fd09}\u{1fd2d}\u3211\u7f30\u{1f858}',
+  size: 21603,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let renderBundle156 = renderBundleEncoder35.finish({label: '\u0c2f\u0a2c\ufe47'});
+try {
+renderPassEncoder60.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(6, buffer6, 0, 2_157);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+renderPassEncoder31.insertDebugMarker('\ue992');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let sampler20 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.18,
+  lodMaxClamp: 89.25,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder64.executeBundles([renderBundle44, renderBundle67, renderBundle47]);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer29, 'uint32', 3_936, 2_928);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer178]);
+} catch {}
+let commandEncoder304 = device1.createCommandEncoder();
+let commandBuffer189 = commandEncoder304.finish({label: '\u636c\u{1f9c8}\u79ec'});
+try {
+computePassEncoder10.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(3, bindGroup27, new Uint32Array(134), 88, 0);
+} catch {}
+try {
+  await promise36;
+} catch {}
+let imageData32 = new ImageData(92, 16);
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup25, new Uint32Array(1292), 41, 0);
+} catch {}
+try {
+renderBundleEncoder36.draw(1, 430, 3, 868_761_723);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer41, 'uint16', 5_062, 877);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline26);
+} catch {}
+await gc();
+let commandEncoder305 = device1.createCommandEncoder({});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup8, new Uint32Array(1289), 67, 0);
+} catch {}
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint32', 5_216, 1_301);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+  await buffer35.mapAsync(GPUMapMode.WRITE, 0, 528);
+} catch {}
+try {
+commandEncoder305.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 24632 */
+  offset: 2588,
+  bytesPerRow: 256,
+  rowsPerImage: 45,
+  buffer: buffer16,
+}, {width: 28, height: 42, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder104.clearBuffer(buffer15, 5564, 600);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(34_379), /* required buffer size: 34_379 */
+{offset: 370, bytesPerRow: 77, rowsPerImage: 110}, {width: 13, height: 2, depthOrArrayLayers: 5});
+} catch {}
+let device3 = await adapter4.requestDevice({
+  label: '\u60bd\u0d55',
+  requiredFeatures: [
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindingsPerBindGroup: 1000,
+    maxTextureDimension1D: 8192,
+    maxUniformBufferBindingSize: 1606492,
+    maxStorageBufferBindingSize: 140469451,
+  },
+});
+try {
+  await promise41;
+} catch {}
+let texture92 = device2.createTexture({
+  label: '\u0738\uf919\u04a2',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder41 = device2.createRenderBundleEncoder({
+  label: '\u06e0\u4345\u{1fd64}\u8a4b\u062d\u{1f97b}\u53a0\ud006\u0d36',
+  colorFormats: ['r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let externalTexture31 = device2.importExternalTexture({label: '\u1c7a\u347c\ud515\u{1f7ec}\u5fea\u03ae', source: video4});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup23, new Uint32Array(912), 535, 0);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup30, new Uint32Array(2246), 113, 0);
+} catch {}
+try {
+renderPassEncoder81.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(151, 119, 136, -1_998_975_983, 951_966_759);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer41, 'uint16', 1_964, 2_487);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 60, depthOrArrayLayers: 37}
+*/
+{
+  source: canvas3,
+  origin: { x: 4, y: 40 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 37},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder69.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder36.draw(2, 100, 0, 104_101_918);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(61, 140, 73, 675_707_962, 1_643_986_017);
+} catch {}
+document.body.prepend(canvas8);
+let texture93 = device2.createTexture({
+  label: '\u0e4f\u{1f8bb}\ud1ab\u048f\u2ad7\u0f17\u0994\u0a9f',
+  size: [1, 120, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder64.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder78.executeBundles([renderBundle139, renderBundle114, renderBundle125, renderBundle142]);
+} catch {}
+try {
+renderPassEncoder81.setIndexBuffer(buffer30, 'uint32', 1_020, 2_481);
+} catch {}
+try {
+renderBundleEncoder36.draw(0, 572, 0, 24_854_380);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(3, buffer33, 0, 221);
+} catch {}
+let commandBuffer190 = commandEncoder305.finish({});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup7, new Uint32Array(2257), 85, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup29);
+} catch {}
+let commandBuffer191 = commandEncoder104.finish();
+try {
+renderPassEncoder60.setVertexBuffer(5, buffer16, 0, 1_225);
+} catch {}
+let img5 = await imageWithData(121, 87, '#5949bd89', '#d3e6744a');
+let commandEncoder306 = device1.createCommandEncoder({label: '\uc49d\u0c4f\u04c1\u4f6d\u4b7c\u0f5c'});
+let textureView69 = texture38.createView({label: '\ue033\u0f1a\u0d54\ue581\u3965\udaca\u{1fdd1}'});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup8, new Uint32Array(1793), 134, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle47]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer18, 'uint32', 3_344, 800);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1420, new Float32Array(18882), 626, 300);
+} catch {}
+video1.height = 106;
+let commandEncoder307 = device2.createCommandEncoder({label: '\u5c23\u757c\u{1fc16}\u8474\u9f4d\ua75f\u0cd0'});
+let commandBuffer192 = commandEncoder307.finish({label: '\u0f5d\uf85a\u{1fac1}\u{1fae1}\uf6a4'});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup22, new Uint32Array(1909), 991, 0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(1, 3, 75, 164_878_276, 815_347_613);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer41, 'uint32', 1_828, 1_185);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline12);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer182, commandBuffer132, commandBuffer179]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 2020, new BigUint64Array(6788), 1835, 372);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 60, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 9, y: 75 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame7 = new VideoFrame(img3, {timestamp: 0});
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let commandEncoder308 = device3.createCommandEncoder({});
+let texture94 = gpuCanvasContext15.getCurrentTexture();
+let renderBundleEncoder42 = device3.createRenderBundleEncoder({label: '\u{1ff5c}\u0b03', colorFormats: ['rg8sint'], sampleCount: 4});
+let commandEncoder309 = device1.createCommandEncoder({label: '\uebe4\ud747\u662e'});
+let texture95 = device1.createTexture({
+  label: '\u190f\u0d0c\uc675\u6be6\u2d8a\u{1faf7}\u2097\u2d15\u33bb\u{1fa79}',
+  size: [603, 1, 1],
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder66.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(6, buffer17, 0, 1_078);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer31, 'uint32', 692, 77);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer6, 1_992, 4_025);
+} catch {}
+try {
+commandEncoder306.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 29, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11056 */
+  offset: 1500,
+  bytesPerRow: 256,
+  rowsPerImage: 7,
+  buffer: buffer16,
+}, {width: 21, height: 3, depthOrArrayLayers: 6});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 1, depthOrArrayLayers: 547}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 58, y: 209 },
+  flipY: false,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 195, y: 0, z: 162},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder310 = device3.createCommandEncoder({label: '\ua403\udb36'});
+let renderBundle157 = renderBundleEncoder42.finish();
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let externalTexture32 = device3.importExternalTexture({source: videoFrame4});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder311 = device3.createCommandEncoder({});
+let commandBuffer193 = commandEncoder308.finish({label: '\u08a5\u{1fcca}\u{1f9c1}\u{1fc5c}\ue3a3\u{1fef9}\u{1fe3e}\uf7a9\u423f\ud630\uc57b'});
+let computePassEncoder74 = commandEncoder310.beginComputePass({label: '\u936c\ua823\u555e\ub1d5\u874a'});
+let renderBundleEncoder43 = device3.createRenderBundleEncoder({colorFormats: ['rg8sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let commandEncoder312 = device3.createCommandEncoder({label: '\u{1f819}\u0479\u3a82\u0fb2\u0df4\u0e9f\u50c5\uf73e\u0378\u{1ffa0}'});
+let pipelineLayout37 = device2.createPipelineLayout({label: '\uf2a1\u0f0f\u04a5', bindGroupLayouts: []});
+let renderBundle158 = renderBundleEncoder37.finish({label: '\u1273\u6355\uf88f\u87dd\u007c\ub966\u6679\ud439'});
+try {
+renderPassEncoder78.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder36.draw(77, 3, 127_898_509);
+} catch {}
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55); };
+} catch {}
+let commandBuffer194 = commandEncoder309.finish({label: '\u674e\u4b24\u00f1'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup7, new Uint32Array(566), 16, 0);
+} catch {}
+try {
+renderPassEncoder86.end();
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer24, 0, 1_180);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer25, 'uint32', 60, 1_481);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 1, depthOrArrayLayers: 547}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 17, y: 11 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 117},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture14.label;
+} catch {}
+let imageData33 = new ImageData(36, 44);
+let commandEncoder313 = device2.createCommandEncoder({label: '\u183b\uf16e\u{1faab}\u0b2a\u6625\u7507'});
+let renderBundle159 = renderBundleEncoder32.finish({label: '\u{1f61c}\u8f20\u0102\u169a\u02d8\u0e49\u5ca5'});
+try {
+renderPassEncoder65.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(7, buffer33);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(276, 2, 40, 88_846_072);
+} catch {}
+try {
+commandEncoder313.resolveQuerySet(querySet19, 24, 7, buffer32, 0);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let bindGroup31 = device1.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 159, resource: sampler17}]});
+let commandBuffer195 = commandEncoder306.finish();
+let renderBundle160 = renderBundleEncoder23.finish({label: '\u4bf1\u07c9\u{1f834}'});
+try {
+renderPassEncoder77.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer6, 0, 687);
+} catch {}
+let arrayBuffer26 = buffer17.getMappedRange(9720, 1448);
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let querySet34 = device1.createQuerySet({type: 'occlusion', count: 4096});
+try {
+computePassEncoder55.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup29, new Uint32Array(963), 13, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer38, 'uint16', 2_312, 2_729);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer17, 1_164, 191);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer167]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 90, height: 20, depthOrArrayLayers: 106}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 356, y: 20 },
+  flipY: false,
+}, {
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 3, y: 5, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder314 = device3.createCommandEncoder({label: '\u017a\u37c0\u1ecc'});
+let commandBuffer196 = commandEncoder314.finish({label: '\ud275\u37bd\u9910'});
+let renderBundle161 = renderBundleEncoder43.finish({label: '\u{1ff23}\u2c85\ucbb4\ucd74\udb6d\u0c97\u6207'});
+try {
+device3.queue.submit([commandBuffer193]);
+} catch {}
+let commandEncoder315 = device2.createCommandEncoder({});
+let commandBuffer197 = commandEncoder315.finish({label: '\uf588\ud273\u6b94\u5f5d\u{1ff7c}\u{1fa44}\udadb\u0188\ueb8d\u3257'});
+try {
+renderPassEncoder82.end();
+} catch {}
+try {
+renderPassEncoder78.executeBundles([renderBundle137]);
+} catch {}
+try {
+renderPassEncoder75.setScissorRect(0, 68, 0, 13);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer30, 'uint32', 2_696, 5_058);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(2, buffer30, 192, 690);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+await gc();
+let buffer43 = device1.createBuffer({
+  label: '\u213b\u{1f735}\u{1fb7a}\u0840\u1ec7\u048b\u687b\u03d4\u{1fef7}\u5fe8',
+  size: 10920,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+computePassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup27, new Uint32Array(575), 23, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer175]);
+} catch {}
+let commandEncoder316 = device3.createCommandEncoder({});
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+commandEncoder312.insertDebugMarker('\ud62a');
+} catch {}
+let commandEncoder317 = device2.createCommandEncoder();
+let commandBuffer198 = commandEncoder313.finish({});
+let texture96 = device2.createTexture({
+  label: '\u0660\u{1fbf0}\u03a1\ube74\u99bc',
+  size: {width: 24, height: 120, depthOrArrayLayers: 437},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder44 = device2.createRenderBundleEncoder({label: '\u0be9\u040e\u8344', colorFormats: ['r8unorm']});
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer41, 'uint16', 1_180, 2_939);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(3, buffer32, 308);
+} catch {}
+try {
+device2.queue.submit([commandBuffer198, commandBuffer188, commandBuffer151]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder318 = device1.createCommandEncoder({label: '\u{1f787}\ud5a2\ud29e\u1b97\u0ca7\u445c\ue018'});
+let computePassEncoder75 = commandEncoder318.beginComputePass({label: '\u{1fbcb}\u{1fa97}\u7a7a\u0511'});
+try {
+renderPassEncoder63.setVertexBuffer(4, buffer24);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer6, 0, 1_646);
+} catch {}
+let texture97 = device2.createTexture({
+  label: '\u685b\u03ad\u7605\u{1fce8}\u{1fbd0}\u7f3b\uf92d\u{1fc42}\u2bd4\ud0e8\u{1fa63}',
+  size: [6, 30, 1],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder76 = commandEncoder317.beginComputePass({label: '\u{1ffdf}\ud8d2'});
+try {
+computePassEncoder63.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle138]);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer33, 'uint16', 680, 288);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 804, new Int16Array(3840), 1577, 760);
+} catch {}
+try {
+canvas10.getContext('webgl');
+} catch {}
+let textureView70 = texture24.createView({label: '\ubef4\u0065\u04fc\u4084\u833f\ue693'});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup27, new Uint32Array(1229), 173, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer29, 'uint16', 2_866, 107);
+} catch {}
+try {
+renderPassEncoder28.insertDebugMarker('\u724e');
+} catch {}
+let commandBuffer199 = commandEncoder312.finish({label: '\u0446\u29ef'});
+let renderBundleEncoder45 = device3.createRenderBundleEncoder({colorFormats: ['rg8sint'], sampleCount: 4, stencilReadOnly: true});
+let commandEncoder319 = device1.createCommandEncoder({label: '\u01dc\u1a87\udede\u0e1e'});
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline5);
+} catch {}
+let imageData34 = new ImageData(44, 32);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule18 = device1.createShaderModule({
+  label: '\u61cf\u2b65\u50b5\u96b8\ubdd8\u5371\u44d9\ue733',
+  code: `@group(0) @binding(79) var et5: texture_external;
+@group(2) @binding(62) var<storage, read> buffer44: u32;
+@group(2) @binding(255) var et6: texture_external;
+@group(2) @binding(504) var sam21: sampler;
+@group(0) @binding(115) var tex4: texture_2d<f32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et5, vec2u());
+r += bitcast<f32>(buffer44);
+r += textureLoad(et6, vec2u());
+_ = sam21;
+r += textureLoad(tex4, vec2u(), 0);
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+var r: vec4f;
+r += textureLoad(et5, vec2u());
+r += bitcast<f32>(buffer44);
+r += textureLoad(et6, vec2u());
+_ = sam21;
+r += textureLoad(tex4, vec2u(), 0);
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f28: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f32>, @builtin(vertex_index) a1: u32) -> VertexOutput0 {
+var r: vec4f;
+r += bitcast<f32>(buffer44);
+r += textureLoad(et6, vec2u());
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let renderPassEncoder87 = commandEncoder319.beginRenderPass({
+  label: '\u{1f764}\u1280\ud526\u5823\u05e6\u88cc\u2047',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 163,
+  clearValue: { r: -3.491, g: 763.7, b: -887.0, a: 319.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 4489819,
+});
+let externalTexture33 = device1.importExternalTexture({
+  label: '\u{1f627}\ub393\u686d\u05c7\u{1feed}\u{1f7b0}\u2e73',
+  source: videoFrame7,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder53.setVertexBuffer(6, buffer16, 0, 15_796);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer25, 0);
+} catch {}
+let imageData35 = new ImageData(88, 76);
+canvas5.width = 1302;
+let querySet35 = device2.createQuerySet({label: '\u4a18\u0b20\u9470', type: 'occlusion', count: 77});
+let texture98 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder51.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder65.draw(3, 22, 0, 44_922_899);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint16', 530, 904);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(0, buffer30, 1_328, 481);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 268, new BigUint64Array(30257), 1173, 132);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer38, 'uint32', 860, 1_114);
+} catch {}
+let arrayBuffer27 = buffer17.getMappedRange(11168, 568);
+document.body.prepend(canvas7);
+let imageData36 = new ImageData(48, 208);
+let commandEncoder320 = device3.createCommandEncoder({});
+let commandBuffer200 = commandEncoder316.finish();
+let commandBuffer201 = commandEncoder320.finish({label: '\u2b28\u0dfd\ud406\u{1fe03}\u7058\u{1fcb7}\uc3e1\u{1fdb0}\u{1f68e}'});
+let externalTexture34 = device3.importExternalTexture({source: video0, colorSpace: 'srgb'});
+await gc();
+let renderBundle162 = renderBundleEncoder38.finish({label: '\u0446\u0ac9\u4682\u{1f6e4}\u57f9\u0e1e'});
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline23);
+} catch {}
+try {
+computePassEncoder75.insertDebugMarker('\u1a66');
+} catch {}
+let videoFrame8 = new VideoFrame(video3, {timestamp: 0});
+try {
+renderPassEncoder18.setIndexBuffer(buffer36, 'uint32', 1_744, 1_892);
+} catch {}
+try {
+device1.queue.submit([commandBuffer176, commandBuffer181]);
+} catch {}
+let commandEncoder321 = device3.createCommandEncoder({label: '\u{1fd81}\u5fc7\u0584\u{1fa0e}\udc15'});
+let commandEncoder322 = device3.createCommandEncoder({});
+let commandBuffer202 = commandEncoder311.finish({label: '\ued9d\u{1f99f}\u2924\ubc68\ud64d\u02b9\u7548\u15ef\u16f8'});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({
+  label: '\u556a\u{1f833}\ub7c7\u9257\ua383\u1777\ub608\ufd85\u0a9d\u{1f60b}\ud378',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder11.dispatchWorkgroupsIndirect(buffer26, 704);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle134]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer25, 'uint32', 1_964, 352);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(4, buffer25, 0, 1_954);
+} catch {}
+try {
+device1.queue.submit([commandBuffer174]);
+} catch {}
+let commandEncoder323 = device2.createCommandEncoder({});
+let commandBuffer203 = commandEncoder323.finish({label: '\uf9b8\u4495\u4c71\u1536\u{1f910}'});
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(5, buffer30);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(1, 3, 148, 454_934_194, 1);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(5, buffer32, 376);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 1416, new DataView(new ArrayBuffer(24748)), 2657, 2316);
+} catch {}
+try {
+renderPassEncoder77.beginOcclusionQuery(672);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(2, buffer25);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer38, 48, new BigUint64Array(5882), 227, 20);
+} catch {}
+let commandEncoder324 = device3.createCommandEncoder({label: '\u8e03\u5114\uc612\u1275'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter3.label = '\uc864\u088f';
+} catch {}
+try {
+querySet30.label = '\u008f\ue378\u{1f9ac}\u0e3b\u0a4b\u03df';
+} catch {}
+let commandEncoder325 = device2.createCommandEncoder();
+let querySet36 = device2.createQuerySet({label: '\u9e71\u005b\u6015\u05d8\udf5c\ueac0\uf7eb\u{1fdf6}', type: 'occlusion', count: 417});
+let computePassEncoder77 = commandEncoder325.beginComputePass({label: '\u{1fb04}\u0088\uef71\u15ff\ucd41\u4e23\u{1fe37}\u{1fe9c}'});
+try {
+computePassEncoder63.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder70.setViewport(0.01619115424390527, 107.72631303295863, 0.16448431071469463, 4.9117970124570025, 0.7197330107371409, 0.8137063450565918);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(58, 8, 254, 459_034_945, 1_573_526_388);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderBundleEncoder36.draw(39, 0, 1_427_651_201, 2);
+} catch {}
+let promise42 = device2.queue.onSubmittedWorkDone();
+await gc();
+let renderBundle163 = renderBundleEncoder45.finish({});
+offscreenCanvas5.height = 1372;
+let bindGroup32 = device1.createBindGroup({label: '\u1710\ua7b8\ucd51\u9300\u{1f698}\u{1fc49}\u{1fe31}', layout: bindGroupLayout26, entries: []});
+let pipelineLayout38 = device1.createPipelineLayout({label: '\u0663\ued11\u04c4\u{1f8be}\u26e8\u0ccb\u0586\uc1f3\u03b3\u0a61\uf36a', bindGroupLayouts: []});
+let commandEncoder326 = device1.createCommandEncoder({label: '\u061f\uafe2\ueaf0\u{1f95b}\u4d2e\u{1ff32}\uefbc\u073f\u7161\u0ac1'});
+let commandBuffer204 = commandEncoder326.finish({label: '\u8554\u09d0\u9773\u5c0f\ub197\u0eb2'});
+try {
+computePassEncoder70.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder77.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer24);
+} catch {}
+let commandEncoder327 = device1.createCommandEncoder({label: '\ufb4e\u{1fbe8}\u{1fa35}\u5022\u{1fe12}\u0726\u{1fe9d}\u05b8\u05db\u{1fc43}'});
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer28 = buffer26.getMappedRange(28160, 0);
+try {
+buffer25.unmap();
+} catch {}
+try {
+renderPassEncoder52.pushDebugGroup('\uacc9');
+} catch {}
+let bindGroup33 = device2.createBindGroup({
+  label: '\u0624\u2121\u08b1\u{1f833}',
+  layout: bindGroupLayout23,
+  entries: [{binding: 391, resource: sampler12}],
+});
+try {
+computePassEncoder71.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(7, buffer32, 0, 629);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(1, buffer32, 36, 77);
+} catch {}
+let commandEncoder328 = device2.createCommandEncoder({label: '\u2f20\u0d8b\ue117\u87ca\uaa9c\u{1ff25}\ud543\u{1fced}\u0dfe\ua534\u{1fad2}'});
+let renderBundle164 = renderBundleEncoder41.finish();
+try {
+renderPassEncoder65.drawIndexed(204, 43, 128, 1_732_849_761, 946_322_128);
+} catch {}
+try {
+renderBundleEncoder36.draw(125, 5, 331_740_776);
+} catch {}
+try {
+commandEncoder328.copyBufferToBuffer(buffer41, 1716, buffer34, 1484, 1688);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData37 = new ImageData(12, 20);
+let querySet37 = device3.createQuerySet({label: '\u081a\u3fd7\u01e2\ue723\u53ed', type: 'occlusion', count: 744});
+let renderBundleEncoder47 = device3.createRenderBundleEncoder({colorFormats: ['rg8sint'], sampleCount: 4, depthReadOnly: true});
+let renderBundle165 = renderBundleEncoder47.finish({label: '\uee02\u0ddf\ua0ac\ub506\u6aba'});
+let promise43 = adapter4.requestAdapterInfo();
+let commandEncoder329 = device1.createCommandEncoder({label: '\uf7d4\u6484\ua5a2'});
+try {
+renderBundleEncoder40.setVertexBuffer(1, undefined);
+} catch {}
+try {
+  await buffer43.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+renderPassEncoder52.popDebugGroup();
+} catch {}
+try {
+adapter4.label = '\u0b7b\u{1f631}\u719e\u{1fc64}\u0a88\u{1fbad}';
+} catch {}
+let commandEncoder330 = device3.createCommandEncoder({label: '\u{1f8cd}\uf776\u0bad\u496f\u{1fb7c}\ufab0\u086e\u754c\u04c1\u9097\u6581'});
+let commandBuffer205 = commandEncoder321.finish({});
+let texture99 = device3.createTexture({
+  label: '\u8178\uc7a0\u0f84\u08ef\ucc5c\u{1feab}\u{1fbe4}\uc299',
+  size: [10, 6, 1],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle166 = renderBundleEncoder45.finish({label: '\u0d0e\u1923\u{1f700}\u5a86'});
+await gc();
+try {
+window.someLabel = commandBuffer193.label;
+} catch {}
+let commandEncoder331 = device3.createCommandEncoder({label: '\u0322\u62d9\u{1f7aa}\u55b3\u7890\u0703\u0a56\u02cd\u047c'});
+let commandBuffer206 = commandEncoder310.finish({label: '\u0861\ua3df\u0af0\u82c5'});
+video1.height = 37;
+offscreenCanvas1.height = 1635;
+let querySet38 = device2.createQuerySet({
+  label: '\ub25c\ue554\u0165\u103c\u0eed\u42f6\u9ad8\u00a3\u9064\u{1f67a}',
+  type: 'occlusion',
+  count: 272,
+});
+let commandBuffer207 = commandEncoder328.finish({});
+try {
+renderPassEncoder78.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(517, 219, 4, 592_023_533, 553_297_926);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(36, 0, 293, 194_164_831, 1);
+} catch {}
+let renderBundle167 = renderBundleEncoder24.finish({label: '\u2895\u{1f6ce}\u042f\u3b32\uf702\u03ff\ud589\u048a'});
+try {
+computePassEncoder71.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(3, bindGroup22, new Uint32Array(2054), 326, 0);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(168, 41, 42, 40_696_188, 363_031_587);
+} catch {}
+let texture100 = device1.createTexture({
+  label: '\u00a2\ud45d\ub2d4\u9e0b\u{1fd2f}\u3c3a\u{1f955}\ua53e\u6a1a',
+  size: [44],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder78 = commandEncoder327.beginComputePass({label: '\u0c60\u{1fe14}\uf1d5\u0d94\u{1ffc3}\u8751\u041d\u22ce\u{1f6a6}\u{1fda8}'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup7, new Uint32Array(437), 11, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer25, 'uint32', 428, 765);
+} catch {}
+let pipeline28 = await device1.createComputePipelineAsync({
+  label: '\u1ec1\u{1f7b1}\u06d9',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule8, entryPoint: 'compute0'},
+});
+try {
+device2.queue.submit([commandBuffer192, commandBuffer203, commandBuffer197]);
+} catch {}
+try {
+  await promise42;
+} catch {}
+let buffer45 = device1.createBuffer({size: 1672, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: true});
+let texture101 = device1.createTexture({
+  label: '\u8b71\ueb22\ufc64\ub023\ubb04\u920e\u022a\u{1fdef}\u{1feda}\ubd49',
+  size: {width: 270},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer31, 'uint32', 200, 677);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer38, 'uint16', 1_444, 786);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(553, 88);
+let imageData38 = new ImageData(48, 52);
+let computePassEncoder79 = commandEncoder330.beginComputePass({label: '\u8a2b\u3347'});
+let bindGroup34 = device1.createBindGroup({
+  label: '\u6c75\u94fb\u9746\uc41e\u73d9\u511c',
+  layout: bindGroupLayout1,
+  entries: [{binding: 159, resource: sampler8}],
+});
+let computePassEncoder80 = commandEncoder329.beginComputePass({label: '\u0490\u9fce\u0581\u{1f70e}\u7b23\uc33e\ub34e'});
+let renderBundleEncoder48 = device1.createRenderBundleEncoder({label: '\ue474\u7d52', colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder49.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer13, 'uint32', 884, 5_669);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline23);
+} catch {}
+let gpuCanvasContext16 = offscreenCanvas7.getContext('webgpu');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let buffer46 = device2.createBuffer({
+  label: '\u{1f6c5}\u3dea\u18dd\u18e2\u0bc4',
+  size: 14683,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundle168 = renderBundleEncoder36.finish();
+let sampler21 = device2.createSampler({
+  label: '\u2882\u{1fe7e}\u{1f6b5}\u004c\u089f\u024a\u06bf\u0851\udbc4',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.36,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(11_851), /* required buffer size: 11_851 */
+{offset: 136, bytesPerRow: 165, rowsPerImage: 66}, {width: 0, height: 6, depthOrArrayLayers: 2});
+} catch {}
+let promise44 = device2.queue.onSubmittedWorkDone();
+let video9 = await videoWithData();
+let commandEncoder332 = device3.createCommandEncoder({label: '\u0075\u{1fc85}\u9506\u34c2\ub956\ue335\u0a21\ua99d\uc888\ud3c4'});
+try {
+renderPassEncoder65.drawIndexed(84, 51, 239, 413_741_402, 526_368_187);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer30, 'uint16', 12_128, 18);
+} catch {}
+document.body.prepend(img5);
+try {
+renderBundleEncoder47.label = '\u{1fcd9}\u09d6';
+} catch {}
+let commandBuffer208 = commandEncoder331.finish({label: '\u{1f767}\u0c51'});
+let computePassEncoder81 = commandEncoder324.beginComputePass({label: '\u5b93\u2741\u04fa\u{1f916}\u{1f837}\u0b37'});
+try {
+computePassEncoder79.end();
+} catch {}
+let adapter5 = await promise26;
+let commandBuffer209 = commandEncoder330.finish({label: '\u{1febb}\u03da\u4da5\u8c8e'});
+let textureView71 = texture99.createView({
+  label: '\u{1f8f7}\u6701\u5dc6\u08c8\u{1fb89}\u0312\u26f3\u537b\u9113',
+  aspect: 'all',
+  format: 'rg8sint',
+});
+let computePassEncoder82 = commandEncoder332.beginComputePass();
+try {
+computePassEncoder81.end();
+} catch {}
+let promise45 = device3.queue.onSubmittedWorkDone();
+try {
+computePassEncoder45.setBindGroup(0, bindGroup31, new Uint32Array(3235), 74, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer31, 'uint16', 448, 152);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(0, bindGroup5, new Uint32Array(1270), 53, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 2852, new DataView(new ArrayBuffer(1035)), 234, 208);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let adapter6 = await promise31;
+try {
+computePassEncoder77.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(4, buffer32, 0);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer41, 'uint16', 2_380, 2_009);
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.WRITE, 16);
+} catch {}
+await gc();
+let commandBuffer210 = commandEncoder324.finish();
+let texture102 = gpuCanvasContext15.getCurrentTexture();
+try {
+computePassEncoder82.end();
+} catch {}
+try {
+device3.queue.submit([commandBuffer196]);
+} catch {}
+let commandEncoder333 = device2.createCommandEncoder();
+let commandBuffer211 = commandEncoder333.finish();
+let texture103 = device2.createTexture({
+  size: [12, 60, 218],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView72 = texture103.createView({label: '\u07cc\u{1faed}', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup33, new Uint32Array(79), 10, 0);
+} catch {}
+try {
+renderPassEncoder85.setBindGroup(0, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 62, 0, 354_276_833);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(501, 76, 195, -1_919_506_720, 17_524_977);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(2, bindGroup23, new Uint32Array(930), 6, 0);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(0, buffer41, 0);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 68, new Float32Array(26509), 10476, 368);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let renderBundle169 = renderBundleEncoder23.finish({label: '\u7354\uf9e3\u02d9'});
+try {
+renderPassEncoder77.end();
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer25, 0, 1_806);
+} catch {}
+let renderBundle170 = renderBundleEncoder24.finish({});
+try {
+renderBundleEncoder44.setVertexBuffer(6, buffer41);
+} catch {}
+try {
+device2.queue.submit([commandBuffer211]);
+} catch {}
+let imageData39 = new ImageData(32, 36);
+await gc();
+let computePassEncoder83 = commandEncoder332.beginComputePass({label: '\u07c3\ubcf2\u{1fabb}\u3b74\ua14b\u6fc5\uaaad\u207e\u{1fe96}'});
+let renderBundle171 = renderBundleEncoder43.finish({});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise45;
+} catch {}
+let renderBundle172 = renderBundleEncoder30.finish({label: '\u7042\uc8c1\u{1f8bf}\ucea0\u6d5b\u08e6\u583e\u5523\u{1f6dc}\u9257\u758c'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer38, 'uint16', 1_346, 1_951);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer24, 0);
+} catch {}
+try {
+computePassEncoder58.insertDebugMarker('\ub6a4');
+} catch {}
+let imageData40 = new ImageData(32, 12);
+let commandEncoder334 = device1.createCommandEncoder({label: '\u209b\u2e6c\u0b5a\u{1fb84}\u{1f652}\u{1f7d8}\u1598\u2c52\u758f'});
+let renderBundle173 = renderBundleEncoder5.finish({label: '\u272a\ubd2a\u9a1e\u28ec\u{1f871}\u{1f977}\u08dd\ue6b7\u039c'});
+try {
+renderPassEncoder60.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer6, 0);
+} catch {}
+try {
+commandEncoder334.copyBufferToBuffer(buffer18, 17332, buffer15, 28028, 608);
+} catch {}
+document.body.prepend(canvas9);
+try {
+renderPassEncoder75.setBindGroup(2, bindGroup26, new Uint32Array(1193), 484, 0);
+} catch {}
+try {
+renderPassEncoder85.setViewport(0.699871717438032, 94.49343255571631, 0.1733754355166198, 171.40535459996994, 0.9807932289946317, 0.9956284847930756);
+} catch {}
+try {
+renderPassEncoder65.draw(1, 26, 0, 387_157_030);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 60, depthOrArrayLayers: 37}
+*/
+{
+  source: imageData2,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 25, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = device2.createRenderPipeline({
+  label: '\u091d\uc6e7\u0cfb',
+  layout: pipelineLayout20,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 2303305569,
+    stencilWriteMask: 1987282098,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 96, stepMode: 'instance', attributes: []},
+      {arrayStride: 924, attributes: []},
+      {arrayStride: 52, stepMode: 'instance', attributes: []},
+      {arrayStride: 332, stepMode: 'vertex', attributes: []},
+      {arrayStride: 84, stepMode: 'instance', attributes: []},
+      {arrayStride: 552, attributes: []},
+      {arrayStride: 432, stepMode: 'instance', attributes: []},
+      {arrayStride: 544, attributes: [{format: 'uint8x4', offset: 84, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back'},
+});
+let imageData41 = new ImageData(8, 24);
+let commandBuffer212 = commandEncoder322.finish({label: '\u{1fa02}\u{1fffa}\u119e\u7ca4\u69ab\ud840\u4064\u0097\u454d\uddce\u0818'});
+let texture104 = device3.createTexture({
+  label: '\u7784\u0843\u{1fe6f}\uf273\u8147\u{1f937}\u0889\u566c\u0ace\u6e9b\u3c43',
+  size: [795],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundle174 = renderBundleEncoder43.finish({label: '\u9212\ub81c\ud313\u7958\uae66'});
+try {
+window.someLabel = externalTexture7.label;
+} catch {}
+let commandEncoder335 = device1.createCommandEncoder({});
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(0, buffer24);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2, buffer24);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 1, depthOrArrayLayers: 547}
+*/
+{
+  source: imageData41,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 101},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img5);
+let video10 = await videoWithData();
+try {
+computePassEncoder61.setBindGroup(0, bindGroup28, new Uint32Array(398), 12, 0);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup22);
+} catch {}
+let renderBundle175 = renderBundleEncoder42.finish({label: '\u7805\u2aed\u772c\u0346\ue352\u3149\ueefb\u0d81\u2f58'});
+let imageData42 = new ImageData(16, 68);
+let commandEncoder336 = device3.createCommandEncoder({label: '\u9619\u0928\ud9bf\u0916'});
+let promise46 = device3.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55); };
+} catch {}
+let promise47 = navigator.gpu.requestAdapter({});
+let commandEncoder337 = device2.createCommandEncoder({});
+let commandBuffer213 = commandEncoder337.finish({label: '\ub766\u0e65\u{1ffd6}\u1d8c\uc053\u{1fe19}'});
+let texture105 = device2.createTexture({
+  label: '\ua52d\u8ca2\ud262\u{1f6bd}\u5517\u0229\u{1faee}\u{1f8c0}\u329d\u{1f776}\u2103',
+  size: [1, 120, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle176 = renderBundleEncoder41.finish({});
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder65.draw(3, 91, 1, 507_439_793);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer33, 'uint32', 1_016, 117);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 60, depthOrArrayLayers: 37}
+*/
+{
+  source: imageData36,
+  origin: { x: 17, y: 34 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 2, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout40 = device3.createBindGroupLayout({
+  label: '\u06ce\u07f0\u{1ff6f}\u0a98\u53b1\u0d87\u{1f991}',
+  entries: [
+    {
+      binding: 265,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder338 = device3.createCommandEncoder({label: '\u4c19\u{1fb0f}\u21f3\uc104\u3b92\u09c4\u{1f639}\u9be8\u0740\u{1f8b2}\u1f72'});
+let commandBuffer214 = commandEncoder336.finish({});
+let texture106 = device3.createTexture({
+  label: '\u0af8\u{1f8f2}\u{1f775}\u07a7',
+  size: {width: 198},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let commandEncoder339 = device3.createCommandEncoder({label: '\u{1f79a}\u{1fad7}\uf09d'});
+let commandBuffer215 = commandEncoder339.finish({label: '\u295f\u{1f6b0}\u4f7d\u{1f84c}\u3915\u02b9'});
+let texture107 = device3.createTexture({
+  size: [5, 3, 161],
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8sint'],
+});
+try {
+commandEncoder338.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup35 = device2.createBindGroup({
+  label: '\u{1fc45}\u{1fc20}\u0522\u09a0\u9b01\u05c0\u0808\udcaa',
+  layout: bindGroupLayout30,
+  entries: [{binding: 22, resource: externalTexture10}],
+});
+let renderBundle177 = renderBundleEncoder39.finish();
+try {
+computePassEncoder77.setBindGroup(3, bindGroup25, new Uint32Array(7138), 563, 0);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder65.draw(1, 10, 1, 303_826_755);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(52, 114, 75, 240_287_487, 2_414_786_041);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(7, buffer32, 200, 71);
+} catch {}
+let imageBitmap7 = await createImageBitmap(canvas8);
+let pipelineLayout39 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout40, bindGroupLayout40]});
+let commandBuffer216 = commandEncoder338.finish({label: '\u{1f89b}\u23ef\ub42b\u316b\ub021\u{1fe83}\uf196'});
+let textureView73 = texture99.createView({label: '\u9525\u0b83\u039a', dimension: '2d-array', baseMipLevel: 0});
+let texture108 = device1.createTexture({
+  size: {width: 176, height: 30, depthOrArrayLayers: 190},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder88 = commandEncoder334.beginRenderPass({
+  label: '\ud926\u04e0\u053c\uc4d2\u{1ff7b}',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 79,
+  clearValue: { r: 702.8, g: -781.4, b: 871.1, a: 386.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 126268400,
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup27, new Uint32Array(3594), 766, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+commandEncoder335.copyBufferToBuffer(buffer31, 388, buffer16, 592, 780);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let shaderModule19 = device3.createShaderModule({
+  code: `@group(1) @binding(58) var st2: texture_storage_2d<r32uint, read_write>;
+@group(0) @binding(58) var st1: texture_storage_2d<r32uint, read_write>;
+@group(1) @binding(265) var tex6: texture_multisampled_2d<f32>;
+@group(0) @binding(265) var tex5: texture_multisampled_2d<f32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+textureStore(st2, vec2u(), bitcast<vec4u>(r));
+textureStore(st1, vec2u(), bitcast<vec4u>(r));
+r += textureLoad(tex6, vec2u(), 0);
+r += textureLoad(tex5, vec2u(), 0);
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<i32>,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec2<u32>, @location(2) a1: vec4<f32>, @location(0) a2: vec3<f16>) -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f29: vec4<u32>,
+  @location(0) f30: vec3<f16>,
+  @location(10) f31: i32,
+  @location(1) f32: f32,
+  @location(8) f33: vec2<f16>,
+  @location(2) f34: vec4<f32>,
+  @builtin(position) f35: vec4<f32>,
+  @location(12) f36: vec3<u32>,
+  @location(7) f37: vec2<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder340 = device3.createCommandEncoder();
+let computePassEncoder84 = commandEncoder340.beginComputePass({label: '\u4a6a\u0927\u{1f743}\ub1e3\u0be5\uc429\u923e'});
+try {
+device3.queue.submit([commandBuffer199]);
+} catch {}
+let renderBundle178 = renderBundleEncoder8.finish({label: '\u0ec5\u{1fe90}\u67dd\u949f\u0428\u059f'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder30.dispatchWorkgroupsIndirect(buffer29, 688);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle178]);
+} catch {}
+try {
+renderPassEncoder87.setVertexBuffer(1, buffer6, 4_748);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer36, 'uint16', 878, 866);
+} catch {}
+try {
+computePassEncoder78.pushDebugGroup('\ucf97');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout40 = device2.createPipelineLayout({
+  label: '\u5fd5\u0389',
+  bindGroupLayouts: [bindGroupLayout30, bindGroupLayout25, bindGroupLayout33, bindGroupLayout22],
+});
+let commandEncoder341 = device2.createCommandEncoder({label: '\u{1f7d4}\u{1f7a4}\ue441\u0d82\u69e3\u02c1\ua708\u0bca\u6d64\u0c16\u2876'});
+let commandBuffer217 = commandEncoder341.finish({label: '\u{1fed3}\u{1f7d2}\u40ac\u020c\u0eea\u0a30\u0a5b\uc157\u30be'});
+let texture109 = device2.createTexture({
+  label: '\u3e40\u635f\uc03e\udf3d\u{1f75e}\u6412\u61bc\u{1fd9f}',
+  size: {width: 12},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder77.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup30, new Uint32Array(1814), 15, 0);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(6, buffer33, 0, 431);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer156, commandBuffer207]);
+} catch {}
+let commandEncoder342 = device2.createCommandEncoder({label: '\u05f5\u3e5d\u27d2\u19d9\u0aab\u55b2'});
+let commandBuffer218 = commandEncoder342.finish({label: '\ue627\u{1f95c}\u0239\u09ed\u4ae8\u0be0\u46d8'});
+let renderBundle179 = renderBundleEncoder39.finish({});
+try {
+computePassEncoder63.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer30, 'uint16', 8_292, 1_178);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer30, 'uint32', 100, 1_155);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(3, buffer33, 448);
+} catch {}
+let renderBundle180 = renderBundleEncoder32.finish({label: '\u23a6\u79ba\u2ebe'});
+try {
+renderPassEncoder74.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder78.executeBundles([renderBundle96, renderBundle115]);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 84, 2, 387_470_698);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(178, 73, 166, 344_292_802, 879_850_035);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer41, 'uint32', 236, 8_039);
+} catch {}
+let pipelineLayout41 = device1.createPipelineLayout({
+  label: '\u{1feef}\uffcf\u0c06\ub772\u{1f88c}\u{1ffb4}\u{1f717}\u{1fde1}\u{1fe4d}\u{1f9f4}\u{1f795}',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout32, bindGroupLayout19],
+});
+let computePassEncoder85 = commandEncoder335.beginComputePass();
+try {
+renderPassEncoder53.setIndexBuffer(buffer25, 'uint16', 188, 538);
+} catch {}
+try {
+renderPassEncoder87.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder87.setVertexBuffer(7, buffer17, 0, 2_222);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let commandEncoder343 = device3.createCommandEncoder({label: '\u08b1\u10fe\u4609\u49a4\u00a8\u2c08\ubb1b\u{1fbd7}\ud803\u06ee'});
+let commandBuffer219 = commandEncoder343.finish({label: '\u0663\u{1f85f}\u0e8d\u591a\u504c'});
+let textureView74 = texture106.createView({label: '\u2e17\u{1fab5}', format: 'rg8sint', mipLevelCount: 1});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+let promise48 = adapter6.requestAdapterInfo();
+let pipelineLayout42 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout28, bindGroupLayout19, bindGroupLayout7]});
+let renderPassEncoder89 = commandEncoder33.beginRenderPass({
+  label: '\ua0f5\u37d1\u{1f7a2}\uc339\u021e\u{1f90b}',
+  colorAttachments: [{
+  view: textureView70,
+  depthSlice: 108,
+  clearValue: { r: 814.1, g: 936.7, b: 110.7, a: -7.376, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder10.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer6, 0, 210);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup29, []);
+} catch {}
+let texture110 = device1.createTexture({
+  label: '\u6d70\ue2ee\u0e38\u{1fef4}',
+  size: [88],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder75.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder76.executeBundles([renderBundle146]);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(4, buffer17, 0, 2_378);
+} catch {}
+let texture111 = device1.createTexture({
+  label: '\u048a\u08c9\u{1f80c}\uafe7\u011a\u5b88\u0adf\uc765',
+  size: {width: 150, height: 1, depthOrArrayLayers: 38},
+  mipLevelCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup27, new Uint32Array(1200), 367, 0);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer13, 'uint32', 5_512, 13);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(0, bindGroup25, new Uint32Array(841), 296, 0);
+} catch {}
+try {
+renderPassEncoder65.draw(3, 136, 2, 184_776_034);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(230, 289, 212, 25_039_315, 2_573_881_851);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(7, buffer33, 112);
+} catch {}
+try {
+  await buffer46.mapAsync(GPUMapMode.WRITE, 0, 1236);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(1, bindGroup33, new Uint32Array(295), 95, 0);
+} catch {}
+try {
+renderPassEncoder79.beginOcclusionQuery(282);
+} catch {}
+try {
+renderPassEncoder79.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder62.setScissorRect(0, 94, 0, 0);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(31, 202, 166, -1_778_194_872, 109_611_393);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(4, buffer30, 0, 356);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer33, 'uint16', 376, 733);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder344 = device2.createCommandEncoder({label: '\u{1fd5b}\ueb91\u4c25\u0ba2\ua06e\uc56f\u75e7\u7685\u010f\u26aa\u0851'});
+let renderPassEncoder90 = commandEncoder344.beginRenderPass({
+  label: '\uf621\u{1fd29}\u{1f829}\u1b74\u031b\u5b13',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: -562.9, g: 255.4, b: -109.1, a: -977.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 5305753,
+});
+let renderBundle181 = renderBundleEncoder44.finish({label: '\u1a60\u59cb\uc8ad\u533f\u0b59\u0aa8\u0fe5\u4a2c\u{1f993}\u7279\u0952'});
+try {
+computePassEncoder76.setPipeline(pipeline18);
+} catch {}
+let commandEncoder345 = device1.createCommandEncoder({label: '\u6d79\u58ac\u9af6'});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer25, 172, 543);
+} catch {}
+let textureView75 = texture52.createView({label: '\u877a\u53b3', format: 'rgb10a2uint'});
+let computePassEncoder86 = commandEncoder345.beginComputePass({label: '\u036d\uab17\uaa54\u4232\u9a43\ufcc8\u0ce5\u88fe\ue90a\u04f4\u836e'});
+let renderBundle182 = renderBundleEncoder34.finish({label: '\uce6e\u5816\u3b2a\u850b\u060a'});
+try {
+computePassEncoder10.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer25, 'uint32', 112, 2_933);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(1, buffer24);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder78.popDebugGroup();
+} catch {}
+let img6 = await imageWithData(10, 6, '#ab413152', '#30cd5780');
+let videoFrame9 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+try {
+  await promise48;
+} catch {}
+let sampler22 = device3.createSampler({
+  label: '\u{1f967}\u0e3f\u279e\u468e\u204d',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 25.59,
+  maxAnisotropy: 12,
+});
+let promise49 = device3.createComputePipelineAsync({layout: pipelineLayout39, compute: {module: shaderModule19, constants: {}}});
+try {
+computePassEncoder51.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder85.executeBundles([renderBundle153, renderBundle119, renderBundle99, renderBundle137, renderBundle142]);
+} catch {}
+try {
+renderPassEncoder78.setPipeline(pipeline26);
+} catch {}
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+let renderBundleEncoder49 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm'], stencilReadOnly: true});
+let externalTexture35 = device2.importExternalTexture({label: '\u6d7d\ud574\u0f6b\u{1fe8b}\uabf4\u0e41\uac46\u4db8\u350c\u069b\ub43c', source: videoFrame2});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(7, buffer33, 64, 283);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 132, new BigUint64Array(10420), 3262, 280);
+} catch {}
+let commandEncoder346 = device2.createCommandEncoder({label: '\u04a1\u0fef'});
+let computePassEncoder87 = commandEncoder346.beginComputePass({label: '\u3643\u{1fdb3}\u{1fd2b}\uc99c\u8f48\ufc68\u0e4a\u06fe\uedd5\u{1f6b2}\u0b0a'});
+let renderBundleEncoder50 = device2.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle183 = renderBundleEncoder49.finish({});
+try {
+renderPassEncoder65.draw(0, 198, 1, 1_012_890_661);
+} catch {}
+let textureView76 = texture106.createView({label: '\u0f0f\u34f8\u09c2\ud1f8\u{1fe10}', format: 'rg8sint', baseMipLevel: 0});
+try {
+computePassEncoder83.pushDebugGroup('\ua665');
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer209]);
+} catch {}
+canvas1.height = 140;
+let bindGroup36 = device1.createBindGroup({label: '\u4ba9\u{1fa4d}\u00cd\u1882\u530e', layout: bindGroupLayout20, entries: []});
+try {
+renderPassEncoder52.setBlendConstant({ r: 441.0, g: -330.3, b: 506.7, a: -495.7, });
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer38, 'uint16', 2_216, 157);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(7, buffer24, 0, 1_239);
+} catch {}
+let commandEncoder347 = device2.createCommandEncoder({});
+let querySet39 = device2.createQuerySet({label: '\u083a\u08e4\u0836', type: 'occlusion', count: 269});
+let computePassEncoder88 = commandEncoder347.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup35, new Uint32Array(3269), 710, 0);
+} catch {}
+try {
+renderPassEncoder65.draw(5, 141, 0, 431_968_690);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline26);
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(29, 82);
+let bindGroupLayout41 = device1.createBindGroupLayout({label: '\u6d2d\u8205\u8a04', entries: []});
+let commandEncoder348 = device1.createCommandEncoder();
+let textureView77 = texture63.createView({label: '\u{1fc89}\u9e9d', baseMipLevel: 3});
+let renderPassEncoder91 = commandEncoder348.beginRenderPass({
+  label: '\u55d3\u24a6\u{1f60e}\u{1f628}\u0d71\u{1f610}\u2521\u08c2\u9225\u{1f88b}\u0381',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 11,
+  clearValue: { r: -193.4, g: -44.07, b: 359.2, a: -322.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 25078090,
+});
+try {
+renderBundleEncoder40.setIndexBuffer(buffer31, 'uint32', 180, 401);
+} catch {}
+let commandEncoder349 = device1.createCommandEncoder({label: '\u{1fb4e}\u{1ff5c}\u0118\u{1fdc2}\ue4ff\u{1fabe}\u0aea\ufdcf\u{1fef2}'});
+let renderPassEncoder92 = commandEncoder349.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  depthSlice: 51,
+  clearValue: { r: 300.6, g: -863.8, b: 84.92, a: 585.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 89488849,
+});
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder87.pushDebugGroup('\ub529');
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas8.getContext('webgpu');
+let externalTexture36 = device3.importExternalTexture({label: '\u029b\u0b8e\u0db9\u064f\u05a4', source: video9, colorSpace: 'display-p3'});
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder350 = device1.createCommandEncoder({label: '\u{1f96b}\ub806\uaec4\u3473\u{1fd4d}\u5d04\u0835\u09f6\u4ddf'});
+let commandBuffer220 = commandEncoder350.finish({label: '\uec34\u7118\u0c2b\u5d22\u7f92\u{1f65b}\u2a17\ud67e\uf7e1'});
+try {
+renderBundleEncoder46.setVertexBuffer(7, buffer6, 584);
+} catch {}
+try {
+renderBundleEncoder48.insertDebugMarker('\u7a78');
+} catch {}
+try {
+gpuCanvasContext17.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(114, 232);
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder351 = device3.createCommandEncoder({});
+let commandBuffer221 = commandEncoder351.finish({});
+let renderBundleEncoder51 = device3.createRenderBundleEncoder({colorFormats: ['rg8sint'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle184 = renderBundleEncoder47.finish();
+try {
+renderBundleEncoder51.setVertexBuffer(4_294_967_294, undefined, 0, 422_164_041);
+} catch {}
+try {
+device3.queue.submit([commandBuffer206]);
+} catch {}
+try {
+computePassEncoder83.popDebugGroup();
+} catch {}
+let promise50 = adapter5.requestDevice({
+  defaultQueue: {label: '\u650e\ub1a2\u{1fa14}\u0ad9\udcec'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxDynamicStorageBuffersPerPipelineLayout: 4,
+    maxTextureDimension1D: 8192,
+    maxUniformBufferBindingSize: 12327056,
+    maxStorageBufferBindingSize: 188058639,
+  },
+});
+let renderBundle185 = renderBundleEncoder23.finish();
+try {
+computePassEncoder17.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer29, 'uint32', 3_036, 4_330);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer25, 'uint32', 1_420, 544);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(7, buffer17, 4_228);
+} catch {}
+offscreenCanvas4.width = 321;
+let texture112 = device3.createTexture({
+  label: '\uf8c2\ua0c2\u0af8',
+  size: [397, 1, 1],
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture37 = device3.importExternalTexture({source: video8});
+try {
+renderBundleEncoder51.setVertexBuffer(7, undefined, 0, 140_973_971);
+} catch {}
+try {
+window.someLabel = texture99.label;
+} catch {}
+let canvas11 = document.createElement('canvas');
+let shaderModule20 = device1.createShaderModule({
+  label: '\u{1ff85}\u0d87\uc338\ub31c\u046a',
+  code: `@group(1) @binding(159) var sam22: sampler;
+@group(0) @binding(79) var et7: texture_external;
+@group(0) @binding(115) var tex7: texture_2d<f32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(et7, vec2u());
+r += textureLoad(tex7, vec2u(), 0);
+}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> @location(200) vec4<f32> {
+var r: vec4f;
+_ = sam22;
+r += textureLoad(et7, vec2u());
+r += textureLoad(tex7, vec2u(), 0);
+return vec4<f32>();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(13) a1: f32) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder87.setIndexBuffer(buffer24, 'uint16', 1_120, 4_867);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(4, buffer17);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+let commandEncoder352 = device3.createCommandEncoder({label: '\u6b87\ud6c8\u0784\u02bb\uc012\u4c93\u{1fee9}\u077f\u011e\u{1fe90}'});
+let sampler23 = device3.createSampler({
+  label: '\u836d\u0961\u8180\ue8ea\u7ed2\uf276\u041d\u1cfc',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.96,
+  lodMaxClamp: 93.31,
+  maxAnisotropy: 18,
+});
+let texture113 = device2.createTexture({
+  label: '\u5273\u08b5\u0d76\ue56d\u074c\ua59c\u{1f9f7}\u{1fa07}\u0d8c\ud80f',
+  size: [1, 240, 29],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle186 = renderBundleEncoder36.finish({label: '\u0be9\u02c3\u2823\u{1fe1e}\u7c36\u2a78\u0753'});
+try {
+computePassEncoder63.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder75.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.draw(1, 11, 0, 77_651_859);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(95, 397, 670, 62_880_251, 19_388_328);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(7, buffer32, 0, 76);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 73, y: 623 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 114, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 122, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img6);
+let textureView78 = texture107.createView({label: '\u8be8\ufc77\u{1f8fc}', baseMipLevel: 0});
+try {
+device3.pushErrorScope('validation');
+} catch {}
+try {
+adapter1.label = '\ucfdd\u8210\u0b2b';
+} catch {}
+let pipelineLayout43 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout9, bindGroupLayout19]});
+let texture114 = device1.createTexture({
+  label: '\u0ec9\u6cf9\u038e\u8abc\u0ade\u0773\ub143\uc153',
+  size: [1206],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle88]);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(2, bindGroup21, []);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer25, 'uint32', 348, 855);
+} catch {}
+try {
+computePassEncoder58.insertDebugMarker('\u2a96');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 2496, new Int16Array(6590), 1002, 1072);
+} catch {}
+let bindGroupLayout43 = device2.createBindGroupLayout({entries: []});
+let querySet40 = device2.createQuerySet({type: 'occlusion', count: 898});
+try {
+renderPassEncoder90.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 123, 0, 260_080_707);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer32, 0, 247);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture115 = device1.createTexture({
+  label: '\u28e3\u42f9\uf144\u48ad\u{1fee2}\u0769\u{1ffa6}\ub6ba\u{1f901}\u8324',
+  size: [301, 1, 221],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder63.setVertexBuffer(0, buffer25);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer13, 'uint16', 194, 909);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device1.queue.submit([commandBuffer195]);
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+video2.width = 7;
+let commandEncoder353 = device2.createCommandEncoder({label: '\u9fba\u0292'});
+let renderPassEncoder93 = commandEncoder353.beginRenderPass({
+  label: '\u4198\u{1f776}\ua45f\u3f9a\u{1f8ab}\u7524\u48bf\u00cb\u3277\u0a6a',
+  colorAttachments: [{
+  view: textureView67,
+  resolveTarget: textureView65,
+  clearValue: { r: -959.6, g: 390.8, b: 133.0, a: 605.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder52 = device2.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder52.insertDebugMarker('\u074f');
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+  await promise44;
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder74.setViewport(0.6843272438416763, 104.51293707016083, 0.03151543385880122, 1.070516249632994, 0.19333554169632106, 0.8836262306103849);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 13, 1, 39_831_726);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas8,
+  origin: { x: 673, y: 0 },
+  flipY: false,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 49, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle187 = renderBundleEncoder45.finish({label: '\u0044\ubf53\u20f4\u{1f81e}\u0686\ue063\uc0fc\u31f8'});
+document.body.prepend(video5);
+try {
+renderBundleEncoder51.setVertexBuffer(4_294_967_294, undefined, 0);
+} catch {}
+let commandEncoder354 = device3.createCommandEncoder({label: '\u0f28\u1f16\u{1feaa}\u5a6a\u{1f7e2}\u456d'});
+let computePassEncoder89 = commandEncoder352.beginComputePass({label: '\u0187\u{1fc45}\u101d\u0590\u8331'});
+let commandEncoder355 = device2.createCommandEncoder({label: '\u2677\u3374\u0bc0'});
+let commandBuffer222 = commandEncoder355.finish();
+try {
+computePassEncoder61.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder70.setViewport(0.9734995820954706, 45.17685150195654, 0.0005498220034433215, 11.20533308804531, 0.6577397044969946, 0.7979248590421544);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(1, bindGroup33);
+} catch {}
+let adapter7 = await promise19;
+try {
+  await promise46;
+} catch {}
+let buffer47 = device3.createBuffer({
+  label: '\u0935\u0a15\u6091',
+  size: 2616,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandBuffer223 = commandEncoder354.finish({label: '\u1226\u{1fccb}\u9801\ue4d3'});
+try {
+renderBundleEncoder51.setVertexBuffer(2, buffer47);
+} catch {}
+try {
+device3.queue.submit([commandBuffer219, commandBuffer223, commandBuffer215]);
+} catch {}
+try {
+if (!arrayBuffer25.detached) { new Uint8Array(arrayBuffer25).fill(0x55); };
+} catch {}
+let commandEncoder356 = device1.createCommandEncoder({});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder27.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder91.end();
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(2, bindGroup21);
+} catch {}
+let commandEncoder357 = device1.createCommandEncoder({label: '\u0ba3\ua8a3\u7f5b\u{1fbfe}\u6abe\ua999\u0e41'});
+let querySet41 = device1.createQuerySet({label: '\u02db\u0604\u{1f796}\u0403\u58a4\ueac7\u0eef\u0b2d\u0737', type: 'occlusion', count: 337});
+let commandBuffer224 = commandEncoder357.finish();
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer25, 'uint32', 484, 81);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder356.resolveQuerySet(querySet4, 92, 73, buffer16, 5120);
+} catch {}
+video10.width = 18;
+await gc();
+let buffer48 = device1.createBuffer({
+  label: '\u41f6\u0b47\u9448\uc0eb\u6284\u5c63\u8d7b\u{1f91d}\u0127\u{1f745}',
+  size: 5574,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder358 = device1.createCommandEncoder({label: '\ubeec\u9826\u{1ff09}\uf4ec\u{1ff6b}\u1062'});
+let textureView79 = texture15.createView({label: '\u07e6\u1c4e\u{1fed3}\u9c74\udd36\uc7ac\u{1fad0}\u9231', baseArrayLayer: 0});
+let renderPassEncoder94 = commandEncoder358.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  depthSlice: 21,
+  clearValue: { r: 917.5, g: -788.4, b: 12.16, a: 678.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder45.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer26, 'uint16', 1_150, 3_960);
+} catch {}
+try {
+commandEncoder356.copyBufferToBuffer(buffer29, 3008, buffer48, 1700, 696);
+} catch {}
+try {
+renderBundleEncoder53.insertDebugMarker('\ud944');
+} catch {}
+try {
+device1.queue.submit([commandBuffer187, commandBuffer168, commandBuffer194]);
+} catch {}
+try {
+  await promise43;
+} catch {}
+try {
+renderPassEncoder70.beginOcclusionQuery(459);
+} catch {}
+try {
+renderPassEncoder93.executeBundles([renderBundle99, renderBundle91]);
+} catch {}
+try {
+renderPassEncoder70.draw(1, 0, 158_900_479);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(5, buffer32, 60, 177);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup35, new Uint32Array(2734), 757, 0);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer33, 'uint16', 1_482, 478);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer41, 0, 118);
+} catch {}
+let gpuCanvasContext18 = canvas11.getContext('webgpu');
+let textureView80 = texture107.createView({label: '\u556b\u0d52\u0f1a', arrayLayerCount: 1});
+let commandEncoder359 = device2.createCommandEncoder();
+let commandBuffer225 = commandEncoder359.finish({label: '\u393d\ude20\u2bd7\u0523\u6ce5'});
+let texture116 = device2.createTexture({
+  label: '\u{1f977}\ub283\u03dd\u2a30\u9f9e',
+  size: {width: 1, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder61.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(140, 0, 95, 734_102_789);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer30, 'uint32', 2_832, 8_665);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer33, 'uint16', 2_764, 116);
+} catch {}
+let gpuCanvasContext19 = offscreenCanvas9.getContext('webgpu');
+let commandBuffer226 = commandEncoder260.finish({label: '\u{1f9c1}\ueae3'});
+let renderBundle188 = renderBundleEncoder32.finish({label: '\u{1fd00}\u1955\u09cd\udfb9\ud87c\u6bac\u{1fb9d}\u1cca\u0299'});
+try {
+renderPassEncoder75.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(797, 89, 121, 297_999_546, 335_246_749);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(3, bindGroup23, new Uint32Array(895), 46, 0);
+} catch {}
+let img7 = await imageWithData(5, 13, '#3fd26d51', '#04bb4551');
+try {
+computePassEncoder69.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer33, 'uint16', 8, 1_486);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup28);
+} catch {}
+let imageData43 = new ImageData(16, 48);
+let shaderModule21 = device3.createShaderModule({
+  label: '\u00dd\u37cd\u0e0a\u9650\u9b1b\u7903\u0305\u0cb2\u6b71',
+  code: `@group(1) @binding(265) var tex9: texture_multisampled_2d<f32>;
+@group(0) @binding(265) var tex8: texture_multisampled_2d<f32>;
+@group(1) @binding(58) var st4: texture_storage_2d<r32uint, read_write>;
+@group(0) @binding(58) var st3: texture_storage_2d<r32uint, read_write>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+r += textureLoad(tex9, vec2u(), 0);
+r += textureLoad(tex8, vec2u(), 0);
+textureStore(st4, vec2u(), bitcast<vec4u>(r));
+textureStore(st3, vec2u(), bitcast<vec4u>(r));
+}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec3<f32>,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+var r: vec4f;
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @builtin(vertex_index) f0: u32,
+  @location(1) f1: vec3<f16>,
+  @location(3) f2: vec3<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(0) f4: f32,
+  @location(9) f5: vec2<f32>,
+  @location(11) f6: vec3<f16>,
+  @location(6) f7: vec3<f16>,
+  @location(14) f8: f32,
+  @location(7) f9: vec3<f32>,
+  @location(2) f10: vec2<f16>,
+  @location(12) f11: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: f16, @location(4) a1: vec2<i32>, @location(10) a2: f32, a3: S4, @location(5) a4: vec4<i32>, @location(15) a5: vec4<f16>, @location(13) a6: vec4<f32>) -> @builtin(position) vec4<f32> {
+var r: vec4f;
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+gpuCanvasContext1.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout44 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout42, bindGroupLayout42, bindGroupLayout42]});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let commandEncoder360 = device1.createCommandEncoder({label: '\u06b8\u143a\u{1fb4a}\u746d\u0703\u5f19\u4902'});
+let renderBundle189 = renderBundleEncoder40.finish();
+try {
+computePassEncoder11.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle56, renderBundle51]);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(5, buffer17, 0);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer29, 'uint16', 3_126, 397);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer25, 1_036, 680);
+} catch {}
+try {
+commandEncoder360.copyBufferToBuffer(buffer13, 3116, buffer15, 124, 828);
+} catch {}
+try {
+commandEncoder356.insertDebugMarker('\u5684');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer38, 1296, new BigUint64Array(954));
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 35, y: 3, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(434_601), /* required buffer size: 434_601 */
+{offset: 170, bytesPerRow: 151, rowsPerImage: 125}, {width: 1, height: 3, depthOrArrayLayers: 24});
+} catch {}
+let commandBuffer227 = commandEncoder360.finish();
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle14, renderBundle33]);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(7, buffer17, 0);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let pipeline30 = await device1.createComputePipelineAsync({
+  label: '\u725c\ubc51\u8a8e\u{1fcf3}\uf0ea\u{1fda8}\uca99\u6085\u0809',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule3},
+});
+await gc();
+let querySet42 = device2.createQuerySet({label: '\u3cd2\u3be7\u08c1\u{1f9d4}\u5fc0\u1ac5\uacb4\u6f89\u{1f902}', type: 'occlusion', count: 121});
+let sampler24 = device2.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 69.78,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(3, bindGroup26, new Uint32Array(478), 71, 0);
+} catch {}
+try {
+renderPassEncoder79.beginOcclusionQuery(101);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(39, 0, 47, 9_948_444);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(2, buffer41, 0, 309);
+} catch {}
+let renderPassEncoder95 = commandEncoder356.beginRenderPass({
+  label: '\u5b33\u0565\u2f9c\ue249\u{1f62e}\u06e3\udc4e\u4c62\ubb72\u8b80\u1d24',
+  colorAttachments: [{view: textureView45, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 29713304,
+});
+try {
+renderPassEncoder71.setIndexBuffer(buffer25, 'uint32', 812, 157);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer31, 'uint32', 80, 244);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer25, 64, 1_948);
+} catch {}
+let renderBundle190 = renderBundleEncoder43.finish({label: '\u{1f831}\u554e\u0f95\u0c53\u0498'});
+document.body.prepend(video3);
+let commandEncoder361 = device3.createCommandEncoder({label: '\u049a\u{1f6d3}\u479c'});
+let commandBuffer228 = commandEncoder361.finish({label: '\u{1f9d7}\udd54\u0f3b\u7598'});
+try {
+renderBundleEncoder51.setVertexBuffer(4_294_967_295, undefined, 0, 1_205_253_588);
+} catch {}
+try {
+renderPassEncoder90.beginOcclusionQuery(335);
+} catch {}
+try {
+renderPassEncoder65.draw(1, 307, 2, 2_317_525_252);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline26);
+} catch {}
+document.body.prepend(img5);
+try {
+renderPassEncoder71.setIndexBuffer(buffer25, 'uint32', 204, 913);
+} catch {}
+try {
+renderPassEncoder84.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder46.draw(9, 3, 331_894_430, 24);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(7, 6, 13, 413_045_210, 61);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer31, 4);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer38, 5492, new Float32Array(1046));
+} catch {}
+let commandEncoder362 = device1.createCommandEncoder({label: '\ucd05\uc8a1'});
+let commandBuffer229 = commandEncoder362.finish({});
+try {
+computePassEncoder11.dispatchWorkgroupsIndirect(buffer6, 1_432);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup36, new Uint32Array(5646), 478, 0);
+} catch {}
+try {
+renderPassEncoder95.setScissorRect(20, 4, 116, 5);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(1, buffer17, 1_308, 4_336);
+} catch {}
+try {
+renderBundleEncoder46.draw(112, 39, 809_339_458, 5);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(5, 11, 6, -1_131_723_388, 9);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer31, 320);
+} catch {}
+let buffer49 = device1.createBuffer({
+  label: '\uac37\u4bbd\ud6e3\u{1fd66}\u0306\u0c05\u045e\ua71d',
+  size: 20037,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder363 = device1.createCommandEncoder({label: '\u033c\u0e2d\u9926'});
+let renderPassEncoder96 = commandEncoder363.beginRenderPass({
+  label: '\u0159\u37e0\u1d21\u04ac\ua9da\u6191',
+  colorAttachments: [{
+  view: textureView21,
+  depthSlice: 47,
+  clearValue: { r: -299.6, g: -787.4, b: -270.4, a: -466.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderPassEncoder94.executeBundles([renderBundle152]);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer26, 'uint32', 8_040, 1_152);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer24);
+} catch {}
+let promise51 = device1.queue.onSubmittedWorkDone();
+let imageData44 = new ImageData(4, 108);
+try {
+computePassEncoder66.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder46.draw(39, 16, 506_902_187, 9);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer6, 5_340);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+renderPassEncoder87.popDebugGroup();
+} catch {}
+try {
+renderBundleEncoder48.insertDebugMarker('\u0ca7');
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise51;
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle56]);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer26, 'uint16', 1_262, 2_941);
+} catch {}
+try {
+renderBundleEncoder46.draw(52, 10, 646_781_658, 5);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(7, 9, 56, -1_910_289_741, 5);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer24, 0, 7_335);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer13, 16, new Float32Array(10140), 327, 548);
+} catch {}
+let commandEncoder364 = device3.createCommandEncoder({label: '\u{1fde3}\u5dcb\u0b03\ub5e7\u{1fd57}\u{1f854}\u05ac\u5c9f\u0a7f\u0bad\u0f6b'});
+let commandBuffer230 = commandEncoder364.finish({label: '\u0130\u0959'});
+let textureView81 = texture104.createView({label: '\u9d04\u0f1b\u{1f865}\u7226\u{1f8e2}\u06a4\u{1fc33}\u0969\u3e7f'});
+try {
+gpuCanvasContext10.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder365 = device3.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder365.beginComputePass({label: '\u07d7\u4a49\u{1f753}\u0475\u{1ff23}\ue5a0\u0a48\u4d86'});
+offscreenCanvas5.height = 576;
+let bindGroupLayout44 = device3.createBindGroupLayout({
+  label: '\u{1f909}\u09d4\uc73d\ue53e',
+  entries: [
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let textureView82 = texture112.createView({label: '\u8c44\u00b5\u69aa\u6bc6\ub65b\u9950\u06cc\u00e8', dimension: '2d-array', arrayLayerCount: 1});
+try {
+adapter4.label = '\u0a7c\u8c06\u0de4\u00d0\u6ce7\u0d0d\u9998\u2f10\u0d58';
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 5, 0, 287_823_360);
+} catch {}
+try {
+device2.queue.submit([commandBuffer222, commandBuffer169, commandBuffer226]);
+} catch {}
+let pipeline31 = await promise35;
+let bindGroupLayout45 = device3.createBindGroupLayout({label: '\ud15a\u{1fe61}\uee07\u022b\u88cc\ua1cc\ufe7f', entries: []});
+let renderBundleEncoder54 = device3.createRenderBundleEncoder({
+  label: '\u00b8\u0868\ufc0c\ube98\u6a6a',
+  colorFormats: ['rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+device3.queue.submit([]);
+} catch {}
+let commandEncoder366 = device3.createCommandEncoder({label: '\u{1fb40}\ue15e\uf99a'});
+let computePassEncoder91 = commandEncoder366.beginComputePass({});
+try {
+computePassEncoder84.insertDebugMarker('\u0921');
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer47, 360);
+} catch {}
+let promise52 = device3.queue.onSubmittedWorkDone();
+let textureView83 = texture71.createView({label: '\u{1f683}\u0ac1\ue173\u849e\ub6d3\ubc04\ufd45\ub001\u06b3\u4b8e', arrayLayerCount: 1});
+try {
+renderBundleEncoder50.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(2, buffer33, 88);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+await gc();
+let commandEncoder367 = device1.createCommandEncoder({label: '\u2d6f\u7137\u01d1'});
+let commandBuffer231 = commandEncoder367.finish({label: '\u0756\u669e\ucea9\ua67a\u{1fb5f}\u0b09\u058d\u{1fbd8}\u3b55'});
+try {
+renderPassEncoder87.setBindGroup(1, bindGroup15, new Uint32Array(978), 0, 0);
+} catch {}
+try {
+renderPassEncoder89.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer16, 8_076);
+} catch {}
+let arrayBuffer29 = buffer43.getMappedRange(312, 60);
+try {
+buffer19.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise52;
+} catch {}
+let commandEncoder368 = device2.createCommandEncoder();
+try {
+computePassEncoder72.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder70.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder78.executeBundles([renderBundle158, renderBundle186, renderBundle167]);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(290, 0, 147, 744_437_219);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer41, 'uint16', 4_526, 1_750);
+} catch {}
+try {
+device2.queue.submit([commandBuffer165, commandBuffer170]);
+} catch {}
+let promise53 = device2.queue.onSubmittedWorkDone();
+let pipelineLayout45 = device1.createPipelineLayout({
+  label: '\u0663\u{1ffb1}\uf1f2\uf4f9\u5dd7\u0b13\u86fc',
+  bindGroupLayouts: [bindGroupLayout35, bindGroupLayout31],
+});
+try {
+renderPassEncoder96.setVertexBuffer(6, buffer49, 680, 8_476);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup15, []);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(81, 47, 16, 10_928_019, 17);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer6, 1_484);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer24, 'uint16', 4_070, 1_038);
+} catch {}
+try {
+computePassEncoder69.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(57, 59, 12, 264_447_360, 61_921_255);
+} catch {}
+document.body.prepend(img2);
+let imageData45 = new ImageData(16, 16);
+let commandEncoder369 = device3.createCommandEncoder();
+let querySet43 = device3.createQuerySet({label: '\u{1fc76}\u0ef5\u0a20\u34fb\u8b24\ue27b\u7c67', type: 'occlusion', count: 154});
+try {
+gpuCanvasContext10.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView84 = texture100.createView({label: '\u20fe\u0c88\ua92f'});
+let sampler25 = device1.createSampler({
+  label: '\u00fe\u06fe\u5161\u4f94\u{1fa9f}\u8fb5\u{1fa78}\u560a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.39,
+  lodMaxClamp: 80.51,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder46.draw(194, 18, 345_295_166, 14);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer48, 548);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer31, 'uint32', 376, 337);
+} catch {}
+await gc();
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup9, new Uint32Array(1200), 58, 0);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(6, buffer17, 0);
+} catch {}
+try {
+renderBundleEncoder46.draw(72, 10, 529_429_111, 2);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(37, 71, 4, -1_639_374_225);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer31, 'uint16', 122, 5);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let commandEncoder370 = device2.createCommandEncoder({label: '\uc315\u25e9\u167f'});
+let commandBuffer232 = commandEncoder368.finish({label: '\u0520\u8074\uea22\u4e25\u0450\u5a86\u8039\u5eee\uf87a'});
+let texture117 = device2.createTexture({
+  label: '\u0ccd\u045a',
+  size: [1, 120, 1],
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder92 = commandEncoder370.beginComputePass();
+let externalTexture38 = device2.importExternalTexture({
+  label: '\u0577\uefb3\u{1f85b}\u9f52\u0f70\ue9fd\u0693\u0c38\u66cc\u0b61',
+  source: videoFrame7,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder79.setIndexBuffer(buffer33, 'uint32', 108, 401);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4, buffer32);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer41, 'uint32', 1_296, 1_391);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer33, 96, new Int16Array(46150), 1369, 64);
+} catch {}
+let bindGroup37 = device2.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [{binding: 507, resource: {buffer: buffer30, offset: 9984, size: 1420}}],
+});
+let renderBundle191 = renderBundleEncoder50.finish();
+try {
+renderPassEncoder79.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(2, buffer33);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise53;
+} catch {}
+try {
+window.someLabel = externalTexture36.label;
+} catch {}
+let commandEncoder371 = device3.createCommandEncoder({label: '\uf6c4\u5e62\u1ccd\u0094\u4288'});
+let texture118 = device3.createTexture({
+  label: '\u6975\u{1f803}\uc901\u{1ff46}\u49f7\u0b66\u4de5\ue0f8\u089f',
+  size: {width: 3, height: 1, depthOrArrayLayers: 13},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder55 = device3.createRenderBundleEncoder({colorFormats: ['rg8sint'], sampleCount: 4, stencilReadOnly: true});
+try {
+renderBundleEncoder55.setVertexBuffer(4, buffer47, 1_076, 134);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+window.someLabel = externalTexture34.label;
+} catch {}
+let computePassEncoder93 = commandEncoder369.beginComputePass({label: '\u{1fb7e}\u33d5\u85e4'});
+let renderBundle192 = renderBundleEncoder47.finish({label: '\u0628\u7d34\uaf43\u5577\u{1fe0c}\u{1feb4}\u0a78\u3631'});
+try {
+commandEncoder371.clearBuffer(buffer47);
+} catch {}
+let commandEncoder372 = device3.createCommandEncoder();
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder371.resolveQuerySet(querySet37, 170, 41, buffer47, 512);
+} catch {}
+let pipeline32 = await device3.createRenderPipelineAsync({
+  label: '\u{1f7c2}\ufd7f\u074f',
+  layout: pipelineLayout39,
+  multisample: {mask: 0x3a298dcd},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilWriteMask: 4151487590,
+    depthBias: -308162185,
+    depthBiasSlopeScale: 638.4516874222244,
+    depthBiasClamp: 39.66985453181127,
+  },
+  vertex: {module: shaderModule19, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', frontFace: 'cw'},
+});
+let promise54 = device3.queue.onSubmittedWorkDone();
+let commandEncoder373 = device3.createCommandEncoder();
+let querySet44 = device3.createQuerySet({label: '\u3eb9\uf614\ufca6', type: 'occlusion', count: 926});
+let renderBundle193 = renderBundleEncoder51.finish({label: '\ud13c\u07e6\ud6bb\ucbe4\uf0b0'});
+try {
+commandEncoder372.resolveQuerySet(querySet44, 73, 39, buffer47, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer47, 548, new Float32Array(5880), 201, 92);
+} catch {}
+await gc();
+try {
+  await promise54;
+} catch {}
+let texture119 = gpuCanvasContext11.getCurrentTexture();
+try {
+computePassEncoder63.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(238, 0, 88, 277_869_477);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer30, 'uint32', 1_704, 4_353);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder374 = device1.createCommandEncoder({label: '\u0f96\u91b8\u3bb4\ub941\u0286\u0adf\u09b6'});
+let commandBuffer233 = commandEncoder374.finish({label: '\u0b97\u99ad\u7b4a\u8d61'});
+try {
+computePassEncoder11.dispatchWorkgroupsIndirect(buffer25, 504);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(10);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer29, 3_584);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer18, 'uint16', 4_990, 1_463);
+} catch {}
+try {
+device1.queue.submit([commandBuffer171, commandBuffer101]);
+} catch {}
+let buffer50 = device3.createBuffer({
+  label: '\u8b6e\u0a29\u7acb\u046c\u{1f840}\u0935\u8d3c\u05fe\u8744\u{1f669}\u{1f72d}',
+  size: 23865,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder94 = commandEncoder372.beginComputePass({label: '\u{1ff8f}\u05e6\u9854\u0ad9\u383f'});
+try {
+renderBundleEncoder54.pushDebugGroup('\ub7f9');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer47, 1260, new DataView(new ArrayBuffer(20407)), 4052, 32);
+} catch {}
+let texture120 = device1.createTexture({
+  size: {width: 45, height: 10, depthOrArrayLayers: 21},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({
+  label: '\u{1f90f}\u{1fcdb}\u0a5a\u1912\ua8ca',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle194 = renderBundleEncoder21.finish({label: '\u4bcd\ub804'});
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer29, 'uint32', 1_448, 992);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+let commandEncoder375 = device1.createCommandEncoder({});
+let querySet45 = device1.createQuerySet({label: '\uf148\u981a\uc897\u9ba8\u60d4\u02e0\u4b70\uda4a', type: 'occlusion', count: 284});
+let commandBuffer234 = commandEncoder375.finish({label: '\u{1fb58}\u{1f6c3}\u26ca\ua110\u34ce\u0312\u{1fa97}'});
+let textureView85 = texture100.createView({});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder95.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup31, new Uint32Array(714), 11, 0);
+} catch {}
+try {
+renderBundleEncoder46.draw(41, 58, 30_483_941, 14);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(52, 22, 49, 196_386_296, 11);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer31, 56);
+} catch {}
+let commandEncoder376 = device2.createCommandEncoder({});
+let renderBundle195 = renderBundleEncoder32.finish();
+try {
+computePassEncoder51.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(6, buffer30, 3_372, 476);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder377 = device3.createCommandEncoder({label: '\ufc1a\u{1f915}\u07b4\ucef6\u6819\u8a06'});
+let renderBundle196 = renderBundleEncoder45.finish({label: '\u06ee\u0aad\u{1fc2f}\u9936\u7583\u70e6'});
+try {
+renderBundleEncoder55.setVertexBuffer(7, buffer50, 2_672, 4_600);
+} catch {}
+let commandEncoder378 = device1.createCommandEncoder({label: '\u7246\u0653\u26c3'});
+let computePassEncoder95 = commandEncoder378.beginComputePass({label: '\u9102\u9468\u42ac\u74fa\u{1fdcd}'});
+try {
+computePassEncoder65.setBindGroup(1, bindGroup11, new Uint32Array(1558), 39, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer25, 0, 326);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer25, 1_084);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer49, 416, 19_621);
+} catch {}
+let arrayBuffer30 = buffer15.getMappedRange(0, 2968);
+let commandEncoder379 = device3.createCommandEncoder({label: '\u0378\u43bf\u0e09\uc5ad\u5914'});
+let texture121 = device3.createTexture({
+  label: '\u0664\ub525',
+  size: {width: 3, height: 1, depthOrArrayLayers: 23},
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView86 = texture106.createView({label: '\u{1fed0}\ue256\u1760\u05a2\ude3b'});
+try {
+commandEncoder371.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas0.height = 86;
+await gc();
+let computePassEncoder96 = commandEncoder244.beginComputePass({label: '\u09ca\u21d4\u4455\u9a60\u7f3e'});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder84.setBindGroup(2, bindGroup18, []);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle24, renderBundle46]);
+} catch {}
+try {
+renderPassEncoder76.setViewport(161.5976244242343, 0.9465787485174593, 4.754511944787266, 23.716895370019433, 0.10080036120311764, 0.9735376291907136);
+} catch {}
+try {
+renderBundleEncoder46.draw(497, 29, 428_613_609, 15);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer25, 676);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer48, 1_748);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(5, undefined, 60_383_802, 705_499_496);
+} catch {}
+video9.height = 32;
+let commandEncoder380 = device2.createCommandEncoder({});
+let renderPassEncoder97 = commandEncoder380.beginRenderPass({
+  label: '\u0784\u{1ff53}\u5e5e\uce4e',
+  colorAttachments: [{
+  view: textureView53,
+  clearValue: { r: 601.9, g: 880.0, b: 163.7, a: -949.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder57 = device2.createRenderBundleEncoder({label: '\u{1fe93}\ud95c\u0386\u0bf9\ubf5c', colorFormats: ['r8unorm'], stencilReadOnly: true});
+let renderBundle197 = renderBundleEncoder57.finish({label: '\u{1ffb4}\uc124\u6171\u0f30\u8b28\u0466\u{1f7d2}\u{1fe90}\u0958\u{1ff0f}\u024c'});
+try {
+renderPassEncoder75.end();
+} catch {}
+try {
+renderPassEncoder65.draw(0, 0, 2, 1_057_063_813);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(219, 0, 76, 34_294_670);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(3, bindGroup33, new Uint32Array(47), 12, 0);
+} catch {}
+let img8 = await imageWithData(15, 37, '#a75de6b8', '#52276eb0');
+try {
+device3.queue.submit([commandBuffer230, commandBuffer214]);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let imageData46 = new ImageData(12, 12);
+let commandEncoder381 = device2.createCommandEncoder();
+let textureView87 = texture50.createView({label: '\ud0f6\u8965\u71c8\udc1b\u495d\uc6f6\ud43f\u336a', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup23, new Uint32Array(1367), 645, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(1_014, 0, 19, 243_010_366);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer31 = buffer46.getMappedRange(0, 44);
+try {
+device2.queue.submit([commandBuffer185]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 120, depthOrArrayLayers: 773}
+*/
+{
+  source: imageData23,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 25, z: 85},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video9);
+let texture122 = device1.createTexture({size: [176, 30, 1], dimension: '2d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let sampler26 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 90.30,
+});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer13, 'uint32', 396, 3_165);
+} catch {}
+try {
+renderPassEncoder84.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder56.setIndexBuffer(buffer25, 'uint16', 840, 1_239);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer49, 6_564, 1_683);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandBuffer235 = commandEncoder373.finish();
+try {
+renderBundleEncoder54.setVertexBuffer(3, buffer50);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+let commandEncoder382 = device2.createCommandEncoder();
+let commandBuffer236 = commandEncoder382.finish({});
+let renderBundleEncoder58 = device2.createRenderBundleEncoder({label: '\ud64d\u{1f6c0}\u0512', colorFormats: ['r8unorm'], sampleCount: 1, depthReadOnly: true});
+let renderBundle198 = renderBundleEncoder36.finish();
+try {
+renderPassEncoder78.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(6, buffer41);
+} catch {}
+try {
+commandEncoder381.copyBufferToBuffer(buffer46, 268, buffer33, 32, 1896);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video5);
+let commandEncoder383 = device2.createCommandEncoder({label: '\u{1f87b}\u70d0\u68fc\u8b8d\u3adf\u{1fe79}\uf288\ueb58\u0021\u2a2a\u{1fca9}'});
+let commandBuffer237 = commandEncoder383.finish({label: '\u02fb\u{1f704}\u0c34'});
+try {
+renderPassEncoder97.executeBundles([renderBundle118, renderBundle158, renderBundle123]);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(110, 224, 47, 1_234_147_733, 192_338_065);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer41, 'uint32', 1_024, 4_534);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(6, buffer30, 4_156, 822);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 181, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(47), /* required buffer size: 47 */
+{offset: 47, bytesPerRow: 99}, {width: 0, height: 173, depthOrArrayLayers: 0});
+} catch {}
+let promise55 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise55;
+} catch {}
+await gc();
+document.body.prepend(video7);
+let adapter8 = await navigator.gpu.requestAdapter({});
+let imageData47 = new ImageData(8, 4);
+let commandEncoder384 = device2.createCommandEncoder({});
+let texture123 = device2.createTexture({
+  size: {width: 6},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder97.setBlendConstant({ r: -931.3, g: -763.9, b: -756.9, a: -667.3, });
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer30, 'uint16', 1_150, 281);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(7, buffer30);
+} catch {}
+offscreenCanvas3.width = 1507;
+let commandEncoder385 = device2.createCommandEncoder({label: '\u5a29\u{1f83f}\ucf37\u560c\u9362\u363f\u7928\u{1f904}'});
+try {
+computePassEncoder92.end();
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup23, new Uint32Array(273), 37, 0);
+} catch {}
+try {
+renderPassEncoder70.draw(270, 0, 1_363_790_509);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(11, 0, 55, -995_883_211);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(2, bindGroup35, new Uint32Array(283), 66, 0);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer30, 'uint16', 3_246, 1_395);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(5, buffer33, 412);
+} catch {}
+try {
+commandEncoder376.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 54608 */
+  offset: 4684,
+  bytesPerRow: 256,
+  rowsPerImage: 16,
+  buffer: buffer28,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 26},
+  aspect: 'all',
+}, {width: 1, height: 4, depthOrArrayLayers: 13});
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\ubf0e');
+} catch {}
+let commandEncoder386 = device2.createCommandEncoder();
+let commandBuffer238 = commandEncoder381.finish();
+try {
+renderPassEncoder79.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder370.resolveQuerySet(querySet19, 83, 20, buffer33, 512);
+} catch {}
+try {
+device2.queue.submit([commandBuffer97, commandBuffer217, commandBuffer236, commandBuffer225, commandBuffer218]);
+} catch {}
+let bindGroupLayout46 = device1.createBindGroupLayout({
+  label: '\u03ff\u1159',
+  entries: [
+    {
+      binding: 492,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder387 = device1.createCommandEncoder({});
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({
+  label: '\u{1fe5d}\ud4ab\u398d\u{1ffa8}\ub369\u6736\ueed7\u{1f83f}\ufbc0',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: false,
+});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder96.setIndexBuffer(buffer31, 'uint32', 400, 126);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 1_360);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer16, 0, 1_924);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet12, 433, 17, buffer45, 0);
+} catch {}
+try {
+computePassEncoder66.insertDebugMarker('\u08f9');
+} catch {}
+try {
+device1.queue.submit([commandBuffer76, commandBuffer234]);
+} catch {}
+let renderBundle199 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup8, new Uint32Array(1037), 157, 0);
+} catch {}
+try {
+renderPassEncoder94.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder88.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder46.draw(320, 4, 563_365_768, 10);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 8_824);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer36, 'uint32', 76, 630);
+} catch {}
+try {
+commandEncoder107.insertDebugMarker('\u740b');
+} catch {}
+let imageData48 = new ImageData(40, 40);
+let buffer51 = device2.createBuffer({size: 6555, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder388 = device2.createCommandEncoder();
+let renderBundle200 = renderBundleEncoder49.finish({label: '\u152b\u92d0\u7a61\u0db1\u0a03\u0e61\u{1faf8}\ubc4b\u0fb5\u{1f8c5}'});
+try {
+computePassEncoder69.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 104, 1, 367_419_503);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer33, 'uint32', 2_192, 210);
+} catch {}
+try {
+commandEncoder385.copyBufferToBuffer(buffer51, 604, buffer34, 8148, 996);
+} catch {}
+try {
+computePassEncoder61.insertDebugMarker('\u0c6c');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 120, depthOrArrayLayers: 773}
+*/
+{
+  source: imageData23,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 152},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData49 = new ImageData(184, 52);
+let commandEncoder389 = device3.createCommandEncoder({label: '\ud834\u{1fc6e}\u0d1c\ua028\uf2a6\u042d\ue155\u{1fbca}\uec3c'});
+let computePassEncoder97 = commandEncoder377.beginComputePass({});
+try {
+renderBundleEncoder55.setVertexBuffer(6, buffer50, 0, 16_907);
+} catch {}
+try {
+externalTexture0.label = '\u0190\u09a3\u{1f701}\uaed0\u{1fc41}\ud821\ucaf6\u9356\u{1fad4}';
+} catch {}
+let commandEncoder390 = device1.createCommandEncoder({label: '\u6eb6\u3377\u0788\u8ab4\u04fe\u{1f794}\u1396\u5050\u{1fc56}\u274a\u{1ff37}'});
+let querySet46 = device1.createQuerySet({label: '\u03f6\ue86a\u34de', type: 'occlusion', count: 219});
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(7, buffer17, 0);
+} catch {}
+try {
+renderBundleEncoder46.draw(17, 74, 1_837_270_085, 20);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer25, 600);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline5);
+} catch {}
+let img9 = await imageWithData(13, 15, '#27a40164', '#71d14201');
+let commandEncoder391 = device2.createCommandEncoder({label: '\u{1faa1}\u0849\u0bdd\uc846\u0fe8\u6858\ud0d3\u{1fffc}'});
+let commandBuffer239 = commandEncoder376.finish({label: '\ue3e6\u7394\u0471'});
+let renderPassEncoder98 = commandEncoder391.beginRenderPass({
+  label: '\ud83f\u37c7\u{1f86c}\u61d5\ud63d\u0162\ub6ce\u6d64\ub6ea\ud3a8',
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: 740.2, g: -953.8, b: -991.2, a: -451.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+});
+try {
+computePassEncoder61.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder90.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(3, buffer41, 840, 972);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(6, buffer33);
+} catch {}
+try {
+commandEncoder386.copyBufferToBuffer(buffer51, 32, buffer34, 1912, 56);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 1544, new Float32Array(6051), 689, 152);
+} catch {}
+let renderBundleEncoder60 = device2.createRenderBundleEncoder({label: '\u8297\u0ba5\u0a45\u1dd0\u06e0\ufa26', colorFormats: ['r8unorm']});
+try {
+computePassEncoder63.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder65.draw(1, 5, 0, 577_035_512);
+} catch {}
+try {
+renderPassEncoder97.setVertexBuffer(4, buffer32, 328, 13);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+document.body.prepend(img9);
+let commandBuffer240 = commandEncoder390.finish({label: '\ucba3\ub307\uc9af\u065c\u16c6\u{1fae5}\u06b8\u0d2b\u4682\u02f8'});
+let texture124 = device1.createTexture({
+  label: '\u0ebf\u{1fd8b}\u0558\uc6bf\u2157\u22c0',
+  size: {width: 180},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle201 = renderBundleEncoder35.finish({label: '\uc251\u0a3b'});
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer18, 'uint32', 3_616, 7_425);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder46.draw(281, 32, 102_095_413, 9);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer31, 256);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer24, 'uint32', 2_868, 480);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(7, buffer16, 10_996, 14_404);
+} catch {}
+try {
+commandEncoder387.copyBufferToBuffer(buffer19, 240, buffer13, 1408, 56);
+} catch {}
+try {
+renderBundleEncoder33.pushDebugGroup('\u{1f764}');
+} catch {}
+try {
+device1.queue.submit([commandBuffer153, commandBuffer231]);
+} catch {}
+try {
+window.someLabel = computePassEncoder90.label;
+} catch {}
+let buffer52 = device3.createBuffer({
+  size: 12012,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder392 = device3.createCommandEncoder({});
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint16', 1_968, 1_116);
+} catch {}
+let commandEncoder393 = device3.createCommandEncoder({label: '\uf17a\u75d2\uf02d\u2d7e\u0264\u05fc\u1507'});
+let commandBuffer241 = commandEncoder393.finish({});
+let renderBundle202 = renderBundleEncoder45.finish({});
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint16', 272, 3_385);
+} catch {}
+try {
+device3.queue.submit([commandBuffer216, commandBuffer241, commandBuffer221]);
+} catch {}
+document.body.prepend(canvas10);
+try {
+renderBundleEncoder54.setVertexBuffer(4, buffer50);
+} catch {}
+offscreenCanvas2.height = 61;
+let commandBuffer242 = commandEncoder379.finish({label: '\u374a\ufda7\u0f98\u{1f76f}\u4b0c\ua3bb\u{1ff7f}\uff8d\u49c0'});
+let externalTexture39 = device3.importExternalTexture({label: '\u0fa6\u0229\ue98b\udcf3', source: video3, colorSpace: 'display-p3'});
+let sampler27 = device2.createSampler({label: '\ua612\u{1fdc5}', addressModeU: 'repeat', lodMaxClamp: 96.15, compare: 'always'});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder78.end();
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(43, 116, 95, 14_395_888, 420_646_223);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer41, 'uint16', 1_754, 456);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(3, bindGroup25, new Uint32Array(6427), 181, 0);
+} catch {}
+let arrayBuffer32 = buffer27.getMappedRange(16, 0);
+try {
+buffer33.unmap();
+} catch {}
+try {
+commandEncoder370.copyTextureToBuffer({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2464 */
+  offset: 2464,
+  bytesPerRow: 0,
+  buffer: buffer34,
+}, {width: 0, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder386.copyTextureToTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+renderBundleEncoder58.setVertexBuffer(4, buffer32, 0);
+} catch {}
+let commandBuffer243 = commandEncoder107.finish({});
+let renderPassEncoder99 = commandEncoder387.beginRenderPass({
+  label: '\ucb9d\u5894\u0ff3\ua1b9\u2552\u43af\u0ac6\ue4b0\u0ceb\u{1faf3}\u6c92',
+  colorAttachments: [{
+  view: textureView75,
+  depthSlice: 88,
+  clearValue: { r: -995.3, g: -489.3, b: -445.7, a: -804.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle203 = renderBundleEncoder4.finish({label: '\u0121\u0ca3\uad3a\u58ae\u0156\u0621'});
+try {
+computePassEncoder95.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder94.setIndexBuffer(buffer29, 'uint16', 890, 13);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(97, 47, 56, 997_625_504, 31);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer29, 244);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer29, 'uint32', 8_668, 251);
+} catch {}
+try {
+renderBundleEncoder16.insertDebugMarker('\u6863');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img5);
+try {
+externalTexture37.label = '\uf5a5\u{1f80d}\ufa89\u7e75\u0840\ubf96\ua28e\u2fed\ud137\u2467';
+} catch {}
+let commandEncoder394 = device3.createCommandEncoder({label: '\uace2\u7030\uc691'});
+let renderBundleEncoder61 = device3.createRenderBundleEncoder({label: '\ua755\u{1fdb9}\u37bd', colorFormats: ['rg8sint'], sampleCount: 4, stencilReadOnly: true});
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer47, 0);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let promise56 = adapter3.requestAdapterInfo();
+let commandEncoder395 = device3.createCommandEncoder();
+let commandBuffer244 = commandEncoder389.finish({label: '\u8343\u{1fba0}\u05c7\u8c8b\u158b\ude44\uae4c'});
+let computePassEncoder98 = commandEncoder394.beginComputePass({label: '\u{1f6f2}\u0fba'});
+try {
+renderBundleEncoder55.setVertexBuffer(3, buffer47, 0);
+} catch {}
+try {
+device3.queue.submit([commandBuffer202]);
+} catch {}
+let pipeline33 = await device3.createRenderPipelineAsync({
+  label: '\u{1ff31}\u509e\ufaf8\uc470\u0fdb\u0423',
+  layout: pipelineLayout39,
+  multisample: {count: 4, mask: 0xc155c73a},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule19, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let bindGroupLayout47 = device3.createBindGroupLayout({entries: []});
+let renderBundleEncoder62 = device3.createRenderBundleEncoder({
+  label: '\uec5b\u0fb7\u20c5\ue210\u07f3\ud31c\u{1fca4}\u0c83\uc81e\u25d8\u{1fa59}',
+  colorFormats: ['rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder371.copyBufferToBuffer(buffer52, 320, buffer47, 216, 364);
+} catch {}
+try {
+renderBundleEncoder54.popDebugGroup();
+} catch {}
+let computePassEncoder99 = commandEncoder288.beginComputePass();
+let renderPassEncoder100 = commandEncoder385.beginRenderPass({
+  label: '\u0bca\u0636\u0d3c\u04ab\ua678\uf1c9',
+  colorAttachments: [{view: textureView53, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+computePassEncoder88.end();
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(3, bindGroup30, new Uint32Array(4409), 480, 0);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(29, 0, 6, 380_582_669);
+} catch {}
+try {
+window.someLabel = renderBundle142.label;
+} catch {}
+let pipelineLayout46 = device2.createPipelineLayout({
+  label: '\u{1fafd}\u729e\u01ba\u8ccc\u1b7b\u{1f70d}',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout43, bindGroupLayout15],
+});
+let commandBuffer245 = commandEncoder370.finish();
+let renderPassEncoder101 = commandEncoder386.beginRenderPass({
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: -381.3, g: -114.7, b: 804.5, a: 865.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 94778449,
+});
+let renderBundle204 = renderBundleEncoder24.finish();
+try {
+renderPassEncoder98.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder90.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer41, 'uint16', 4_074, 698);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline12);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+commandEncoder388.copyBufferToBuffer(buffer28, 9084, buffer34, 2376, 736);
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let commandBuffer246 = commandEncoder388.finish({label: '\uda39\u9b5e\u385a\u{1ff2d}\u1340\ud8c4'});
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(4, buffer33);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let commandBuffer247 = commandEncoder371.finish({});
+let textureView88 = texture107.createView({arrayLayerCount: 1});
+let renderBundle205 = renderBundleEncoder51.finish();
+let sampler28 = device3.createSampler({
+  label: '\uec9e\u0b77\u{1fa88}\u3678\u{1f6ac}\u{1f965}\u{1fef8}\uba3d\u63fe\u4fbe',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 17.62,
+  lodMaxClamp: 45.46,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder395.copyBufferToBuffer(buffer50, 1404, buffer47, 24, 320);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline34 = device3.createComputePipeline({label: '\u0666\ubc72', layout: pipelineLayout39, compute: {module: shaderModule19, constants: {}}});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let adapter9 = await promise47;
+let commandEncoder396 = device2.createCommandEncoder({label: '\ubdcc\u6353\u0179\uacc0\u{1f899}'});
+let commandBuffer248 = commandEncoder396.finish({label: '\u{1fb57}\u{1fd4e}\u6ffa\u{1fca4}\u57bd\uac53\u007a\uddcc\u1997'});
+let renderPassEncoder102 = commandEncoder384.beginRenderPass({
+  label: '\u09e1\udfdb\u8b65\u0afa\u4bee\u0cac\u{1f75c}',
+  colorAttachments: [{
+  view: textureView68,
+  clearValue: { r: -307.8, g: 812.9, b: 606.8, a: 200.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 14026913,
+});
+let renderBundle206 = renderBundleEncoder57.finish({label: '\u0525\uc3ab\uec1c\u0c75\u9a8e\u0de8\u53b8'});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder60.setIndexBuffer(buffer41, 'uint32', 2_288, 2_708);
+} catch {}
+try {
+device2.queue.submit([commandBuffer238, commandBuffer232, commandBuffer245]);
+} catch {}
+offscreenCanvas6.width = 755;
+let commandBuffer249 = commandEncoder347.finish({label: '\u0833\u{1fadd}\u0c92\uefaf\ud789\u499d'});
+let texture125 = device2.createTexture({
+  size: {width: 1, height: 240, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle207 = renderBundleEncoder37.finish({label: '\u85d2\udaa5'});
+try {
+computePassEncoder71.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder70.draw(185, 0, 639_647_115);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(3, buffer33, 44);
+} catch {}
+let promise57 = device2.queue.onSubmittedWorkDone();
+let commandEncoder397 = device1.createCommandEncoder({label: '\u127e\u56e7\u{1f8e4}\ud327\u0178\u{1fc9c}\u12d8'});
+let texture126 = gpuCanvasContext1.getCurrentTexture();
+let renderPassEncoder103 = commandEncoder397.beginRenderPass({
+  label: '\u0a99\u2860\u{1fc64}\u076d\u138f\u7421\u1c2b\u0a8d\u8717\u{1fab8}',
+  colorAttachments: [{view: textureView15, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 90858620,
+});
+try {
+renderPassEncoder61.executeBundles([renderBundle44, renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer13, 'uint32', 180, 616);
+} catch {}
+try {
+renderPassEncoder68.insertDebugMarker('\ubf31');
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+let renderBundle208 = renderBundleEncoder53.finish({label: '\u015f\u{1fcde}\u{1f609}\u8ecf\u0cd9\u0585\u442f\u3e6b\u0dae'});
+try {
+renderPassEncoder60.setPipeline(pipeline23);
+} catch {}
+let arrayBuffer33 = buffer35.getMappedRange(0, 60);
+try {
+device1.queue.submit([commandBuffer190, commandBuffer224]);
+} catch {}
+try {
+  await promise56;
+} catch {}
+let computePassEncoder100 = commandEncoder202.beginComputePass();
+try {
+renderPassEncoder70.setBindGroup(2, bindGroup22, new Uint32Array(2242), 680, 0);
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle170]);
+} catch {}
+let commandEncoder398 = device2.createCommandEncoder({label: '\u052f\u0692\u0612\u25b4\udc7d\u5c63\u2627\u06ae\u0810\u0d64\ub052'});
+let commandBuffer250 = commandEncoder398.finish();
+try {
+renderPassEncoder93.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder81.setBindGroup(2, bindGroup22, new Uint32Array(819), 298, 0);
+} catch {}
+try {
+renderPassEncoder65.beginOcclusionQuery(208);
+} catch {}
+try {
+renderPassEncoder102.setViewport(0.8586469876776524, 59.11034273885107, 0.12648998460494712, 0.27730095548709366, 0.231549945847616, 0.24224077136349045);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(3, 0, 21, 181_028_687);
+} catch {}
+try {
+renderPassEncoder93.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer41, 'uint32', 4_220, 1_416);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let renderBundle209 = renderBundleEncoder59.finish({label: '\u452c\ud5dd'});
+try {
+computePassEncoder11.dispatchWorkgroupsIndirect(buffer6, 5_940);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(28, 77, 48, 83_613_229, 1);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer16, 260);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2, buffer25, 0, 241);
+} catch {}
+try {
+computePassEncoder58.pushDebugGroup('\u{1fcf3}');
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder399 = device1.createCommandEncoder();
+let commandBuffer251 = commandEncoder399.finish();
+let textureView89 = texture86.createView({label: '\uebc1\u2da6\u{1f9ff}\u0109', dimension: '1d'});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder84.executeBundles([renderBundle38, renderBundle78, renderBundle63, renderBundle124, renderBundle67]);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer48, 532);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer6, 392);
+} catch {}
+try {
+renderBundleEncoder56.setIndexBuffer(buffer13, 'uint16', 2_038, 1_564);
+} catch {}
+canvas10.width = 940;
+let video11 = await videoWithData();
+try {
+computePassEncoder61.dispatchWorkgroups(4, 1, 4);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup25, new Uint32Array(792), 2, 0);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline35 = device2.createRenderPipeline({
+  layout: pipelineLayout25,
+  fragment: {module: shaderModule17, entryPoint: 'fragment0', constants: {}, targets: [{format: 'r8unorm'}]},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {failOp: 'increment-wrap'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilReadMask: 2421364556,
+    stencilWriteMask: 1647956400,
+    depthBiasSlopeScale: 396.48052354751496,
+    depthBiasClamp: 120.0743901243437,
+  },
+  vertex: {module: shaderModule17, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let buffer53 = device1.createBuffer({
+  size: 14568,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder400 = device1.createCommandEncoder({label: '\u02c0\ue8e9\u08bc\u0571\ud046\u554a\ue786\u{1fcaf}\ub03a\u030f\u{1f851}'});
+try {
+computePassEncoder11.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder99.executeBundles([renderBundle110, renderBundle209]);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer38, 'uint32', 2_628, 167);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderBundleEncoder46.draw(468, 24, 62_267_728, 60);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(20, 10, 37, 87_143_522, 82);
+} catch {}
+offscreenCanvas9.height = 136;
+let textureView90 = texture118.createView({format: 'rg8sint', baseArrayLayer: 0, arrayLayerCount: 3});
+try {
+renderBundleEncoder62.setIndexBuffer(buffer52, 'uint16', 1_976, 370);
+} catch {}
+let renderBundle210 = renderBundleEncoder61.finish({label: '\u9b50\u{1fc84}\u0f6c\u4caf\u8591\u{1f7b2}\ucdb3'});
+try {
+device3.queue.submit([commandBuffer208, commandBuffer210]);
+} catch {}
+let promise58 = device3.queue.onSubmittedWorkDone();
+let pipeline36 = await device3.createRenderPipelineAsync({
+  label: '\u0e60\ufafe\u{1f8c7}\u{1f6d1}\u39f7\u0079\uac8c\u0413\u978a\u{1faa2}\u3c1e',
+  layout: pipelineLayout39,
+  multisample: {mask: 0x640a50e7},
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule21,
+    buffers: [
+      {
+        arrayStride: 260,
+        attributes: [
+          {format: 'sint32x2', offset: 0, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 208,
+        attributes: [
+          {format: 'snorm8x4', offset: 36, shaderLocation: 11},
+          {format: 'float16x4', offset: 88, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 2, shaderLocation: 14},
+          {format: 'uint32x3', offset: 0, shaderLocation: 12},
+          {format: 'float16x4', offset: 16, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 212, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 904,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 216, shaderLocation: 7}],
+      },
+      {arrayStride: 248, attributes: [{format: 'snorm16x4', offset: 60, shaderLocation: 15}]},
+      {
+        arrayStride: 168,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 4, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 0},
+          {format: 'sint32', offset: 36, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 864,
+        attributes: [
+          {format: 'float16x4', offset: 12, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 124, shaderLocation: 13},
+          {format: 'sint8x4', offset: 72, shaderLocation: 5},
+          {format: 'float32x4', offset: 40, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+try {
+  await promise58;
+} catch {}
+try {
+  await promise57;
+} catch {}
+try {
+adapter1.label = '\u0391\u2ca8\u042b\u9e68\u03c2';
+} catch {}
+let commandEncoder401 = device3.createCommandEncoder({});
+let commandBuffer252 = commandEncoder392.finish({label: '\u66a6\u998e\u1bb9'});
+let renderBundle211 = renderBundleEncoder55.finish({label: '\u0e3c\u{1fcda}'});
+let sampler29 = device3.createSampler({
+  label: '\u32ed\u09d6\ua89b\uc1d8\u4fdd',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 80.82,
+  lodMaxClamp: 84.92,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder94.setPipeline(pipeline34);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(14, 1, 5, 5);
+} catch {}
+try {
+renderBundleEncoder46.draw(22, 5, 103_079_412, 2);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer24, 'uint16', 14_808, 1_806);
+} catch {}
+try {
+computePassEncoder58.popDebugGroup();
+} catch {}
+await gc();
+let texture127 = device1.createTexture({
+  label: '\u162e\u0e5a\ufa30\u00b6\u9c9b\u056e\u{1fecd}\u3665\u0b12\u{1fcb5}\uca6f',
+  size: [90, 20, 12],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder101 = commandEncoder400.beginComputePass({label: '\u04bc\u206b\u{1f86e}\u0211\u0424\u{1f625}\u0e05\uae89'});
+try {
+renderPassEncoder92.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder95.setVertexBuffer(1, buffer6);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(79, 3, 62, -594_005_656, 48);
+} catch {}
+try {
+renderBundleEncoder29.insertDebugMarker('\u05d6');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+try {
+computePassEncoder58.setBindGroup(2, bindGroup18, new Uint32Array(24), 9, 0);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder94.setBindGroup(1, bindGroup32, new Uint32Array(1243), 99, 0);
+} catch {}
+try {
+renderPassEncoder64.setStencilReference(555);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer31, 'uint32', 448, 40);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder46.draw(163, 36, 276_613_314, 41);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer24, 432);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer38, 'uint32', 2_400, 4_935);
+} catch {}
+let imageData50 = new ImageData(4, 16);
+try {
+computePassEncoder61.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder70.draw(201, 0, 1_068_990_737);
+} catch {}
+try {
+renderPassEncoder101.setIndexBuffer(buffer41, 'uint32', 276, 3_179);
+} catch {}
+try {
+renderPassEncoder90.setVertexBuffer(7, buffer32, 24);
+} catch {}
+let bindGroup38 = device1.createBindGroup({label: '\u9666\u7aa4\u7efd\u050a\u{1f7bd}', layout: bindGroupLayout20, entries: []});
+let commandEncoder402 = device1.createCommandEncoder();
+let commandBuffer253 = commandEncoder402.finish({label: '\u0f37\u04af\ud762\u{1ff4e}\ufa6b'});
+let renderBundle212 = renderBundleEncoder46.finish({label: '\u{1fd75}\u03d9'});
+try {
+renderPassEncoder52.setStencilReference(1432);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer25, 'uint16', 150, 585);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(3, buffer53);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4_294_967_295, undefined, 0, 369_354_500);
+} catch {}
+try {
+renderBundleEncoder33.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder88.setIndexBuffer(buffer25, 'uint32', 168, 878);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(3, buffer25, 0, 391);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 360, height: 80, depthOrArrayLayers: 424}
+*/
+{
+  source: canvas3,
+  origin: { x: 5, y: 123 },
+  flipY: true,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 12, y: 39, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroupLayout48 = device1.createBindGroupLayout({
+  label: '\u7736\u0227\u{1f9b9}\u0ff6',
+  entries: [{binding: 57, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }}],
+});
+let renderBundle213 = renderBundleEncoder34.finish({label: '\u{1fbec}\u3e21\u{1ff30}\ue035\u062a'});
+let externalTexture40 = device1.importExternalTexture({label: '\u537b\uc93c', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder101.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder87.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer24, 'uint16', 3_558, 9_673);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(3, buffer24, 1_568);
+} catch {}
+let arrayBuffer34 = buffer10.getMappedRange(0, 0);
+try {
+  await buffer43.mapAsync(GPUMapMode.WRITE, 48);
+} catch {}
+try {
+device1.queue.submit([commandBuffer220, commandBuffer233]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(9), /* required buffer size: 9 */
+{offset: 9}, {width: 66, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = await device1.createComputePipelineAsync({
+  label: '\u55df\u{1fdf8}\u{1f901}\u{1ff85}\u0780\ue54e\u0005\u{1fb40}\u0251\ud643',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule13, constants: {}},
+});
+let canvas12 = document.createElement('canvas');
+let commandEncoder403 = device2.createCommandEncoder({label: '\uff78\u57d5'});
+let texture128 = device2.createTexture({
+  label: '\ufd0e\u0979\u4903\u355d',
+  size: [24, 120, 437],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView91 = texture87.createView({
+  label: '\u62db\u{1fb44}\u073b\uc072\u{1f9ec}\u8340\uca9c\u{1fe61}\u{1f602}\u0c44\u{1fba3}',
+  aspect: 'all',
+});
+try {
+renderPassEncoder81.setViewport(0.19576946018439467, 319.23416413353436, 0.5373288055814092, 17.531711709125812, 0.5619510149919335, 0.980044539718145);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(5, 173, 72, 144_111_237, 864_174_853);
+} catch {}
+try {
+commandEncoder403.copyBufferToBuffer(buffer51, 168, buffer34, 5420, 608);
+} catch {}
+try {
+commandEncoder403.insertDebugMarker('\u50bf');
+} catch {}
+let commandEncoder404 = device1.createCommandEncoder({label: '\u{1f6c7}\ud8db\u0e10\u02c8\uf828\u{1f905}\u0b78\u{1fc02}\u4c0b\u{1fbbc}'});
+let commandBuffer254 = commandEncoder404.finish({label: '\ua194\u5787\u376a\u538f\u7f4d\u{1f6d6}\u67b0\u4e41'});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder405 = device3.createCommandEncoder({label: '\u8fdf\u0b71\u03d4\u3de5\u{1fc2d}\u06ef\u{1ff8b}\u{1f6e9}\u01fc\ud678\ubdf7'});
+let texture129 = device3.createTexture({
+  label: '\u968c\u0899',
+  size: [20, 12, 1],
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder62.setVertexBuffer(0, buffer47, 292, 312);
+} catch {}
+try {
+commandEncoder401.copyBufferToBuffer(buffer50, 1560, buffer47, 52, 72);
+} catch {}
+document.body.prepend(canvas7);
+let gpuCanvasContext20 = canvas12.getContext('webgpu');
+let imageBitmap8 = await createImageBitmap(imageData6);
+let buffer54 = device3.createBuffer({
+  label: '\u019f\u1ec4\u0e27',
+  size: 21848,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder406 = device3.createCommandEncoder({label: '\u0546\u5221\u0fe7'});
+try {
+renderBundleEncoder62.setPipeline(pipeline33);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer47, 1136, new BigUint64Array(11834), 1099, 28);
+} catch {}
+let renderBundle214 = renderBundleEncoder13.finish({});
+let externalTexture41 = device1.importExternalTexture({source: video5, colorSpace: 'srgb'});
+try {
+renderPassEncoder32.setBlendConstant({ r: -395.2, g: -503.4, b: 527.2, a: -873.9, });
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer29, 2_996);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(2, buffer49, 12_964, 1_640);
+} catch {}
+let querySet47 = device1.createQuerySet({label: '\u08ca\uac4e\uab3c\u0e6f', type: 'occlusion', count: 725});
+let externalTexture42 = device1.importExternalTexture({source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder94.executeBundles([renderBundle189, renderBundle201]);
+} catch {}
+try {
+renderPassEncoder19.draw(1_000, 0, 825_530_198);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer6, 3_904);
+} catch {}
+try {
+renderPassEncoder88.setIndexBuffer(buffer13, 'uint32', 5_648, 371);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer53, 5_156, 160);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+device1.queue.submit([commandBuffer229]);
+} catch {}
+document.body.prepend(video1);
+let pipelineLayout47 = device3.createPipelineLayout({
+  label: '\ua9a9\u{1fe3b}\uf61a\u760e\u25fd\u0625\u0de3\u0a80\udfee\u5d4c\uc448',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout45, bindGroupLayout45],
+});
+let commandBuffer255 = commandEncoder405.finish({label: '\u{1fa41}\u495c\u2cd5\u{1fbce}'});
+try {
+computePassEncoder94.setPipeline(pipeline34);
+} catch {}
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 4_952, 53);
+} catch {}
+let pipelineLayout48 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout43]});
+let commandEncoder407 = device2.createCommandEncoder();
+let commandBuffer256 = commandEncoder407.finish();
+let texture130 = device2.createTexture({
+  label: '\u06ae\u0420\u12f7\ua290\u{1fed8}\u8012\u8ec2\u{1fccf}\u3198',
+  size: [1, 120, 1],
+  sampleCount: 4,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder104 = commandEncoder403.beginRenderPass({
+  label: '\u{1fa2f}\u0e2f',
+  colorAttachments: [{
+  view: textureView87,
+  clearValue: { r: 108.1, g: 523.4, b: -697.4, a: 574.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 195499334,
+});
+try {
+computePassEncoder63.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder102.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder97.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 60, 1, 616_452_548);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer33, 'uint32', 256, 163);
+} catch {}
+let commandEncoder408 = device3.createCommandEncoder({label: '\u056b\u0706\u094f\u034e\u06c7\u{1fcbf}\u0a0b\u046a\u0ffd\u05ca\u{1f7bd}'});
+let externalTexture43 = device3.importExternalTexture({
+  label: '\u{1f895}\u2904\u{1fbc5}\u{1fe1f}\u3991\u57cd\u0bb3\ua0d6\u05ba\u0676',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let arrayBuffer35 = buffer54.getMappedRange(1352);
+try {
+commandEncoder408.clearBuffer(buffer47);
+} catch {}
+try {
+device3.queue.submit([commandBuffer242]);
+} catch {}
+let textureView92 = texture104.createView({label: '\u0284\u23ef\u{1fead}\u{1fc93}\ufd68\u{1fc98}\u10fb\u037b\u{1ff29}'});
+let renderBundle215 = renderBundleEncoder45.finish();
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 2_908, 2_630);
+} catch {}
+try {
+device3.queue.submit([commandBuffer228]);
+} catch {}
+let commandEncoder409 = device2.createCommandEncoder({label: '\u7178\u0c79\u{1f6ad}\u0de1\u0a72'});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup26, new Uint32Array(2666), 561, 0);
+} catch {}
+try {
+renderPassEncoder104.beginOcclusionQuery(1275);
+} catch {}
+try {
+renderPassEncoder93.executeBundles([renderBundle132, renderBundle118, renderBundle123, renderBundle186, renderBundle149]);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer41, 'uint16', 3_714, 1_335);
+} catch {}
+try {
+commandEncoder409.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1148 */
+  offset: 1148,
+  bytesPerRow: 0,
+  rowsPerImage: 36,
+  buffer: buffer51,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 358},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 242});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 4, y: 89 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img10 = await imageWithData(40, 20, '#2dc8ccdd', '#352d6113');
+let computePassEncoder102 = commandEncoder409.beginComputePass({label: '\u0f2c\u0a07\uc1bd'});
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup33, new Uint32Array(1564), 15, 0);
+} catch {}
+try {
+renderPassEncoder85.setViewport(0.7718857343365318, 432.07987735547704, 0.12704903606457638, 25.884223723853268, 0.9154232524557208, 0.9246430826186764);
+} catch {}
+try {
+renderPassEncoder65.draw(1, 257, 1, 197_407_924);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(22, 0, 1, 901_818_004);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer33, 'uint16', 256, 2);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter6.label = '\u{1faf9}\u6437\u{1fb63}';
+} catch {}
+let pipelineLayout49 = device3.createPipelineLayout({label: '\u{1f753}\u2536\ud8be\u{1f744}\u7ee8\u9558\u33a0\u63ae', bindGroupLayouts: []});
+let commandEncoder410 = device3.createCommandEncoder({label: '\u7e31\u38ba\u0b53\u{1f650}\u84a8\udb5e\uf8f2'});
+let renderBundle216 = renderBundleEncoder43.finish({label: '\u07d5\u{1f89f}\u{1f622}'});
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 1_260, 2_686);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder62.setVertexBuffer(0, buffer50, 0, 5_556);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+await gc();
+let commandEncoder411 = device1.createCommandEncoder();
+let commandBuffer257 = commandEncoder411.finish({});
+let renderBundle217 = renderBundleEncoder48.finish({label: '\ub693\u{1f657}\ub474\u2242\uc51b\u0360\u{1fd1b}\ud6cd\u8b81'});
+try {
+computePassEncoder55.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer48, 380);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(4, buffer16);
+} catch {}
+let arrayBuffer36 = buffer31.getMappedRange(88);
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline38 = device1.createComputePipeline({
+  label: '\u079d\u4271\u{1f701}\u{1fa15}\u0376\u{1f725}',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule20, constants: {}},
+});
+video0.height = 54;
+let commandBuffer258 = commandEncoder408.finish({label: '\ua27e\u7e92\u9d40\u8659\u0ba2\u8125'});
+let computePassEncoder103 = commandEncoder410.beginComputePass({});
+let renderBundle218 = renderBundleEncoder62.finish({label: '\ue186\uf5eb'});
+try {
+computePassEncoder84.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint16', 540, 2_806);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let texture131 = device1.createTexture({
+  label: '\uba14\u{1fbb1}\u{1fc48}\uacf7\u2827',
+  size: [540, 1, 587],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup8, new Uint32Array(1482), 162, 0);
+} catch {}
+try {
+renderPassEncoder19.draw(124, 0, 411_976_069, 2);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer16, 5_896);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(4, buffer25, 0);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder86.pushDebugGroup('\u0a3b');
+} catch {}
+try {
+if (!arrayBuffer33.detached) { new Uint8Array(arrayBuffer33).fill(0x55); };
+} catch {}
+let renderBundle219 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder101.end();
+} catch {}
+try {
+renderPassEncoder84.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder84.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder400.copyBufferToBuffer(buffer31, 536, buffer15, 10868, 36);
+} catch {}
+video5.height = 20;
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let commandEncoder412 = device1.createCommandEncoder({label: '\u04f8\u6b3a\u0538'});
+let commandBuffer259 = commandEncoder400.finish({});
+try {
+renderPassEncoder19.drawIndexed(6, 0, 36, 872_843_134);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer31, 284);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(2, buffer25);
+} catch {}
+try {
+commandEncoder412.clearBuffer(buffer6);
+} catch {}
+try {
+computePassEncoder86.popDebugGroup();
+} catch {}
+let texture132 = device2.createTexture({
+  label: '\u8e4b\u{1ffb7}\u{1f7f7}\u{1f9d0}\ue0d7\u{1f752}\u0fa8\uc855\u65fc\ua4da\u3197',
+  size: [1, 480, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder102.setBindGroup(2, bindGroup30, []);
+} catch {}
+try {
+renderPassEncoder102.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer51, 700, new Int16Array(4336), 1158, 936);
+} catch {}
+document.body.prepend(img9);
+let computePassEncoder104 = commandEncoder401.beginComputePass({label: '\u{1fcbd}\u6a9e\u0895\u92f8\u7e53\u0715'});
+let renderBundle220 = renderBundleEncoder45.finish({label: '\u{1fd91}\u{1f6fe}\u0b0e'});
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+externalTexture20.label = '\udd32\u{1f76f}\ua6c9\uc924';
+} catch {}
+let commandEncoder413 = device2.createCommandEncoder({});
+try {
+renderPassEncoder79.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder65.draw(0, 373, 1, 219_651_012);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(0, buffer33, 0);
+} catch {}
+try {
+commandEncoder413.resolveQuerySet(querySet26, 75, 33, buffer33, 512);
+} catch {}
+let pipeline39 = device2.createRenderPipeline({
+  label: '\u02ad\u{1f72f}\u0396\ud599\uf07b\uf1d5\u02d2\u0c4b\u925a\u{1fe92}',
+  layout: pipelineLayout25,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 1820656352,
+    stencilWriteMask: 3273090354,
+    depthBias: 1512519060,
+  },
+  vertex: {module: shaderModule9, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let pipelineLayout50 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout42]});
+let commandEncoder414 = device3.createCommandEncoder({});
+let renderBundle221 = renderBundleEncoder42.finish();
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer47, 56, new Float32Array(8892), 1558, 140);
+} catch {}
+let shaderModule22 = device1.createShaderModule({
+  code: `@group(2) @binding(159) var sam23: sampler;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+var r: vec4f;
+}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec2<u32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+var r: vec4f;
+_ = sam23;
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(14) f38: vec3<f16>,
+  @builtin(position) f39: vec4<f32>,
+  @location(11) f40: vec2<u32>,
+  @location(7) f41: vec3<f16>,
+  @location(10) f42: vec3<i32>,
+  @location(3) f43: i32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32) -> VertexOutput0 {
+var r: vec4f;
+  return VertexOutput0();
+}
+
+`,
+});
+let computePassEncoder105 = commandEncoder412.beginComputePass({label: '\u87a7\uca31\uf64d\u5cd9\u0d03\u4def\u8d75\u6db5\uc5b9\u{1fc3a}\u0662'});
+try {
+renderPassEncoder19.draw(283, 0, 131_197_060);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer6, 3_072);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer16, 14_332);
+} catch {}
+try {
+renderPassEncoder99.setIndexBuffer(buffer13, 'uint32', 3_512, 536);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(3, buffer24, 0);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(0, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder68.insertDebugMarker('\u04af');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+canvas5.height = 541;
+let commandBuffer260 = commandEncoder413.finish({});
+try {
+renderPassEncoder104.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder65.draw(1, 290, 0, 1_572_034_571);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(108, 8, 15, 95_882_324, 615_163_137);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer41, 'uint16', 3_322, 675);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+let bindGroupLayout49 = device3.createBindGroupLayout({
+  label: '\u0c74\ub669\u{1fbe4}\u9acc\u{1fabb}\udce6\u04b3\u1c5d\u08ec\u0a42',
+  entries: [{binding: 53, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }}],
+});
+let buffer55 = device3.createBuffer({label: '\u0fe0\u24ff\u7920\u2945\uf143\u9400', size: 12789, usage: GPUBufferUsage.MAP_WRITE});
+let renderBundle222 = renderBundleEncoder61.finish();
+try {
+computePassEncoder104.end();
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint16', 648, 4_604);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer50, 0, 1_390);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let promise59 = adapter6.requestAdapterInfo();
+let querySet48 = device3.createQuerySet({label: '\u6002\ud188\u{1fde2}\u082f\uf048\u80bc\u44ca\u{1ff7d}\u0820', type: 'occlusion', count: 1192});
+try {
+renderBundleEncoder54.setVertexBuffer(1, buffer47, 508);
+} catch {}
+let arrayBuffer37 = buffer52.getMappedRange(344, 2276);
+try {
+commandEncoder401.clearBuffer(buffer47);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u0aa2');
+} catch {}
+try {
+device3.queue.submit([commandBuffer258, commandBuffer244]);
+} catch {}
+let promise60 = device3.queue.onSubmittedWorkDone();
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 1_136, 3_486);
+} catch {}
+try {
+commandEncoder414.copyBufferToBuffer(buffer52, 2348, buffer47, 912, 16);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\ueb3d');
+} catch {}
+canvas1.height = 998;
+let bindGroupLayout50 = device3.createBindGroupLayout({
+  label: '\u{1fab5}\uf7cf\u0af8',
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder415 = device3.createCommandEncoder({label: '\u68cf\u966b\u{1f9ff}\u0442\u0257\u{1fd62}\uc601\ub960\u0dea\ucaa1'});
+try {
+renderBundleEncoder54.setVertexBuffer(5, buffer50, 0, 3_657);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let arrayBuffer38 = buffer54.getMappedRange(8, 360);
+try {
+buffer52.unmap();
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint16', 30, 215);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer50);
+} catch {}
+let bindGroupLayout51 = device2.createBindGroupLayout({
+  label: '\u8787\u{1fd44}\u0aee\u{1f922}\u0c2c\u0119\u7d98\ua55d\ub815',
+  entries: [
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 68, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder416 = device2.createCommandEncoder({label: '\u{1f82b}\u4e96'});
+let commandBuffer261 = commandEncoder416.finish({label: '\u0f0b\u2293\u61fa\ub83a\u2ead\u7ad6\u{1f963}\ua6d9\u0b88\u0374\u0a2b'});
+let textureView93 = texture132.createView({dimension: '2d-array', format: 'r8unorm', mipLevelCount: 1});
+let renderBundleEncoder63 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm']});
+let renderBundle223 = renderBundleEncoder44.finish({label: '\u6574\u{1f90f}\u{1fa2c}\u2028\u9cae\u{1f998}\u{1ff39}\u03c2\u71fc\u08f2'});
+try {
+computePassEncoder61.dispatchWorkgroups(1, 1, 1);
+} catch {}
+try {
+renderPassEncoder104.setBindGroup(0, bindGroup35, new Uint32Array(1676), 134, 0);
+} catch {}
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(38, 0, 2, 554_252_442);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder63.setIndexBuffer(buffer30, 'uint32', 6_204, 584);
+} catch {}
+try {
+  await promise60;
+} catch {}
+let commandBuffer262 = commandEncoder406.finish();
+try {
+computePassEncoder91.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(0, buffer50, 0, 741);
+} catch {}
+let arrayBuffer39 = buffer54.getMappedRange(0, 0);
+try {
+commandEncoder401.copyBufferToBuffer(buffer54, 7936, buffer47, 288, 268);
+} catch {}
+try {
+commandEncoder414.clearBuffer(buffer47, 460);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let commandEncoder417 = device1.createCommandEncoder({label: '\u1f52\u5325\u4268\u{1f8da}\uc0c7\u{1fdf3}\u{1fa86}'});
+let commandBuffer263 = commandEncoder417.finish({label: '\u1237\u66ce'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup21, new Uint32Array(1240), 440, 0);
+} catch {}
+try {
+renderPassEncoder35.setViewport(165.30250230584207, 4.32517931824854, 6.193612791606698, 1.112179127054098, 0.7388575195895538, 0.8246438187567707);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer16, 1_696);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(5, buffer17, 0);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup38, new Uint32Array(2302), 202, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer25, 0, 313);
+} catch {}
+let commandEncoder418 = device3.createCommandEncoder({label: '\uaac0\u0ece'});
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 336, 299);
+} catch {}
+let texture133 = device1.createTexture({
+  label: '\u{1fd3e}\u{1f89b}',
+  size: {width: 90},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle224 = renderBundleEncoder28.finish({label: '\u{1fdc9}\u{1f94a}'});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup18, new Uint32Array(3656), 982, 0);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(0, buffer25, 1_304, 948);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 270, height: 1, depthOrArrayLayers: 547}
+*/
+{
+  source: imageData43,
+  origin: { x: 7, y: 5 },
+  flipY: false,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 55},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+let commandEncoder419 = device3.createCommandEncoder();
+let textureView94 = texture99.createView({label: '\ud1e2\u0667\u{1facc}', dimension: '2d-array'});
+let computePassEncoder106 = commandEncoder401.beginComputePass({label: '\u0caf\u0c72\u822e\u31b3\uba3d\u44b8\u3141\u0e31\uf366'});
+let renderBundleEncoder64 = device3.createRenderBundleEncoder({colorFormats: ['rg8uint'], stencilReadOnly: true});
+let sampler30 = device3.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.78,
+  maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint16', 446, 1_304);
+} catch {}
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle136, renderBundle168, renderBundle117, renderBundle83, renderBundle99]);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(4, 1, 16, 348_006_872);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(1, bindGroup23, new Uint32Array(2835), 554, 0);
+} catch {}
+try {
+renderBundleEncoder63.setIndexBuffer(buffer33, 'uint16', 416, 283);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+offscreenCanvas8.width = 1344;
+let commandEncoder420 = device2.createCommandEncoder({label: '\u0a9a\ua72c'});
+let commandBuffer264 = commandEncoder170.finish();
+let renderBundle225 = renderBundleEncoder39.finish({label: '\u7843\u{1f956}\u17ae\u066c\u54d2'});
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(188, 1, 4, -1_815_473_890);
+} catch {}
+try {
+commandEncoder420.clearBuffer(buffer33, 64, 428);
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+offscreenCanvas9.width = 2061;
+let canvas13 = document.createElement('canvas');
+let commandBuffer265 = commandEncoder420.finish({label: '\u029f\u{1faa5}\u0774\u88e2\u3fd1'});
+try {
+renderPassEncoder65.draw(237, 2, 648_477_909);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer41, 'uint32', 752, 2_683);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder421 = device1.createCommandEncoder({label: '\u0f57\u6d40\u9867\u970e\u0a71\u9a5e\u04a4\u0bf9\u0484'});
+let commandBuffer266 = commandEncoder421.finish({label: '\u07ac\u0739\u7fe6\u0422\u63ff\u0c64'});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder84.executeBundles([renderBundle66, renderBundle214, renderBundle110]);
+} catch {}
+try {
+renderPassEncoder19.draw(28, 0, 163_676_584, 3);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer29, 2_372);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer13, 'uint32', 2_068, 965);
+} catch {}
+try {
+if (!arrayBuffer36.detached) { new Uint8Array(arrayBuffer36).fill(0x55); };
+} catch {}
+let device4 = await adapter6.requestDevice({
+  label: '\u{1f727}\u80ab\u05bc\u3ce8',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let imageData51 = new ImageData(8, 16);
+try {
+renderBundle194.label = '\u01bb\ua474\u{1f908}\u92fc\u0788\u873a\u3d0c\ub04d\u7673\ubce2';
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder19.draw(52, 1, 3_283_551_489);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer38, 'uint32', 196, 1_151);
+} catch {}
+try {
+renderPassEncoder23.pushDebugGroup('\u0f59');
+} catch {}
+try {
+  await promise59;
+} catch {}
+let commandBuffer267 = commandEncoder415.finish({label: '\u9820\u06f7\ub075\u{1faa0}\u86fc\u3fd0\u0ad4'});
+let textureView95 = texture129.createView({label: '\u{1fba5}\u841c\u80f3\u{1f8e7}', dimension: '2d-array', baseMipLevel: 0});
+try {
+computePassEncoder97.end();
+} catch {}
+try {
+renderBundleEncoder64.setIndexBuffer(buffer52, 'uint32', 3_344, 2_630);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let adapter10 = await navigator.gpu.requestAdapter({});
+try {
+adapter2.label = '\u0a56\u0325\u0e5b\u57b9\u0da3\u{1fc60}\u69c5\ua288';
+} catch {}
+offscreenCanvas8.height = 530;
+let texture134 = device3.createTexture({
+  label: '\u67cc\u6b1e\u{1fb98}\u0971\u0a17\u0e46\u01f8',
+  size: {width: 12, height: 7, depthOrArrayLayers: 92},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderBundleEncoder64.setIndexBuffer(buffer52, 'uint32', 3_104, 174);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(3, buffer47, 420, 121);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+canvas4.width = 906;
+let commandEncoder422 = device1.createCommandEncoder();
+try {
+computePassEncoder10.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder92.setBlendConstant({ r: -487.8, g: -89.96, b: 2.523, a: -775.1, });
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(24, 1, 41, 1_021_709_668, 3);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer48, 380);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(6, buffer25);
+} catch {}
+let commandEncoder423 = device3.createCommandEncoder();
+let commandBuffer268 = commandEncoder418.finish({label: '\u0a0a\uc702\ub40a\ua13c\u1f59'});
+let renderBundle226 = renderBundleEncoder43.finish({label: '\u{1fe1b}\udc97\u{1f899}\u3db5\u{1fcd1}\u62c1\u000e'});
+try {
+computePassEncoder103.setPipeline(pipeline34);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+let texture135 = device4.createTexture({
+  label: '\uf9a3\u0830\u{1fee7}',
+  size: [1, 40, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+gpuCanvasContext16.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let textureView96 = texture135.createView({label: '\u9ab0\u4363\u{1ffe1}\u{1f754}\u0f68\u6982\u9936'});
+try {
+device4.queue.submit([]);
+} catch {}
+let pipelineLayout51 = device2.createPipelineLayout({
+  label: '\u584c\u0ec6\uca75\u25ba\u0a56\ufdbb\u6393',
+  bindGroupLayouts: [bindGroupLayout30, bindGroupLayout23],
+});
+let textureView97 = texture132.createView({label: '\u6d88\u{1fc3c}', dimension: '2d-array', aspect: 'all', baseMipLevel: 2});
+try {
+renderPassEncoder65.draw(37, 0, 389_843_720, 1);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(28, 0, 2, -2_004_166_397);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer41, 'uint16', 2_176, 833);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder52.draw(36, 7, 315_105_303, 30);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(115, 8, 3, 650_242_899, 2);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer30, 'uint32', 14_680, 227);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+video3.height = 67;
+try {
+buffer47.unmap();
+} catch {}
+await gc();
+try {
+computePassEncoder17.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer31, 1_144);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer16, 5_252);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(4, buffer16, 0);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(1, bindGroup38, []);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(0, buffer25, 0, 1_389);
+} catch {}
+let renderBundle227 = renderBundleEncoder50.finish({label: '\u{1fb31}\u03db\u{1fdd0}\u09d6\u0847\uacc0\u073b\ua6c6\u0ac6'});
+try {
+renderBundleEncoder52.draw(59, 2, 799_686_307, 13);
+} catch {}
+try {
+renderBundleEncoder63.setIndexBuffer(buffer33, 'uint16', 1_810, 693);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(7, buffer33);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video11);
+await gc();
+let imageData52 = new ImageData(64, 36);
+let commandEncoder424 = device3.createCommandEncoder({});
+try {
+computePassEncoder93.end();
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 128, 3_050);
+} catch {}
+try {
+commandEncoder369.copyBufferToBuffer(buffer54, 3588, buffer47, 740, 400);
+} catch {}
+try {
+commandEncoder395.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer52, 'uint32', 7_768, 569);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(3, buffer47, 0);
+} catch {}
+try {
+device3.queue.submit([commandBuffer255, commandBuffer201]);
+} catch {}
+let pipeline40 = await device3.createComputePipelineAsync({layout: pipelineLayout39, compute: {module: shaderModule21, constants: {}}});
+let commandEncoder425 = device4.createCommandEncoder({label: '\u050f\u0b2a\u{1fdea}\u9bba\u9ef3\u{1f601}\u4a69'});
+try {
+canvas13.getContext('webgl2');
+} catch {}
+document.body.prepend(img3);
+try {
+adapter6.label = '\ue6e3\u080e\u5016\ub80d\u0227\u036a\u3e73\uccaa\u07b5\u1c94';
+} catch {}
+let computePassEncoder107 = commandEncoder414.beginComputePass({label: '\u6127\u080f\u01ca'});
+try {
+commandEncoder424.copyBufferToBuffer(buffer50, 1604, buffer52, 2376, 2004);
+} catch {}
+let commandEncoder426 = device4.createCommandEncoder({label: '\u1153\u0491\u0c51\ua760\u{1fdf5}'});
+let buffer56 = device2.createBuffer({
+  label: '\u429e\u0dfa\ud397\u3448\u4b2f\ufeec',
+  size: 822,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder427 = device2.createCommandEncoder({label: '\u0501\u702e\u0654\u{1f8a0}\u0c95\ua979'});
+let computePassEncoder108 = commandEncoder427.beginComputePass({label: '\u{1f68b}\u77df\u0dfe\u0748\u05b6\udfc1\ube77\u07a0\u05d6\u{1fba2}'});
+try {
+renderPassEncoder62.setViewport(0.08065411696905878, 110.28449507996777, 0.3946052030931268, 9.360844042651339, 0.6820253230772427, 0.9509885604134978);
+} catch {}
+try {
+renderPassEncoder93.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(4, buffer32, 0, 80);
+} catch {}
+try {
+renderBundleEncoder63.setIndexBuffer(buffer30, 'uint16', 600, 3_453);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(6, buffer30, 0);
+} catch {}
+try {
+renderPassEncoder98.pushDebugGroup('\u{1ffea}');
+} catch {}
+let commandEncoder428 = device4.createCommandEncoder();
+let querySet49 = device4.createQuerySet({label: '\u9999\u3eca\ud7fa\u09c4\u071f\u96a9\ub7af\u{1f925}\u57ee', type: 'occlusion', count: 982});
+let commandBuffer269 = commandEncoder428.finish({label: '\udd5b\u{1fdd6}\u42e2\u9a58\u0418\u1861\u0812\u{1fa93}\u{1fd37}\u049f\u0474'});
+let externalTexture44 = device4.importExternalTexture({
+  label: '\u08b6\u0f6e\u{1f771}\u6da4\u9605\uc501\u{1f70e}\u{1f8ec}\u3418\ua9f1',
+  source: video10,
+  colorSpace: 'srgb',
+});
+let commandEncoder429 = device1.createCommandEncoder({label: '\u5746\u60e1\u3009\u7651\u2747\u4170\u7ff4\u957b\u{1fdd8}\u56b8\u23a0'});
+let commandBuffer270 = commandEncoder422.finish({label: '\u109a\u067a\u01af\ufec6\u732a\u37de\u0cc2\u8854\u{1f8aa}\u890e\u2de9'});
+let texture136 = device1.createTexture({size: [90], dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+try {
+computePassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder96.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder19.draw(105, 0, 344_117_312, 4);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer29, 20);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer53, 1_132);
+} catch {}
+let commandEncoder430 = device1.createCommandEncoder();
+let computePassEncoder109 = commandEncoder429.beginComputePass({label: '\u{1f62a}\u087c\u04d7\u02a4\u0d9e\ubd62\u{1f9a0}\u393f\u{1f9cd}'});
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer6, 8_676);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer24, 11_832);
+} catch {}
+try {
+renderPassEncoder87.setVertexBuffer(2, buffer25);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4_294_967_294, undefined, 0);
+} catch {}
+let commandBuffer271 = commandEncoder425.finish({});
+let renderBundleEncoder65 = device4.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], stencilReadOnly: true});
+canvas7.height = 84;
+let commandEncoder431 = device4.createCommandEncoder({});
+let renderBundle228 = renderBundleEncoder65.finish({label: '\u{1ff0a}\u0027'});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout52 = device4.createBindGroupLayout({label: '\u01a9\u851c\u{1fad7}', entries: []});
+let textureView98 = texture135.createView({label: '\u0a2c\u6644\u013b\u19e8\u014d\u{1f8c1}\u1fd0\u5df2\u78b2', baseMipLevel: 0});
+try {
+gpuCanvasContext19.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroupLayout53 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 112,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let renderBundle229 = renderBundleEncoder42.finish({label: '\u18c1\u9a2b\uba5f\ufa3c\u387e\ub69f\u0a95\u0f99\u{1fdb5}\u{1fdfc}'});
+try {
+computePassEncoder94.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder369.copyBufferToBuffer(buffer52, 4904, buffer47, 752, 4);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u{1fe82}');
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder432 = device3.createCommandEncoder({});
+let commandBuffer272 = commandEncoder423.finish({});
+let computePassEncoder110 = commandEncoder395.beginComputePass({label: '\ub3b8\u84b9\ud7ee\u0bff\u36c9\u8277\u625f\u02fd\ub2e9'});
+let renderBundle230 = renderBundleEncoder42.finish({});
+let sampler31 = device3.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.32,
+  lodMaxClamp: 52.49,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder83.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+canvas8.height = 5089;
+let commandBuffer273 = commandEncoder430.finish({label: '\u5f65\u{1fade}\u0d52\u2d16\u1d98\u{1f906}\u553e'});
+try {
+renderPassEncoder19.drawIndexed(101, 0, 22, 1_224_653_427);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer26, 8_100);
+} catch {}
+try {
+renderPassEncoder67.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup21, new Uint32Array(2466), 460, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(7, buffer24);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer29, 248, new Int16Array(657), 497);
+} catch {}
+let pipelineLayout52 = device1.createPipelineLayout({label: '\ue7f9\ub01e\u815a\u0837\uaee1\u{1f658}\u4f3e', bindGroupLayouts: [bindGroupLayout26]});
+let commandEncoder433 = device1.createCommandEncoder({label: '\ueffa\u43a7\u{1ffdd}\u314c\uade4\ufe6c\u70d7\u0ee2\u6530'});
+let commandBuffer274 = commandEncoder433.finish({label: '\u7075\uc00a\u6fd5\ua586'});
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({
+  label: '\u93b3\u0e7d\u462a\ua6b2\u35ca\u047f\u97e1\u{1f77a}',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder92.setViewport(34.46975072899366, 3.737993737318236, 3.85768824308443, 1.8933680193108546, 0.6459796194721729, 0.6798552476887353);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer26, 19_284);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(2, buffer49);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 1260, new Int16Array(17260), 8122, 304);
+} catch {}
+let buffer57 = device3.createBuffer({
+  label: '\u6469\u6135\u9e01\u{1f8e9}\uc0a9\u{1ffd5}\ua91b',
+  size: 21510,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer275 = commandEncoder377.finish({label: '\u0687\uae72\u3228\ue2f6\u0fed\udc48\u{1fc86}\udf31\ue7fd\u{1f62c}\u{1f9a8}'});
+try {
+renderBundleEncoder64.setVertexBuffer(0, buffer57, 0, 4_871);
+} catch {}
+let bindGroupLayout54 = device2.createBindGroupLayout({label: '\ue883\u{1fbfc}\u47e3\ub217\u0257\u{1ffc2}\u{1ff1e}', entries: []});
+let renderBundleEncoder67 = device2.createRenderBundleEncoder({label: '\u009f\uf018\u{1f6fc}\u33ff\uf6f6\u{1f9aa}', colorFormats: ['r8unorm'], depthReadOnly: true});
+let renderBundle231 = renderBundleEncoder63.finish({label: '\ubdc1\u360e\u1a88\u7312\u{1f896}\u{1fa2a}'});
+let externalTexture45 = device2.importExternalTexture({label: '\u03fd\ubdd7\u7730\ue822\u9bee\u4bd3', source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder102.setBindGroup(2, bindGroup23, new Uint32Array(618), 5, 0);
+} catch {}
+try {
+renderPassEncoder70.draw(33, 0, 799_862_355);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(83, 0, 8, 780_705_771, 1);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer261, commandBuffer237, commandBuffer213, commandBuffer264]);
+} catch {}
+canvas9.width = 65;
+let computePassEncoder111 = commandEncoder369.beginComputePass();
+try {
+computePassEncoder103.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder64.setIndexBuffer(buffer57, 'uint32', 1_700, 106);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline33);
+} catch {}
+try {
+commandEncoder419.copyBufferToBuffer(buffer54, 3624, buffer47, 0, 204);
+} catch {}
+try {
+commandEncoder419.resolveQuerySet(querySet44, 374, 14, buffer50, 6912);
+} catch {}
+try {
+device3.queue.submit([commandBuffer212]);
+} catch {}
+let promise61 = device3.queue.onSubmittedWorkDone();
+let imageData53 = new ImageData(48, 20);
+let commandEncoder434 = device4.createCommandEncoder({});
+try {
+  await promise61;
+} catch {}
+let commandBuffer276 = commandEncoder432.finish({label: '\ub2bd\u6894\u{1fddf}'});
+let textureView99 = texture134.createView({
+  label: '\u81ba\u{1ff03}\u{1fd47}\ua7a0\u7cd0\u8a3d\u6a7c\u06ec\u0a28',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundle232 = renderBundleEncoder43.finish({});
+try {
+computePassEncoder110.insertDebugMarker('\u01e0');
+} catch {}
+let commandEncoder435 = device2.createCommandEncoder({label: '\u{1ffa9}\u25eb\u1f2e\u9a43\u{1ffb4}\u0f7c\uc9e0\u8227'});
+let querySet50 = device2.createQuerySet({label: '\u{1ff1e}\u78bc\u14a9\u{1fde1}\u274f', type: 'occlusion', count: 28});
+let commandBuffer277 = commandEncoder435.finish({label: '\u{1fba2}\u016c\u8dbc\u63f3\u6207\uecf8\udc70\u{1f9e1}\u6c58\uc31c'});
+try {
+renderPassEncoder102.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder98.setViewport(0.9124745856204195, 51.75130194104051, 0.03797431957467248, 317.77125825505965, 0.556374607639115, 0.7905583443788522);
+} catch {}
+try {
+renderPassEncoder65.draw(4, 1, 1_214_055_923);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(93, 215, 309, 234_159_375, 2_565_389_999);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+let bindGroupLayout55 = device2.createBindGroupLayout({label: '\ua996\u0ec2\u5e22\u5dc3\u0058', entries: []});
+let commandEncoder436 = device2.createCommandEncoder({label: '\u256c\uaf24\ubc69\u8a21\u0d4b\ue057'});
+let textureView100 = texture113.createView({
+  label: '\u5168\u035f\u0760\u09d2\u{1f64b}\ud1d0\u1049\u064b\u0828\u081d\ud097',
+  dimension: '3d',
+  format: 'bgra8unorm',
+  baseMipLevel: 4,
+});
+let renderPassEncoder105 = commandEncoder436.beginRenderPass({
+  label: '\ue9d5\u24a5',
+  colorAttachments: [{
+  view: textureView54,
+  clearValue: { r: 300.4, g: -962.2, b: -994.0, a: 426.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 273548459,
+});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder105.beginOcclusionQuery(754);
+} catch {}
+try {
+renderPassEncoder102.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder52.draw(7, 9, 0, 1_098_708_968);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(6, 1, 70, 32_272_027, 11_003_293);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer41, 'uint16', 1_246, 4_512);
+} catch {}
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+let commandEncoder437 = device4.createCommandEncoder({label: '\u{1fac3}\udd2e\u06ab\u0c49\u{1fe05}'});
+let commandBuffer278 = commandEncoder437.finish({label: '\u6118\u{1ff0f}\u7274\u065b\ua1a3\ud641\u7a1a'});
+let commandEncoder438 = device3.createCommandEncoder({label: '\u0ee2\u0748\ud319\u{1f749}\u002e\uac54'});
+let querySet51 = device3.createQuerySet({label: '\u{1fd1a}\u081d\u5959', type: 'occlusion', count: 582});
+let commandBuffer279 = commandEncoder419.finish({label: '\u7ae1\uacb8'});
+let renderBundle233 = renderBundleEncoder45.finish({label: '\u0674\uad15\ud8bb\u{1f8b8}\u0876'});
+try {
+renderBundleEncoder64.setVertexBuffer(1, buffer50, 4_104);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer52, 140, new DataView(new ArrayBuffer(4402)), 413, 924);
+} catch {}
+try {
+device4.label = '\u098e\u13a8';
+} catch {}
+let commandEncoder439 = device4.createCommandEncoder({});
+let commandBuffer280 = commandEncoder439.finish();
+let textureView101 = texture135.createView({aspect: 'stencil-only', baseMipLevel: 0});
+let computePassEncoder112 = commandEncoder431.beginComputePass({label: '\u8e1b\u7fc4\u37a8'});
+await gc();
+let renderBundle234 = renderBundleEncoder37.finish({label: '\u{1ff78}\uf2fe\u161f\u{1fce2}\u008e\u4115'});
+try {
+renderPassEncoder105.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder102.setStencilReference(1077);
+} catch {}
+try {
+renderPassEncoder70.drawIndexed(43, 0, 6, -1_547_819_149);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(13, 251, 49, 286_862_199, 15_337_886);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 120, depthOrArrayLayers: 773}
+*/
+{
+  source: canvas5,
+  origin: { x: 342, y: 264 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 42, z: 102},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder440 = device2.createCommandEncoder();
+let texture137 = gpuCanvasContext10.getCurrentTexture();
+let computePassEncoder113 = commandEncoder440.beginComputePass({label: '\u0644\u8063\u0f10\u07e6\ue482'});
+try {
+renderPassEncoder85.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+renderPassEncoder100.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder65.draw(8, 3, 402_162_913, 1);
+} catch {}
+try {
+renderPassEncoder65.drawIndexed(8, 1, 21, -1_130_703_547, 2);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder52.draw(0, 28, 0, 106_419_627);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(32, 430, 73, 669_923_529, 410_745_718);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(2, buffer30);
+} catch {}
+await gc();
+let commandEncoder441 = device3.createCommandEncoder({label: '\u{1fa2d}\u667a\u5c1e\u4da6'});
+try {
+computePassEncoder89.setPipeline(pipeline34);
+} catch {}
+try {
+device3.queue.submit([commandBuffer235]);
+} catch {}
+video7.width = 24;
+try {
+  await adapter9.requestAdapterInfo();
+} catch {}
+let bindGroupLayout56 = device1.createBindGroupLayout({
+  label: '\u2235\ua566\u{1f6d7}\u{1fc38}\u9aef\u0c80\ufb51',
+  entries: [
+    {
+      binding: 351,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder442 = device1.createCommandEncoder({label: '\u2636\u{1f8f6}\u5f9c\ub54e\u09ec\ub977\ub997\u482b\ub852\u{1fb8e}'});
+let commandBuffer281 = commandEncoder442.finish({label: '\u6245\u8081'});
+let renderBundle235 = renderBundleEncoder20.finish({label: '\u03c6\u00b8\u0494\u553d'});
+let sampler32 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.45,
+  lodMaxClamp: 59.90,
+  compare: 'equal',
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder92.beginOcclusionQuery(107);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer29, 1_168);
+} catch {}
+try {
+renderBundleEncoder66.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 900, new Float32Array(12768), 3190, 304);
+} catch {}
+let commandEncoder443 = device2.createCommandEncoder();
+let computePassEncoder114 = commandEncoder443.beginComputePass({label: '\u86d3\ud68e\u0733\u0c91\u09fd\u82b4\u8254\ue68e\u0121\u968c'});
+try {
+renderPassEncoder105.executeBundles([renderBundle151]);
+} catch {}
+try {
+renderPassEncoder79.setViewport(0.9542919489486602, 49.188002935803766, 0.030789836379769037, 63.76104476206934, 0.35507871208799024, 0.4708368462623263);
+} catch {}
+try {
+renderPassEncoder70.draw(7, 0, 70_312_155);
+} catch {}
+try {
+renderPassEncoder100.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(138, 246, 39, 340_199_571, 591_261_104);
+} catch {}
+try {
+renderPassEncoder98.popDebugGroup();
+} catch {}
+try {
+device2.queue.submit([commandBuffer180, commandBuffer239]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+let pipelineLayout53 = device4.createPipelineLayout({label: '\u{1faf3}\u03a3\u7345\ude35\u02c8\udf86', bindGroupLayouts: [bindGroupLayout52]});
+let computePassEncoder115 = commandEncoder434.beginComputePass({label: '\ub53f\u00d4\uaeba\u0a7e\u095c'});
+canvas1.height = 1200;
+let bindGroup39 = device1.createBindGroup({
+  label: '\u3ca1\u77b9\u063e\u0e73\u5dc5\ufd78\u{1f60d}\u{1f9e6}',
+  layout: bindGroupLayout28,
+  entries: [{binding: 18, resource: {buffer: buffer48, offset: 1280, size: 1816}}],
+});
+let commandEncoder444 = device1.createCommandEncoder({});
+try {
+renderPassEncoder19.drawIndirect(buffer24, 8_580);
+} catch {}
+try {
+commandEncoder444.copyBufferToBuffer(buffer6, 800, buffer31, 16, 16);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -901,7 +901,7 @@ bool RenderBundleEncoder::validToEncodeCommand() const
 
 Ref<RenderBundle> RenderBundleEncoder::finish(const WGPURenderBundleDescriptor& descriptor)
 {
-    if (!m_icbDescriptor || m_debugGroupStackSize || !m_device->isValid()) {
+    if (!m_icbDescriptor || m_debugGroupStackSize || !m_device->isValid() || m_finished) {
         m_device->generateAValidationError(m_lastErrorString);
         return RenderBundle::createInvalid(m_device, m_lastErrorString);
     }

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1774,7 +1774,6 @@ WGPUPrimitiveTopology RenderPipeline::primitiveTopology() const
 
 MTLIndexType RenderPipeline::stripIndexFormat() const
 {
-    ASSERT(m_descriptor.primitive.stripIndexFormat == WGPUIndexFormat_Uint16 || m_descriptor.primitive.stripIndexFormat == WGPUIndexFormat_Uint32);
     return m_descriptor.primitive.stripIndexFormat == WGPUIndexFormat_Uint16 ? MTLIndexTypeUInt16 : MTLIndexTypeUInt32;
 }
 


### PR DESCRIPTION
#### 6fc3c742419cb479a9fbc1c31039aae37f23b6a7
<pre>
[WebGPU] RenderBundleEncoder::finish does not handle repeated calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=277928">https://bugs.webkit.org/show_bug.cgi?id=277928</a>
radar://133539397

Reviewed by Tadeu Zagallo.

Repeated calls to GPURenderBundleEncoder.finish() would result in a new
ICB being created, which is incorrect.

* LayoutTests/fast/webgpu/nocrash/fuzz-277928-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277928.html: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277928b-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277928b.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::finish):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::stripIndexFormat const):

Canonical link: <a href="https://commits.webkit.org/282169@main">https://commits.webkit.org/282169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbbfedb6f58a33fe608f1f452fb2f3a796a9411e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66184 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50131 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8818 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11148 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67914 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57795 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5082 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9379 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37358 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->