### PR TITLE
Fix background-images on table columns

### DIFF
--- a/LayoutTests/fast/table/col-background-image-expected.html
+++ b/LayoutTests/fast/table/col-background-image-expected.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table col/colgroup background image spans col/colgroup</title>
+    <style type="text/css">
+      div { margin-bottom: 1em; }
+      div.x {}
+      table { border: 5px solid red; }
+      td { border: 2px solid blue; }
+      td { width: 100px; height: 20px; }
+      .w-200 { width: 200px; }
+      td.v { width: 20px; height: 50px; }
+      .b { background: black; }
+      .w { background: white; }
+      .r { background: #ff0000; }
+      .g { background: #00ff00; }
+    </style>
+  </head>
+  <body>
+    <ol>
+      <li>Left cells should be black, right cells white (normal)
+        <div class="x"><table>
+          <tbody>
+            <tr><td class="b"></td><td class="w w-200"></td></tr>
+            <tr><td class="b"></td><td class="w w-200"></td></tr>
+          </tbody>
+        </table></div>
+      </li>
+      <li>Left cells should be black, right cells white (rtl)
+        <div class="x"><table>
+          <tbody>
+            <tr><td class="b"></td><td class="w w-200"></td></tr>
+            <tr><td class="b"></td><td class="w w-200"></td></tr>
+          </tbody>
+        </table></div>
+      </li>
+      <li>Left cells should be black, right cells white (vertical-lr writing mode)
+        <div class="x"><table>
+          <tbody>
+            <tr><td class="b v"></td><td class="w v"></td></tr>
+          </tbody>
+        </table></div>
+      </li>
+      <li>Top cells should be black, bottom cells white, multiple sections
+        <div class="x"><table>
+          <caption>Caption</caption>
+          <tbody>
+            <tr><td class="b"></td><td class="b"></td></tr>
+            <tr><td class="b"></td><td class="b"></td></tr>
+          </tbody>
+          <tfoot>
+            <tr><td class="w"></td><td class="w"></td></tr>
+            <tr><td class="w"></td><td class="w"></td></tr>
+          </tfoot>
+        </table></div>
+      </li>
+      <li>Black-black-red-black/white-white-green-white, column groups and columns and spans
+        <div class="x"><table>
+          <tbody>
+            <tr><td class="b"></td><td class="b"></td><td class="r"></td><td class="b"></td></tr>
+            <tr><td class="b"></td><td class="b"></td><td class="r"></td><td class="b"></td></tr>
+          </tbody>
+          <tfoot>
+            <tr><td class="w"></td><td class="w"></td><td class="g"></td><td class="w"></td></tr>
+            <tr><td class="w"></td><td class="w"></td><td class="g"></td><td class="w"></td></tr>
+          </tfoot>
+        </table></div>
+      </li>
+    </ol>
+  </body>
+</html>

--- a/LayoutTests/fast/table/col-background-image.html
+++ b/LayoutTests/fast/table/col-background-image.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table col/colgroup background image spans col/colgroup</title>
+    <style type="text/css">
+      div { margin-bottom: 1em; }
+      div.x {}
+      table { border: 5px solid red; }
+      td { border: 2px solid blue; }
+      td { width: 100px; height: 20px; }
+      .w-200 { width: 200px; }
+      td.v { width: 20px; height: 50px; }
+      .bwh { background-image: linear-gradient(to right, black 0 50%, white 50% 100%); }
+      .bwv { background-image: linear-gradient(to bottom, black 0 50%, white 50% 100%); }
+      .rgv { background-image: linear-gradient(to bottom, #ff0000 0 50%, #00ff00 50% 100%); }
+      .b { background-image: linear-gradient(to bottom, black 0 100%); }
+      .w { background-image: linear-gradient(to bottom, white 0 100%); }
+    </style>
+  </head>
+  <body>
+    <ol>
+      <li>Left cells should be black, right cells white (normal)
+        <div class="x"><table>
+          <col class="b"><col class="w">
+          <tbody>
+            <tr><td></td><td class="w-200"></td></tr>
+            <tr><td></td><td></td></tr>
+          </tbody>
+        </table></div>
+      </li>
+      <li>Left cells should be black, right cells white (rtl)
+        <div class="x"><table style="direction:rtl">
+          <col class="w"><col class="b">
+          <tbody>
+            <tr><td class="w-200"></td><td></td></tr>
+            <tr><td></td><td></td></tr>
+          </tbody>
+        </table></div>
+      </li>
+      <li>Left cells should be black, right cells white (vertical-lr writing mode)
+        <div class="x"><table style="writing-mode: vertical-lr">
+          <col class="bwh">
+          <tbody><tr><td class="v"></td></tr><tr><td class="v"></td></tr></tbody>
+        </table></div>
+      </li>
+      <li>Top cells should be black, bottom cells white, multiple sections
+        <div class="x"><table>
+          <caption>Caption</caption>
+          <colgroup span="2" class="bwv">
+          <tbody>
+            <tr><td></td><td></td></tr>
+            <tr><td></td><td></td></tr>
+          </tbody>
+          <tfoot>
+            <tr><td></td><td></td></tr>
+            <tr><td></td><td></td></tr>
+          </tfoot>
+        </table></div>
+      </li>
+      <li>Black-black-red-black/white-white-green-white, column groups and columns and spans
+        <div class="x"><table>
+          <colgroup class="rgv">
+            <col class="bwv" span="2">
+            <col>
+          </colgroup>
+          <col class="bwv">
+          <tbody>
+            <tr><td></td><td></td><td></td><td></td></tr>
+            <tr><td></td><td></td><td></td><td></td></tr>
+          </tbody>
+          <tfoot>
+            <tr><td></td><td></td><td></td><td></td></tr>
+            <tr><td></td><td></td><td></td><td></td></tr>
+          </tfoot>
+        </table></div>
+      </li>
+    </ol>
+  </body>
+</html>

--- a/LayoutTests/fast/table/row-background-image-span-expected.html
+++ b/LayoutTests/fast/table/row-background-image-span-expected.html
@@ -1,0 +1,93 @@
+<html>
+<head>
+<title>Row background image span</title>
+<style>* { box-sizing: border-box }
+caption { caption-side: bottom; font-family: sans-serif; font-size: smaller; text-align: left; margin-top: 16px }</style>
+</head>
+<body>
+    <p>A repeating background image applied to a table row should cover the whole area of contained cells, even if those cells span multiple rows, since this is how background colors behave. Also, rounded borders apply to cells, and row backgrounds are restricted to cell contents. If a cell spans multiple rows or columns, rounding should apply at the relevant <em>cell</em> corners.</p>
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>1. Row background color</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background-color: black"></td>
+            <td style="width: 60px; height: 120px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>2. Row repeating solid gradient (should equal #1)</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background-color: black"></td>
+            <td style="width: 60px; height: 120px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>3. Row repeating gradient</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background: repeat top/30px 30px border-box linear-gradient(to bottom, royalblue 0, black 100%)"></td>
+            <td style="width: 60px; height: 120px; background: repeat top/30px 30px linear-gradient(to bottom, royalblue 0, black 100%)" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>4. Row non-repeating gradient should not span to second row</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background-color: black"></td>
+            <td style="width: 60px; height: 60px; background-color: black"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 60px"></td>
+        </tr>
+    </table>
+</div>
+
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>5. Row background color with rounded corners</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px; background-color: black"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>6. Repeating solid gradient with rounded corners (should equal #5)</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px; background-color: black"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>7. Non-repeating solid gradient with rounded corners</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px; background-color: black"></td>
+            <td style="width: 60px; height: 60px; border-radius: 10px; border-bottom-left-radius: 0; border-bottom-right-radius: 0; background-color: black"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/table/row-background-image-span.html
+++ b/LayoutTests/fast/table/row-background-image-span.html
@@ -1,0 +1,92 @@
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-67; totalPixels=0-15000" />
+<title>Row background image span</title>
+<style>* { box-sizing: border-box }
+caption { caption-side: bottom; font-family: sans-serif; font-size: smaller; text-align: left; margin-top: 16px }</style>
+</head>
+<body>
+    <p>A repeating background image applied to a table row should cover the whole area of contained cells, even if those cells span multiple rows, since this is how background colors behave. Also, rounded borders apply to cells, and row backgrounds are restricted to cell contents. If a cell spans multiple rows or columns, rounding should apply at the relevant <em>cell</em> corners.</p>
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>1. Row background color</caption>
+        <tr style="background-color: black">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>2. Row repeating solid gradient (should equal #1)</caption>
+        <tr style="background: repeat top/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>3. Row repeating gradient</caption>
+        <tr style="background: repeat top/30px 30px linear-gradient(to bottom, royalblue 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>4. Row non-repeating gradient should not span to second row</caption>
+        <tr style="background: no-repeat top/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+</div>
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>5. Row background color with rounded corners</caption>
+        <tr style="background-color: black">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>6. Repeating solid gradient with rounded corners (should equal #5)</caption>
+        <tr style="background: repeat center/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>7. Non-repeating solid gradient with rounded corners</caption>
+        <tr style="background: no-repeat center/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -144,13 +144,13 @@ void BackgroundPainter::paintFillLayers(const Color& color, const FillLayer& fil
     auto baseBgColorUsage = BaseBackgroundColorUse;
 
     if (shouldDrawBackgroundInSeparateBuffer) {
-        paintFillLayer(color, *layers.last(), rect, bleedAvoidance, { }, { }, op, backgroundObject, BaseBackgroundColorOnly);
+        paintFillLayer(color, *layers.last(), rect, bleedAvoidance, { }, op, backgroundObject, BaseBackgroundColorOnly);
         baseBgColorUsage = BaseBackgroundColorSkip;
         context.beginTransparencyLayer(1);
     }
 
     for (auto& layer : makeReversedRange(layers))
-        paintFillLayer(color, *layer, rect, bleedAvoidance, { }, { }, op, backgroundObject, baseBgColorUsage);
+        paintFillLayer(color, *layer, rect, bleedAvoidance, { }, op, backgroundObject, baseBgColorUsage);
 
     if (shouldDrawBackgroundInSeparateBuffer)
         context.endTransparencyLayer();
@@ -167,7 +167,7 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const RenderSt
 }
 
 void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLayer, const LayoutRect& rect,
-    BleedAvoidance bleedAvoidance, const InlineIterator::InlineBoxIterator& inlineBoxIterator, const LayoutRect& backgroundImageStrip, CompositeOperator op, RenderElement* backgroundObject, BaseBackgroundColorUsage baseBgColorUsage) const
+    BleedAvoidance bleedAvoidance, const InlineIterator::InlineBoxIterator& inlineBoxIterator, CompositeOperator op, RenderElement* backgroundObject, BaseBackgroundColorUsage baseBgColorUsage) const
 {
     GraphicsContext& context = m_paintInfo.context();
 
@@ -183,7 +183,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
 
     bool hasRoundedBorder = style.hasBorderRadius()
         && (closedEdges.start(style.writingMode()) || closedEdges.end(style.writingMode()));
-    bool clippedWithLocalScrolling = m_renderer.hasNonVisibleOverflow() && bgLayer.attachment() == FillAttachment::LocalBackground;
+    bool clippedWithLocalScrolling = m_renderer.hasNonVisibleOverflow() && bgLayer.attachment() == FillAttachment::LocalBackground && !m_imageRect;
     bool isBorderFill = layerClip == FillBox::BorderBox;
     bool isRoot = m_renderer.isDocumentElementRenderer();
 
@@ -471,10 +471,9 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
 
     // no progressive loading of the background image
     if (!baseBgColorOnly && shouldPaintBackgroundImage) {
-        // Multiline inline boxes paint like the image was one long strip spanning lines. The backgroundImageStrip is this fictional rectangle.
-        auto imageRect = backgroundImageStrip.isEmpty() ? scrolledPaintRect : backgroundImageStrip;
-        auto paintOffset = backgroundImageStrip.isEmpty() ? rect.location() : backgroundImageStrip.location();
-        auto geometry = calculateBackgroundImageGeometry(m_renderer, m_paintInfo.paintContainer, bgLayer, paintOffset, imageRect, m_overrideOrigin);
+        // m_imageRect, if provided, is used for sizing the image. It is set for table rows and for inline boxes (multiline inline boxes paint like the image was one long strip spanning lines).
+        auto paintOffset = m_imageRect ? m_imageRect->location() : rect.location();
+        auto geometry = calculateBackgroundImageGeometry(m_renderer, m_paintInfo.paintContainer, bgLayer, paintOffset, scrolledPaintRect, m_imageRect);
 
         auto& clientForBackgroundImage = backgroundObject ? *backgroundObject : m_renderer;
         bgImage->setContainerContextForRenderer(clientForBackgroundImage, geometry.tileSizeWithoutPixelSnapping, m_renderer.style().usedZoom());
@@ -547,7 +546,7 @@ static void pixelSnapBackgroundImageGeometryForPainting(LayoutRect& destinationR
     destinationRect = LayoutRect(snapRectToDevicePixels(destinationRect, scaleFactor));
 }
 
-BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(const RenderBoxModelObject& renderer, const RenderLayerModelObject* paintContainer, const FillLayer& fillLayer, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin)
+BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(const RenderBoxModelObject& renderer, const RenderLayerModelObject* paintContainer, const FillLayer& fillLayer, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, const std::optional<LayoutRect>& imageRect)
 {
     auto& view = renderer.view();
 
@@ -560,19 +559,18 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
     bool isTransformed = renderer.isTransformed() || (enclosingLayer && enclosingLayer->hasTransformedAncestor());
     bool fixedAttachment = fillLayer.attachment() == FillAttachment::FixedBackground && !isTransformed;
 
-    LayoutRect destinationRect(borderBoxRect);
+    LayoutRect destinationRect(imageRect.value_or(borderBoxRect));
     float deviceScaleFactor = renderer.document().deviceScaleFactor();
     if (!fixedAttachment) {
         LayoutUnit right;
         LayoutUnit bottom;
         // Scroll and Local.
-        auto fillLayerOrigin = overrideOrigin.value_or(fillLayer.origin());
-        if (fillLayerOrigin != FillBox::BorderBox) {
+        if (fillLayer.origin() != FillBox::BorderBox && !imageRect) {
             left = renderer.borderLeft();
             right = renderer.borderRight();
             top = renderer.borderTop();
             bottom = renderer.borderBottom();
-            if (fillLayerOrigin == FillBox::ContentBox) {
+            if (fillLayer.origin() == FillBox::ContentBox) {
                 left += renderer.paddingLeft();
                 right += renderer.paddingRight();
                 top += renderer.paddingTop();
@@ -592,7 +590,7 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
                 top += (renderer.marginTop() - extendedBackgroundRect.y());
             }
         } else {
-            positioningAreaSize = borderBoxRect.size() - LayoutSize(left + right, top + bottom);
+            positioningAreaSize = destinationRect.size() - LayoutSize(left + right, top + bottom);
             positioningAreaSize = LayoutSize(snapRectToDevicePixels(LayoutRect(paintOffset, positioningAreaSize), deviceScaleFactor).size());
         }
     } else {
@@ -719,11 +717,19 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
     }
 
     if (fixedAttachment) {
-        LayoutPoint attachmentPoint = borderBoxRect.location();
+        LayoutPoint attachmentPoint = imageRect.value_or(borderBoxRect).location();
         phase.expand(std::max<LayoutUnit>(attachmentPoint.x() - destinationRect.x(), 0), std::max<LayoutUnit>(attachmentPoint.y() - destinationRect.y(), 0));
     }
 
-    destinationRect.intersect(borderBoxRect);
+    if (imageRect) {
+        destinationRect.intersect(*imageRect);
+        // expand repeating background to cover whole borderBoxRect in repeat directions
+        if (backgroundRepeatX == FillRepeat::Repeat)
+            destinationRect.unite({ borderBoxRect.x(), destinationRect.y(), borderBoxRect.width(), destinationRect.height() });
+        if (backgroundRepeatY == FillRepeat::Repeat)
+            destinationRect.unite({ destinationRect.x(), borderBoxRect.y(), destinationRect.width(), borderBoxRect.height() });
+    } else
+        destinationRect.intersect(borderBoxRect);
 
     auto tileSizeWithoutPixelSnapping = tileSize;
     pixelSnapBackgroundImageGeometryForPainting(destinationRect, tileSize, phase, spaceSize, deviceScaleFactor);

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -66,17 +66,17 @@ public:
     BackgroundPainter(RenderBoxModelObject&, const PaintInfo&);
 
     void setOverrideClip(FillBox overrideClip) { m_overrideClip = overrideClip; }
-    void setOverrideOrigin(FillBox overrideOrigin) { m_overrideOrigin = overrideOrigin; }
+    void setImageRect(const LayoutRect& imageRect) { m_imageRect = imageRect; }
 
     void paintBackground(const LayoutRect&, BleedAvoidance) const;
 
     void paintFillLayers(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, CompositeOperator, RenderElement* backgroundObject = nullptr) const;
-    void paintFillLayer(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, const InlineIterator::InlineBoxIterator&, const LayoutRect& backgroundImageStrip = { }, CompositeOperator = CompositeOperator::SourceOver, RenderElement* backgroundObject = nullptr, BaseBackgroundColorUsage = BaseBackgroundColorUse) const;
+    void paintFillLayer(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, const InlineIterator::InlineBoxIterator&, CompositeOperator = CompositeOperator::SourceOver, RenderElement* backgroundObject = nullptr, BaseBackgroundColorUsage = BaseBackgroundColorUse) const;
 
     void paintBoxShadow(const LayoutRect&, const RenderStyle&, ShadowStyle, RectEdges<bool> closedEdges = { true, true, true, true }) const;
 
     static bool paintsOwnBackground(const RenderBoxModelObject&);
-    static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin = std::nullopt);
+    static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, const std::optional<LayoutRect>& imageRect = std::nullopt);
     static void clipRoundedInnerRect(GraphicsContext&, const FloatRoundedRect& clipRect);
     static bool boxShadowShouldBeAppliedToBackground(const RenderBoxModelObject&, const LayoutPoint& paintOffset, BleedAvoidance, const InlineIterator::InlineBoxIterator&);
 
@@ -91,7 +91,7 @@ private:
     RenderBoxModelObject& m_renderer;
     const PaintInfo& m_paintInfo;
     std::optional<FillBox> m_overrideClip;
-    std::optional<FillBox> m_overrideOrigin;
+    std::optional<LayoutRect> m_imageRect;
 };
 
 }

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -308,14 +308,14 @@ void InlineBoxPainter::paintFillLayer(const Color& color, const FillLayer& fillL
     BackgroundPainter backgroundPainter { renderer(), m_paintInfo };
 
     if (!hasFillImageOrBorderRadious || !m_inlineBox.isSplit() || m_isRootInlineBox) {
-        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, { }, op);
+        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, op);
         return;
     }
 
     if (renderer().style().boxDecorationBreak() == BoxDecorationBreak::Clone) {
         GraphicsContextStateSaver stateSaver(m_paintInfo.context());
         m_paintInfo.context().clip({ rect.location(), m_inlineBox.visualRectIgnoringBlockDirection().size() });
-        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, { }, op);
+        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, op);
         return;
     }
 
@@ -346,10 +346,11 @@ void InlineBoxPainter::paintFillLayer(const Color& color, const FillLayer& fillL
         isHorizontal() ? totalLogicalWidth : LayoutUnit(m_inlineBox.visualRectIgnoringBlockDirection().width()),
         isHorizontal() ? LayoutUnit(m_inlineBox.visualRectIgnoringBlockDirection().height()) : totalLogicalWidth
     };
+    backgroundPainter.setImageRect(backgroundImageStrip);
 
     GraphicsContextStateSaver stateSaver(m_paintInfo.context());
     m_paintInfo.context().clip(FloatRect { rect });
-    backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, backgroundImageStrip, op);
+    backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, op);
 }
 
 void InlineBoxPainter::paintBoxShadow(ShadowStyle shadowStyle, const LayoutRect& paintRect)

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -246,8 +246,6 @@ void RenderTable::removeCaption(RenderTableCaption& oldCaption)
 void RenderTable::invalidateCachedColumns()
 {
     m_columnRenderersValid = false;
-    m_columnRenderers.shrink(0);
-    m_effectiveColumnIndexMap.clear();
 }
 
 void RenderTable::invalidateCachedColumnOffsets()
@@ -594,6 +592,9 @@ void RenderTable::layout()
 
         // position the table sections
         RenderTableSection* section = topSection();
+        bool seenNonEmptySection = false;
+        m_columnBlockStart = m_columnBlockLength = 0;
+
         while (section) {
             sectionCount++;
             if (!sectionMoved && section->logicalTop() != logicalHeight()) {
@@ -602,9 +603,20 @@ void RenderTable::layout()
             }
             section->setLogicalLocation(LayoutPoint(sectionLogicalLeft, logicalHeight()));
 
-            setLogicalHeight(logicalHeight() + section->logicalHeight());
+            auto sectionTop = logicalHeight();
+            auto sectionBottom = sectionTop + section->logicalHeight();
+
+            if (section->numRows()) {
+                if (!seenNonEmptySection) {
+                    seenNonEmptySection = true;
+                    m_columnBlockStart = sectionTop + m_vSpacing;
+                }
+                m_columnBlockLength = sectionBottom - m_vSpacing - m_columnBlockStart;
+            }
+
+            setLogicalHeight(sectionBottom);
             section->addVisualEffectOverflow();
-            
+
             section = sectionBelow(section);
         }
 
@@ -1034,20 +1046,16 @@ RenderTableCol* RenderTable::firstColumn() const
 void RenderTable::updateColumnCache() const
 {
     ASSERT(m_hasColElements);
-    ASSERT(m_columnRenderers.isEmpty());
-    ASSERT(m_effectiveColumnIndexMap.isEmpty());
     ASSERT(!m_columnRenderersValid);
 
     unsigned columnIndex = 0;
     for (RenderTableCol* columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
+        columnRenderer->setColumnIndex(columnIndex);
         if (columnRenderer->isTableColumnGroupWithColumnChildren())
             continue;
-        m_columnRenderers.append(columnRenderer);
-        // FIXME: We should look to compute the effective column index successively from previous values instead of
-        // calling colToEffCol(), which is in O(numEffCols()). Although it's unlikely that this is a hot function.
-        m_effectiveColumnIndexMap.add(*columnRenderer, colToEffCol(columnIndex));
         columnIndex += columnRenderer->span();
     }
+    m_tableColumnSpan = columnIndex;
     m_columnRenderersValid = true;
 }
 
@@ -1055,14 +1063,21 @@ unsigned RenderTable::effectiveIndexOfColumn(const RenderTableCol& column) const
 {
     if (!m_columnRenderersValid)
         updateColumnCache();
-    const RenderTableCol* columnToUse = &column;
-    if (columnToUse->isTableColumnGroupWithColumnChildren())
-        columnToUse = columnToUse->nextColumn(); // First column in column-group
-    auto it = m_effectiveColumnIndexMap.find(columnToUse);
-    ASSERT(it != m_effectiveColumnIndexMap.end());
-    if (it == m_effectiveColumnIndexMap.end())
-        return std::numeric_limits<unsigned>::max();
-    return it->value;
+    return colToEffCol(column.columnIndex());
+}
+
+unsigned RenderTable::spanOfColumn(const RenderTableCol& column) const
+{
+    if (!m_columnRenderersValid)
+        updateColumnCache();
+    if (!column.firstChild())
+        return column.span();
+    // |column| is a column group with children, so its span is the sum
+    // of its childrens' spans.
+    RenderObject* next = column.nextSibling();
+    if (RenderTableCol* nextColumn = next ? dynamicDowncast<RenderTableCol>(next) : nullptr)
+        return nextColumn->columnIndex() - column.columnIndex();
+    return m_tableColumnSpan - column.columnIndex();
 }
 
 LayoutUnit RenderTable::offsetTopForColumn(const RenderTableCol& column) const
@@ -1087,32 +1102,13 @@ LayoutUnit RenderTable::offsetLeftForColumn(const RenderTableCol& column) const
 
 LayoutUnit RenderTable::offsetWidthForColumn(const RenderTableCol& column) const
 {
-    const RenderTableCol* currentColumn = &column;
-    bool hasColumnChildren;
-    if ((hasColumnChildren = currentColumn->isTableColumnGroupWithColumnChildren()))
-        currentColumn = currentColumn->nextColumn(); // First column in column-group
+    unsigned index = effectiveIndexOfColumn(column);
+    unsigned span = spanOfColumn(column);
     unsigned numberOfEffectiveColumns = numEffCols();
+    if (!span || index >= numberOfEffectiveColumns)
+        return 0;
     ASSERT_WITH_SECURITY_IMPLICATION(m_columnPos.size() >= numberOfEffectiveColumns + 1);
-    LayoutUnit width;
-    LayoutUnit spacing = m_hSpacing;
-    while (currentColumn) {
-        unsigned columnIndex = effectiveIndexOfColumn(*currentColumn);
-        unsigned span = currentColumn->span();
-        while (span && columnIndex < numberOfEffectiveColumns) {
-            width += m_columnPos[columnIndex + 1] - m_columnPos[columnIndex] - spacing;
-            span -= m_columns[columnIndex].span;
-            ++columnIndex;
-            if (span)
-                width += spacing;
-        }
-        if (!hasColumnChildren)
-            break;
-        currentColumn = currentColumn->nextColumn();
-        if (!currentColumn || currentColumn->isTableColumnGroup())
-            break;
-        width += spacing;
-    }
-    return width;
+    return m_columnPos[effectiveColumnAfter(index, span)] - m_columnPos[index] - m_hSpacing;
 }
 
 LayoutUnit RenderTable::offsetHeightForColumn(const RenderTableCol& column) const
@@ -1138,8 +1134,8 @@ RenderTableCol* RenderTable::slowColElement(unsigned col, bool* startEdge, bool*
         updateColumnCache();
 
     unsigned columnCount = 0;
-    for (auto& columnRenderer : m_columnRenderers) {
-        if (!columnRenderer)
+    for (RenderTableCol* columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
+        if (columnRenderer->isTableColumnGroupWithColumnChildren())
             continue;
         unsigned span = columnRenderer->span();
         unsigned startCol = columnCount;
@@ -1151,7 +1147,7 @@ RenderTableCol* RenderTable::slowColElement(unsigned col, bool* startEdge, bool*
                 *startEdge = startCol == col;
             if (endEdge)
                 *endEdge = endCol == col;
-            return columnRenderer.get();
+            return columnRenderer;
         }
     }
     return nullptr;

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -146,6 +146,21 @@ public:
         return c;
     }
 
+    unsigned effectiveColumnAfter(unsigned index, unsigned span) const
+    {
+        unsigned numColumns = numEffCols();
+        if (!m_hasCellColspanThatDeterminesTableWidth
+            && index <= numColumns
+            && numColumns - index <= span)
+            return index + span;
+        unsigned currentSpan = 0;
+        while (index < numColumns && currentSpan < span) {
+            currentSpan += m_columns[index].span;
+            ++index;
+        }
+        return index;
+    }
+
     LayoutUnit borderSpacingInRowDirection() const
     {
         if (unsigned effectiveColumnCount = numEffCols())
@@ -212,11 +227,16 @@ public:
     LayoutUnit offsetWidthForColumn(const RenderTableCol&) const;
     LayoutUnit offsetHeightForColumn(const RenderTableCol&) const;
     
+    unsigned effectiveIndexOfColumn(const RenderTableCol&) const;
+    unsigned spanOfColumn(const RenderTableCol&) const;
+
     void markForPaginationRelayoutIfNeeded() final;
 
     void willInsertTableColumn(RenderTableCol& child, RenderObject* beforeChild);
     void willInsertTableSection(RenderTableSection& child, RenderObject* beforeChild);
 
+    LayoutUnit columnBlockStart() const { return m_columnBlockStart; }
+    LayoutUnit columnBlockLength() const { return m_columnBlockLength; }
     LayoutUnit sumCaptionsLogicalHeight() const;
 
     // Whether a table has opaque foreground depends on many factors, e.g. border spacing, missing cells, etc.
@@ -278,11 +298,8 @@ private:
     mutable Vector<LayoutUnit> m_columnPos;
     mutable Vector<ColumnStruct> m_columns;
     mutable Vector<SingleThreadWeakPtr<RenderTableCaption>> m_captions;
-    mutable Vector<SingleThreadWeakPtr<RenderTableCol>> m_columnRenderers;
 
-    unsigned effectiveIndexOfColumn(const RenderTableCol&) const;
-    using EffectiveColumnIndexMap = UncheckedKeyHashMap<SingleThreadWeakRef<const RenderTableCol>, unsigned>;
-    mutable EffectiveColumnIndexMap m_effectiveColumnIndexMap;
+    mutable unsigned m_tableColumnSpan { 0 }; // total span of all RenderTableCol elements
 
     mutable SingleThreadWeakPtr<RenderTableSection> m_head;
     mutable SingleThreadWeakPtr<RenderTableSection> m_foot;
@@ -317,6 +334,8 @@ private:
     LayoutUnit m_vSpacing;
     LayoutUnit m_borderStart;
     LayoutUnit m_borderEnd;
+    LayoutUnit m_columnBlockStart;
+    LayoutUnit m_columnBlockLength;
     mutable LayoutUnit m_columnOffsetTop;
     mutable LayoutUnit m_columnOffsetHeight;
     unsigned m_recursiveSectionMovedWithPaginationLevel { 0 };

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -28,6 +28,7 @@
 
 #include "BackgroundPainter.h"
 #include "BorderPainter.h"
+#include "BorderShape.h"
 #include "CollapsedBorderValue.h"
 #include "ElementInlines.h"
 #include "FillLayer.h"
@@ -1378,50 +1379,41 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
     if (!tableElt->collapseBorders() && style().emptyCells() == EmptyCell::Hide && !firstChild())
         return;
 
-    const auto& style = backgroundObject->style();
-    auto& bgLayer = style.backgroundLayers();
+    const auto& bgStyle = backgroundObject->style();
+    auto& bgLayer = bgStyle.backgroundLayers();
 
-    auto color = style.visitedDependentColor(CSSPropertyBackgroundColor);
+    auto color = bgStyle.visitedDependentColor(CSSPropertyBackgroundColor);
     if (!bgLayer.hasImage() && !color.isVisible())
         return;
 
-    color = style.colorByApplyingColorFilter(color);
+    color = bgStyle.colorByApplyingColorFilter(color);
 
-    LayoutPoint adjustedPaintOffset = paintOffset;
+    LayoutRect fillRect { paintOffset, size() };
     if (backgroundObject != this)
-        adjustedPaintOffset.moveBy(location());
+        fillRect.moveBy(location());
 
-    // Background images attached to the row or row group must span the row
-    // or row group. Draw them at the backgroundObject's dimensions, but
-    // clipped to this cell.
-    // FIXME: This should also apply to columns and column groups.
-    bool paintBackgroundObject = backgroundObject != this && bgLayer.hasImage() && !is<RenderTableCol>(backgroundObject);
-    // We have to clip here because the background would paint
-    // on top of the borders otherwise. This only matters for cells and rows.
-    bool shouldClip = paintBackgroundObject || (backgroundObject->hasLayer() && (backgroundObject == this || backgroundObject == parent()) && tableElt->collapseBorders());
-    GraphicsContextStateSaver stateSaver(paintInfo.context(), shouldClip);
-    if (paintBackgroundObject)
-        paintInfo.context().clip({ adjustedPaintOffset, size() });
-    else if (shouldClip) {
-        LayoutRect clipRect(adjustedPaintOffset.x() + borderLeft(), adjustedPaintOffset.y() + borderTop(),
-            width() - borderLeft() - borderRight(), height() - borderTop() - borderBottom());
-        paintInfo.context().clip(clipRect);
-    }
-    LayoutRect fillRect;
-    if (paintBackgroundObject) {
-        if (auto* tableSectionRenderer = dynamicDowncast<RenderTableSection>(backgroundObject))
-            fillRect = backgroundRectForSection(*tableSectionRenderer, *tableElt);
-        else
-            fillRect = backgroundRectForRow(*backgroundObject, *tableElt);
-        fillRect.moveBy(backgroundPaintOffset);
-    } else
-        fillRect = LayoutRect { adjustedPaintOffset, size() };
-    auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     BackgroundPainter painter { *this, paintInfo };
     if (backgroundObject != this) {
         painter.setOverrideClip(FillBox::BorderBox);
-        painter.setOverrideOrigin(FillBox::BorderBox);
+        // Background images attached to the row or row group must span the
+        // row or row group. Draw them as sized for that element, but clipped
+        // to this cell.
+        // FIXME: This should also apply to columns and column groups.
+        if (bgLayer.hasImage() && !is<RenderTableCol>(backgroundObject)) {
+            LayoutRect imageRect;
+            if (auto* tableSectionRenderer = dynamicDowncast<RenderTableSection>(backgroundObject))
+                imageRect = backgroundRectForSection(*tableSectionRenderer, *tableElt);
+            else
+                imageRect = backgroundRectForRow(*backgroundObject, *tableElt);
+            imageRect.moveBy(backgroundPaintOffset);
+            painter.setImageRect(imageRect);
+        }
     }
+    if (backgroundObject->hasLayer() && (backgroundObject == this || backgroundObject == parent()) && tableElt->collapseBorders()) {
+        // Shrink the drawn area to account for collapsed borders (cell and row only)
+        fillRect.contract(borderWidths());
+    }
+    auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     painter.paintFillLayers(color, bgLayer, fillRect, BleedAvoidance::None, compositeOp, backgroundObject);
 }
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1365,6 +1365,26 @@ static LayoutRect backgroundRectForSection(const RenderTableSection& tableSectio
     return rect;
 }
 
+static LayoutRect backgroundRectForCol(const RenderTableCol& tableCol, const RenderTable& table)
+{
+    unsigned colStart = table.effectiveIndexOfColumn(tableCol);
+    unsigned colEnd = table.effectiveColumnAfter(colStart, table.spanOfColumn(tableCol));
+    unsigned numCols = table.numEffCols();
+    if (colStart >= numCols || colStart >= colEnd)
+        return { };
+
+    auto hSpacing = table.hBorderSpacing();
+    auto inlineStart = hSpacing + table.columnPositions()[colStart];
+    auto inlineLength = table.columnPositions()[colEnd] - inlineStart;
+    auto blockLength = table.columnBlockLength();
+    if (!table.style().isLeftToRightDirection())
+        inlineStart = hSpacing + table.columnPositions()[numCols] - (inlineStart + inlineLength);
+
+    if (table.isHorizontalWritingMode())
+        return { inlineStart, 0, inlineLength, blockLength };
+    return { 0, inlineStart, blockLength, inlineLength };
+}
+
 void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoint paintOffset, RenderBox* backgroundObject, LayoutPoint backgroundPaintOffset)
 {
     ASSERT(backgroundObject);
@@ -1399,10 +1419,12 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
         // row or row group. Draw them as sized for that element, but clipped
         // to this cell.
         // FIXME: This should also apply to columns and column groups.
-        if (bgLayer.hasImage() && !is<RenderTableCol>(backgroundObject)) {
+        if (bgLayer.hasImage()) {
             LayoutRect imageRect;
             if (auto* tableSectionRenderer = dynamicDowncast<RenderTableSection>(backgroundObject))
                 imageRect = backgroundRectForSection(*tableSectionRenderer, *tableElt);
+            else if (auto* tableColRenderer = dynamicDowncast<RenderTableCol>(backgroundObject))
+                imageRect = backgroundRectForCol(*tableColRenderer, *tableElt);
             else
                 imageRect = backgroundRectForRow(*backgroundObject, *tableElt);
             imageRect.moveBy(backgroundPaintOffset);

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -45,6 +45,9 @@ public:
     unsigned span() const { return m_span; }
     void setSpan(unsigned span) { m_span = span; }
 
+    unsigned columnIndex() const { return m_columnIndex; }
+    void setColumnIndex(unsigned columnIndex) { m_columnIndex = columnIndex; }
+
     bool isTableColumnGroupWithColumnChildren() const { return firstChild(); }
     bool isTableColumn() const { return style().display() == DisplayType::TableColumn; }
     bool isTableColumnGroup() const { return style().display() == DisplayType::TableColumnGroup; }
@@ -90,6 +93,7 @@ private:
     RenderTable* table() const;
 
     unsigned m_span { 1 };
+    unsigned m_columnIndex { 0 };
 };
 
 inline RenderTableCol* RenderTableCol::enclosingColumnGroupIfAdjacentBefore() const

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -969,9 +969,21 @@ void RenderTableSection::paintCell(RenderTableCell* cell, PaintInfo& paintInfo, 
         // Note that we deliberately ignore whether or not the cell has a layer, since these backgrounds paint "behind" the
         // cell.
         if (RenderTableCol* column = table()->colElement(cell->col())) {
+            // The backgroundOffset for the column is the top left corner
+            // of the table's nonempty sections (including hBorderSpacing);
+            // how we get there depends on writing mode
+            LayoutPoint columnPoint = paintOffset;
+            auto& tableElt = *table();
+            if (tableElt.isHorizontalWritingMode())
+                columnPoint.move(0, tableElt.columnBlockStart() - y());
+            else if (tableElt.writingMode().isBlockFlipped())
+                columnPoint.move(x() + width() - (tableElt.columnBlockStart() + tableElt.columnBlockLength()), 0);
+            else
+                columnPoint.move(tableElt.columnBlockStart() - x(), 0);
+
             if (RenderTableCol* columnGroup = column->enclosingColumnGroup())
-                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup, cellPoint);
-            cell->paintBackgroundsBehindCell(paintInfo, cellPoint, column, cellPoint);
+                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup, columnPoint);
+            cell->paintBackgroundsBehindCell(paintInfo, cellPoint, column, columnPoint);
         }
 
         // Paint the row group next.


### PR DESCRIPTION
<pre>
Fix background-images on table columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=278001">https://bugs.webkit.org/show_bug.cgi?id=278001</a>

Reviewed by NOBODY (OOPS!).

Render column background-images over the whole column, clipped to each relevant cell.

This change requires correct position and dimension for each column. Existing functions
were not suitable, for instance they don't account for writing-direction. Added new
functions.

RenderTable and the new backgroundRectForCol() function need to extract the column index
for a RenderTableCol. Previous code implemented this with a hashmap, but by *effective*
index, not HTML-level index. Replace hashmap and an array of renderers with
RenderTableCol::m_columnIndex; update RenderTable to update and use that field.

* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableCol.h:
(WebCore::RenderTableCol::columnIndex):
(WebCore::RenderTableCol::setColumnIndex):
(WebCore::RenderTable::invalidateCachedColumns):
(WebCore::RenderTable::updateColumnCache const):
(WebCore::RenderTable::effectiveIndexOfColumn const):
(WebCore::RenderTable::slowColElement const):

RenderTable::effectiveSpanOfColumn(col) returns the HTML span of a RenderTableCol. This is
typically the column's span attribute, but for a column group, it is the sum of the spans
of the colgroup's <col> children.

RenderTable::effectiveColumnAfter(index, span) returns the effective column index placed an
HTML span after the input effective column. This equals `index + span` unless there are
table columns with HTML span > 1, but effective span == 1.

Use these functions to implement offsetWidthForColumn.

* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTable.h:
(WebCore::RenderTable::effectiveSpanOfColumn const):
(WebCore::RenderTable::effectiveColumnAfter const): (WebCore::RenderTable::offsetWidthForColumn const):

RenderTable::layout() tracks the block-start position and block-direction length of the
table's columns.

* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTable.h:
(WebCore::RenderTable::columnBlockStart const):
(WebCore::RenderTable::columnBlockLength const):
(WebCore::RenderTable::layout):

Finally, use this information in RenderTableCell::paintBackgroundsBehindCell.

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::backgroundRectForCol):
(WebCore::RenderTableCell::paintBackgroundsBehindCell):
* Source/WebCore/rendering/RenderTableSection.cpp: (WebCore::RenderTableSection::paintCell):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e76bfab72033ff1c879ba157033d5a91e33f4690

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50165 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36682 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97627 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78046 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22499 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21122 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11286 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23329 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17725 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->