### PR TITLE
[WPE] WPE Platform: add window minimization to WPEToplevel

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -50,19 +50,136 @@ gboolean webkitWebViewRunFileChooser(WebKitWebView*, WebKitFileChooserRequest*)
     return FALSE;
 }
 
-void webkitWebViewMaximizeWindow(WebKitWebView*, CompletionHandler<void()>&& completionHandler)
+struct ToplevelStateEvent {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    enum class Type { Maximize, Minimize, Restore };
+
+    ToplevelStateEvent(Type type, CompletionHandler<void()>&& completionHandler)
+        : type(type)
+        , completionHandler(WTFMove(completionHandler))
+        , completeTimer(RunLoop::main(), this, &ToplevelStateEvent::complete)
+    {
+        // Complete the event if not done after one second.
+        completeTimer.startOneShot(1_s);
+    }
+
+    ~ToplevelStateEvent()
+    {
+        complete();
+    }
+
+    void complete()
+    {
+        if (auto handler = std::exchange(completionHandler, nullptr))
+            handler();
+    }
+
+    Type type;
+    CompletionHandler<void()> completionHandler;
+    RunLoop::Timer completeTimer;
+};
+
+static const char* toplevelStateEventID = "wpe-toplevel-state-event";
+
+static void toplevelStateChangedCallback(WPEView* view, WPEToplevelState previousState)
 {
-    completionHandler();
+    auto* state = static_cast<ToplevelStateEvent*>(g_object_get_data(G_OBJECT(view), toplevelStateEventID));
+    if (!state) {
+        g_signal_handlers_disconnect_by_func(view, reinterpret_cast<gpointer>(toplevelStateChangedCallback), nullptr);
+        return;
+    }
+
+    WPEToplevelState toplevelState = wpe_view_get_toplevel_state(view);
+    bool eventCompleted = false;
+    switch (state->type) {
+    case ToplevelStateEvent::Type::Maximize:
+        if (toplevelState & WPE_TOPLEVEL_STATE_MAXIMIZED)
+            eventCompleted = true;
+        break;
+    case ToplevelStateEvent::Type::Minimize:
+        if (toplevelState & WPE_TOPLEVEL_STATE_NONE)
+            eventCompleted = true;
+        break;
+    case ToplevelStateEvent::Type::Restore:
+        if ((previousState & WPE_TOPLEVEL_STATE_MAXIMIZED) && !(toplevelState & WPE_TOPLEVEL_STATE_MAXIMIZED))
+            eventCompleted = true;
+        break;
+    }
+
+    if (eventCompleted) {
+        g_signal_handlers_disconnect_by_func(view, reinterpret_cast<gpointer>(toplevelStateChangedCallback), nullptr);
+        g_object_set_data(G_OBJECT(view), toplevelStateEventID, nullptr);
+    }
 }
 
-void webkitWebViewMinimizeWindow(WebKitWebView*, CompletionHandler<void()>&& completionHandler)
+static void
+monitorToplevelState(WPEView* view, ToplevelStateEvent::Type type, CompletionHandler<void()>&& completionHandler)
 {
-    completionHandler();
+    g_object_set_data_full(G_OBJECT(view), toplevelStateEventID, new ToplevelStateEvent(type, WTFMove(completionHandler)), [](gpointer userData) {
+        delete static_cast<ToplevelStateEvent*>(userData);
+    });
+    g_signal_connect_after(view, "toplevel-state-changed", G_CALLBACK(toplevelStateChangedCallback), nullptr);
 }
 
-void webkitWebViewRestoreWindow(WebKitWebView*, CompletionHandler<void()>&& completionHandler)
+void webkitWebViewMaximizeWindow(WebKitWebView* view, CompletionHandler<void()>&& completionHandler)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (auto* wpeView = webkit_web_view_get_wpe_view(view)) {
+        auto* toplevel = wpe_view_get_toplevel(wpeView);
+        if (!WPE_IS_TOPLEVEL(toplevel) || (wpe_toplevel_get_state(toplevel) & WPE_TOPLEVEL_STATE_MAXIMIZED)) {
+            completionHandler();
+            return;
+        }
+
+        monitorToplevelState(wpeView, ToplevelStateEvent::Type::Maximize, WTFMove(completionHandler));
+        if (wpe_toplevel_maximize(toplevel))
+            return;
+    }
+#endif
+
     completionHandler();
+    return;
+}
+
+void webkitWebViewMinimizeWindow(WebKitWebView* view, CompletionHandler<void()>&& completionHandler)
+{
+#if ENABLE(WPE_PLATFORM)
+    if (auto* wpeView = webkit_web_view_get_wpe_view(view)) {
+        auto* toplevel = wpe_view_get_toplevel(wpeView);
+        if (!WPE_IS_TOPLEVEL(toplevel)) {
+            completionHandler();
+            return;
+        }
+
+        monitorToplevelState(wpeView, ToplevelStateEvent::Type::Minimize, WTFMove(completionHandler));
+        if (wpe_toplevel_minimize(toplevel))
+            return;
+    }
+#endif
+
+    completionHandler();
+    return;
+}
+
+void webkitWebViewRestoreWindow(WebKitWebView* view, CompletionHandler<void()>&& completionHandler)
+{
+#if ENABLE(WPE_PLATFORM)
+    if (auto* wpeView = webkit_web_view_get_wpe_view(view)) {
+        auto* toplevel = wpe_view_get_toplevel(wpeView);
+        if (!WPE_IS_TOPLEVEL(toplevel)) {
+            completionHandler();
+            return;
+        }
+
+        monitorToplevelState(wpeView, ToplevelStateEvent::Type::Restore, WTFMove(completionHandler));
+        if ((wpe_toplevel_get_state(toplevel) & WPE_TOPLEVEL_STATE_MAXIMIZED) && wpe_toplevel_unmaximize(toplevel))
+            return;
+    }
+#endif
+
+    completionHandler();
+    return;
 }
 
 /**


### PR DESCRIPTION
#### 0acefe36f0146eb81a20ac914ee1518cc405b429
<pre>
[WPE] WPE Platform: add window minimization to WPEToplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=276905">https://bugs.webkit.org/show_bug.cgi?id=276905</a>

Reviewed by NOBODY (OOPS!).

Add toplevel minimization support to the webdriver. Wayland compositor
does not notify when the minimization actually happens, hence we only ask
the toplevel to be minimized.

* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
(WindowStateEvent::WindowStateEvent):
(WindowStateEvent::~WindowStateEvent):
(WindowStateEvent::complete):
(toplevelStateChangedCallback):
(webkitWebViewMonitorWindowState):
(webkitWebViewMaximizeWindow):
(webkitWebViewMinimizeWindow):
(webkitWebViewRestoreWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0acefe36f0146eb81a20ac914ee1518cc405b429

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12767 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50145 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8832 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35300 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67932 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57518 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57738 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5091 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37376 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->