### PR TITLE
`-renderedText` should not be empty for targeted elements resolved using compound selectors

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -400,6 +400,7 @@ TEST(ElementTargeting, RequestElementsFromSelectors)
     EXPECT_EQ(1U, [targets count]);
     EXPECT_WK_STREQ("DIV.absolute.bottom-right", [target selectorsIncludingShadowHosts].firstObject.firstObject);
     EXPECT_TRUE([target isInVisibilityAdjustmentSubtree]);
+    EXPECT_WK_STREQ("Bottom Right", [target renderedText]);
 
     didAdjustVisibility = false;
 


### PR DESCRIPTION
#### e002db6b59bb5a5e7861a47de7e752d8604a18a1
<pre>
`-renderedText` should not be empty for targeted elements resolved using compound selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=277968">https://bugs.webkit.org/show_bug.cgi?id=277968</a>
<a href="https://rdar.apple.com/133705519">rdar://133705519</a>

Reviewed by Tim Horton.

Make a couple of adjustments to the element targeting heuristic:

1.  Walk the ancestor chain and check `m_adjustedElements` to determine whether an element is in a
    visibility adjustment subtree. We do this instead of checking against the element&apos;s ancestors&apos;
    `visibilityAdjustment()` states, because we may have temporarily reverted visibility adjustments
    when handling a targeting request.

2.  Allow selector-based targeting to find elements that have already been hidden by visibility
    adjustment.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::selectorForElementRecursive):
(WebCore::siblingRelativeSelectorRecursive):
(WebCore::parentRelativeSelectorRecursive):
(WebCore::selectorsForTarget):
(WebCore::ElementTargetingController::targetedElementInfo):
(WebCore::shouldIgnoreExistingVisibilityAdjustments):
(WebCore::ElementTargetingController::extractTargets):

Ensure that `isInVisibilityAdjustmentSubtree` is correctly computed in the case where we&apos;re
resolving a target inside of a visibility adjustment subtree using either selector- or search-text-
based targeting.

(WebCore::targetedElementInfo): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, RequestElementsFromSelectors)):

Augment an existing test to exercise this change, by verifying that `-renderedText` is equal to
&quot;Bottom Right&quot; for the bottom right hidden container.

Canonical link: <a href="https://commits.webkit.org/282163@main">https://commits.webkit.org/282163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cff19fcf7ee0d0838967e61a0f9237e2d3b1cf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66270 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50190 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11225 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5159 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37444 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->