### PR TITLE
Element reflection attributes should be able to retrieve disconnected elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-disconnected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-disconnected-expected.txt
@@ -1,4 +1,6 @@
 
-FAIL Element references should stay valid when content is disconnected (single element) assert_true: idrefs should continue to work when target is disconnected expected true got false
-FAIL Element references should stay valid when content is disconnected (element array) assert_true: idrefs should continue to work when target is disconnected expected true got false
+
+
+PASS Element references should stay valid when content is disconnected (single element)
+PASS Element references should stay valid when content is disconnected (element array)
 


### PR DESCRIPTION
#### e2e8c4d0c409bcc8195459ee8c2279a9174b95ea
<pre>
Element reflection attributes should be able to retrieve disconnected elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=277956">https://bugs.webkit.org/show_bug.cgi?id=277956</a>
<a href="https://rdar.apple.com/133693674">rdar://133693674</a>

Reviewed by Ryosuke Niwa.

Because disconnected elements are not stored in TreeScope::m_elementsById,
we failed to return them from element reflection getters `Element::getElementAttribute`
and `Element::getElementsArrayAttribute`. But the spec does not require elements
to be connected to be returned from these mechanisms:

<a href="https://html.spec.whatwg.org/#attr-associated-element">https://html.spec.whatwg.org/#attr-associated-element</a>

This patch fixes this by continuing to use TreeScope::getElementById() for connected elements,
and walking the tree to find the element-by-id for disconnected elements.

Inspired by <a href="https://github.com/chromium/chromium/commit/b237124847af1f6a8316af8fb5c78e35bd03df0a.">https://github.com/chromium/chromium/commit/b237124847af1f6a8316af8fb5c78e35bd03df0a.</a>

* LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-disconnected-expected.txt:
Mark this test as passing.

* Source/WebCore/dom/Element.cpp:
(WebCore::getElementByIdIncludingDisconnected):
Added.

(WebCore::Element::getElementAttribute const):
(WebCore::Element::getElementsArrayAttribute const):
Handle disconnected nodes.

(WebCore::Element::customElementDefaultARIA):

Drive-by fix to spelling: deafult -&gt; default
Canonical link: <a href="https://commits.webkit.org/282204@main">https://commits.webkit.org/282204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4259635cd98760faf568d6be7ac7de0031dad20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66355 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50270 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8927 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5252 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37526 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38611 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->