### PR TITLE
Unreviewed, fix the macOS build on some versions of the macOS Sequoia SDK

### DIFF
--- a/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
@@ -293,6 +293,11 @@ static NSMutableArray<NSFilePromiseReceiver *> *allFilePromiseReceivers()
 {
 }
 
+- (id)localContext
+{
+    return nil;
+}
+
 @end
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
@@ -206,6 +206,11 @@ IGNORE_WARNINGS_END
 {
 }
 
+- (id)localContext
+{
+    return nil;
+}
+
 @end
 
 namespace TestWebKitAPI {

--- a/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
+++ b/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
@@ -157,6 +157,11 @@ IGNORE_WARNINGS_END
 {
 }
 
+- (id)localContext
+{
+    return nil;
+}
+
 @end
 
 #endif // ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerDraggingInfo.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerDraggingInfo.mm
@@ -153,4 +153,9 @@ using namespace WTR;
 {
 }
 
+- (id)localContext
+{
+    return nil;
+}
+
 @end


### PR DESCRIPTION
#### 720aeec4b0d6a7bc6e9fb61696045307d2ca17bd
<pre>
Unreviewed, fix the macOS build on some versions of the macOS Sequoia SDK

Add some method stubs to implement a new required protocol method in several mock objects that
implement `NSDraggingInfo`. `-localContext` was recently promoted from SPI to API.

See <a href="https://rdar.apple.com/129788853">rdar://129788853</a> for more information.

* Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm:
(-[DumpRenderTreeDraggingInfo localContext]):
* Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm:
(-[DragInfo localContext]):
* Tools/TestWebKitAPI/mac/TestDraggingInfo.mm:
(-[TestDraggingInfo localContext]):
* Tools/WebKitTestRunner/mac/WebKitTestRunnerDraggingInfo.mm:
(-[WebKitTestRunnerDraggingInfo localContext]):

Canonical link: <a href="https://commits.webkit.org/282099@main">https://commits.webkit.org/282099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfadb69f90ebb0082de415bde44feeff9f5e82d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12977 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8731 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38467 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35111 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6035 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57634 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/4947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9346 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37246 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->