### PR TITLE
Use dynamicdowncast in MathMLTokenElement.cpp.

### DIFF
--- a/Source/WebCore/mathml/MathMLTokenElement.cpp
+++ b/Source/WebCore/mathml/MathMLTokenElement.cpp
@@ -54,17 +54,15 @@ Ref<MathMLTokenElement> MathMLTokenElement::create(const QualifiedName& tagName,
 void MathMLTokenElement::didAttachRenderers()
 {
     MathMLPresentationElement::didAttachRenderers();
-    auto* mathmlRenderer = renderer();
-    if (is<RenderMathMLToken>(mathmlRenderer))
-        downcast<RenderMathMLToken>(*mathmlRenderer).updateTokenContent();
+    if (CheckedPtr mathmlRenderer = dynamicDowncast<RenderMathMLToken>(renderer()))
+        mathmlRenderer->updateTokenContent();
 }
 
 void MathMLTokenElement::childrenChanged(const ChildChange& change)
 {
     MathMLPresentationElement::childrenChanged(change);
-    auto* mathmlRenderer = renderer();
-    if (is<RenderMathMLToken>(mathmlRenderer))
-        downcast<RenderMathMLToken>(*mathmlRenderer).updateTokenContent();
+    if (CheckedPtr mathmlRenderer = dynamicDowncast<RenderMathMLToken>(renderer()))
+        mathmlRenderer->updateTokenContent();
 }
 
 RenderPtr<RenderElement> MathMLTokenElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)


### PR DESCRIPTION
#### 5fff80695a55b0315bcd4dc6bec64789a4cf03e1
<pre>
Use dynamicdowncast in MathMLTokenElement.cpp.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277947">https://bugs.webkit.org/show_bug.cgi?id=277947</a>

Reviewed by Tim Nguyen.

Use dynamicdowncast in MathMLTokenElement.cpp.

* Source/WebCore/mathml/MathMLTokenElement.cpp:
(WebCore::MathMLTokenElement::didAttachRenderers):
(WebCore::MathMLTokenElement::childrenChanged):

Canonical link: <a href="https://commits.webkit.org/282119@main">https://commits.webkit.org/282119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec950dd4d87f9b3d6fffddfbd0f16bf8a8c2373

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50066 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30876 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11610 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67843 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6077 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11143 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5008 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->