### PR TITLE
Introducing CONJECTURE_ASSERT.

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -754,6 +754,24 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 
 #endif /* ASSERT_ENABLED */
 
+/* CONJECTURE_ASSERT is only used to facilitate on-going analysis work to test conjectures
+   about the code. We want to be able to land these in the code base for some time to enable
+   extended testing.
+
+   If the conjecture is proven false it, the CONJECTURE_ASSERT should either be removed or
+   updated to test a new conjecture. If the conjecture is proven true, the CONJECTURE_ASSERT
+   should either be promoted to an ASSERT or RELEASE_ASSERT as appropriate, or removed if
+   deemed of low value.
+
+   The number of CONJECTURE_ASSERTs should not be growing unboundedly, and they should not
+   stay in the codebase perpetually.
+ */
+#if ENABLE(CONJECTURE_ASSERT)
+#define CONJECTURE_ASSERT(assertion, ...) RELEASE_ASSERT(assertion, __VA_ARGS__)
+#else
+#define CONJECTURE_ASSERT(assertion, ...)
+#endif
+
 #ifdef __cplusplus
 #define RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE(...) RELEASE_ASSERT_WITH_MESSAGE(assertionFailureDueToUnreachableCode, __VA_ARGS__)
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -104,6 +104,10 @@
 
 /* Do not use PLATFORM() tests in this section ! */
 
+#if !defined(ENABLE_CONJECTURE_ASSERT)
+#define ENABLE_CONJECTURE_ASSERT 0
+#endif
+
 #if !defined(ENABLE_ACCESSIBILITY_ANIMATION_CONTROL)
 #define ENABLE_ACCESSIBILITY_ANIMATION_CONTROL 0
 #endif


### PR DESCRIPTION
#### 70cc817deff298529ad393fdd664cb79a2e8b20e
<pre>
Introducing CONJECTURE_ASSERT.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277938">https://bugs.webkit.org/show_bug.cgi?id=277938</a>
<a href="https://rdar.apple.com/133656316">rdar://133656316</a>

Reviewed by Keith Miller.

CONJECTURE_ASSERT is only used to facilitate on-going analysis work to test conjectures about the code.
We want to be able to land these in the code base for some time to enable extended testing.

If the conjecture is proven false it, the CONJECTURE_ASSERT should either be removed or updated to test
a new conjecture.

If the conjecture is proven true, the CONJECTURE_ASSERT should either be promoted to an ASSERT or
RELEASE_ASSERT as appropriate, or removed if deemed of low value.

The number of CONJECTURE_ASSERTs should not be growing unboundedly, and they should not stay in the
code base perpetually.

* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/PlatformEnable.h:

Canonical link: <a href="https://commits.webkit.org/282132@main">https://commits.webkit.org/282132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be2e7c872126cd027b2c184b92ce6def69d8fe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12661 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50040 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8755 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11042 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11592 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55212 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61358 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6059 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11109 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57415 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57659 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4978 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9357 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37270 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14571 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->