### PR TITLE
Release assert in TimerBase::setNextFireTime via DispatchWorkItem::~DispatchWorkItem

### DIFF
--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -728,7 +728,7 @@ void DataDetection::detectContentInFrame(LocalFrame* frame, OptionSet<DataDetect
 
     workQueue().dispatch([scanner = WTFMove(scanner), types, referenceDateFromContext, scanQuery = WTFMove(scanQuery), document = Ref { *document }, fragments = WTFMove(fragments), completionHandler = WTFMove(completionHandler)]() mutable {
         if (!PAL::softLink_DataDetectorsCore_DDScannerScanQuery(scanner.get(), scanQuery.get())) {
-            callOnMainRunLoop([completionHandler = WTFMove(completionHandler)]() mutable {
+            callOnMainRunLoop([scanner = WTFMove(scanner), scanQuery = WTFMove(scanQuery), document = WTFMove(document), fragments = WTFMove(fragments), completionHandler = WTFMove(completionHandler)]() mutable {
                 completionHandler(nil);
             });
             return;


### PR DESCRIPTION
#### 46c9caf0ef79bcb88a2ec52d949df21c8040b8ab
<pre>
Release assert in TimerBase::setNextFireTime via DispatchWorkItem::~DispatchWorkItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=277955">https://bugs.webkit.org/show_bug.cgi?id=277955</a>

Reviewed by Chris Dumez and Wenson Hsieh.

The release assert was hit because we were trying to destruct Document in a background thread.
Fixed the bug by destructing the document and other main-thread only objects in the main thread.

* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::DataDetection::detectContentInFrame):

Canonical link: <a href="https://commits.webkit.org/282128@main">https://commits.webkit.org/282128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbd642058244432498d23491a8acc181483c34f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50098 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56973 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11407 "Found 1 new test failure: http/tests/media/now-playing-info-media-session-artwork-favicon.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11177 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57474 "Found 1 new test failure: fast/forms/search/search-size-with-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57698 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5045 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9355 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->