### PR TITLE
Refactor setVisualUpdatesAllowed to allow adding more reasons.

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4043,6 +4043,8 @@ void Page::forEachRenderableDocument(const Function<void(Document&)>& functor) c
             continue;
         if (document->renderingIsSuppressedForViewTransition())
             continue;
+        if (!document->visualUpdatesAllowed())
+            continue;
         documents.append(*document);
     }
     for (auto& document : documents)


### PR DESCRIPTION
#### 59f02dbfbc2353adafbef64ec5f8ac5875c21559
<pre>
Refactor setVisualUpdatesAllowed to allow adding more reasons.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277931">https://bugs.webkit.org/show_bug.cgi?id=277931</a>
&lt;<a href="https://rdar.apple.com/133648465">rdar://133648465</a>&gt;

Reviewed by Tim Horton.

The state changes for enabling/disabling visual updates allowed are complicated,
and will get worse if we try to add new reasons to prevent updates.

Render blocking (bug 268743) will want to use this, and I think we can fold in
view-transition rendering suppression too.

This adds a set of flags, and visual updates are prevented when any are present.

There are a few behaviour changes:

The explicit flushing of layout and compositing layers has been removed. Any
code that needs to result of these (like a rendering update) should already be
calling these as needed, and we shouldn&apos;t need to preemptively do so at this
point.

A suspend/resume pair no longer clobbers the state, and will now leave
client-requested blocking in place.

rAF is also skipped for Documents with visual updates prevented. This is
required for render-blocking and rendering suppression, and seems like it would
also be the right thing for the existing uses too.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setReadyState):
(WebCore::Document::setVisualUpdatesAllowed):
(WebCore::Document::addVisualUpdatePreventedReason):
(WebCore::Document::removeVisualUpdatePreventedReasons):
(WebCore::Document::visualUpdatesSuppressionTimerFired):
(WebCore::Document::setVisualUpdatesAllowedByClient):
(WebCore::Document::suspend):
(WebCore::Document::resume):
* Source/WebCore/dom/Document.h:
(WebCore::Document::visualUpdatesAllowed const):
(WebCore::Document::visualUpdatePreventReasonsClearedByTimer):
(WebCore::Document::visualUpdatePreventRequiresLayoutMilestones):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::forEachRenderableDocument const):

Canonical link: <a href="https://commits.webkit.org/282185@main">https://commits.webkit.org/282185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58557c6e5eb5b33be61870553ed8cd843648827e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50013 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8740 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11019 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6044 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11086 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57391 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57641 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13861 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4956 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37255 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->