### PR TITLE
[css-anchor-position-1] Add restrictions on valid anchor and anchor-positioned elements

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -346,6 +346,15 @@ Length AnchorPositionEvaluator::resolveAnchorValue(const BuilderState& builderSt
         return Length(0, LengthType::Fixed);
     Ref anchorPositionedElement = *builderState.element();
 
+    // FIXME: Support pseudo-elements.
+    if (builderState.style().pseudoElementType() != PseudoId::None)
+        return Length(0, LengthType::Fixed);
+
+    // In-flow elements cannot be anchor-positioned.
+    // FIXME: Should attempt to resolve the fallback value.
+    if (!builderState.style().hasOutOfFlowPosition())
+        return Length(0, LengthType::Fixed);
+
     auto* anchorPositionedStateMap = builderState.cssToLengthConversionData().anchorPositionedStateMap();
     if (!anchorPositionedStateMap)
         return Length(0, LengthType::Fixed);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1326,6 +1326,12 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     if (!style)
         return AnchorPositionedElementAction::None;
 
+    bool isAnchor = generatesBox(*style) && !style->anchorNames().isEmpty();
+    auto* anchorPositionedElementState = m_anchorPositionedStateMap.get(element);
+    bool isAnchorPositioned = !!anchorPositionedElementState;
+    if (!isAnchor && !isAnchorPositioned)
+        return AnchorPositionedElementAction::None;
+
     // Maintain the list of anchors (in tree order) used for anchor-positioned elements
     if (!style->anchorNames().isEmpty()) {
         for (auto& anchorName : style->anchorNames()) {
@@ -1337,7 +1343,6 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     }
 
     // Check if this element is anchor-positioned
-    auto* anchorPositionedElementState = m_anchorPositionedStateMap.get(element);
     if (!anchorPositionedElementState)
         return AnchorPositionedElementAction::None;
 


### PR DESCRIPTION
#### 9cf82786bf79ae7bae6d9e38b2b0f0277f661be1
<pre>
[css-anchor-position-1] Add restrictions on valid anchor and anchor-positioned elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=277969">https://bugs.webkit.org/show_bug.cgi?id=277969</a>
<a href="https://rdar.apple.com/133705664">rdar://133705664</a>

Reviewed by Antti Koivisto.

This patch ensures that anchor elements generate a principal box.
It also explicitly prevents in-flow elements and pseudo-elements from
being anchor-positioned. (Pseudo-element support should come later.)

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateAnchorPositioningState):

Canonical link: <a href="https://commits.webkit.org/282166@main">https://commits.webkit.org/282166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2631c66d398b19d04239b4e98376217a6485ad4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50132 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30928 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11144 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11679 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57506 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5081 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37357 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->