### PR TITLE
[JSC] Parse a critical flag on TZ annotation for Temporal

### DIFF
--- a/JSTests/stress/temporal-instant-tz-critical-flags.js
+++ b/JSTests/stress/temporal-instant-tz-critical-flags.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useTemporal=1")
+
+const cases = [
+    ["1970-01-01T00:00:00Z[!UTC]", "1970-01-01T00:00:00Z[!UTC]"],
+    ["1970-01-01T00:00:00Z[!UTC]", "1970-01-01T00:00:00Z"],
+    ["1970-01-01T00:00:00+02:00[!UTC]", "1970-01-01T00:00:00+02:00"],
+    ["1970-01-01T00:00:00+09:00[!UTC]", "1970-01-01T00:00:00+09:00[Asia/Tokyo]"]
+];
+
+for (const [str1, str2] of cases) {
+    const instant = Temporal.Instant.from(str1);
+    if (!instant.equals(str2))
+        throw new Error(`"${str1}" and "${str2}" should result in the same Temporal.Instant.`)
+}

--- a/JSTests/stress/temporal-plaindate-tz-critical-flags.js
+++ b/JSTests/stress/temporal-plaindate-tz-critical-flags.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useTemporal=1")
+
+const cases = [
+    ["2000-05-02T00+00:00[!UTC]", "2000-05-02T00+00:00[!UTC]"],
+    ["2000-05-02T00+00:00[!UTC]", "2000-05-02T00+00:00"],
+    ["2000-05-02T00+02:00[!UTC]", "2000-05-02T00+02:00"],
+    ["2000-05-02T00+09:00[!UTC]", "2000-05-02T00+09:00[Asia/Tokyo]"],
+];
+
+for (const [str1, str2] of cases) {
+    const plainDate = Temporal.PlainDate.from(str1);
+    if (!plainDate.equals(str2))
+        throw new Error(`"${str1}" and "${str2}" should result in the same Temporal.PlainDate.`)
+}

--- a/JSTests/stress/temporal-plaindatetime-tz-critical-flags.js
+++ b/JSTests/stress/temporal-plaindatetime-tz-critical-flags.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useTemporal=1")
+
+const cases = [
+    ["1976-11-18T15:23+00:00[!UTC]", "1976-11-18T15:23+00:00[!UTC]"],
+    ["1976-11-18T15:23+00:00[!UTC]", "1976-11-18T15:23+00:00"],
+    ["1976-11-18T15:23+02:00[!UTC]", "1976-11-18T15:23+02:00"],
+    ["1976-11-18T15:23+09:00[!UTC]", "1976-11-18T15:23+09:00[Asia/Tokyo]"],
+];
+
+for (const [str1, str2] of cases) {
+    const plainDateTime = Temporal.PlainDateTime.from(str1);
+    if (!plainDateTime.equals(str2))
+        throw new Error(`"${str1}" and "${str2}" should result in the same Temporal.PlainDateTime.`)
+}

--- a/JSTests/stress/temporal-plaintime-tz-critical-flags.js
+++ b/JSTests/stress/temporal-plaintime-tz-critical-flags.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useTemporal=1")
+
+const cases = [
+    ["12:34:56.987654321+00:00[!UTC]", "12:34:56.987654321+00:00[!UTC]"],
+    ["12:34:56.987654321+00:00[!UTC]", "12:34:56.987654321+00:00"],
+    ["12:34:56.987654321+02:00[!UTC]", "12:34:56.987654321+02:00"],
+    ["12:34:56.987654321+09:00[!UTC]", "12:34:56.987654321+09:00[Asia/Tokyo]"],
+];
+
+for (const [str1, str2] of cases) {
+    const plainTime = Temporal.PlainTime.from(str1);
+    if (!plainTime.equals(str2))
+        throw new Error(`"${str1}" and "${str2}" should result in the same Temporal.PlainTime.`)
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -248,14 +248,14 @@ test/built-ins/Temporal/Duration/prototype/total/total-of-each-unit-relativeto.j
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(63072000_000_000_000n /* = 1972-01-01T00Z */, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(63072000_000_000_000n /* = 1972-01-01T00Z */, \"UTC\")')"
 test/built-ins/Temporal/Instant/compare/argument-string-date-with-utc-offset.js:
-  default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-  strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
+  default: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/compare/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/from/argument-string-date-with-utc-offset.js:
-  default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-  strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
+  default: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/from/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -266,8 +266,8 @@ test/built-ins/Temporal/Instant/prototype/epochMilliseconds/basic.js:
   default: 'Test262Error: epochMilliseconds pre epoch Expected SameValue(«-217175010876», «-217175010877») to be true'
   strict mode: 'Test262Error: epochMilliseconds pre epoch Expected SameValue(«-217175010876», «-217175010877») to be true'
 test/built-ins/Temporal/Instant/prototype/equals/argument-string-date-with-utc-offset.js:
-  default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-  strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
+  default: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/prototype/equals/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -275,8 +275,8 @@ test/built-ins/Temporal/Instant/prototype/equals/instant-string-sub-minute-offse
   default: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/prototype/since/argument-string-date-with-utc-offset.js:
-  default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-  strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
+  default: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/prototype/since/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -326,8 +326,8 @@ test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js:
   default: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
   strict mode: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/prototype/until/argument-string-date-with-utc-offset.js:
-  default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-  strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
+  default: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15Z" UTC offset without time is not valid for Instant Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/prototype/until/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -386,8 +386,8 @@ test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-iso-stri
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDate/compare/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid date string'
-  strict mode: 'RangeError: invalid date string'
+  default: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/compare/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
@@ -524,8 +524,8 @@ test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid date string'
-  strict mode: 'RangeError: invalid date string'
+  default: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -533,8 +533,8 @@ test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDate/prototype/since/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid date string'
-  strict mode: 'RangeError: invalid date string'
+  default: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/prototype/since/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -608,8 +608,8 @@ test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDate/prototype/until/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid date string'
-  strict mode: 'RangeError: invalid date string'
+  default: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDate Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/prototype/until/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -677,8 +677,8 @@ test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-iso-
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDateTime/compare/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid date string'
-  strict mode: 'RangeError: invalid date string'
+  default: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDateTime (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDateTime (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDateTime/compare/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
@@ -815,8 +815,8 @@ test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-cale
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid date string'
-  strict mode: 'RangeError: invalid date string'
+  default: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDateTime Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: "2022-09-15+00:00" UTC offset without time is not valid for PlainDateTime Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -1003,15 +1003,9 @@ test/built-ins/Temporal/PlainDateTime/second-undefined.js:
 test/built-ins/Temporal/PlainDateTime/subclass.js:
   default: 'Test262Error: Expected SameValue(«undefined», «string») to be true'
   strict mode: 'Test262Error: Expected SameValue(«undefined», «string») to be true'
-test/built-ins/Temporal/PlainTime/compare/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid time string'
-  strict mode: 'RangeError: invalid time string'
 test/built-ins/Temporal/PlainTime/compare/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainTime/from/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid time string'
-  strict mode: 'RangeError: invalid time string'
 test/built-ins/Temporal/PlainTime/from/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -1024,15 +1018,9 @@ test/built-ins/Temporal/PlainTime/prototype/add/argument-duration-out-of-range.j
 test/built-ins/Temporal/PlainTime/prototype/add/precision-exact-mathematical-values-1.js:
   default: 'Test262Error: microsecond result: Expected SameValue(«992», «993») to be true'
   strict mode: 'Test262Error: microsecond result: Expected SameValue(«992», «993») to be true'
-test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid time string'
-  strict mode: 'RangeError: invalid time string'
 test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainTime/prototype/since/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid time string'
-  strict mode: 'RangeError: invalid time string'
 test/built-ins/Temporal/PlainTime/prototype/since/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
@@ -1048,9 +1036,6 @@ test/built-ins/Temporal/PlainTime/prototype/subtract/precision-exact-mathematica
 test/built-ins/Temporal/PlainTime/prototype/toString/order-of-operations.js:
   default: 'Test262Error: Expected [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainTime/prototype/until/argument-string-date-with-utc-offset.js:
-  default: 'RangeError: invalid time string'
-  strict mode: 'RangeError: invalid time string'
 test/built-ins/Temporal/PlainTime/prototype/until/argument-string-minus-sign.js:
   default: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: variant minus sign: 1976-11-18T15:23:30.12−02:00 Expected a RangeError to be thrown but no exception was thrown at all'

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -580,6 +580,9 @@ static std::optional<std::variant<Vector<LChar>, int64_t>> parseTimeZoneBrackete
         return std::nullopt;
     buffer.advance();
 
+    if (*buffer == '!')
+        buffer.advance();
+
     switch (static_cast<UChar>(*buffer)) {
     case '+':
     case '-':


### PR DESCRIPTION
#### 380f93b87d14ee78a1e693ac3794e0588e874d64
<pre>
[JSC] Parse a critical flag on TZ annotation for Temporal
<a href="https://bugs.webkit.org/show_bug.cgi?id=277942">https://bugs.webkit.org/show_bug.cgi?id=277942</a>

Reviewed by Yusuke Suzuki.

RFC 3339[1] and RFC 9557[2] allows that bracketed timezone annotations include a critical flag(!)[3].
It indicate that the parsing should be rejected if there is a conflict between the offset and the
timezone annotation.

Temporal API has added this feature into the spec[4]. While the critical flag does not affect the
behavior of Temporal, parsing must still succeed.

Currently, JSC throws an error when creating a Temporal object from a string that includes a
critical flag.

This patch changes to allow creating Temporal objects from strings that include a critical flag.

[1]: <a href="https://www.rfc-editor.org/rfc/rfc3339">https://www.rfc-editor.org/rfc/rfc3339</a>
[2]: <a href="https://www.rfc-editor.org/rfc/rfc9557">https://www.rfc-editor.org/rfc/rfc9557</a>
[3]: <a href="https://www.rfc-editor.org/rfc/rfc9557.html#name-inconsistent-time-offset-an">https://www.rfc-editor.org/rfc/rfc9557.html#name-inconsistent-time-offset-an</a>
[4]: <a href="https://github.com/tc39/proposal-temporal/pull/2397">https://github.com/tc39/proposal-temporal/pull/2397</a>

* JSTests/stress/temporal-instant-tz-critical-flags.js: Added.
* JSTests/stress/temporal-plaindate-tz-critical-flags.js: Added.
* JSTests/stress/temporal-plaindatetime-tz-critical-flags.js: Added.
* JSTests/stress/temporal-plaintime-tz-critical-flags.js: Added.
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseTimeZoneBracketedAnnotation):

Canonical link: <a href="https://commits.webkit.org/282211@main">https://commits.webkit.org/282211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adc232e35deea4abcca7fe9e534b7b13f97332c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12669 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50050 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8761 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11600 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55220 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67833 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61366 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6067 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57664 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4992 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83130 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9398 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37278 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14573 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->