### PR TITLE
[Cocoa] Mail sometimes shows placeholder text instead of an adaptive image glyph

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -421,8 +421,6 @@ void Editor::insertMultiRepresentationHEIC(const std::span<const uint8_t>& data,
     auto fragment = document->createDocumentFragment();
     fragment->appendChild(WTFMove(picture));
 
-    ReplaceSelectionCommand::create(document.get(), WTFMove(fragment), { ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting }, EditAction::Insert)->apply();
-
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (DeprecatedGlobalSettings::attachmentElementEnabled()) {
         auto primaryAttachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document.get());
@@ -436,6 +434,8 @@ void Editor::insertMultiRepresentationHEIC(const std::span<const uint8_t>& data,
         image->setAttachmentElement(WTFMove(fallbackAttachment));
     }
 #endif
+
+    ReplaceSelectionCommand::create(document.get(), WTFMove(fragment), { ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting }, EditAction::Insert)->apply();
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
@@ -486,6 +486,63 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)
     EXPECT_TRUE([[webView stringByEvaluatingJavaScript:@"document.querySelector('img').attachmentIdentifier"] isEqualToString:pngAttachment.uniqueIdentifier]);
 }
 
+TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAttachmentElementEnabled:YES];
+
+    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    [webView _setEditable:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body dir='auto' role='textbox' aria-label='Message Body'><br><div id='AppleMailSignature' dir='ltr'><!-- signature open -->Sent from my iPhone <!-- signature close --></div></body>"];
+    [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
+
+    NSString *setSelectionJavaScript = @""
+    "(() => {"
+    "  const element = document.getElementById('AppleMailSignature');"
+    "  const range = document.createRange();"
+    "  range.setStart(element.childNodes[1], 20);"
+    "  range.setEnd(element.childNodes[1], 20);"
+    "  "
+    "  var selection = window.getSelection();"
+    "  selection.removeAllRanges();"
+    "  selection.addRange(range);"
+    "})();";
+    [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
+
+    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.mainBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic" subdirectory:@"TestWebKitAPI.resources"]];
+
+    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+
+    [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
+    [webView waitForNextPresentationUpdate];
+
+    auto attachmentSortFunction = ^(_WKAttachment *a, _WKAttachment *b) {
+        return [a.info.contentType compare:b.info.contentType];
+    };
+
+    auto insertedAttachments = [[webView insertedAttachments] sortedArrayUsingComparator:attachmentSortFunction];
+    EXPECT_EQ(insertedAttachments.count, 2U);
+    EXPECT_EQ([[webView removedAttachments] count], 0U);
+
+    auto heicAttachment = [insertedAttachments objectAtIndex:0];
+    auto heicAttachmentInfo = heicAttachment.info;
+    EXPECT_WK_STREQ(heicAttachmentInfo.contentType, "image/heic");
+    EXPECT_TRUE([heicAttachmentInfo.name containsString:@"heic"]);
+    EXPECT_EQ(heicAttachmentInfo.data.length, 23499U);
+    EXPECT_TRUE(heicAttachmentInfo.shouldPreserveFidelity);
+
+    auto pngAttachment = [insertedAttachments objectAtIndex:1];
+    auto pngAttachmentInfo =  pngAttachment.info;
+    EXPECT_WK_STREQ(pngAttachmentInfo.contentType, "image/png");
+    EXPECT_TRUE([pngAttachmentInfo.name containsString:@"png"]);
+    EXPECT_EQ(pngAttachmentInfo.data.length, 2986U);
+    EXPECT_FALSE(pngAttachmentInfo.shouldPreserveFidelity);
+
+    EXPECT_TRUE([[webView stringByEvaluatingJavaScript:@"document.querySelector('source').attachmentIdentifier"] isEqualToString:heicAttachment.uniqueIdentifier]);
+    EXPECT_TRUE([[webView stringByEvaluatingJavaScript:@"document.querySelector('img').attachmentIdentifier"] isEqualToString:pngAttachment.uniqueIdentifier]);
+}
+
 TEST(AdaptiveImageGlyph, InsertMultiple)
 {
     auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 800)]);


### PR DESCRIPTION
#### 1235e0b1e525aa28ff5572f3d3624ea273eab719
<pre>
[Cocoa] Mail sometimes shows placeholder text instead of an adaptive image glyph
<a href="https://bugs.webkit.org/show_bug.cgi?id=277937">https://bugs.webkit.org/show_bug.cgi?id=277937</a>
<a href="https://rdar.apple.com/130934430">rdar://130934430</a>

Reviewed by Richard Robinson.

Adaptive image glyph attachments are occasionally going missing in Mail. In the
failure scenario, it is observed that `-[WKWebView _webView:didInsertAttachment:withSource:]`
is not being called.

The cause of the issue is due to the fact that attachment elements are created
and attached to the originally created `&lt;source&gt;` and `&lt;img&gt;` elements after
the `ReplaceSelectionCommand` performed. This is problematic as
`ReplaceSelectionCommand` may clone nodes and discard the original, in order
to merge paragraphs. Consequently, the attachment elements can be added to
&quot;stale&quot; nodes which are never actually inserted into the document.

Fix by creating and associating attachment elements prior to performing
the `ReplaceSelectionCommand`. This ensures that attachment elements are
always present on the nodes which end up in the document.

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::insertMultiRepresentationHEIC):

Associate attachments before performing the `ReplaceSelectionCommand`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm:
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)):

Use a test case directly from real Mail content.

Canonical link: <a href="https://commits.webkit.org/282121@main">https://commits.webkit.org/282121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ae76241771acd32304504b91d88949cf5368290

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50030 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6056 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11105 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57407 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4969 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9353 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37267 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38351 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->