### PR TITLE
[Writing Tools] Mail body temporarily disappears when accepting short form smart reply until questionnaire appears

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -78,12 +78,12 @@ public:
     void removeTransparentMarkersForSessionID(const WTF::UUID& sessionUUID);
     void removeTransparentMarkersForTextAnimationID(const WTF::UUID&);
 
-    void removeInitialTextAnimation(const WTF::UUID& sessionUUID);
-    void addInitialTextAnimation(const WTF::UUID& sessionUUID);
-    void addSourceTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimation(const WTF::UUID& sessionUUID, const std::optional<WebCore::CharacterRange>&, const String&);
+    void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&);
+    void addInitialTextAnimation(const WebCore::WritingTools::SessionID&);
+    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
+    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const std::optional<WebCore::CharacterRange>&, const String&);
 
-    void clearAnimationsForSessionID(const WTF::UUID& sessionUUID);
+    void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&);
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool visible, CompletionHandler<void()>&&);
 
@@ -103,12 +103,11 @@ private:
     RefPtr<WebCore::Document> document() const;
     WeakPtr<WebPage> m_webPage;
 
-    // All of these HashMap keys are SessionIDs
-    HashMap<WTF::UUID, WTF::UUID> m_initialAnimations;
-    HashMap<WTF::UUID, Vector<TextAnimationRange>> m_textAnimationRanges;
-    HashMap<WTF::UUID, std::optional<ReplacedRangeAndString>> m_alreadyReplacedRanges;
-    HashMap<WTF::UUID, std::optional<TextAnimationUnstyledRangeData>> m_unstyledRanges;
-    HashMap<WTF::UUID, Ref<WebCore::Range>> m_manuallyEnabledAnimationRanges;
+    HashMap<WebCore::WritingTools::SessionID, WTF::UUID> m_initialAnimations;
+    HashMap<WebCore::WritingTools::SessionID, Vector<TextAnimationRange>> m_textAnimationRanges;
+    HashMap<WebCore::WritingTools::SessionID, std::optional<ReplacedRangeAndString>> m_alreadyReplacedRanges;
+    HashMap<WebCore::WritingTools::SessionID, std::optional<TextAnimationUnstyledRangeData>> m_unstyledRanges;
+    HashMap<WebCore::WritingTools::SessionID, Ref<WebCore::Range>> m_manuallyEnabledAnimationRanges;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -78,7 +78,7 @@ RefPtr<WebCore::Document> TextAnimationController::document() const
     return frame->document();
 }
 
-std::optional<WebCore::SimpleRange> TextAnimationController::unreplacedRangeForSessionWithID(const WebCore::WritingTools::SessionID& sessionID) const
+std::optional<WebCore::SimpleRange> TextAnimationController::unreplacedRangeForSessionWithID(const WebCore::WritingTools::Session::ID& sessionID) const
 {
     auto sessionRange = contextRangeForSessionWithID(sessionID);
     if (!sessionRange) {
@@ -121,22 +121,21 @@ std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForText
     if (auto iterator = m_manuallyEnabledAnimationRanges.find(animationUUID); iterator != m_manuallyEnabledAnimationRanges.end())
         return WebCore::makeSimpleRange(iterator->value.get());
 
-    for (auto sessionUUID : m_initialAnimations.keys()) {
-        if (m_initialAnimations.get(sessionUUID) == animationUUID)
-            return unreplacedRangeForSessionWithID(sessionUUID);
+    for (auto [sessionID, initialAnimationID] : m_initialAnimations) {
+        if (initialAnimationID == animationUUID)
+            return unreplacedRangeForSessionWithID(sessionID);
     }
 
-    for (auto sessionUUID : m_textAnimationRanges.keys()) {
-        for (auto animationRange : m_textAnimationRanges.get(sessionUUID)) {
+    for (auto [sessionID, animationRanges] : m_textAnimationRanges) {
+        for (auto animationRange : animationRanges) {
             if (animationRange.animationUUID == animationUUID) {
-                if (auto fullSessionRange = contextRangeForSessionWithID(sessionUUID))
+                if (auto fullSessionRange = contextRangeForSessionWithID(sessionID))
                     return WebCore::resolveCharacterRange(*fullSessionRange, animationRange.range, defaultTextAnimationControllerTextIteratorBehaviors);
             }
         }
     }
 
-    for (auto sessionUUID : m_unstyledRanges.keys()) {
-        auto unstyledRangeData = m_unstyledRanges.get(sessionUUID);
+    for (auto unstyledRangeData : m_unstyledRanges.values()) {
         if (unstyledRangeData->animationUUID == animationUUID)
             return unstyledRangeData->range;
     }
@@ -144,18 +143,19 @@ std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForText
     return std::nullopt;
 }
 
-void TextAnimationController::removeTransparentMarkersForSessionID(const WTF::UUID& sessionUUID)
+void TextAnimationController::removeTransparentMarkersForSessionID(const WebCore::WritingTools::Session::ID& sessionID)
 {
-    if (auto iterator = m_initialAnimations.find(sessionUUID); iterator != m_initialAnimations.end())
+    if (auto iterator = m_initialAnimations.find(sessionID); iterator != m_initialAnimations.end())
         removeTransparentMarkersForTextAnimationID(iterator->value);
 
-    auto animationStates = m_textAnimationRanges.take(sessionUUID);
+    auto animationStates = m_textAnimationRanges.take(sessionID);
     if (animationStates.isEmpty())
         return;
+
     for (auto animationState : animationStates)
         removeTransparentMarkersForTextAnimationID(animationState.animationUUID);
 
-    if (auto rangeData = m_unstyledRanges.get(sessionUUID))
+    if (auto rangeData = m_unstyledRanges.get(sessionID))
         removeTransparentMarkersForTextAnimationID(rangeData->animationUUID);
 }
 
@@ -172,9 +172,9 @@ void TextAnimationController::removeTransparentMarkersForTextAnimationID(const W
     });
 }
 
-void TextAnimationController::removeInitialTextAnimation(const WTF::UUID& sessionUUID)
+void TextAnimationController::removeInitialTextAnimation(const WebCore::WritingTools::Session::ID& sessionID)
 {
-    if (auto animationID = m_initialAnimations.take(sessionUUID))
+    if (auto animationID = m_initialAnimations.take(sessionID))
         m_webPage->removeTextAnimationForAnimationID(animationID);
 }
 
@@ -189,27 +189,27 @@ static WebCore::CharacterRange remainingCharacterRange(WebCore::CharacterRange t
     return WebCore::CharacterRange { location, length };
 };
 
-void TextAnimationController::addInitialTextAnimation(const WTF::UUID& sessionUUID)
+void TextAnimationController::addInitialTextAnimation(const WebCore::WritingTools::Session::ID& sessionID)
 {
     auto initialAnimationUUID = WTF::UUID::createVersion4();
-    auto animatingRange = unreplacedRangeForSessionWithID(sessionUUID);
+    auto animatingRange = unreplacedRangeForSessionWithID(sessionID);
 
-    if (!animatingRange || animatingRange->collapsed()) {
+    if (!animatingRange || animatingRange->collapsed())
         return;
-    }
+
     auto textIndicatorData = createTextIndicatorForRange(*animatingRange);
     if (!textIndicatorData)
         return;
 
     m_webPage->addTextAnimationForAnimationID(initialAnimationUUID, { WebCore::TextAnimationType::Initial, WebCore::TextAnimationRunMode::RunAnimation, WTF::UUID(WTF::UUID::emptyValue) }, *textIndicatorData);
 
-    m_initialAnimations.set(sessionUUID, initialAnimationUUID);
+    m_initialAnimations.set(sessionID, initialAnimationUUID);
 }
 
-void TextAnimationController::addSourceTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange& replacingRange, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+void TextAnimationController::addSourceTextAnimation(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::CharacterRange& replacingRange, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
 #if PLATFORM(MAC)
-    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionUUID);
+    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionID);
     auto replaceCharacterRange = replacingRange;
 
     WebCore::TextAnimationRunMode runMode = WebCore::TextAnimationRunMode::RunAnimation;
@@ -222,7 +222,7 @@ void TextAnimationController::addSourceTextAnimation(const WTF::UUID& sessionUUI
             replaceCharacterRange = remainingCharacterRange(replacingRange, (*previouslyReplacedRange)->range);
     }
 
-    auto sessionRange = contextRangeForSessionWithID(sessionUUID);
+    auto sessionRange = contextRangeForSessionWithID(sessionID);
     if (!sessionRange) {
         ASSERT_NOT_REACHED();
         return;
@@ -241,7 +241,7 @@ void TextAnimationController::addSourceTextAnimation(const WTF::UUID& sessionUUI
     m_webPage->addTextAnimationForAnimationID(sourceTextIndicatorUUID, { WebCore::TextAnimationType::Source, runMode, WTF::UUID(WTF::UUID::emptyValue) }, *textIndicatorData, WTFMove(completionHandler));
 
     TextAnimationRange animationState = { sourceTextIndicatorUUID, replaceCharacterRange };
-    auto& animationRanges = m_textAnimationRanges.ensure(sessionUUID, [&] {
+    auto& animationRanges = m_textAnimationRanges.ensure(sessionID, [&] {
         return Vector<TextAnimationRange> { };
     }).iterator->value;
 
@@ -249,7 +249,7 @@ void TextAnimationController::addSourceTextAnimation(const WTF::UUID& sessionUUI
 #endif
 }
 
-void TextAnimationController::addDestinationTextAnimation(const WTF::UUID& sessionUUID, const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
+void TextAnimationController::addDestinationTextAnimation(const WebCore::WritingTools::Session::ID& sessionID, const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
 {
     if (!characterRangeAfterReplace) {
         m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
@@ -257,7 +257,7 @@ void TextAnimationController::addDestinationTextAnimation(const WTF::UUID& sessi
     }
 
     auto destinationTextIndicatorUUID = WTF::UUID::createVersion4();
-    auto sessionRange = contextRangeForSessionWithID(sessionUUID);
+    auto sessionRange = contextRangeForSessionWithID(sessionID);
     if (!sessionRange) {
         m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
         ASSERT_NOT_REACHED();
@@ -271,7 +271,7 @@ void TextAnimationController::addDestinationTextAnimation(const WTF::UUID& sessi
         return;
     }
 
-    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionUUID);
+    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionID);
 
     auto replacedCharacterRange = *characterRangeAfterReplace;
     if (previouslyReplacedRange)
@@ -279,13 +279,13 @@ void TextAnimationController::addDestinationTextAnimation(const WTF::UUID& sessi
 
     auto replacedRangeAfterReplace = WebCore::resolveCharacterRange(*sessionRange, replacedCharacterRange, defaultTextAnimationControllerTextIteratorBehaviors);
 
-    auto unstyledRange = WebCore::makeRangeSelectingNodeContents(*document);
+    auto unstyledRange = *sessionRange;
     unstyledRange.start.container = replacedRangeAfterReplace.endContainer();
     unstyledRange.start.offset = replacedRangeAfterReplace.endOffset();
 
     auto unstyledRangeUUID = WTF::UUID::createVersion4();
     TextAnimationUnstyledRangeData unstyledRangeData = { unstyledRangeUUID, unstyledRange };
-    m_unstyledRanges.set(sessionUUID, unstyledRangeData);
+    m_unstyledRanges.set(sessionID, unstyledRangeData);
 
     auto textIndicatorData = createTextIndicatorForRange(replacedRangeAfterReplace);
     if (!textIndicatorData) {
@@ -293,34 +293,34 @@ void TextAnimationController::addDestinationTextAnimation(const WTF::UUID& sessi
         return;
     }
 
-    m_webPage->addTextAnimationForAnimationID(destinationTextIndicatorUUID, { WebCore::TextAnimationType::Final, WebCore::TextAnimationRunMode::RunAnimation, unstyledRangeUUID }, *textIndicatorData, [weakWebPage = WeakPtr { *m_webPage }, sessionUUID](WebCore::TextAnimationRunMode runMode) mutable {
+    m_webPage->addTextAnimationForAnimationID(destinationTextIndicatorUUID, { WebCore::TextAnimationType::Final, WebCore::TextAnimationRunMode::RunAnimation, unstyledRangeUUID }, *textIndicatorData, [weakWebPage = WeakPtr { *m_webPage }, sessionID](WebCore::TextAnimationRunMode runMode) mutable {
         if (runMode == WebCore::TextAnimationRunMode::DoNotRun)
             return;
 
         if (!weakWebPage)
             return;
 
-        weakWebPage->addInitialTextAnimation(sessionUUID);
+        weakWebPage->addInitialTextAnimation(sessionID);
     });
 
     TextAnimationRange animationState = { destinationTextIndicatorUUID, replacedCharacterRange };
-    auto& animationRanges = m_textAnimationRanges.ensure(sessionUUID, [&] {
+    auto& animationRanges = m_textAnimationRanges.ensure(sessionID, [&] {
         return Vector<TextAnimationRange> { };
     }).iterator->value;
 
     animationRanges.append(animationState);
 
     ReplacedRangeAndString replacedRange = { *characterRangeAfterReplace, string };
-    m_alreadyReplacedRanges.set(sessionUUID, replacedRange);
+    m_alreadyReplacedRanges.set(sessionID, replacedRange);
 }
 
 void TextAnimationController::showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID& animationId)
 {
     auto sessionIDForAnimationID = [&] -> std::optional<WebCore::WritingTools::Session::ID> {
-        for (auto& [sessionUUID, animationRanges] : m_textAnimationRanges) {
+        for (auto& [sessionID, animationRanges] : m_textAnimationRanges) {
             for (auto& animationRange : animationRanges) {
                 if (animationRange.animationUUID == animationId)
-                    return sessionUUID;
+                    return sessionID;
             }
         }
 
@@ -350,11 +350,11 @@ void TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID(c
         removeTransparentMarkersForTextAnimationID(uuid);
     else {
         auto animationRange = contextRangeForTextAnimationID(uuid);
-
         if (!animationRange) {
             completionHandler();
             return;
         }
+
         document->markers().addTransparentContentMarker(*animationRange, uuid);
     }
 
@@ -388,7 +388,7 @@ std::optional<WebCore::TextIndicatorData> TextAnimationController::createTextInd
     return textIndicatorData;
 }
 
-void TextAnimationController::clearAnimationsForSessionID(const WTF::UUID& sessionID)
+void TextAnimationController::clearAnimationsForSessionID(const WebCore::WritingTools::Session::ID& sessionID)
 {
     removeTransparentMarkersForSessionID(sessionID);
     removeInitialTextAnimation(sessionID);
@@ -412,6 +412,7 @@ void TextAnimationController::createTextIndicatorForTextAnimationID(const WTF::U
         completionHandler(std::nullopt);
         return;
     }
+
     completionHandler(createTextIndicatorForRange(*sessionRange));
 }
 


### PR DESCRIPTION
#### 29fb9af4daf6d574c95c76bceb58b70372ccb826
<pre>
[Writing Tools] Mail body temporarily disappears when accepting short form smart reply until questionnaire appears
<a href="https://bugs.webkit.org/show_bug.cgi?id=277966">https://bugs.webkit.org/show_bug.cgi?id=277966</a>
<a href="https://rdar.apple.com/132910026">rdar://132910026</a>

Reviewed by Tim Horton.

During the Writing Tools text animation, the text in the session range that has not yet been animated is supposed
to be hidden for the duration of the animation. However, the entire text from the end of the animated range to the
end of the entire document was erroneously being hidden.

As a result, when using Smart Replies, the entire document is hidden during the animation since the session range
is a caret range.

Fix by adjusting the range of the text that is not yet animated to end at the end of the session range instead of
the entire document.

Also, fix some formatting issues, and use the correct types in more places.

* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::unreplacedRangeForSessionWithID const):
(WebKit::TextAnimationController::contextRangeForTextAnimationID const):
(WebKit::TextAnimationController::removeTransparentMarkersForSessionID):
(WebKit::TextAnimationController::removeInitialTextAnimation):
(WebKit::TextAnimationController::addInitialTextAnimation):
(WebKit::TextAnimationController::addSourceTextAnimation):
(WebKit::TextAnimationController::addDestinationTextAnimation):
(WebKit::TextAnimationController::showSelectionForWritingToolsSessionAssociatedWithAnimationID):
(WebKit::TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::TextAnimationController::clearAnimationsForSessionID):
(WebKit::TextAnimationController::createTextIndicatorForTextAnimationID):

Canonical link: <a href="https://commits.webkit.org/282133@main">https://commits.webkit.org/282133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08bb54b69ed4d89ef214a185c467744a68a1f173

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12744 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38597 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/30926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11675 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67909 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57723 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5079 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9358 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->