### PR TITLE
Unreviewed, try to fix the macOS debug build after rdar://129788853

### DIFF
--- a/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.h
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.h
@@ -52,6 +52,8 @@
 - (void)slideDraggedImageTo:(NSPoint)screenPoint;
 - (NSArray *)namesOfPromisedFilesDroppedAtDestination:(NSURL *)dropDestination;
 
+@property (nonatomic, readonly) id localContext;
+
 + (void)clearAllFilePromiseReceivers;
 @end
 

--- a/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
@@ -86,6 +86,7 @@
     NSInteger _numberOfValidItemsForDrop;
 }
 @property (nonatomic) NSPoint lastMousePosition;
+@property (nonatomic, readonly) id localContext;
 @end
 
 @implementation DragInfo

--- a/Tools/TestWebKitAPI/mac/TestDraggingInfo.h
+++ b/Tools/TestWebKitAPI/mac/TestDraggingInfo.h
@@ -42,6 +42,7 @@
 @property (nonatomic, strong) NSImage *draggedImage;
 @property (nonatomic, weak) id draggingSource;
 @property (nonatomic, readonly) NSArray<NSFilePromiseReceiver *> *filePromiseReceivers;
+@property (nonatomic, readonly) id localContext;
 
 @end
 

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerDraggingInfo.h
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerDraggingInfo.h
@@ -48,6 +48,9 @@
 
 - (void)slideDraggedImageTo:(NSPoint)screenPoint;
 - (NSArray *)namesOfPromisedFilesDroppedAtDestination:(NSURL *)dropDestination;
+
+@property (nonatomic, readonly) id localContext;
+
 @end
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### e02d05ca1c3a243db13244675549e322c971ce49
<pre>
Unreviewed, try to fix the macOS debug build after <a href="https://rdar.apple.com/129788853">rdar://129788853</a>
<a href="https://rdar.apple.com/133681792">rdar://133681792</a>

Try to fix the debug macOS build by explicitly declaring a readonly property for `-localContext` in
classes that implement `NSDraggingInfo`, to prevent the compiler from attempting to auto-synthesize
ivars for the readonly property.

* Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.h:
* Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm:
* Tools/TestWebKitAPI/mac/TestDraggingInfo.h:
* Tools/WebKitTestRunner/mac/WebKitTestRunnerDraggingInfo.h:

Canonical link: <a href="https://commits.webkit.org/282118@main">https://commits.webkit.org/282118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dbd2ee0085b056c701b66bd47c563bdf1f4fab3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13037 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65221 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/38555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30893 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11628 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67862 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6095 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53806 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/5036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9351 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37306 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->