### PR TITLE
[WebDriver] Update imported selenium tests to incorporate 0.0.0.0 changes after 279835@main

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner_selenium.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner_selenium.py
@@ -23,12 +23,15 @@
 import logging
 import os
 
+from webkitcorepy import AutoInstall, Package, Version
 from webkitpy.common.webkit_finder import WebKitFinder
 from webkitpy.webdriver_tests.webdriver_selenium_executor import WebDriverSeleniumExecutor
 from webkitpy.webdriver_tests.webdriver_test_result import WebDriverTestResult
 
 _log = logging.getLogger(__name__)
 
+# Package required by Selenium for BiDi tests
+AutoInstall.register(Package('websocket', Version(1, 8, 0), pypi_name='websocket-client'))
 
 class WebDriverTestRunnerSelenium(object):
 

--- a/WebDriverTests/imported/selenium/common/src/web/fedcm/fedcm.html
+++ b/WebDriverTests/imported/selenium/common/src/web/fedcm/fedcm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script>
 
-let configURL = `https://${location.host}/fedcm/fedcm.json`;
+let configURL = `http://${location.host}/fedcm/fedcm.json`;
 let promise = null;
 
 function triggerFedCm() {

--- a/WebDriverTests/imported/selenium/common/src/web/fedcm/fedcm.json
+++ b/WebDriverTests/imported/selenium/common/src/web/fedcm/fedcm.json
@@ -2,5 +2,6 @@
   "accounts_endpoint": "accounts.json",
   "client_metadata_endpoint": "client_metadata.json",
   "id_assertion_endpoint": "id_assertion",
-  "signin_url": "/signin"
+  "signin_url": "/signin",
+  "login_url": "/login"
 }

--- a/WebDriverTests/imported/selenium/common/src/web/select_space.html
+++ b/WebDriverTests/imported/selenium/common/src/web/select_space.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<title>Multiple Selection test page</title>
+</head>
+<body>
+  <select id="selectWithoutMultiple">
+    <option value="one">one</option>
+    <option value="two">&nbsp;&nbsp;two</option>
+    <option value="three">&nbsp;&nbsp;&nbsp;three</option>
+    <option value="four">&nbsp;&nbsp;&nbsp;&nbsp;four</option>
+    <option value="five">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;five</option>
+</body>
+</html>

--- a/WebDriverTests/imported/selenium/importer.json
+++ b/WebDriverTests/imported/selenium/importer.json
@@ -1,6 +1,6 @@
 {
     "repository": "https://github.com/SeleniumHQ/selenium.git",
-    "revision": "907b2197dada02fe80de04843799f50d3d129f54",
+    "revision": "00a3f4c2d20d74cf0148c273786bfc712923ca6c",
     "paths_to_import": [
         "common",
         "py/conftest.py",
@@ -50,6 +50,8 @@
         "py/test/selenium/webdriver/chrome",
         "py/test/selenium/webdriver/firefox",
         "py/test/selenium/webdriver/ie",
-        "py/test/selenium/webdriver/marionette"
+        "py/test/selenium/webdriver/marionette",
+        "py/test/selenium/webdriver/common/devtools_tests.py",
+        "py/test/selenium/webdriver/common/driver_finder_tests.py"
     ]
 }

--- a/WebDriverTests/imported/selenium/py/conftest.py
+++ b/WebDriverTests/imported/selenium/py/conftest.py
@@ -79,6 +79,13 @@ def pytest_addoption(parser):
         dest="use_lan_ip",
         help="Whether to start test server with lan ip instead of localhost",
     )
+    parser.addoption(
+        "--bidi",
+        action="store",
+        dest="bidi",
+        metavar="BIDI",
+        help="Whether to enable BiDi support",
+    )
 
 
 def pytest_ignore_collect(path, config):
@@ -158,6 +165,20 @@ def driver(request):
         driver_instance = getattr(webdriver, driver_class)(**kwargs)
     yield driver_instance
 
+    # Close the browser after BiDi tests. Those make event subscriptions
+    # and doesn't seems to be stable enough, causing the flakiness of the
+    # subsequent tests.
+    # Remove this when BiDi implementation and API is stable.
+    if bool(request.config.option.bidi):
+
+        def fin():
+            global driver_instance
+            if driver_instance is not None:
+                driver_instance.quit()
+            driver_instance = None
+
+        request.addfinalizer(fin)
+
     if request.node.get_closest_marker("no_driver_after_test"):
         driver_instance = None
 
@@ -166,6 +187,7 @@ def get_options(driver_class, config):
     browser_path = config.option.binary
     browser_args = config.option.args
     headless = bool(config.option.headless)
+    bidi = bool(config.option.bidi)
     options = None
 
     if browser_path or browser_args:
@@ -187,6 +209,13 @@ def get_options(driver_class, config):
             options.add_argument("--headless=new")
         if driver_class == "Firefox":
             options.add_argument("-headless")
+
+    if bidi:
+        if not options:
+            options = getattr(webdriver, f"{driver_class}Options")()
+
+        options.web_socket_url = True
+
     return options
 
 
@@ -291,7 +320,7 @@ def server(request):
 
 @pytest.fixture(autouse=True, scope="session")
 def webserver(request):
-    host = get_lan_ip() if request.config.getoption("use_lan_ip") else "0.0.0.0"
+    host = get_lan_ip() if request.config.getoption("use_lan_ip") else None
 
     webserver = SimpleWebServer(host=host)
     webserver.start()

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/bidi/script.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/bidi/script.py
@@ -1,0 +1,111 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import typing
+from dataclasses import dataclass
+
+from .session import session_subscribe
+from .session import session_unsubscribe
+
+
+class Script:
+    def __init__(self, conn):
+        self.conn = conn
+        self.log_entry_subscribed = False
+
+    def add_console_message_handler(self, handler):
+        self._subscribe_to_log_entries()
+        return self.conn.add_callback(LogEntryAdded, self._handle_log_entry("console", handler))
+
+    def add_javascript_error_handler(self, handler):
+        self._subscribe_to_log_entries()
+        return self.conn.add_callback(LogEntryAdded, self._handle_log_entry("javascript", handler))
+
+    def remove_console_message_handler(self, id):
+        self.conn.remove_callback(LogEntryAdded, id)
+        self._unsubscribe_from_log_entries()
+
+    remove_javascript_error_handler = remove_console_message_handler
+
+    def _subscribe_to_log_entries(self):
+        if not self.log_entry_subscribed:
+            self.conn.execute(session_subscribe(LogEntryAdded.event_class))
+            self.log_entry_subscribed = True
+
+    def _unsubscribe_from_log_entries(self):
+        if self.log_entry_subscribed and LogEntryAdded.event_class not in self.conn.callbacks:
+            self.conn.execute(session_unsubscribe(LogEntryAdded.event_class))
+            self.log_entry_subscribed = False
+
+    def _handle_log_entry(self, type, handler):
+        def _handle_log_entry(log_entry):
+            if log_entry.type_ == type:
+                handler(log_entry)
+
+        return _handle_log_entry
+
+
+class LogEntryAdded:
+    event_class = "log.entryAdded"
+
+    @classmethod
+    def from_json(cls, json):
+        print(json)
+        if json["type"] == "console":
+            return ConsoleLogEntry.from_json(json)
+        elif json["type"] == "javascript":
+            return JavaScriptLogEntry.from_json(json)
+
+
+@dataclass
+class ConsoleLogEntry:
+    level: str
+    text: str
+    timestamp: str
+    method: str
+    args: typing.List[dict]
+    type_: str
+
+    @classmethod
+    def from_json(cls, json):
+        return cls(
+            level=json["level"],
+            text=json["text"],
+            timestamp=json["timestamp"],
+            method=json["method"],
+            args=json["args"],
+            type_=json["type"],
+        )
+
+
+@dataclass
+class JavaScriptLogEntry:
+    level: str
+    text: str
+    timestamp: str
+    stacktrace: dict
+    type_: str
+
+    @classmethod
+    def from_json(cls, json):
+        return cls(
+            level=json["level"],
+            text=json["text"],
+            timestamp=json["timestamp"],
+            stacktrace=json["stackTrace"],
+            type_=json["type"],
+        )

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/bidi/session.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/bidi/session.py
@@ -16,4 +16,27 @@
 # under the License.
 
 
-__version__ = "4.31.1"
+def session_subscribe(*events, browsing_contexts=[]):
+    cmd_dict = {
+        "method": "session.subscribe",
+        "params": {
+            "events": events,
+        },
+    }
+    if browsing_contexts:
+        cmd_dict["params"]["browsingContexts"] = browsing_contexts
+    _ = yield cmd_dict
+    return None
+
+
+def session_unsubscribe(*events, browsing_contexts=[]):
+    cmd_dict = {
+        "method": "session.unsubscribe",
+        "params": {
+            "events": events,
+        },
+    }
+    if browsing_contexts:
+        cmd_dict["params"]["browsingContexts"] = browsing_contexts
+    _ = yield cmd_dict
+    return None

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/by.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/by.py
@@ -16,6 +16,8 @@
 # under the License.
 """The By implementation."""
 
+from typing import Literal
+
 
 class By:
     """Set of supported locator strategies."""
@@ -28,3 +30,6 @@ class By:
     TAG_NAME = "tag name"
     CLASS_NAME = "class name"
     CSS_SELECTOR = "css selector"
+
+
+ByType = Literal["id", "xpath", "link text", "partial link text", "name", "tag name", "class name", "css selector"]

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/options.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/options.py
@@ -44,12 +44,23 @@ class _BaseOptionsDescriptor:
         self.name = name
 
     def __get__(self, obj, cls):
+        if self.name == "enableBidi":
+            # whether BiDi is or will be enabled
+            value = obj._caps.get("webSocketUrl")
+            return value is True or isinstance(value, str)
+        if self.name == "webSocketUrl":
+            # Return socket url or None if not created yet
+            value = obj._caps.get(self.name)
+            return None if not isinstance(value, str) else value
         if self.name in ("acceptInsecureCerts", "strictFileInteractability", "setWindowRect", "se:downloadsEnabled"):
             return obj._caps.get(self.name, False)
         return obj._caps.get(self.name)
 
     def __set__(self, obj, value):
-        obj.set_capability(self.name, value)
+        if self.name == "enableBidi":
+            obj.set_capability("webSocketUrl", value)
+        else:
+            obj.set_capability(self.name, value)
 
 
 class _PageLoadStrategyDescriptor:
@@ -249,6 +260,50 @@ class BaseOptions(metaclass=ABCMeta):
         - `None`
     """
 
+    enable_bidi = _BaseOptionsDescriptor("enableBidi")
+    """Gets and Set whether the session has WebDriverBiDi enabled.
+
+    Usage
+    -----
+    - Get
+        - `self.enable_bidi`
+    - Set
+        - `self.enable_bidi` = `value`
+
+    Parameters
+    ----------
+    `value`: `bool`
+
+    Returns
+    -------
+    - Get
+        - `bool`
+    - Set
+        - `None`
+    """
+
+    web_socket_url = _BaseOptionsDescriptor("webSocketUrl")
+    """Gets and Set whether the session accepts insecure certificates.
+
+    Usage
+    -----
+    - Get
+        - `self.web_socket_url`
+    - Set
+        - `self.web_socket_url` = `value`
+
+    Parameters
+    ----------
+    `value`: `str`
+
+    Returns
+    -------
+    - Get
+        - `str` or `None`
+    - Set
+        - `None`
+    """
+
     page_load_strategy = _PageLoadStrategyDescriptor("pageLoadStrategy")
     """:Gets and Sets page load strategy, the default is "normal".
 
@@ -361,12 +416,35 @@ class BaseOptions(metaclass=ABCMeta):
         - `None`
     """
 
+    web_socket_url = _BaseOptionsDescriptor("webSocketUrl")
+    """Gets and Sets WebSocket URL.
+
+    Usage
+    -----
+    - Get
+        - `self.web_socket_url`
+    - Set
+        - `self.web_socket_url` = `value`
+
+    Parameters
+    ----------
+    `value`: `bool`
+
+    Returns
+    -------
+    - Get
+        - `bool`
+    - Set
+        - `None`
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self._caps = self.default_capabilities
         self._proxy = None
         self.set_capability("pageLoadStrategy", PageLoadStrategy.normal)
         self.mobile_options = None
+        self._ignore_local_proxy = False
 
     @property
     def capabilities(self):
@@ -404,6 +482,11 @@ class BaseOptions(metaclass=ABCMeta):
     def default_capabilities(self):
         """Return minimal capabilities necessary as a dictionary."""
 
+    def ignore_local_proxy_environment_variables(self) -> None:
+        """By calling this you will ignore HTTP_PROXY and HTTPS_PROXY from
+        being picked up and used."""
+        self._ignore_local_proxy = True
+
 
 class ArgOptions(BaseOptions):
     BINARY_LOCATION_ERROR = "Binary Location Must be a String"
@@ -411,7 +494,6 @@ class ArgOptions(BaseOptions):
     def __init__(self) -> None:
         super().__init__()
         self._arguments = []
-        self._ignore_local_proxy = False
 
     @property
     def arguments(self):
@@ -432,7 +514,7 @@ class ArgOptions(BaseOptions):
     def ignore_local_proxy_environment_variables(self) -> None:
         """By calling this you will ignore HTTP_PROXY and HTTPS_PROXY from
         being picked up and used."""
-        self._ignore_local_proxy = True
+        super().ignore_local_proxy_environment_variables()
 
     def to_capabilities(self):
         return self._caps

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/print_page_options.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/print_page_options.py
@@ -19,6 +19,7 @@
 from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
+from typing import Type
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -125,10 +126,9 @@ class _PageOrientationDescriptor:
 class _ValidateTypeDescriptor:
     """Base Class Descriptor which validates type of any subclass attribute."""
 
-    expected_type = None
-
-    def __init__(self, name, expected_type):
+    def __init__(self, name, expected_type: Type):
         self.name = name
+        self.expected_type = expected_type
 
     def __get__(self, obj, cls):
         return obj._print_options.get(self.name, None)
@@ -142,19 +142,22 @@ class _ValidateTypeDescriptor:
 class _ValidateBackGround(_ValidateTypeDescriptor):
     """Expected type of background attribute."""
 
-    expected_type = bool
+    def __init__(self, name):
+        super().__init__(name, bool)
 
 
 class _ValidateShrinkToFit(_ValidateTypeDescriptor):
-    """Expected type of shirnk to fit attribute."""
+    """Expected type of shrink to fit attribute."""
 
-    expected_type = bool
+    def __init__(self, name):
+        super().__init__(name, bool)
 
 
 class _ValidatePageRanges(_ValidateTypeDescriptor):
-    """Excepted type of page ranges attribute."""
+    """Expected type of page ranges attribute."""
 
-    expected_type = list
+    def __init__(self, name):
+        super().__init__(name, list)
 
 
 class PrintOptions:
@@ -190,7 +193,7 @@ class PrintOptions:
     - Set
         - `self.page_width` = `value`
 
-    Patameters
+    Parameters
     ----------
     `value`: `float`
 
@@ -210,7 +213,7 @@ class PrintOptions:
     - Get
         - `self.margin_top`
     - Set
-        - `slef.margin_top` = `value`
+        - `self.margin_top` = `value`
 
     Parameters
     ----------
@@ -253,7 +256,7 @@ class PrintOptions:
     -----
     - Get
         - `self.margin_left`
-    -Set
+    - Set
         - `self.margin_left` = `value`
 
     Parameters
@@ -334,13 +337,13 @@ class PrintOptions:
         - `None`
     """
 
-    background = _ValidateBackGround("background", bool)
+    background = _ValidateBackGround("background")
     """Gets and Sets background:
 
     Usage
     -----
     - Get
-        - `self.backgorund`
+        - `self.background`
     - Set
         - `self.background` = `value`
 
@@ -356,7 +359,7 @@ class PrintOptions:
         - `None`
     """
 
-    shrink_to_fit = _ValidateShrinkToFit("shrinkToFit", bool)
+    shrink_to_fit = _ValidateShrinkToFit("shrinkToFit")
     """Gets and Sets shrink_to_fit:
 
     Usage
@@ -378,7 +381,7 @@ class PrintOptions:
         - `None`
     """
 
-    page_ranges = _ValidatePageRanges("pageRanges", list)
+    page_ranges = _ValidatePageRanges("pageRanges")
     """Gets and Sets page_ranges:
 
     Usage
@@ -415,4 +418,4 @@ class PrintOptions:
             raise ValueError(f"{property_name} should be an integer or a float")
 
         if value < 0:
-            raise ValueError(f"{property_name} cannot be less then 0")
+            raise ValueError(f"{property_name} cannot be less than 0")

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/selenium_manager.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/selenium_manager.py
@@ -20,11 +20,11 @@ import os
 import platform
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 from typing import List
 
 from selenium.common import WebDriverException
-from selenium.webdriver.common.options import BaseOptions
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +35,26 @@ class SeleniumManager:
     This implementation is still in beta, and may change.
     """
 
+    def binary_paths(self, args: List) -> dict:
+        """Determines the locations of the requested assets.
+
+        :Args:
+         - args: the commands to send to the selenium manager binary.
+        :Returns: dictionary of assets and their path
+        """
+
+        args = [str(self._get_binary())] + args
+        if logger.getEffectiveLevel() == logging.DEBUG:
+            args.append("--debug")
+        args.append("--language-binding")
+        args.append("python")
+        args.append("--output")
+        args.append("json")
+
+        return self._run(args)
+
     @staticmethod
-    def get_binary() -> Path:
+    def _get_binary() -> Path:
         """Determines the path of the correct Selenium Manager binary.
 
         :Returns: The Selenium Manager executable location
@@ -44,30 +62,35 @@ class SeleniumManager:
         :Raises: WebDriverException if the platform is unsupported
         """
 
+        compiled_path = Path(__file__).parent.joinpath("selenium-manager")
+        exe = sysconfig.get_config_var("EXE")
+        if exe is not None:
+            compiled_path = compiled_path.with_suffix(exe)
+
         if (path := os.getenv("SE_MANAGER_PATH")) is not None:
-            return Path(path)
+            logger.debug("Selenium Manager set by env SE_MANAGER_PATH to: %s", path)
+            path = Path(path)
+        elif compiled_path.exists():
+            path = compiled_path
+        else:
+            allowed = {
+                ("darwin", "any"): "macos/selenium-manager",
+                ("win32", "any"): "windows/selenium-manager.exe",
+                ("cygwin", "any"): "windows/selenium-manager.exe",
+                ("linux", "x86_64"): "linux/selenium-manager",
+                ("freebsd", "x86_64"): "linux/selenium-manager",
+                ("openbsd", "x86_64"): "linux/selenium-manager",
+            }
 
-        dirs = {
-            ("darwin", "any"): "macos",
-            ("win32", "any"): "windows",
-            ("cygwin", "any"): "windows",
-            ("linux", "x86_64"): "linux",
-            ("freebsd", "x86_64"): "linux",
-            ("openbsd", "x86_64"): "linux",
-        }
+            arch = platform.machine() if sys.platform in ("linux", "freebsd", "openbsd") else "any"
+            if sys.platform in ["freebsd", "openbsd"]:
+                logger.warning("Selenium Manager binary may not be compatible with %s; verify settings", sys.platform)
 
-        arch = platform.machine() if sys.platform in ("linux", "freebsd", "openbsd") else "any"
+            location = allowed.get((sys.platform, arch))
+            if location is None:
+                raise WebDriverException(f"Unsupported platform/architecture combination: {sys.platform}/{arch}")
 
-        directory = dirs.get((sys.platform, arch))
-        if directory is None:
-            raise WebDriverException(f"Unsupported platform/architecture combination: {sys.platform}/{arch}")
-
-        if sys.platform in ["freebsd", "openbsd"]:
-            logger.warning("Selenium Manager binary may not be compatible with %s; verify settings", sys.platform)
-
-        file = "selenium-manager.exe" if directory == "windows" else "selenium-manager"
-
-        path = Path(__file__).parent.joinpath(directory, file)
+            path = Path(__file__).parent.joinpath(location)
 
         if not path.is_file():
             raise WebDriverException(f"Unable to obtain working Selenium Manager binary; {path}")
@@ -76,60 +99,14 @@ class SeleniumManager:
 
         return path
 
-    def driver_location(self, options: BaseOptions) -> str:
-        """Determines the path of the correct driver.
-
-        :Args:
-         - browser: which browser to get the driver path for.
-        :Returns: The driver path to use
-        """
-
-        browser = options.capabilities["browserName"]
-
-        args = [str(self.get_binary()), "--browser", browser]
-
-        if options.browser_version:
-            args.append("--browser-version")
-            args.append(str(options.browser_version))
-
-        binary_location = getattr(options, "binary_location", None)
-        if binary_location:
-            args.append("--browser-path")
-            args.append(str(binary_location))
-
-        proxy = options.proxy
-        if proxy and (proxy.http_proxy or proxy.ssl_proxy):
-            args.append("--proxy")
-            value = proxy.ssl_proxy if proxy.ssl_proxy else proxy.http_proxy
-            args.append(value)
-
-        output = self.run(args)
-
-        browser_path = output["browser_path"]
-        driver_path = output["driver_path"]
-        logger.debug("Using driver at: %s", driver_path)
-
-        if hasattr(options.__class__, "binary_location") and browser_path:
-            options.binary_location = browser_path
-            options.browser_version = None  # if we have the binary location we no longer need the version
-
-        return driver_path
-
     @staticmethod
-    def run(args: List[str]) -> dict:
+    def _run(args: List[str]) -> dict:
         """Executes the Selenium Manager Binary.
 
         :Args:
          - args: the components of the command being executed.
         :Returns: The log string containing the driver location.
         """
-        if logger.getEffectiveLevel() == logging.DEBUG:
-            args.append("--debug")
-        args.append("--language-binding")
-        args.append("python")
-        args.append("--output")
-        args.append("json")
-
         command = " ".join(args)
         logger.debug("Executing process: %s", command)
         try:
@@ -139,17 +116,22 @@ class SeleniumManager:
                 completed_proc = subprocess.run(args, capture_output=True)
             stdout = completed_proc.stdout.decode("utf-8").rstrip("\n")
             stderr = completed_proc.stderr.decode("utf-8").rstrip("\n")
-            output = json.loads(stdout)
-            result = output["result"]
+            output = json.loads(stdout) if stdout != "" else {"logs": [], "result": {}}
         except Exception as err:
             raise WebDriverException(f"Unsuccessful command executed: {command}") from err
 
-        for item in output["logs"]:
+        SeleniumManager._process_logs(output["logs"])
+        result = output["result"]
+        if completed_proc.returncode:
+            raise WebDriverException(
+                f"Unsuccessful command executed: {command}; code: {completed_proc.returncode}\n{result}\n{stderr}"
+            )
+        return result
+
+    @staticmethod
+    def _process_logs(log_items: List[dict]):
+        for item in log_items:
             if item["level"] == "WARN":
                 logger.warning(item["message"])
-            if item["level"] == "DEBUG" or item["level"] == "INFO":
+            elif item["level"] in ["DEBUG", "INFO"]:
                 logger.debug(item["message"])
-
-        if completed_proc.returncode:
-            raise WebDriverException(f"Unsuccessful command executed: {command}.\n{result}{stderr}")
-        return result

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/common/timeouts.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/common/timeouts.py
@@ -68,9 +68,9 @@ class Timeouts:
             before throwing an error.
         """
 
-        self.implicit_wait = implicit_wait
-        self.page_load = page_load
-        self.script = script
+        self._implicit_wait = self._convert(implicit_wait)
+        self._page_load = self._convert(page_load)
+        self._script = self._convert(script)
 
     # Creating descriptor objects
     implicit_wait = _TimeoutsDescriptor("_implicit_wait")

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/remote_connection.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/remote_connection.py
@@ -136,7 +136,11 @@ class RemoteConnection:
     """
 
     browser_name = None
-    _timeout = socket._GLOBAL_DEFAULT_TIMEOUT
+    _timeout = (
+        float(os.getenv("GLOBAL_DEFAULT_TIMEOUT"))
+        if "GLOBAL_DEFAULT_TIMEOUT" in os.environ
+        else socket._GLOBAL_DEFAULT_TIMEOUT
+    )
     _ca_certs = os.getenv("REQUESTS_CA_BUNDLE") if "REQUESTS_CA_BUNDLE" in os.environ else certifi.where()
 
     @classmethod

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/webdriver.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/webdriver.py
@@ -20,6 +20,7 @@ import contextlib
 import copy
 import os
 import pkgutil
+import tempfile
 import types
 import typing
 import warnings
@@ -40,6 +41,7 @@ from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchCookieException
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.common.bidi.script import Script
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.options import BaseOptions
 from selenium.webdriver.common.print_page_options import PrintOptions
@@ -62,8 +64,10 @@ from .script_key import ScriptKey
 from .shadowroot import ShadowRoot
 from .switch_to import SwitchTo
 from .webelement import WebElement
+from .websocket_connection import WebSocketConnection
 
 cdp = None
+devtools = None
 
 
 def import_cdp():
@@ -160,10 +164,10 @@ class WebDriver(BaseWebDriver):
 
     def __init__(
         self,
-        command_executor="http://127.0.0.1:4444",
-        keep_alive=True,
-        file_detector=None,
-        options: Union[BaseOptions, List[BaseOptions]] = None,
+        command_executor: Union[str, RemoteConnection] = "http://127.0.0.1:4444",
+        keep_alive: bool = True,
+        file_detector: Optional[FileDetector] = None,
+        options: Optional[Union[BaseOptions, List[BaseOptions]]] = None,
     ) -> None:
         """Create a new driver that will issue commands using the wire
         protocol.
@@ -203,6 +207,9 @@ class WebDriver(BaseWebDriver):
         self._authenticator_id = None
         self.start_client()
         self.start_session(capabilities)
+
+        self._websocket_connection = None
+        self._script = None
 
     def __repr__(self):
         return f'<{type(self).__module__}.{type(self).__name__} (session="{self.session_id}")>'
@@ -871,7 +878,7 @@ class WebDriver(BaseWebDriver):
 
         return {k: size[k] for k in ("width", "height")}
 
-    def set_window_position(self, x, y, windowHandle: str = "current") -> dict:
+    def set_window_position(self, x: float, y: float, windowHandle: str = "current") -> dict:
         """Sets the x,y position of the current window. (window.moveTo)
 
         :Args:
@@ -1014,6 +1021,32 @@ class WebDriver(BaseWebDriver):
         """
         return self.execute(Command.GET_LOG, {"type": log_type})["value"]
 
+    def start_devtools(self):
+        global devtools
+        if self._websocket_connection:
+            return devtools, self._websocket_connection
+        else:
+            global cdp
+            import_cdp()
+
+            if not devtools:
+                if self.caps.get("se:cdp"):
+                    ws_url = self.caps.get("se:cdp")
+                    version = self.caps.get("se:cdpVersion").split(".")[0]
+                else:
+                    version, ws_url = self._get_cdp_details()
+
+                if not ws_url:
+                    raise WebDriverException("Unable to find url to connect to from capabilities")
+
+                devtools = cdp.import_devtools(version)
+            self._websocket_connection = WebSocketConnection(ws_url)
+            targets = self._websocket_connection.execute(devtools.target.get_targets())
+            target_id = targets[0].target_id
+            session = self._websocket_connection.execute(devtools.target.attach_to_target(target_id, True))
+            self._websocket_connection.session_id = session
+            return devtools, self._websocket_connection
+
     @asynccontextmanager
     async def bidi_connection(self):
         global cdp
@@ -1033,6 +1066,24 @@ class WebDriver(BaseWebDriver):
             target_id = targets[0].target_id
             async with conn.open_session(target_id) as session:
                 yield BidiConnection(session, cdp, devtools)
+
+    @property
+    def script(self):
+        if not self._websocket_connection:
+            self._start_bidi()
+
+        if not self._script:
+            self._script = Script(self._websocket_connection)
+
+        return self._script
+
+    def _start_bidi(self):
+        if self.caps.get("webSocketUrl"):
+            ws_url = self.caps.get("webSocketUrl")
+        else:
+            raise WebDriverException("Unable to find url to connect to from capabilities")
+
+        self._websocket_connection = WebSocketConnection(ws_url)
 
     def _get_cdp_details(self):
         import json
@@ -1144,12 +1195,13 @@ class WebDriver(BaseWebDriver):
 
         contents = self.execute(Command.DOWNLOAD_FILE, {"name": file_name})["value"]["contents"]
 
-        target_file = os.path.join(target_directory, file_name)
-        with open(target_file, "wb") as file:
-            file.write(base64.b64decode(contents))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            zip_file = os.path.join(tmp_dir, file_name + ".zip")
+            with open(zip_file, "wb") as file:
+                file.write(base64.b64decode(contents))
 
-        with zipfile.ZipFile(target_file, "r") as zip_ref:
-            zip_ref.extractall(target_directory)
+            with zipfile.ZipFile(zip_file, "r") as zip_ref:
+                zip_ref.extractall(target_directory)
 
     def delete_downloadable_files(self) -> None:
         """Deletes all downloadable files."""

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/webelement.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/webelement.py
@@ -191,7 +191,7 @@ class WebElement(BaseWebElement):
         """Returns whether the element is enabled."""
         return self._execute(Command.IS_ELEMENT_ENABLED)["value"]
 
-    def send_keys(self, *value) -> None:
+    def send_keys(self, *value: str) -> None:
         """Simulates typing into the element.
 
         :Args:

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/websocket_connection.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/remote/websocket_connection.py
@@ -1,0 +1,146 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import logging
+from ssl import CERT_NONE
+from threading import Thread
+from time import sleep
+
+from websocket import WebSocketApp
+
+logger = logging.getLogger(__name__)
+
+
+class WebSocketConnection:
+    _response_wait_timeout = 30
+    _response_wait_interval = 0.1
+
+    _max_log_message_size = 9999
+
+    def __init__(self, url):
+        self.callbacks = {}
+        self.session_id = None
+        self.url = url
+
+        self._id = 0
+        self._messages = {}
+        self._started = False
+
+        self._start_ws()
+        self._wait_until(lambda: self._started)
+
+    def close(self):
+        self._ws_thread.join(timeout=self._response_wait_timeout)
+        self._ws.close()
+        self._started = False
+        self._ws = None
+
+    def execute(self, command):
+        self._id += 1
+        payload = self._serialize_command(command)
+        payload["id"] = self._id
+        if self.session_id:
+            payload["sessionId"] = self.session_id
+
+        data = json.dumps(payload)
+        logger.debug(f"-> {data}"[: self._max_log_message_size])
+        self._ws.send(data)
+
+        self._wait_until(lambda: self._id in self._messages)
+        response = self._messages.pop(self._id)
+
+        if "error" in response:
+            raise Exception(response["error"])
+        else:
+            result = response["result"]
+            return self._deserialize_result(result, command)
+
+    def add_callback(self, event, callback):
+        event_name = event.event_class
+        if event_name not in self.callbacks:
+            self.callbacks[event_name] = []
+
+        def _callback(params):
+            callback(event.from_json(params))
+
+        self.callbacks[event_name].append(_callback)
+        return id(_callback)
+
+    on = add_callback
+
+    def remove_callback(self, event, callback_id):
+        event_name = event.event_class
+        if event_name in self.callbacks:
+            for callback in self.callbacks[event_name]:
+                if id(callback) == callback_id:
+                    self.callbacks[event_name].remove(callback)
+                    return
+
+    def _serialize_command(self, command):
+        return next(command)
+
+    def _deserialize_result(self, result, command):
+        try:
+            _ = command.send(result)
+            raise Exception("The command's generator function did not exit when expected!")
+        except StopIteration as exit:
+            return exit.value
+
+    def _start_ws(self):
+        def on_open(ws):
+            self._started = True
+
+        def on_message(ws, message):
+            self._process_message(message)
+
+        def on_error(ws, error):
+            logger.debug(f"error: {error}")
+            ws.close()
+
+        def run_socket():
+            if self.url.startswith("wss://"):
+                self._ws.run_forever(sslopt={"cert_reqs": CERT_NONE}, suppress_origin=True)
+            else:
+                self._ws.run_forever(suppress_origin=True)
+
+        self._ws = WebSocketApp(self.url, on_open=on_open, on_message=on_message, on_error=on_error)
+        self._ws_thread = Thread(target=run_socket)
+        self._ws_thread.start()
+
+    def _process_message(self, message):
+        message = json.loads(message)
+        logger.debug(f"<- {message}"[: self._max_log_message_size])
+
+        if "id" in message:
+            self._messages[message["id"]] = message
+
+        if "method" in message:
+            params = message["params"]
+            for callback in self.callbacks.get(message["method"], []):
+                callback(params)
+
+    def _wait_until(self, condition):
+        timeout = self._response_wait_timeout
+        interval = self._response_wait_interval
+
+        while timeout > 0:
+            result = condition()
+            if result:
+                return result
+            else:
+                timeout -= interval
+                sleep(interval)

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/safari/webdriver.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/safari/webdriver.py
@@ -45,7 +45,7 @@ class WebDriver(RemoteWebDriver):
         self.service = service if service else Service()
         options = options if options else Options()
 
-        self.service.path = DriverFinder.get_path(self.service, options)
+        self.service.path = DriverFinder(self.service, options).get_driver_path()
 
         if not self.service.reuse_service:
             self.service.start()

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/support/relative_locator.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/support/relative_locator.py
@@ -16,11 +16,14 @@
 # under the License.
 from typing import Dict
 from typing import List
+from typing import NoReturn
 from typing import Optional
 from typing import Union
+from typing import overload
 
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.by import ByType
 from selenium.webdriver.remote.webelement import WebElement
 
 
@@ -37,10 +40,10 @@ def with_tag_name(tag_name: str) -> "RelativeBy":
     """
     if not tag_name:
         raise WebDriverException("tag_name can not be null")
-    return RelativeBy({"css selector": tag_name})
+    return RelativeBy({By.CSS_SELECTOR: tag_name})
 
 
-def locate_with(by: By, using: str) -> "RelativeBy":
+def locate_with(by: ByType, using: str) -> "RelativeBy":
     """Start searching for relative objects your search criteria with By.
 
     :Args:
@@ -70,7 +73,9 @@ class RelativeBy:
         assert "mid" in ids
     """
 
-    def __init__(self, root: Optional[Dict[Union[By, str], str]] = None, filters: Optional[List] = None):
+    LocatorType = Dict[ByType, str]
+
+    def __init__(self, root: Optional[Dict[ByType, str]] = None, filters: Optional[List] = None):
         """Creates a new RelativeBy object. It is preferred if you use the
         `locate_with` method as this signature could change.
 
@@ -82,7 +87,13 @@ class RelativeBy:
         self.root = root
         self.filters = filters or []
 
-    def above(self, element_or_locator: Union[WebElement, Dict] = None) -> "RelativeBy":
+    @overload
+    def above(self, element_or_locator: Union[WebElement, LocatorType]) -> "RelativeBy": ...
+
+    @overload
+    def above(self, element_or_locator: None = None) -> "NoReturn": ...
+
+    def above(self, element_or_locator: Union[WebElement, LocatorType, None] = None) -> "RelativeBy":
         """Add a filter to look for elements above.
 
         :Args:
@@ -94,7 +105,13 @@ class RelativeBy:
         self.filters.append({"kind": "above", "args": [element_or_locator]})
         return self
 
-    def below(self, element_or_locator: Union[WebElement, Dict] = None) -> "RelativeBy":
+    @overload
+    def below(self, element_or_locator: Union[WebElement, LocatorType]) -> "RelativeBy": ...
+
+    @overload
+    def below(self, element_or_locator: None = None) -> "NoReturn": ...
+
+    def below(self, element_or_locator: Union[WebElement, Dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements below.
 
         :Args:
@@ -106,7 +123,13 @@ class RelativeBy:
         self.filters.append({"kind": "below", "args": [element_or_locator]})
         return self
 
-    def to_left_of(self, element_or_locator: Union[WebElement, Dict] = None) -> "RelativeBy":
+    @overload
+    def to_left_of(self, element_or_locator: Union[WebElement, LocatorType]) -> "RelativeBy": ...
+
+    @overload
+    def to_left_of(self, element_or_locator: None = None) -> "NoReturn": ...
+
+    def to_left_of(self, element_or_locator: Union[WebElement, Dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements to the left of.
 
         :Args:
@@ -118,7 +141,13 @@ class RelativeBy:
         self.filters.append({"kind": "left", "args": [element_or_locator]})
         return self
 
-    def to_right_of(self, element_or_locator: Union[WebElement, Dict] = None) -> "RelativeBy":
+    @overload
+    def to_right_of(self, element_or_locator: Union[WebElement, LocatorType]) -> "RelativeBy": ...
+
+    @overload
+    def to_right_of(self, element_or_locator: None = None) -> "NoReturn": ...
+
+    def to_right_of(self, element_or_locator: Union[WebElement, Dict, None] = None) -> "RelativeBy":
         """Add a filter to look for elements right of.
 
         :Args:
@@ -130,16 +159,25 @@ class RelativeBy:
         self.filters.append({"kind": "right", "args": [element_or_locator]})
         return self
 
-    def near(self, element_or_locator_distance: Union[WebElement, Dict, int] = None) -> "RelativeBy":
+    @overload
+    def near(self, element_or_locator: Union[WebElement, LocatorType], distance: int = 50) -> "RelativeBy": ...
+
+    @overload
+    def near(self, element_or_locator: None = None, distance: int = 50) -> "NoReturn": ...
+
+    def near(self, element_or_locator: Union[WebElement, LocatorType, None] = None, distance: int = 50) -> "RelativeBy":
         """Add a filter to look for elements near.
 
         :Args:
-            - element_or_locator_distance: Element to look near by the element or within a distance
+            - element_or_locator: Element to look near by the element or within a distance
+            - distance: distance in pixel
         """
-        if not element_or_locator_distance:
-            raise WebDriverException("Element or locator or distance must be given when calling near method")
+        if not element_or_locator:
+            raise WebDriverException("Element or locator must be given when calling near method")
+        if distance <= 0:
+            raise WebDriverException("Distance must be positive")
 
-        self.filters.append({"kind": "near", "args": [element_or_locator_distance]})
+        self.filters.append({"kind": "near", "args": [element_or_locator, distance]})
         return self
 
     def to_dict(self) -> Dict:

--- a/WebDriverTests/imported/selenium/py/selenium/webdriver/wpewebkit/webdriver.py
+++ b/WebDriverTests/imported/selenium/py/selenium/webdriver/wpewebkit/webdriver.py
@@ -40,11 +40,10 @@ class WebDriver(RemoteWebDriver):
          - options : an instance of ``WPEWebKitOptions``
          - service : Service object for handling the browser driver if you need to pass extra details
         """
-        if not options:
-            options = Options()
 
+        options = options if options else Options()
         self.service = service if service else Service()
-        self.service.path = DriverFinder.get_path(self.service, options)
+        self.service.path = DriverFinder(self.service, options).get_driver_path()
         self.service.start()
 
         super().__init__(command_executor=self.service.service_url, options=options)

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/bidi_script_tests.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/bidi_script_tests.py
@@ -1,0 +1,99 @@
+# Licensed to the Software Freedom Conservancy (SFC) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The SFC licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+@pytest.mark.xfail_safari
+def test_logs_console_messages(driver, pages):
+    pages.load("bidi/logEntryAdded.html")
+
+    log_entries = []
+    driver.script.add_console_message_handler(log_entries.append)
+
+    driver.find_element(By.ID, "jsException").click()
+    driver.find_element(By.ID, "consoleLog").click()
+
+    WebDriverWait(driver, 5).until(lambda _: log_entries)
+
+    log_entry = log_entries[0]
+    assert log_entry.level == "info"
+    assert log_entry.method == "log"
+    assert log_entry.text == "Hello, world!"
+    assert log_entry.type_ == "console"
+
+
+@pytest.mark.xfail_safari
+def test_logs_console_errors(driver, pages):
+    pages.load("bidi/logEntryAdded.html")
+    log_entries = []
+
+    def log_error(entry):
+        if entry.level == "error":
+            log_entries.append(entry)
+
+    driver.script.add_console_message_handler(log_error)
+
+    driver.find_element(By.ID, "consoleLog").click()
+    driver.find_element(By.ID, "consoleError").click()
+
+    WebDriverWait(driver, 5).until(lambda _: log_entries)
+
+    assert len(log_entries) == 1
+
+    log_entry = log_entries[0]
+    assert log_entry.level == "error"
+    assert log_entry.method == "error"
+    assert log_entry.text == "I am console error"
+    assert log_entry.type_ == "console"
+
+
+@pytest.mark.xfail_safari
+def test_logs_multiple_console_messages(driver, pages):
+    pages.load("bidi/logEntryAdded.html")
+
+    log_entries = []
+    driver.script.add_console_message_handler(log_entries.append)
+    driver.script.add_console_message_handler(log_entries.append)
+
+    driver.find_element(By.ID, "jsException").click()
+    driver.find_element(By.ID, "consoleLog").click()
+
+    WebDriverWait(driver, 5).until(lambda _: len(log_entries) > 1)
+    assert len(log_entries) == 2
+
+
+@pytest.mark.xfail_safari
+def test_removes_console_message_handler(driver, pages):
+    pages.load("bidi/logEntryAdded.html")
+
+    log_entries1 = []
+    log_entries2 = []
+
+    id = driver.script.add_console_message_handler(log_entries1.append)
+    driver.script.add_console_message_handler(log_entries2.append)
+
+    driver.find_element(By.ID, "consoleLog").click()
+    WebDriverWait(driver, 5).until(lambda _: len(log_entries1) and len(log_entries2))
+
+    driver.script.remove_console_message_handler(id)
+    driver.find_element(By.ID, "consoleLog").click()
+
+    WebDriverWait(driver, 5).until(lambda _: len(log_entries2) == 2)
+    assert len(log_entries1) == 1

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/clear_tests.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/clear_tests.py
@@ -29,6 +29,7 @@ def test_writable_text_input_should_clear(driver, pages):
 
 
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_text_input_should_not_clear_when_disabled(driver, pages):
     pages.load("readOnlyPage.html")
     element = driver.find_element(By.ID, "textInputNotEnabled")
@@ -52,6 +53,7 @@ def test_writable_text_area_should_clear(driver, pages):
 
 
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_text_area_should_not_clear_when_disabled(driver, pages):
     pages.load("readOnlyPage.html")
     element = driver.find_element(By.ID, "textAreaNotEnabled")

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/driver_element_finding_tests.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/driver_element_finding_tests.py
@@ -194,6 +194,7 @@ def test_should_not_be_able_to_locate_by_tag_name_multiple_elements_that_do_not_
 @pytest.mark.xfail_remote(reason="https://github.com/mozilla/geckodriver/issues/2007")
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises NoSuchElementException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_asingle_element_by_empty_tag_name_should_throw(driver, pages):
     pages.load("formPage.html")
     with pytest.raises(InvalidSelectorException):
@@ -204,6 +205,7 @@ def test_finding_asingle_element_by_empty_tag_name_should_throw(driver, pages):
 @pytest.mark.xfail_remote(reason="https://github.com/mozilla/geckodriver/issues/2007")
 @pytest.mark.xfail_safari(reason="unlike chrome, safari returns an empty list")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_multiple_elements_by_empty_tag_name_should_throw(driver, pages):
     pages.load("formPage.html")
     with pytest.raises(InvalidSelectorException):
@@ -279,6 +281,7 @@ def test_should_not_find_element_by_class_when_the_name_queried_is_shorter_than_
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_asingle_element_by_empty_class_name_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     msg = r"\/errors#invalid-selector-exception"
@@ -288,6 +291,7 @@ def test_finding_asingle_element_by_empty_class_name_should_throw(driver, pages)
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_multiple_elements_by_empty_class_name_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):
@@ -302,6 +306,7 @@ def test_finding_asingle_element_by_compound_class_name_should_throw(driver, pag
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_asingle_element_by_invalid_class_name_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):
@@ -310,6 +315,7 @@ def test_finding_asingle_element_by_invalid_class_name_should_throw(driver, page
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_multiple_elements_by_invalid_class_name_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):
@@ -394,6 +400,7 @@ def test_should_throw_an_exception_when_there_is_no_link_to_click(driver, pages)
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_invalid_in_driver_find_element(
     driver, pages
 ):
@@ -404,6 +411,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_inv
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_invalid_in_driver_find_elements(
     driver, pages
 ):
@@ -414,6 +422,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_inv
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_invalid_in_element_find_element(
     driver, pages
 ):
@@ -425,6 +434,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_inv
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_invalid_in_element_find_elements(
     driver, pages
 ):
@@ -436,6 +446,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_is_syntactically_inv
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_in_driver_find_element(driver, pages):
     pages.load("formPage.html")
     with pytest.raises(InvalidSelectorException):
@@ -444,6 +455,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_i
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_in_driver_find_elements(driver, pages):
     pages.load("formPage.html")
     with pytest.raises(InvalidSelectorException):
@@ -452,6 +464,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_i
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_in_element_find_element(driver, pages):
     pages.load("formPage.html")
     body = driver.find_element(By.TAG_NAME, "body")
@@ -461,6 +474,7 @@ def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_i
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_throw_invalid_selector_exception_when_xpath_returns_wrong_type_in_element_find_elements(driver, pages):
     pages.load("formPage.html")
     body = driver.find_element(By.TAG_NAME, "body")
@@ -534,6 +548,7 @@ def test_should_not_find_elements_by_css_selector_when_there_is_no_such_element(
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_asingle_element_by_empty_css_selector_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):
@@ -542,6 +557,7 @@ def test_finding_asingle_element_by_empty_css_selector_should_throw(driver, page
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_multiple_elements_by_empty_css_selector_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):
@@ -550,6 +566,7 @@ def test_finding_multiple_elements_by_empty_css_selector_should_throw(driver, pa
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_asingle_element_by_invalid_css_selector_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):
@@ -558,6 +575,7 @@ def test_finding_asingle_element_by_invalid_css_selector_should_throw(driver, pa
 
 @pytest.mark.xfail_safari(reason="unlike chrome, safari raises TimeoutException")
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_finding_multiple_elements_by_invalid_css_selector_should_throw(driver, pages):
     pages.load("xhtmlTest.html")
     with pytest.raises(InvalidSelectorException):

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/w3c_interaction_tests.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/w3c_interaction_tests.py
@@ -178,8 +178,18 @@ def test_dragging_element_with_mouse_fires_events(driver, pages):
 @pytest.mark.xfail_remote
 def test_pen_pointer_properties(driver, pages):
     pages.load("pointerActionsPage.html")
-    pointerArea = driver.find_element(By.CSS_SELECTOR, "#pointerArea")
+
     pointer_input = PointerInput(interaction.POINTER_PEN, "pen")
+
+    # Make sure the pointer starts in a known location
+    reset_actions = ActionBuilder(driver, mouse=pointer_input)
+    reset_actions.pointer_action.move_to_location(x=0, y=0)
+    reset_actions.perform()
+    # Clear the events state
+    driver.execute_script("allEvents.events = [];")
+
+    pointerArea = driver.find_element(By.CSS_SELECTOR, "#pointerArea")
+
     actions = ActionBuilder(driver, mouse=pointer_input)
     center = _get_inview_center(pointerArea.rect, _get_viewport_rect(driver))
     actions.pointer_action.move_to(pointerArea).pointer_down(pressure=0.36, tilt_x=-72, tilt_y=9, twist=86).move_to(

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/webdriverwait_tests.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/webdriverwait_tests.py
@@ -34,6 +34,7 @@ def throw_sere(driver):
 
 
 @pytest.mark.xfail_chrome(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
+@pytest.mark.xfail_edge(reason="https://bugs.chromium.org/p/chromedriver/issues/detail?id=4743")
 def test_should_fail_with_invalid_selector_exception(driver, pages):
     pages.load("dynamic.html")
     with pytest.raises(InvalidSelectorException):

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/webserver.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/webserver.py
@@ -138,7 +138,7 @@ class SimpleWebServer:
 
     def __init__(self, host=DEFAULT_HOST_IP, port=DEFAULT_PORT):
         self.stop_serving = False
-        host = host
+        host = host if host else DEFAULT_HOST_IP
         port = port
         while True:
             try:
@@ -171,7 +171,8 @@ class SimpleWebServer:
 
     def where_is(self, path, localhost=False) -> str:
         # True force serve the page from localhost
-        if localhost:
+        # 0.0.0.0 shouldn't be used as a destination address, so fallback to localhost
+        if localhost or self.host == "0.0.0.0":
             return f"http://{DEFAULT_HOST}:{self.port}/{path}"
         return f"http://{self.host}:{self.port}/{path}"
 

--- a/WebDriverTests/imported/selenium/py/test/selenium/webdriver/support/relative_by_tests.py
+++ b/WebDriverTests/imported/selenium/py/test/selenium/webdriver/support/relative_by_tests.py
@@ -31,11 +31,29 @@ def test_should_be_able_to_find_first_one(driver, pages):
     assert el.get_attribute("id") == "mid"
 
 
+def test_should_be_able_to_find_first_one_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    el = driver.find_element(with_tag_name("p").above({By.ID: "below"}))
+
+    assert el.get_attribute("id") == "mid"
+
+
 def test_should_be_able_to_find_elements_above_another(driver, pages):
     pages.load("relative_locators.html")
     lowest = driver.find_element(By.ID, "below")
 
     elements = driver.find_elements(with_tag_name("p").above(lowest))
+
+    ids = [el.get_attribute("id") for el in elements]
+    assert "above" in ids
+    assert "mid" in ids
+
+
+def test_should_be_able_to_find_elements_above_another_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    elements = driver.find_elements(with_tag_name("p").above({By.ID: "below"}))
 
     ids = [el.get_attribute("id") for el in elements]
     assert "above" in ids
@@ -55,6 +73,15 @@ def test_should_be_able_to_combine_filters(driver, pages):
     assert "third" in ids
 
 
+def test_should_be_able_to_combine_filters_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    elements = driver.find_elements(with_tag_name("td").above({By.ID: "center"}).to_right_of({By.ID: "second"}))
+
+    ids = [el.get_attribute("id") for el in elements]
+    assert "third" in ids
+
+
 def test_should_be_able_to_use_css_selectors(driver, pages):
     pages.load("relative_locators.html")
 
@@ -62,6 +89,17 @@ def test_should_be_able_to_use_css_selectors(driver, pages):
         locate_with(By.CSS_SELECTOR, "td")
         .above(driver.find_element(By.ID, "center"))
         .to_right_of(driver.find_element(By.ID, "second"))
+    )
+
+    ids = [el.get_attribute("id") for el in elements]
+    assert "third" in ids
+
+
+def test_should_be_able_to_use_css_selectors_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    elements = driver.find_elements(
+        locate_with(By.CSS_SELECTOR, "td").above({By.ID: "center"}).to_right_of({By.ID: "second"})
     )
 
     ids = [el.get_attribute("id") for el in elements]
@@ -81,11 +119,27 @@ def test_should_be_able_to_use_xpath(driver, pages):
     assert "fourth" in ids
 
 
+def test_should_be_able_to_use_xpath_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    elements = driver.find_elements(locate_with(By.XPATH, "//td[1]").below({By.ID: "second"}).above({By.ID: "seventh"}))
+
+    ids = [el.get_attribute("id") for el in elements]
+    assert "fourth" in ids
+
+
 def test_no_such_element_is_raised_rather_than_index_error(driver, pages):
     pages.load("relative_locators.html")
     with pytest.raises(NoSuchElementException) as exc:
         anchor = driver.find_element(By.ID, "second")
         driver.find_element(locate_with(By.ID, "nonexistentid").above(anchor))
+    assert "Cannot locate relative element with: {'id': 'nonexistentid'}" in exc.value.msg
+
+
+def test_no_such_element_is_raised_rather_than_index_error_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+    with pytest.raises(NoSuchElementException) as exc:
+        driver.find_element(locate_with(By.ID, "nonexistentid").above({By.ID: "second"}))
     assert "Cannot locate relative element with: {'id': 'nonexistentid'}" in exc.value.msg
 
 
@@ -98,6 +152,14 @@ def test_near_locator_should_find_near_elements(driver, pages):
     assert el.get_attribute("id") == "rect2"
 
 
+def test_near_locator_should_find_near_elements_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    el = driver.find_element(locate_with(By.ID, "rect2").near({By.ID: "rect1"}))
+
+    assert el.get_attribute("id") == "rect2"
+
+
 def test_near_locator_should_not_find_far_elements(driver, pages):
     pages.load("relative_locators.html")
     rect3 = driver.find_element(By.ID, "rect3")
@@ -106,3 +168,29 @@ def test_near_locator_should_not_find_far_elements(driver, pages):
         driver.find_element(locate_with(By.ID, "rect4").near(rect3))
 
     assert "Cannot locate relative element with: {'id': 'rect4'}" in exc.value.msg
+
+
+def test_near_locator_should_not_find_far_elements_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    with pytest.raises(NoSuchElementException) as exc:
+        driver.find_element(locate_with(By.ID, "rect4").near({By.ID: "rect3"}))
+
+    assert "Cannot locate relative element with: {'id': 'rect4'}" in exc.value.msg
+
+
+def test_near_locator_should_find_far_elements(driver, pages):
+    pages.load("relative_locators.html")
+    rect3 = driver.find_element(By.ID, "rect3")
+
+    el = driver.find_element(locate_with(By.ID, "rect4").near(rect3, 100))
+
+    assert el.get_attribute("id") == "rect4"
+
+
+def test_near_locator_should_find_far_elements_by_locator(driver, pages):
+    pages.load("relative_locators.html")
+
+    el = driver.find_element(locate_with(By.ID, "rect4").near({By.ID: "rect3"}, 100))
+
+    assert el.get_attribute("id") == "rect4"


### PR DESCRIPTION
#### 74b0a6d11aa64f370447b013a76416f88ef00bc2
<pre>
[WebDriver] Update imported selenium tests to incorporate 0.0.0.0 changes after 279835@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=277791">https://bugs.webkit.org/show_bug.cgi?id=277791</a>

Reviewed by Carlos Garcia Campos.

- Added fix for 0.0.0.0 issue running tests
- Updated BiDi testing (Preparation for bug230615)

* Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner_selenium.py:
* WebDriverTests/imported/selenium/common/src/web/fedcm/fedcm.html:
* WebDriverTests/imported/selenium/common/src/web/fedcm/fedcm.json:
* WebDriverTests/imported/selenium/common/src/web/select_space.html: Added.
* WebDriverTests/imported/selenium/importer.json:
* WebDriverTests/imported/selenium/py/conftest.py:
* WebDriverTests/imported/selenium/py/selenium/__init__.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/bidi/script.py: Added.
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/bidi/session.py: Copied from WebDriverTests/imported/selenium/py/selenium/webdriver/common/by.py.
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/by.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/driver_finder.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/options.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/print_page_options.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/selenium_manager.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/common/timeouts.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/remote/remote_connection.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/remote/webdriver.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/remote/webelement.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/remote/websocket_connection.py: Added.
* WebDriverTests/imported/selenium/py/selenium/webdriver/safari/webdriver.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/support/relative_locator.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/webkitgtk/webdriver.py:
* WebDriverTests/imported/selenium/py/selenium/webdriver/wpewebkit/webdriver.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/bidi_script_tests.py: Added.
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/clear_tests.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/driver_element_finding_tests.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/selenium_manager_tests.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/w3c_interaction_tests.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/webdriverwait_tests.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/common/webserver.py:
* WebDriverTests/imported/selenium/py/test/selenium/webdriver/support/relative_by_tests.py:

Canonical link: <a href="https://commits.webkit.org/282113@main">https://commits.webkit.org/282113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/856ed7027e745c0310394e008aac103e529ffe4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50004 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30835 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/61601 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6033 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11075 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57382 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57632 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4945 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37244 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38328 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->