### PR TITLE
Simplify SMILTime operators and use NaN/Inf to represent 'unresolved/indefinite' SMILTimes

### DIFF
--- a/Source/WebCore/svg/animation/SMILTime.cpp
+++ b/Source/WebCore/svg/animation/SMILTime.cpp
@@ -30,36 +30,11 @@
 
 namespace WebCore {
 
-const double SMILTime::unresolvedValue = DBL_MAX;
-// Just a big value smaller than DBL_MAX. Our times are relative to 0, we don't really need the full range.
-const double SMILTime::indefiniteValue = FLT_MAX;    
-
-SMILTime operator+(const SMILTime& a, const SMILTime& b)
-{
-    if (a.isUnresolved() || b.isUnresolved())
-        return SMILTime::unresolved();
-    if (a.isIndefinite() || b.isIndefinite())
-        return SMILTime::indefinite();
-    return a.value() + b.value();
-}
-
-SMILTime operator-(const SMILTime& a, const SMILTime& b)
-{
-    if (a.isUnresolved() || b.isUnresolved())
-        return SMILTime::unresolved();
-    if (a.isIndefinite() || b.isIndefinite())
-        return SMILTime::indefinite();
-    return a.value() - b.value();
-}
-
 SMILTime operator*(const SMILTime& a,  const SMILTime& b)
 {
-    if (a.isUnresolved() || b.isUnresolved())
-        return SMILTime::unresolved();
+    // Equal operators have to be used instead of negation here to make NaN work as well.
     if (!a.value() || !b.value())
         return SMILTime(0);
-    if (a.isIndefinite() || b.isIndefinite())
-        return SMILTime::indefinite();
     return a.value() * b.value();
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -828,8 +828,11 @@ SMILTime SVGSMILElement::repeatingDuration() const
     SMILTime simpleDuration = this->simpleDuration();
     if (!simpleDuration || (repeatDur.isUnresolved() && repeatCount.isUnresolved()))
         return simpleDuration;
+    repeatDur = std::min(repeatDur, SMILTime::indefinite());
     SMILTime repeatCountDuration = simpleDuration * repeatCount;
-    return std::min(repeatCountDuration, std::min(repeatDur, SMILTime::indefinite()));
+    if (!repeatCountDuration.isUnresolved())
+        return std::min(repeatDur, repeatCountDuration);
+    return repeatDur;
 }
 
 SMILTime SVGSMILElement::resolveActiveEnd(SMILTime resolvedBegin, SMILTime resolvedEnd) const
@@ -902,7 +905,7 @@ void SVGSMILElement::resolveFirstInterval()
         m_intervalBegin = begin;
         m_intervalEnd = end;
         notifyDependentsIntervalChanged();
-        m_nextProgressTime = std::min(m_nextProgressTime, m_intervalBegin);
+        m_nextProgressTime = m_nextProgressTime.isUnresolved() ? m_intervalBegin : std::min(m_nextProgressTime, m_intervalBegin);
 
         if (RefPtr timeContainer = m_timeContainer)
             timeContainer->notifyIntervalsChanged();
@@ -920,7 +923,7 @@ bool SVGSMILElement::resolveNextInterval()
         m_intervalBegin = begin;
         m_intervalEnd = end;
         notifyDependentsIntervalChanged();
-        m_nextProgressTime = std::min(m_nextProgressTime, m_intervalBegin);
+        m_nextProgressTime = m_nextProgressTime.isUnresolved() ? m_intervalBegin : std::min(m_nextProgressTime, m_intervalBegin);
         return true;
     }
     return false;


### PR DESCRIPTION
#### 92c8a31c710721aa8ecc08dea0bf1d4f9d7bbccc
<pre>
Simplify SMILTime operators and use NaN/Inf to represent &apos;unresolved/indefinite&apos; SMILTimes

<a href="https://bugs.webkit.org/show_bug.cgi?id=250313">https://bugs.webkit.org/show_bug.cgi?id=250313</a>
<a href="https://rdar.apple.com/problem/104295073">rdar://problem/104295073</a>

Reviewed by NOBODY (OOPS!).

Partial Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/f3d854b85d8204d3f2ab2bda895b464f884e090f">https://chromium.googlesource.com/chromium/blink/+/f3d854b85d8204d3f2ab2bda895b464f884e090f</a> &amp;
<a href="https://chromium.googlesource.com/chromium/blink/+/7fe1ac80f6b2e96a4cb675776d147598e4e1f4e6">https://chromium.googlesource.com/chromium/blink/+/7fe1ac80f6b2e96a4cb675776d147598e4e1f4e6</a>

This patch is to use &apos;std::isnan&apos; and &apos;std::isfinite&apos; throughout code and consequently simplify
time operators.

NOTE - this does not merge all changes especially those which were were in now deleted functions
(e.g., handleConditionEvent) and which were reverted later on (e.g., beginByLinkActivation).

* Source/WebCore/svg/animation/SMILTime.cpp:
(unresolvedValue): Deleted
(indefiniteValue): Ditto
(SMILTime operator+): Ditto
(SMILTime operator-): Ditto
(SMILTime operator*):
* Source/WebCore/svg/animation/SMILTime.h: Inline some functions and update comments
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(SVGSMILElement::repeatingDuration):
(SVGSMILElement::resolveFirstInterval):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92c8a31c710721aa8ecc08dea0bf1d4f9d7bbccc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54722 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16668 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62196 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62223 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3781 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43806 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->