### PR TITLE
Add onpageswap/reveal Window event handlers.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/old_vt_promises_bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/old_vt_promises_bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL VT object created on the old Document is skipped before persisting in BFCache promise_test: Unhandled rejection with value: object "Error: Can't find variable: onpageswap"
+NOTRUN VT object created on the old Document is skipped before persisting in BFCache Should be BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation-expected.txt
@@ -1,10 +1,11 @@
+CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new", "push", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on navigation from script Test timed out
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new", "push", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on navigation from script Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect-expected.txt
@@ -1,10 +1,11 @@
+CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?new", "push", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on navigation with same-origin redirect Test timed out
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?new", "push", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on navigation with same-origin redirect Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation-expected.txt
@@ -1,10 +1,11 @@
+CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?new", "replace", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?new", "replace", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on replace navigation from script Test timed out
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?new", "replace", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?new", "replace", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on replace navigation from script Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View transitions: skipTransition() in pageswap aborts the transition assert_equals: viewTransition must have been skipped. expected null but got object "[object ViewTransition]"
+PASS View transitions: skipTransition() in pageswap aborts the transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt
@@ -1,10 +1,11 @@
+CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on traverse navigation from script Test timed out
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pagehide"] length 1
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
 
 TIMEOUT pageswap on traverse navigation from script Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View transitions: types from rule are reflected in pagereveal and pageswap assert_array_equals: lengths differ, expected array ["check"] length 1, got [] length 0
+FAIL View transitions: types from rule are reflected in pagereveal and pageswap promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'ev.viewTransition.types')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/zero-named-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/zero-named-elements-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT transition finishes with no named elements Test timed out
+PASS transition finishes with no named elements
 

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -283,7 +283,9 @@ onoffline
 ononline
 onorientationchange
 onpagehide
+onpagereveal
 onpageshow
+onpageswap
 onpaste
 onpause
 onplay

--- a/Source/WebCore/page/WindowEventHandlers.idl
+++ b/Source/WebCore/page/WindowEventHandlers.idl
@@ -36,7 +36,9 @@ interface mixin WindowEventHandlers {
     [WindowEventHandler] attribute EventHandler onoffline;
     [WindowEventHandler] attribute EventHandler ononline;
     [WindowEventHandler] attribute EventHandler onpagehide;
+    [WindowEventHandler] attribute EventHandler onpagereveal;
     [WindowEventHandler] attribute EventHandler onpageshow;
+    [WindowEventHandler] attribute EventHandler onpageswap;
     [WindowEventHandler] attribute EventHandler onpopstate;
     [WindowEventHandler] attribute EventHandler onrejectionhandled;
     [WindowEventHandler] attribute EventHandler onstorage;


### PR DESCRIPTION
#### de17411e291c99b64b301ad643944293e6ca0e8c
<pre>
Add onpageswap/reveal Window event handlers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277940">https://bugs.webkit.org/show_bug.cgi?id=277940</a>
&lt;<a href="https://rdar.apple.com/133660588">rdar://133660588</a>&gt;

Reviewed by Tim Nguyen.

Lots of the tests wait on these, rather than the version without &apos;on&apos;.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/old_vt_promises_bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/zero-named-elements-expected.txt:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/page/WindowEventHandlers.idl:

Canonical link: <a href="https://commits.webkit.org/282139@main">https://commits.webkit.org/282139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05f2e27f8df8621a1000befe1bd496bbfb786317

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50058 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11061 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57432 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57667 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4998 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37282 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->