### PR TITLE
[LFC] Perform nested float layout from IFC

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1852,6 +1852,7 @@ layout/integration/inline/LayoutIntegrationPagination.cpp
 layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
 layout/integration/LayoutIntegrationBoxTree.cpp
 layout/integration/LayoutIntegrationCoverage.cpp
+layout/integration/LayoutIntegrationFormattingContextLayout.cpp
 layout/layouttree/LayoutBox.cpp
 layout/layouttree/LayoutBoxGeometry.cpp
 layout/layouttree/LayoutElementBox.cpp

--- a/Source/WebCore/layout/LayoutState.cpp
+++ b/Source/WebCore/layout/LayoutState.cpp
@@ -42,10 +42,11 @@ namespace Layout {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LayoutState);
 
-LayoutState::LayoutState(const Document& document, const ElementBox& rootContainer, Type type)
+LayoutState::LayoutState(const Document& document, const ElementBox& rootContainer, Type type, Function<void(const ElementBox&, LayoutState&)>&& formattingContextLayoutFunction)
     : m_type(type)
     , m_rootContainer(rootContainer)
     , m_securityOrigin(document.securityOrigin())
+    , m_formattingContextLayoutFunction(WTFMove(formattingContextLayoutFunction))
 {
     // It makes absolutely no sense to construct a dedicated layout state for a non-formatting context root (layout would be a no-op).
     ASSERT(root().establishesFormattingContext());
@@ -148,6 +149,11 @@ void LayoutState::destroyInlineContentCache(const ElementBox& formattingContextR
 {
     ASSERT(formattingContextRoot.establishesInlineFormattingContext());
     m_inlineContentCaches.remove(&formattingContextRoot);
+}
+
+void LayoutState::layoutWithFormattingContextForBox(const ElementBox& box)
+{
+    return m_formattingContextLayoutFunction(box, *this);
 }
 
 }

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -62,7 +62,7 @@ public:
     // Primary layout state has a direct geometry cache in layout boxes.
     enum class Type { Primary, Secondary };
 
-    LayoutState(const Document&, const ElementBox& rootContainer, Type);
+    LayoutState(const Document&, const ElementBox& rootContainer, Type, Function<void(const ElementBox&, LayoutState&)>&& formattingContextLayoutFunction);
     ~LayoutState();
 
     Type type() const { return m_type; }
@@ -103,6 +103,8 @@ public:
 
     const ElementBox& root() const { return m_rootContainer; }
 
+    void layoutWithFormattingContextForBox(const ElementBox&);
+
 private:
     void setQuirksMode(QuirksMode quirksMode) { m_quirksMode = quirksMode; }
     BoxGeometry& ensureGeometryForBoxSlow(const Box&);
@@ -122,6 +124,8 @@ private:
 
     CheckedRef<const ElementBox> m_rootContainer;
     Ref<SecurityOrigin> m_securityOrigin;
+
+    Function<void(const ElementBox&, LayoutState&)> m_formattingContextLayoutFunction;
 };
 
 inline bool LayoutState::hasBoxGeometry(const Box& layoutBox) const

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
@@ -35,8 +35,10 @@
 #include "LayoutDescendantIterator.h"
 #include "LayoutElementBox.h"
 #include "LayoutInitialContainingBlock.h"
+#include "LayoutIntegrationBoxGeometryUpdater.h"
 #include "LayoutState.h"
 #include "Logging.h"
+#include "RenderBlockFlow.h"
 #include "RenderStyleInlines.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -90,7 +90,7 @@ static bool isEmptyInlineContent(const InlineItemList& inlineItemList)
 
 InlineFormattingContext::InlineFormattingContext(const ElementBox& rootBlockContainer, LayoutState& layoutState, BlockLayoutState& parentBlockLayoutState)
     : m_rootBlockContainer(rootBlockContainer)
-    , m_layoutState(layoutState)
+    , m_globalLayoutState(layoutState)
     , m_floatingContext(rootBlockContainer, layoutState, parentBlockLayoutState.placedFloats())
     , m_inlineFormattingUtils(*this)
     , m_inlineQuirks(*this)
@@ -327,11 +327,14 @@ void InlineFormattingContext::layoutFloatContentOnly(const ConstraintsForInlineC
     auto floatingContext = this->floatingContext();
     auto& placedFloats = layoutState().placedFloats();
 
-    InlineItemsBuilder { inlineContentCache, root(), m_layoutState.securityOrigin() }.build({ });
+    InlineItemsBuilder { inlineContentCache, root(), m_globalLayoutState.securityOrigin() }.build({ });
 
     for (auto& inlineItem : inlineContentCache.inlineItems().content()) {
         if (inlineItem.isFloat()) {
             auto& floatBox = inlineItem.layoutBox();
+
+            layoutWithFormattingContextForBox(downcast<ElementBox>(floatBox));
+
             auto& floatBoxGeometry = geometryForBox(floatBox);
             auto staticPosition = LayoutPoint { constraints.horizontal().logicalLeft, constraints.logicalTop() };
             staticPosition.move(floatBoxGeometry.marginStart(), floatBoxGeometry.marginBefore());
@@ -507,13 +510,13 @@ static inline bool isOkToAccessBoxGeometry(const Box& layoutBox, const ElementBo
 const BoxGeometry& InlineFormattingContext::geometryForBox(const Box& layoutBox, std::optional<EscapeReason> escapeReason) const
 {
     ASSERT_UNUSED(escapeReason, isOkToAccessBoxGeometry(layoutBox, root(), escapeReason));
-    return m_layoutState.geometryForBox(layoutBox);
+    return m_globalLayoutState.geometryForBox(layoutBox);
 }
 
 BoxGeometry& InlineFormattingContext::geometryForBox(const Box& layoutBox, std::optional<EscapeReason> escapeReason)
 {
     ASSERT_UNUSED(escapeReason, isOkToAccessBoxGeometry(layoutBox, root(), escapeReason));
-    return m_layoutState.ensureGeometryForBox(layoutBox);
+    return m_globalLayoutState.ensureGeometryForBox(layoutBox);
 }
 
 void InlineFormattingContext::rebuildInlineItemListIfNeeded(InlineDamage* lineDamage)
@@ -538,11 +541,17 @@ void InlineFormattingContext::rebuildInlineItemListIfNeeded(InlineDamage* lineDa
         // Unsupported damage. Need to run full build/layout.
         return { };
     };
-    InlineItemsBuilder { inlineContentCache, root(), m_layoutState.securityOrigin() }.build(startPositionForInlineItemsBuilding());
+    InlineItemsBuilder { inlineContentCache, root(), m_globalLayoutState.securityOrigin() }.build(startPositionForInlineItemsBuilding());
     if (lineDamage)
         lineDamage->setInlineItemListClean();
     inlineContentCache.clearMaximumIntrinsicWidthLineContent();
 }
+
+void InlineFormattingContext::layoutWithFormattingContextForBox(const ElementBox& box)
+{
+    m_globalLayoutState.layoutWithFormattingContextForBox(box);
+}
+
 
 }
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -71,6 +71,8 @@ public:
     InlineLayoutState& layoutState() { return m_inlineLayoutState; }
     const InlineLayoutState& layoutState() const { return m_inlineLayoutState; }
 
+    void layoutWithFormattingContextForBox(const ElementBox&);
+
     enum class EscapeReason {
         InkOverflowNeedsInitialContiningBlockForStrokeWidth
     };
@@ -95,7 +97,7 @@ private:
 
 private:
     const ElementBox& m_rootBlockContainer;
-    LayoutState& m_layoutState;
+    LayoutState& m_globalLayoutState;
     const FloatingContext m_floatingContext;
     const InlineFormattingUtils m_inlineFormattingUtils;
     const InlineQuirks m_inlineQuirks;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -909,6 +909,8 @@ bool LineBuilder::tryPlacingFloatBox(const Box& floatBox, MayOverConstrainLine m
     if (isFloatLayoutSuspended())
         return false;
 
+    formattingContext().layoutWithFormattingContextForBox(downcast<ElementBox>(floatBox));
+
     auto& floatingContext = this->floatingContext();
     auto boxGeometry = [&]() -> BoxGeometry {
         auto marginTrim = rootStyle().marginTrim();

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -75,6 +75,8 @@ static Layout::Box::ElementAttributes elementAttributes(const RenderElement& ren
             return is<RenderImage>(renderer) ? Layout::Box::NodeType::Image : Layout::Box::NodeType::ReplacedElement;
         if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer))
             return renderLineBreak->isWBR() ? Layout::Box::NodeType::WordBreakOpportunity : Layout::Box::NodeType::LineBreak;
+        if (is<RenderTable>(renderer))
+            return Layout::Box::NodeType::TableBox;
         return Layout::Box::NodeType::GenericElement;
     }();
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LayoutIntegrationFormattingContextLayout.h"
+
+#include "LayoutIntegrationBoxGeometryUpdater.h"
+#include "RenderElement.h"
+
+namespace WebCore {
+namespace LayoutIntegration {
+
+void layoutWithFormattingContextForBox(const Layout::ElementBox& box, Layout::LayoutState& layoutState)
+{
+    ASSERT(box.establishesFormattingContext());
+
+    auto& renderer = *box.rendererForIntegration();
+    renderer.layoutIfNeeded();
+
+    auto updater = BoxGeometryUpdater { layoutState };
+    updater.updateGeometryAfterLayout(box);
+}
+
+}
+}

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+namespace Layout {
+
+class ElementBox;
+class LayoutState;
+}
+
+namespace LayoutIntegration {
+
+void layoutWithFormattingContextForBox(const Layout::ElementBox&, Layout::LayoutState&);
+
+}
+}

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -66,6 +66,11 @@ BoxGeometryUpdater::BoxGeometryUpdater(BoxTree& boxTree, Layout::LayoutState& la
 {
 }
 
+BoxGeometryUpdater::BoxGeometryUpdater(Layout::LayoutState& layoutState)
+    : m_layoutState(layoutState)
+{
+}
+
 void BoxGeometryUpdater::updateListMarkerDimensions(const RenderListMarker& listMarker, std::optional<Layout::IntrinsicWidthMode> intrinsicWidthMode)
 {
     updateLayoutBoxDimensions(listMarker, intrinsicWidthMode);
@@ -341,6 +346,9 @@ void BoxGeometryUpdater::setGeometriesForLayout()
         if (is<RenderText>(renderer))
             continue;
 
+        if (renderer.isFloating())
+            continue;
+
         if (is<RenderReplaced>(renderer) || is<RenderTable>(renderer) || is<RenderListItem>(renderer) || is<RenderBlock>(renderer) || is<RenderFrameSet>(renderer)) {
             updateLayoutBoxDimensions(downcast<RenderBox>(renderer));
             continue;
@@ -420,6 +428,16 @@ Layout::ConstraintsForInlineContent BoxGeometryUpdater::updateInlineContentConst
     createRootGeometryIfNeeded();
 
     return { { horizontalConstraints, contentBoxTop }, visualLeft };
+}
+
+void BoxGeometryUpdater::updateGeometryAfterLayout(const Layout::ElementBox& box)
+{
+    auto* renderer = dynamicDowncast<RenderBox>(box.rendererForIntegration());
+    if (!renderer) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    updateLayoutBoxDimensions(*renderer);
 }
 
 const Layout::ElementBox& BoxGeometryUpdater::rootLayoutBox() const

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.h
@@ -45,9 +45,11 @@ namespace LayoutIntegration {
 class BoxGeometryUpdater {
 public:
     BoxGeometryUpdater(BoxTree&, Layout::LayoutState&);
+    BoxGeometryUpdater(Layout::LayoutState&);
 
     void setGeometriesForLayout();
     void setGeometriesForIntrinsicWidth(Layout::IntrinsicWidthMode);
+    void updateGeometryAfterLayout(const Layout::ElementBox&);
 
     Layout::ConstraintsForInlineContent updateInlineContentConstraints();
     HashMap<const Layout::ElementBox*, LayoutUnit> takeNestedListMarkerOffsets() { return WTFMove(m_nestedListMarkerOffsets); }

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -92,6 +92,7 @@ bool Box::establishesFormattingContext() const
         || establishesBlockFormattingContext()
         || establishesTableFormattingContext()
         || establishesFlexFormattingContext()
+        || establishesGridFormattingContext()
         || establishesIndependentFormattingContext();
 }
 
@@ -118,7 +119,7 @@ bool Box::establishesBlockFormattingContext() const
     if (isFloatingPositioned()) {
         // Not all floating or out-of-positioned block level boxes establish BFC.
         // See [9.7 Relationships between 'display', 'position', and 'float'] for details.
-        return style().display() == DisplayType::Block;
+        return isBlockContainer();
     }
 
     if (isBlockContainer() && !isBlockBox())
@@ -160,6 +161,11 @@ bool Box::establishesTableFormattingContext() const
 bool Box::establishesFlexFormattingContext() const
 {
     return isFlexBox();
+}
+
+bool Box::establishesGridFormattingContext() const
+{
+    return isGridBox();
 }
 
 bool Box::establishesIndependentFormattingContext() const

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -83,6 +83,7 @@ public:
     bool establishesInlineFormattingContext() const;
     bool establishesTableFormattingContext() const;
     bool establishesFlexFormattingContext() const;
+    bool establishesGridFormattingContext() const;
     bool establishesIndependentFormattingContext() const;
 
     bool isInFlow() const { return !isFloatingOrOutOfFlowPositioned(); }
@@ -141,6 +142,7 @@ public:
     bool isInternalTableBox() const;
     bool isFlexBox() const { return style().display() == DisplayType::Flex || style().display() == DisplayType::InlineFlex; }
     bool isFlexItem() const;
+    bool isGridBox() const { return style().display() == DisplayType::Grid || style().display() == DisplayType::InlineGrid; }
     bool isIFrame() const { return m_nodeType == NodeType::IFrame; }
     bool isImage() const { return m_nodeType == NodeType::Image; }
     bool isLineBreakBox() const { return m_nodeType == NodeType::LineBreak || m_nodeType == NodeType::WordBreakOpportunity; }

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "LayoutElementBox.h"
 
+#include "RenderElement.h"
 #include "RenderStyleInlines.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -215,6 +216,11 @@ LayoutUnit ElementBox::intrinsicRatio() const
 bool ElementBox::hasAspectRatio() const
 {
     return isImage();
+}
+
+RenderElement* ElementBox::rendererForIntegration() const
+{
+    return downcast<RenderElement>(Box::rendererForIntegration());
 }
 
 }

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class CachedImage;
+class RenderElement;
 class RenderStyle;
 
 namespace Layout {
@@ -96,6 +97,8 @@ public:
 
     // FIXME: This doesn't belong.
     CachedImage* cachedImage() const { return m_replacedData ? m_replacedData->cachedImage : nullptr; }
+
+    RenderElement* rendererForIntegration() const;
 
 private:
     friend class Box;

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -579,7 +579,7 @@ void printLayoutTreeForLiveDocuments()
         // FIXME: Need to find a way to output geometry without layout context.
         auto& renderView = *document->renderView();
         auto layoutTree = TreeBuilder::buildLayoutTree(renderView);
-        auto layoutState = LayoutState { document, layoutTree->root(), Layout::LayoutState::Type::Secondary };
+        auto layoutState = LayoutState { document, layoutTree->root(), Layout::LayoutState::Type::Secondary, { } };
 
         LayoutContext(layoutState).layout(renderView.size());
         showLayoutTree(downcast<InitialContainingBlock>(layoutState.root()), &layoutState);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3947,9 +3947,9 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
             setFullRepaintOnParentInlineBoxLayerIfNeeded(*renderText);
 
         auto shouldRunInFlowLayout = renderer.isInFlow() && is<RenderElement>(renderer) && !is<RenderLineBreak>(renderer) && !is<RenderInline>(renderer) && !is<RenderCounter>(renderer);
-        if (shouldRunInFlowLayout || renderer.isFloating())
+        if (shouldRunInFlowLayout)
             downcast<RenderElement>(renderer).layoutIfNeeded();
-        else if (!renderer.isOutOfFlowPositioned())
+        else if (!renderer.isOutOfFlowPositioned() && !renderer.isFloating())
             renderer.clearNeedsLayout();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE) && ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -35,6 +35,7 @@
 #include "ImageQualityController.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutInitialContainingBlock.h"
+#include "LayoutIntegrationFormattingContextLayout.h"
 #include "LayoutState.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LocalFrame.h"
@@ -79,7 +80,7 @@ RenderView::RenderView(Document& document, RenderStyle&& style)
     : RenderBlockFlow(Type::View, document, WTFMove(style))
     , m_frameView(*document.view())
     , m_initialContainingBlock(makeUniqueRef<Layout::InitialContainingBlock>(RenderStyle::clone(this->style())))
-    , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, *m_initialContainingBlock, Layout::LayoutState::Type::Primary))
+    , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, *m_initialContainingBlock, Layout::LayoutState::Type::Primary, LayoutIntegration::layoutWithFormattingContextForBox))
     , m_selection(*this)
 {
     // FIXME: We should find a way to enforce this at compile time.


### PR DESCRIPTION
#### 3637bd1b58352db313aef075f91e59b27a693281
<pre>
[LFC] Perform nested float layout from IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=277732">https://bugs.webkit.org/show_bug.cgi?id=277732</a>
<a href="https://rdar.apple.com/133374470">rdar://133374470</a>

Reviewed by Alan Baradlay.

Add a mechanism to call back into render tree layout code from formatting context layout
and use it for IFC floats. This mechanism will be important for flex where we must invoke
nested layout from the middle.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/LayoutState.cpp:
(WebCore::Layout::LayoutState::LayoutState):
(WebCore::Layout::LayoutState::layoutWithFormattingContextForBox):

Keep callback function in LayoutState.

* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/formattingContexts/FormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::InlineFormattingContext):
(WebCore::Layout::InlineFormattingContext::layoutFloatContentOnly):

Use the nested layout mechanism for floats.

(WebCore::Layout::InlineFormattingContext::geometryForBox const):
(WebCore::Layout::InlineFormattingContext::geometryForBox):
(WebCore::Layout::InlineFormattingContext::rebuildInlineItemListIfNeeded):
(WebCore::Layout::InlineFormattingContext::layoutWithFormattingContextForBox):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::tryPlacingFloatBox):

Use the nested layout mechanism for floats.

* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::elementAttributes):

Fix the node type for render tree tables show they establish a formatting context.

* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp: Added.
(WebCore::LayoutIntegration::layoutWithFormattingContextForBox):

Integration layout function that calls back into render tree and updates the geometry after.

* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::BoxGeometryUpdater):
(WebCore::LayoutIntegration::BoxGeometryUpdater::setGeometriesForLayout):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateGeometryAfterLayout):

Add function for post-layout geometry update.

* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.h:
* Source/WebCore/layout/layouttree/LayoutElementBox.cpp:
(WebCore::Layout::ElementBox::rendererForIntegration const):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::printLayoutTreeForLiveDocuments):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):

Don&apos;t layout floats before entering IFC.

* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RenderView):

Establish the layout callback function.

Canonical link: <a href="https://commits.webkit.org/282112@main">https://commits.webkit.org/282112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6f8a29c64477267348ed9d121bdf1a244af956

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12674 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50060 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8765 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56942 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57436 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13803 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5002 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37283 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->