### PR TITLE
[LFC][IFC] Perform nested layouts from IFC

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -658,6 +658,9 @@ void LineBuilder::candidateContentForLine(LineCandidate& lineCandidate, size_t c
         auto& inlineItem = m_inlineItemList[index];
         auto& style = isFirstFormattedLine() ? inlineItem.firstLineStyle() : inlineItem.style();
 
+        if (inlineItem.isFloat() || inlineItem.isBox())
+            formattingContext().layoutWithFormattingContextForBox(downcast<ElementBox>(inlineItem.layoutBox()));
+
         if (inlineItem.isFloat()) {
             lineCandidate.floatItem = &inlineItem;
             // This is a soft wrap opportunity, must be the only item in the list.
@@ -908,8 +911,6 @@ bool LineBuilder::tryPlacingFloatBox(const Box& floatBox, MayOverConstrainLine m
 {
     if (isFloatLayoutSuspended())
         return false;
-
-    formattingContext().layoutWithFormattingContextForBox(downcast<ElementBox>(floatBox));
 
     auto& floatingContext = this->floatingContext();
     auto boxGeometry = [&]() -> BoxGeometry {

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -34,8 +34,6 @@ namespace LayoutIntegration {
 
 void layoutWithFormattingContextForBox(const Layout::ElementBox& box, Layout::LayoutState& layoutState)
 {
-    ASSERT(box.establishesFormattingContext());
-
     auto& renderer = *box.rendererForIntegration();
     renderer.layoutIfNeeded();
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -349,22 +349,7 @@ void BoxGeometryUpdater::setGeometriesForLayout()
         if (renderer.isFloating())
             continue;
 
-        if (is<RenderReplaced>(renderer) || is<RenderTable>(renderer) || is<RenderListItem>(renderer) || is<RenderBlock>(renderer) || is<RenderFrameSet>(renderer)) {
-            updateLayoutBoxDimensions(downcast<RenderBox>(renderer));
-            continue;
-        }
-        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderer)) {
-            updateListMarkerDimensions(*renderListMarker);
-            continue;
-        }
-        if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer)) {
-            updateLineBreakBoxDimensions(*renderLineBreak);
-            continue;
-        }
-        if (auto* renderInline = dynamicDowncast<RenderInline>(renderer)) {
-            updateInlineBoxDimensions(*renderInline);
-            continue;
-        }
+        updateGeometryAfterLayout(downcast<RenderElement>(renderer));
     }
 }
 
@@ -432,12 +417,22 @@ Layout::ConstraintsForInlineContent BoxGeometryUpdater::updateInlineContentConst
 
 void BoxGeometryUpdater::updateGeometryAfterLayout(const Layout::ElementBox& box)
 {
-    auto* renderer = dynamicDowncast<RenderBox>(box.rendererForIntegration());
-    if (!renderer) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    updateLayoutBoxDimensions(*renderer);
+    updateGeometryAfterLayout(*dynamicDowncast<RenderBox>(box.rendererForIntegration()));
+}
+
+void BoxGeometryUpdater::updateGeometryAfterLayout(const RenderElement& renderer)
+{
+    if (is<RenderReplaced>(renderer) || is<RenderTable>(renderer) || is<RenderListItem>(renderer) || is<RenderBlock>(renderer) || is<RenderFrameSet>(renderer))
+        updateLayoutBoxDimensions(downcast<RenderBox>(renderer));
+
+    if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderer))
+        updateListMarkerDimensions(*renderListMarker);
+
+    if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer))
+        updateLineBreakBoxDimensions(*renderLineBreak);
+
+    if (auto* renderInline = dynamicDowncast<RenderInline>(renderer))
+        updateInlineBoxDimensions(*renderInline);
 }
 
 const Layout::ElementBox& BoxGeometryUpdater::rootLayoutBox() const

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.h
@@ -59,6 +59,7 @@ private:
     void updateLineBreakBoxDimensions(const RenderLineBreak&);
     void updateInlineBoxDimensions(const RenderInline&, std::optional<Layout::IntrinsicWidthMode> = std::nullopt);
     void updateListMarkerDimensions(const RenderListMarker&, std::optional<Layout::IntrinsicWidthMode> = std::nullopt);
+    void updateGeometryAfterLayout(const RenderElement&);
 
     BoxTree& boxTree() { return *m_boxTree; }
     const BoxTree& boxTree() const { return *m_boxTree; }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3943,17 +3943,17 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
         if (auto* renderText = dynamicDowncast<RenderText>(renderer))
             setFullRepaintOnParentInlineBoxLayerIfNeeded(*renderText);
 
-        if (auto* inlineLevelBox = dynamicDowncast<RenderBlock>(renderer)) {
+        if (auto* inlineLevelBox = dynamicDowncast<RenderBox>(renderer)) {
             // FIXME: Move this to where the actual content change happens and call it on the parent IFC.
-            auto shouldTriggerFullLayout = inlineLevelBox->isInline() && inlineLevelBox->normalChildNeedsLayout() && modernLineLayout();
+            auto shouldTriggerFullLayout = inlineLevelBox->isInline() && inlineLevelBox->needsLayout() && modernLineLayout();
             if (shouldTriggerFullLayout)
                 modernLineLayout()->boxContentWillChange(*inlineLevelBox);
         }
 
-        auto shouldRunInFlowLayout = renderer.isInFlow() && is<RenderElement>(renderer) && !is<RenderLineBreak>(renderer) && !is<RenderInline>(renderer) && !is<RenderCounter>(renderer);
-        if (shouldRunInFlowLayout)
-            downcast<RenderElement>(renderer).layoutIfNeeded();
-        else if (!renderer.isOutOfFlowPositioned() && !renderer.isFloating())
+        if (box && box->style().display() == DisplayType::RubyAnnotation)
+            box->layoutIfNeeded();
+
+        if (is<RenderLineBreak>(renderer) || is<RenderInline>(renderer) || is<RenderText>(renderer))
             renderer.clearNeedsLayout();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE) && ENABLE(AX_THREAD_TEXT_APIS)


### PR DESCRIPTION
#### e83f193e61a566ab4851867605f7c6e5f04c8cf3
<pre>
[LFC][IFC] Perform nested layouts from IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=277949">https://bugs.webkit.org/show_bug.cgi?id=277949</a>
<a href="https://rdar.apple.com/133677700">rdar://133677700</a>

Reviewed by Alan Baradlay.

Cover also non-float cases.

* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::candidateContentForLine):
(WebCore::Layout::LineBuilder::tryPlacingFloatBox):
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
(WebCore::LayoutIntegration::layoutWithFormattingContextForBox):
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::setGeometriesForLayout):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateGeometryAfterLayout):
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):

Canonical link: <a href="https://commits.webkit.org/282348@main">https://commits.webkit.org/282348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/855ffb2c4e601b3e27392f1dca9b3d56ddf5d3c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50716 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58030 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58227 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13949 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5715 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38073 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39153 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->