### PR TITLE
Implement blocking=render attribute for <script> and <style>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6908,6 +6908,8 @@ imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-022.html [ Failure ]
 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-036.html [ Failure ]
 
+webkit.org/b/278192 imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-033.html [ Failure ]
+
 # AudioDecoder, AudioEncoder and AudioData implementations missing.
 imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker.html [ Failure ]
@@ -7605,10 +7607,10 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/a
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-opt-in-auto-with-types.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html [ ImageOnlyFailure ]
+
+# prerender not supported.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/prerender-removed-during-navigation.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-cross-origin.sub.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/transition-to-prerender.html [ Skip ]
 
 # View transitions Level 2 - types.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/blocking-idl-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/blocking-idl-attr-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Supported tokens of the 'blocking' IDL attribute of the link element
 PASS Setting the 'blocking' IDL attribute of the link element
-FAIL Supported tokens of the 'blocking' IDL attribute of the script element undefined is not an object (evaluating 'script.blocking.supports')
-FAIL Setting the 'blocking' IDL attribute of the script element assert_equals: expected (string) "asdf" but got (undefined) undefined
-FAIL Supported tokens of the 'blocking' IDL attribute of the style element undefined is not an object (evaluating 'style.blocking.supports')
-FAIL Setting the 'blocking' IDL attribute of the style element assert_equals: expected (string) "asdf" but got (undefined) undefined
+PASS Supported tokens of the 'blocking' IDL attribute of the script element
+PASS Setting the 'blocking' IDL attribute of the script element
+PASS Supported tokens of the 'blocking' IDL attribute of the style element
+PASS Setting the 'blocking' IDL attribute of the style element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-033-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-033-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL blocking defers frames until full parsing assert_false: expected false got true
+PASS blocking defers frames until full parsing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-async-inline-module-with-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-async-inline-module-with-import-expected.txt
@@ -1,4 +1,4 @@
 some text
 
-FAIL Parser-inserted async inline module script elements with "blocking=render" are render-blocking assert_true: Parser-inserted async render-blocking inline module script should execute before rAF callback expected true got false
+PASS Parser-inserted async inline module script elements with "blocking=render" are render-blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-async-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-async-script-expected.txt
@@ -1,5 +1,5 @@
 Some text
 
-FAIL Rendering is blocked before render-blocking resources are loaded assert_true: expected true got false
+PASS Rendering is blocked before render-blocking resources are loaded
 PASS Parser-inserted render-blocking async script is evaluated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-defer-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-defer-script-expected.txt
@@ -1,5 +1,5 @@
 Some text
 
-FAIL Rendering is blocked before render-blocking resources are loaded assert_true: expected true got false
+PASS Rendering is blocked before render-blocking resources are loaded
 PASS Parser-inserted render-blocking defer script is evaluated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-inline-module-with-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-inline-module-with-import-expected.txt
@@ -1,4 +1,4 @@
 some text
 
-FAIL Parser-inserted module script elements with "blocking=render" are render-blocking assert_true: Parser-inserted render-blocking inline module script should execute before rAF callback expected true got false
+PASS Parser-inserted module script elements with "blocking=render" are render-blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-module-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-module-script-expected.txt
@@ -1,5 +1,5 @@
 1
 
-FAIL Rendering is blocked before render-blocking resources are loaded assert_true: expected true got false
+PASS Rendering is blocked before render-blocking resources are loaded
 PASS Parser-inserted render-blocking module script is evaluated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-inline-module-with-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-inline-module-with-import-expected.txt
@@ -1,4 +1,4 @@
 some text
 
-FAIL Script-inserted module script elements with "blocking=render" are render-blocking assert_true: Script-inserted render-blocking inline module script should execute before rAF callback expected true got false
+PASS Script-inserted module script elements with "blocking=render" are render-blocking
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-module-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-module-script-expected.txt
@@ -1,5 +1,5 @@
 1
 
-FAIL Rendering is blocked before render-blocking resources are loaded assert_true: expected true got false
+PASS Rendering is blocked before render-blocking resources are loaded
 PASS Script-inserted render-blocking module script is evaluated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-script-expected.txt
@@ -1,5 +1,5 @@
 Some text
 
-FAIL Rendering is blocked before render-blocking resources are loaded assert_true: expected true got false
+PASS Rendering is blocked before render-blocking resources are loaded
 PASS Script-inserted render-blocking script is evaluated
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1827,7 +1827,9 @@ public:
 
     bool allowsAddingRenderBlockedElements() const;
     bool isRenderBlocked() const;
-    void blockRenderingOn(Element&);
+
+    enum class ImplicitRenderBlocking : bool { Yes, No };
+    void blockRenderingOn(Element&, ImplicitRenderBlocking = ImplicitRenderBlocking::No);
     void unblockRenderingOn(Element&);
     void processInternalResourceLinks(HTMLAnchorElement&);
 
@@ -2073,7 +2075,8 @@ private:
     static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventReasonsClearedByTimer() { return { VisualUpdatesPreventedReason::ReadyState, VisualUpdatesPreventedReason::RenderBlocking }; }
     static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventRequiresLayoutMilestones() { return { VisualUpdatesPreventedReason::Client, VisualUpdatesPreventedReason::ReadyState }; }
 
-    void addVisualUpdatePreventedReason(VisualUpdatesPreventedReason);
+    enum class CompletePageTransition : bool { Yes, No };
+    void addVisualUpdatePreventedReason(VisualUpdatesPreventedReason, CompletePageTransition = CompletePageTransition::Yes);
     void removeVisualUpdatePreventedReasons(OptionSet<VisualUpdatesPreventedReason>);
 
     void visualUpdatesSuppressionTimerFired();
@@ -2665,6 +2668,7 @@ private:
 
     bool m_hasBeenRevealed { false };
     bool m_visualUpdatesAllowedChangeRequiresLayoutMilestones { false };
+    bool m_visualUpdatesAllowedChangeCompletesPageTransition { false };
 
     static bool hasEverCreatedAnAXObjectCache;
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -244,12 +244,14 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         if (hasSourceAttribute()) {
             if (!requestClassicScript(sourceAttributeValue()))
                 return false;
+            potentiallyBlockRendering();
         }
         break;
     }
     case ScriptType::Module: {
         if (!requestModuleScript(scriptStartPosition))
             return false;
+        potentiallyBlockRendering();
         break;
     }
     case ScriptType::ImportMap: {
@@ -265,6 +267,7 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         if (hasSourceAttribute()) {
             if (!requestImportMap(*frame, sourceAttributeValue()))
                 return false;
+            potentiallyBlockRendering();
         } else
             frame->script().setPendingImportMaps();
         break;
@@ -582,6 +585,7 @@ void ScriptElement::executeScriptAndDispatchEvent(LoadableScript& loadableScript
 
 void ScriptElement::executePendingScript(PendingScript& pendingScript)
 {
+    unblockRendering();
     auto* loadableScript = pendingScript.loadableScript();
     RefPtr<Document> document { &element().document() };
     if (document->identifier() != m_preparationTimeDocumentIdentifier) {

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -111,6 +111,9 @@ protected:
 
     void setTrustedScriptText(const String&);
 
+    virtual void potentiallyBlockRendering() { }
+    virtual void unblockRendering() { }
+
 private:
     void executeScriptAndDispatchEvent(LoadableScript&);
 

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -30,6 +30,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "JSRequestPriority.h"
+#include "NodeName.h"
 #include "RequestPriority.h"
 #include "Settings.h"
 #include "Text.h"
@@ -72,13 +73,23 @@ void HTMLScriptElement::finishParsingChildren()
     ScriptElement::finishParsingChildren();
 }
 
+void HTMLScriptElement::removedFromAncestor(RemovalType type, ContainerNode& container)
+{
+    HTMLElement::removedFromAncestor(type, container);
+    unblockRendering();
+}
+
 void HTMLScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == srcAttr)
         handleSourceAttribute(newValue);
     else if (name == asyncAttr)
         handleAsyncAttribute();
-    else
+    else if (name == blockingAttr) {
+        blocking().associatedAttributeValueChanged();
+        if (!blocking().contains("render"_s))
+            unblockRendering();
+    } else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
@@ -96,6 +107,42 @@ void HTMLScriptElement::didFinishInsertingNode()
 void HTMLScriptElement::setText(String&& value)
 {
     setTextContent(WTFMove(value));
+}
+
+DOMTokenList& HTMLScriptElement::blocking()
+{
+    if (!m_blockingList) {
+        m_blockingList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::blockingAttr, [](Document&, StringView token) {
+            if (equalLettersIgnoringASCIICase(token, "render"_s))
+                return true;
+            return false;
+        });
+    }
+    return *m_blockingList;
+}
+
+// https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model:implicitly-potentially-render-blocking
+bool HTMLScriptElement::isImplicitlyPotentiallyRenderBlocking() const
+{
+    return scriptType() == ScriptType::Classic && isParserInserted() == ParserInserted::Yes && !hasDeferAttribute() && !hasAsyncAttribute();
+}
+
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#potentially-render-blocking
+void HTMLScriptElement::potentiallyBlockRendering()
+{
+    bool explicitRenderBlocking = m_blockingList && m_blockingList->contains("render"_s);
+    if (explicitRenderBlocking || isImplicitlyPotentiallyRenderBlocking()) {
+        document().blockRenderingOn(*this, explicitRenderBlocking ? Document::ImplicitRenderBlocking::No : Document::ImplicitRenderBlocking::Yes);
+        m_isRenderBlocking = true;
+    }
+}
+
+void HTMLScriptElement::unblockRendering()
+{
+    if (m_isRenderBlocking) {
+        document().unblockRenderingOn(*this);
+        m_isRenderBlocking = false;
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#dom-script-text

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "DOMTokenList.h"
 #include "HTMLElement.h"
 #include "ScriptElement.h"
 
@@ -71,6 +72,8 @@ public:
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriorityHint() const override;
 
+    WEBCORE_EXPORT DOMTokenList& blocking();
+
 private:
     HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
 
@@ -79,6 +82,11 @@ private:
     void didFinishInsertingNode() final;
     void childrenChanged(const ChildChange&) final;
     void finishParsingChildren() final;
+    void removedFromAncestor(RemovalType, ContainerNode&) final;
+
+    void potentiallyBlockRendering() final;
+    void unblockRendering() final;
+    bool isImplicitlyPotentiallyRenderBlocking() const;
 
     ExceptionOr<void> setTextContent(ExceptionOr<String>);
 
@@ -100,6 +108,9 @@ private:
     bool isScriptPreventedByAttributes() const final;
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) final;
+
+    std::unique_ptr<DOMTokenList> m_blockingList;
+    bool m_isRenderBlocking { false };
 };
 
 } //namespace

--- a/Source/WebCore/html/HTMLScriptElement.idl
+++ b/Source/WebCore/html/HTMLScriptElement.idl
@@ -36,6 +36,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString integrity;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
     [CEReactions=NotNeeded, EnabledBySetting=FetchPriorityEnabled, ImplementedAs=fetchPriorityForBindings] attribute [AtomString] DOMString fetchPriority;
+    [PutForwards=value] readonly attribute DOMTokenList blocking;
 
     static boolean supports(DOMString type);
 };

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -101,10 +101,29 @@ void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomStr
         if (auto* scope = m_styleSheetOwner.styleScope())
             scope->didChangeStyleSheetContents();
         break;
+    case AttributeNames::blockingAttr:
+        if (m_blockingList)
+            m_blockingList->associatedAttributeValueChanged();
+        break;
     default:
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
         break;
     }
+}
+
+// https://html.spec.whatwg.org/multipage/semantics.html#dom-style-blocking
+// FIXME: Bug 88869 - This isn't currently connected to anything, because style elements are
+// parser blocking, even when script inserted.
+DOMTokenList& HTMLStyleElement::blocking()
+{
+    if (!m_blockingList) {
+        m_blockingList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::blockingAttr, [](Document&, StringView token) {
+            if (equalLettersIgnoringASCIICase(token, "render"_s))
+                return true;
+            return false;
+        });
+    }
+    return *m_blockingList;
 }
 
 void HTMLStyleElement::finishParsingChildren()

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -53,6 +53,8 @@ public:
 
     void finishParsingChildren() final;
 
+    WEBCORE_EXPORT DOMTokenList& blocking();
+
 private:
     HTMLStyleElement(const QualifiedName&, Document&, bool createdByParser);
 
@@ -69,6 +71,7 @@ private:
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 
     InlineStyleSheetOwner m_styleSheetOwner;
+    std::unique_ptr<DOMTokenList> m_blockingList;
     bool m_loadedSheet { false };
 };
 

--- a/Source/WebCore/html/HTMLStyleElement.idl
+++ b/Source/WebCore/html/HTMLStyleElement.idl
@@ -24,6 +24,8 @@
     attribute boolean disabled;
     [CEReactions=NotNeeded, Reflect] attribute DOMString media;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
+
+    [PutForwards=value] readonly attribute DOMTokenList blocking;
 };
 
 HTMLStyleElement includes LinkStyle;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1926,7 +1926,9 @@ void Page::updateRendering()
     });
 
     runProcessingStep(RenderingUpdateStep::Reveal, [] (Document& document) {
-        document.reveal();
+        // FIXME: Bug 278193 - Hidden docs should already be excluded.
+        if (document.visibilityState() != VisibilityState::Hidden)
+            document.reveal();
     });
 
     runProcessingStep(RenderingUpdateStep::FlushAutofocusCandidates, [] (Document& document) {


### PR DESCRIPTION
#### 184cdfcc57261e42ed198e5874c1514a90325cd2
<pre>
Implement blocking=render attribute for &lt;script&gt; and &lt;style&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=267232">https://bugs.webkit.org/show_bug.cgi?id=267232</a>
&lt;<a href="https://rdar.apple.com/121008856">rdar://121008856</a>&gt;

Reviewed by Tim Nguyen.

Implements the &apos;blocking&apos; attribute for both &lt;script&gt; and &lt;style&gt;.

For &lt;script&gt;, it makes the element render blocking (for async scripts with a src
attribute, or modules).

&lt;style&gt; elements are already always script blocking (even when not parser
inserted) - See bug 88869. These are already implicitly render blocking due to
this, so there&apos;s currently nothing else to do other than roundtrip the
attribute.

WebKit2 has an existing, related concept called layer tree freezing that
prevents rendering updates during page transitions (for top-level documents
only). This blocking is removed when the first contentful layout is completed,
or when render blocking ends. In some of the tests this means that rendering
updates start sooner than before, when render blocking starts and then ends
before we have sufficient page content to hit the &apos;contentful&apos; milestone. It&apos;s
possible, but unlikely for real web content to do the same.

To avoid changing behaviour for sites that haven&apos;t used blocking=&quot;render&quot;
explicitly, this passes information from the HTMLScriptElement to the Document
about whether the blocking was implicit or not. The Document then only overrides
the layer tree freezing if there was at least one explicit cause of render
blocking (or any of the other visual update prevented reasons).

This fixes most of the relevant tests, except for two that use script inserted
stylesheets. These are always render blocking (and script blocking) so they
Break the tests attempts to unblock rendering. Manually removing the stylesheet
components of the test results in the rest of the test passing correctly.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/blocking-idl-attr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-async-inline-module-with-import-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-async-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-defer-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-inline-module-with-import-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/parser-inserted-module-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-inline-module-with-import-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-module-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/script-inserted-script-expected.txt:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::executePendingScript):
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::potentiallyBlockRendering):
(WebCore::ScriptElement::unblockRendering):
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::removedFromAncestor):
(WebCore::HTMLScriptElement::attributeChanged):
(WebCore::HTMLScriptElement::blocking):
(WebCore::HTMLScriptElement::potentiallyBlockRendering):
(WebCore::HTMLScriptElement::unblockRendering):
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLScriptElement.idl:
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::attributeChanged):
(WebCore::HTMLStyleElement::blocking):
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/html/HTMLStyleElement.idl:

Canonical link: <a href="https://commits.webkit.org/282319@main">https://commits.webkit.org/282319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bb68c4a7b6c1819ab7d457539573a116e3847a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13698 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54410 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6756 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54465 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5649 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9461 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->