### PR TITLE
Background-clip: border-area on inlines need to respect -webkit-box-decoration-break

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-expected.html
@@ -1,0 +1,27 @@
+<style>
+    div {
+        margin: 20px;
+        font-size: 24pt;
+        line-height: 1.5em;
+    }
+
+    .test {
+        border: 10px solid blue;
+    }
+
+    .clone {
+        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
+    }
+
+    .slice {
+        -webkit-box-decoration-break: slice;
+        box-decoration-break: slice;
+    }
+</style>
+</head>
+<body>
+<div>AAA<span class="test clone">AAA<br>AA</span>AA</div>
+<div>AAA<span class="test slice">AAA<br>AA</span>AA</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-ref.html
@@ -1,0 +1,27 @@
+<style>
+    div {
+        margin: 20px;
+        font-size: 24pt;
+        line-height: 1.5em;
+    }
+
+    .test {
+        border: 10px solid blue;
+    }
+
+    .clone {
+        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
+    }
+
+    .slice {
+        -webkit-box-decoration-break: slice;
+        box-decoration-break: slice;
+    }
+</style>
+</head>
+<body>
+<div>AAA<span class="test clone">AAA<br>AA</span>AA</div>
+<div>AAA<span class="test slice">AAA<br>AA</span>AA</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-box-decoration-break-ref.html">
+<meta name="fuzzy" content="maxDifference=0-150; totalPixels=0-200">
+<meta name="assert" content="background-clip: border-area respects box-decoration-break">
+<style>
+    div {
+        margin: 20px;
+        font-size: 24pt;
+        line-height: 1.5em;
+    }
+
+    .test {
+        border: 10px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/blue-100.png);
+    }
+
+    .clone {
+        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
+    }
+
+    .slice {
+        -webkit-box-decoration-break: slice;
+        box-decoration-break: slice;
+    }
+</style>
+</head>
+<body>
+<div>AAA<span class="test clone">AAA<br>AA</span>AA</div>
+<div>AAA<span class="test slice">AAA<br>AA</span>AA</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -340,7 +340,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         break;
     }
     case FillBox::BorderArea: {
-        auto borderAreaPath = BorderPainter::pathForBorderArea(rect, style, deviceScaleFactor);
+        auto borderAreaPath = BorderPainter::pathForBorderArea(rect, style, deviceScaleFactor, includeLeftEdge, includeRightEdge);
         if (borderAreaPath) {
             backgroundClipStateSaver.save();
             context.clipPath(borderAreaPath.value());


### PR DESCRIPTION
#### 2410dac70431f24a09005efcf318c580ace0dc5e
<pre>
Background-clip: border-area on inlines need to respect -webkit-box-decoration-break
<a href="https://bugs.webkit.org/show_bug.cgi?id=277964">https://bugs.webkit.org/show_bug.cgi?id=277964</a>
<a href="https://rdar.apple.com/133697782">rdar://133697782</a>

Reviewed by Tim Nguyen.

Need to pass `includeLeftEdge, includeRightEdge` to `BorderPainter::pathForBorderArea()` to handle box decoration
break.

Added WPT.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):

Canonical link: <a href="https://commits.webkit.org/282187@main">https://commits.webkit.org/282187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12561bcc66ed82c346e1761091b341fe42ea9290

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50265 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8914 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38771 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54024 "Found 1 new API test failure: TestWebKitAPI.VideoControlsManager.StartPlayingLargestVideoInViewport (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11329 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57635 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54040 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5243 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37516 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->