### PR TITLE
Web Inspector: Console: show `boundThis` for arrow functions

### DIFF
--- a/LayoutTests/inspector/model/remote-object-get-properties-expected.txt
+++ b/LayoutTests/inspector/model/remote-object-get-properties-expected.txt
@@ -478,6 +478,92 @@ ALL PROPERTIES:
 -----------------------------------------------------
 
 -----------------------------------------------------
+EXPRESSION: window.unboundArrowFunction
+type: function
+description: () => {}
+
+OWN PROPERTIES:
+    length
+    name
+    __proto__
+    boundThis
+
+DISPLAYABLE PROPERTIES:
+    length
+    name
+    arguments
+    caller
+    __proto__
+    boundThis
+
+ALL PROPERTIES:
+    length
+    name
+    toString
+    apply
+    call
+    bind
+    arguments
+    caller
+    constructor
+    Symbol(Symbol.hasInstance)
+    toLocaleString
+    valueOf
+    hasOwnProperty
+    propertyIsEnumerable
+    isPrototypeOf
+    __defineGetter__
+    __defineSetter__
+    __lookupGetter__
+    __lookupSetter__
+    __proto__
+    boundThis
+-----------------------------------------------------
+
+-----------------------------------------------------
+EXPRESSION: window.boundArrowFunction
+type: function
+description: () => this
+
+OWN PROPERTIES:
+    length
+    name
+    __proto__
+    boundThis
+
+DISPLAYABLE PROPERTIES:
+    length
+    name
+    arguments
+    caller
+    __proto__
+    boundThis
+
+ALL PROPERTIES:
+    length
+    name
+    toString
+    apply
+    call
+    bind
+    arguments
+    caller
+    constructor
+    Symbol(Symbol.hasInstance)
+    toLocaleString
+    valueOf
+    hasOwnProperty
+    propertyIsEnumerable
+    isPrototypeOf
+    __defineGetter__
+    __defineSetter__
+    __lookupGetter__
+    __lookupSetter__
+    __proto__
+    boundThis
+-----------------------------------------------------
+
+-----------------------------------------------------
 EXPRESSION: window.objectWithSymbolProperties
 type: object
 description: Object

--- a/LayoutTests/inspector/model/remote-object-get-properties.html
+++ b/LayoutTests/inspector/model/remote-object-get-properties.html
@@ -45,6 +45,8 @@ var complexObject = new SuperFoo;
 var badGetterObject = new ClassWithBadGetter;
 var unboundFunction = function() { console.log(arguments); }
 var boundFunction = unboundFunction.bind(document.body, 1, 2, 3);
+var unboundArrowFunction = (function() { return () => {}; }).call({foo: 42});
+var boundArrowFunction = (function() { return () => this; }).call({foo: 42});
 var objectWithSymbolProperties = {prop:1, [Symbol()]:2, [Symbol('sym')]:3, [Symbol('sym')]:4, [Symbol()]: Symbol(), [Symbol.toStringTag]: new String("IgnoredTag"), prop2: 5};
 var objectWithSymbolToStringTag = {[Symbol.toStringTag]: "Foo"};
 var objectWithShadowedSymbolToStringTag = new (class Foo extends EventTarget {});
@@ -65,6 +67,8 @@ function test()
         {expression: "window.badGetterObject"},
         {expression: "window.unboundFunction"},
         {expression: "window.boundFunction"},
+        {expression: "window.unboundArrowFunction"},
+        {expression: "window.boundArrowFunction"},
         {expression: "window.objectWithSymbolProperties"},
         {expression: "window.objectWithSymbolToStringTag"},
         {expression: "window.objectWithShadowedSymbolToStringTag"},

--- a/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
@@ -132,6 +132,54 @@ Internal Properties:
     "boundThis"       =>  null (object null)  []
     "boundArgs"       =>  "Array" (object array)  []
 
+-- Running test case: Runtime.getDisplayableProperties.ArrowFunction
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "length"     =>  3 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "arguments"  =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "caller"     =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  undefined (undefined)  []
+
+-- Running test case: Runtime.getDisplayableProperties.ArrowFunctionNoParameters
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "length"     =>  0 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "arguments"  =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "caller"     =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  undefined (undefined)  []
+
+-- Running test case: Runtime.getDisplayableProperties.BoundArrowFunction
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "length"     =>  3 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "arguments"  =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "caller"     =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  "Object" (object)  []
+
+-- Running test case: Runtime.getDisplayableProperties.BoundArrowFunctionNoParameters
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "length"     =>  0 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "arguments"  =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "caller"     =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  "Object" (object)  []
+
 -- Running test case: Runtime.getDisplayableProperties.Private.Instance.Parent
 Evaluating expression...
 Getting displayable properties...

--- a/LayoutTests/inspector/runtime/getDisplayableProperties.html
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties.html
@@ -110,6 +110,26 @@ function test()
     });
 
     addTestCase({
+        name: "Runtime.getDisplayableProperties.ArrowFunction",
+        expression: `(function() { return ((a, b, c)=>{}); }).call({foo: 42})`,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.ArrowFunctionNoParameters",
+        expression: `(function() { return (()=>{}); }).call({foo: 42})`,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.BoundArrowFunction",
+        expression: `(function() { return ((a, b, c)=>{this}); }).call({foo: 42})`,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.BoundArrowFunctionNoParameters",
+        expression: `(function() { return (()=>{this}); }).call({foo: 42})`,
+    });
+
+    addTestCase({
         name: "Runtime.getDisplayableProperties.Private.Instance.Parent",
         expression: `new PrivateMembersTestClassParent`,
     });

--- a/LayoutTests/inspector/runtime/getProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getProperties-expected.txt
@@ -114,6 +114,46 @@ Internal Properties:
     "boundThis"       =>  null (object null)  []
     "boundArgs"       =>  "Array" (object array)  []
 
+-- Running test case: Runtime.getProperties.ArrowFunction
+Evaluating expression...
+Getting own properties...
+Properties:
+    "length"     =>  3 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  undefined (undefined)  []
+
+-- Running test case: Runtime.getProperties.ArrowFunctionNoParameters
+Evaluating expression...
+Getting own properties...
+Properties:
+    "length"     =>  0 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  undefined (undefined)  []
+
+-- Running test case: Runtime.getProperties.BoundArrowFunction
+Evaluating expression...
+Getting own properties...
+Properties:
+    "length"     =>  3 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  "Object" (object)  []
+
+-- Running test case: Runtime.getProperties.BoundArrowFunctionNoParameters
+Evaluating expression...
+Getting own properties...
+Properties:
+    "length"     =>  0 (number)  [configurable | isOwn]
+    "name"       =>  "" (string)  [configurable | isOwn]
+    "__proto__"  =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+Internal Properties:
+    "boundThis"  =>  "Object" (object)  []
+
 -- Running test case: Runtime.getProperties.Private.Instance.Parent
 Evaluating expression...
 Getting own properties...

--- a/LayoutTests/inspector/runtime/getProperties.html
+++ b/LayoutTests/inspector/runtime/getProperties.html
@@ -125,6 +125,30 @@ function test()
     });
 
     addTestCase({
+        name: "Runtime.getProperties.ArrowFunction",
+        expression: `(function() { return ((a, b, c)=>{}); }).call({foo: 42})`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.ArrowFunctionNoParameters",
+        expression: `(function() { return (()=>{}); }).call({foo: 42})`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.BoundArrowFunction",
+        expression: `(function() { return ((a, b, c)=>{this}); }).call({foo: 42})`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.BoundArrowFunctionNoParameters",
+        expression: `(function() { return (()=>{this}); }).call({foo: 42})`,
+        ownProperties: true,
+    });
+
+    addTestCase({
         name: "Runtime.getProperties.Private.Instance.Parent",
         expression: `new PrivateMembersTestClassParent`,
         ownProperties: true,

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -27,6 +27,7 @@
 #include "JSInjectedScriptHost.h"
 
 #include "ArrayPrototype.h"
+#include "BuiltinNames.h"
 #include "Completion.h"
 #include "DateInstance.h"
 #include "DeferGCInlines.h"
@@ -381,6 +382,18 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
             return array;
         }
         return array;
+    }
+    if (JSArrowFunction* arrowFunction = jsDynamicCast<JSArrowFunction*>(value)) {
+        if (JSScope* jsScope = arrowFunction->scope()) {
+            unsigned index = 0;
+            JSArray* array = constructEmptyArray(globalObject, nullptr);
+            RETURN_IF_EXCEPTION(scope, JSValue());
+            JSValue thisObject = jsScope->get(globalObject, vm.propertyNames->builtinNames().thisPrivateName());
+            RETURN_IF_EXCEPTION(scope, JSValue());
+            array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "boundThis"_s, thisObject));
+            RETURN_IF_EXCEPTION(scope, JSValue());
+            return array;
+        }
     }
     if (JSRemoteFunction* remoteFunction = jsDynamicCast<JSRemoteFunction*>(value)) {
         unsigned index = 0;


### PR DESCRIPTION
#### 40f536f802efe55195f7480ff4ea1fdadf2adb98
<pre>
Web Inspector: Console: show `boundThis` for arrow functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=277960">https://bugs.webkit.org/show_bug.cgi?id=277960</a>

Reviewed by Keith Miller.

This will help developers debug issues with `this` similar to `Function.prototype.bind()`.

Note that if `this` isn&apos;t used within the body of the arrow function, it&apos;s not captured.

* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::getInternalProperties):

* LayoutTests/inspector/model/remote-object-get-properties.html:
* LayoutTests/inspector/model/remote-object-get-properties-expected.txt:
* LayoutTests/inspector/runtime/getDisplayableProperties.html:
* LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt:
* LayoutTests/inspector/runtime/getProperties.html:
* LayoutTests/inspector/runtime/getProperties-expected.txt:

Canonical link: <a href="https://commits.webkit.org/282553@main">https://commits.webkit.org/282553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5856d6fa66a20cd446fca9a989039bd4a54994f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51104 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12946 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56578 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69183 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62711 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58412 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58646 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6185 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84472 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38643 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14887 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39722 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40834 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->