### PR TITLE
[DRAFT][Not For Review] Test WebKit/NetworkProcess

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -313,7 +313,7 @@
 #if CPU(ARM64) && OS(DARWIN)
 // Only MacroAssemblerARM64 is known to build.
 // Building with TZONE_MALLOC currently disabled for all platforms.
-#define USE_TZONE_MALLOC 0
+#define USE_TZONE_MALLOC 1
 #else
 #define USE_TZONE_MALLOC 0
 #endif

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -35,6 +35,7 @@
 #include "WebErrors.h"
 #include <WebCore/BackgroundFetchRequest.h>
 #include <WebCore/ClientOrigin.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 #define BGLOAD_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - BackgroundFetchLoad::" fmt, this, ##__VA_ARGS__)
@@ -42,6 +43,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetchLoad);
 
 BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, BackgroundFetchRecordLoaderClient& client, const BackgroundFetchRequest& request, size_t responseDataSize, const ClientOrigin& clientOrigin)
     : m_sessionID(WTFMove(sessionID))

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -31,6 +31,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -56,7 +57,7 @@ class NetworkLoadChecker;
 class NetworkProcess;
 
 class BackgroundFetchLoad final : public WebCore::BackgroundFetchRecordLoader, public NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackgroundFetchLoad);
 public:
     BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, WebCore::BackgroundFetchRecordLoaderClient&, const WebCore::BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&);
     ~BackgroundFetchLoad();

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -55,6 +55,7 @@
 #include <wtf/Scope.h>
 #include <wtf/StdSet.h>
 #include <wtf/SuspendableWorkQueue.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -347,6 +348,8 @@ static WeakHashSet<ResourceLoadStatisticsStore>& allStores()
     static NeverDestroyed<WeakHashSet<ResourceLoadStatisticsStore>> map;
     return map;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ResourceLoadStatisticsStore);
 
 ResourceLoadStatisticsStore::ResourceLoadStatisticsStore(WebResourceLoadStatisticsStore& store, SuspendableWorkQueue& workQueue, ShouldIncludeLocalhost shouldIncludeLocalhost, const String& storageDirectoryPath, PAL::SessionID sessionID)
     : DatabaseUtilities(FileSystem::pathByAppendingComponent(storageDirectoryPath, "observations.db"_s))

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -33,6 +33,7 @@
 #include <pal/SessionID.h>
 #include <wtf/Forward.h>
 #include <wtf/StdSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if HAVE(CORE_PREDICTION)
@@ -95,7 +96,7 @@ enum class DataRemovalFrequency : uint8_t { Never, Short, Long };
 
 // This is always constructed / used / destroyed on the WebResourceLoadStatisticsStore's statistics queue.
 class ResourceLoadStatisticsStore final : public DatabaseUtilities, public CanMakeWeakPtr<ResourceLoadStatisticsStore> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ResourceLoadStatisticsStore);
 public:
     using ResourceLoadStatistics = WebCore::ResourceLoadStatistics;
     using RegistrableDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -37,12 +37,15 @@
 #include <WebCore/HTTPCookieAcceptPolicy.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCookieManager);
 
 ASCIILiteral WebCookieManager::supplementName()
 {

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakRef.h>
 
@@ -50,7 +51,7 @@ namespace WebKit {
 class NetworkProcess;
 
 class WebCookieManager : public NetworkProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebCookieManager);
     WTF_MAKE_NONCOPYABLE(WebCookieManager);
 public:
     WebCookieManager(NetworkProcess&);

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -33,8 +33,11 @@
 #include "NetworkProcessCreationParameters.h"
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyCustomProtocolManager);
 
 ASCIILiteral LegacyCustomProtocolManager::supplementName()
 {

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -54,7 +55,7 @@ class NetworkProcess;
 struct NetworkProcessCreationParameters;
 
 class LegacyCustomProtocolManager : public NetworkProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LegacyCustomProtocolManager);
     WTF_MAKE_NONCOPYABLE(LegacyCustomProtocolManager);
 public:
     explicit LegacyCustomProtocolManager(NetworkProcess&);

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -40,6 +40,7 @@
 #include "SandboxExtension.h"
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/NotImplemented.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "NetworkDataTaskCocoa.h"
@@ -49,6 +50,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Download);
 
 Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NetworkDataTask& download, NetworkSession& session, const String& suggestedName)
     : m_downloadManager(downloadManager)

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -37,6 +37,7 @@
 #include <pal/SessionID.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
@@ -70,7 +71,8 @@ class NetworkSession;
 class WebPage;
 
 class Download : public IPC::MessageSender, public CanMakeWeakPtr<Download> {
-    WTF_MAKE_NONCOPYABLE(Download); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Download);
+    WTF_MAKE_NONCOPYABLE(Download);
 public:
     Download(DownloadManager&, DownloadID, NetworkDataTask&, NetworkSession&, const String& suggestedFilename = { });
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -28,6 +28,7 @@
 
 #include "Download.h"
 #include "Logging.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #define DOWNLOAD_MONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - DownloadMonitor::" fmt, this, ##__VA_ARGS__)
 
@@ -65,6 +66,8 @@ DownloadMonitor::DownloadMonitor(Download& download)
     : m_download(download)
 {
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DownloadMonitor);
 
 double DownloadMonitor::measuredThroughputRate() const
 {

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -27,13 +27,15 @@
 
 #include <WebCore/Timer.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class Download;
 
 class DownloadMonitor {
-    WTF_MAKE_NONCOPYABLE(DownloadMonitor); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DownloadMonitor);
+    WTF_MAKE_NONCOPYABLE(DownloadMonitor);
 public:
     DownloadMonitor(Download&);
     

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -32,9 +32,12 @@
 #include "NetworkLoad.h"
 #include "NetworkProcess.h"
 #include "WebCoreArgumentCoders.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PendingDownload);
 
 PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, NetworkLoadParameters&& parameters, DownloadID downloadID, NetworkSession& networkSession, const String& suggestedName)
     : m_networkLoad(makeUnique<NetworkLoad>(*this, WTFMove(parameters), networkSession))

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -29,6 +29,7 @@
 #include "MessageSender.h"
 #include "NetworkLoadClient.h"
 #include "SandboxExtension.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class PendingDownload;
@@ -55,7 +56,7 @@ class NetworkLoadParameters;
 class NetworkSession;
 
 class PendingDownload : public NetworkLoadClient, public IPC::MessageSender, public CanMakeWeakPtr<PendingDownload> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PendingDownload);
 public:
     PendingDownload(IPC::Connection*, NetworkLoadParameters&&, DownloadID, NetworkSession&, const String& suggestedName);
     PendingDownload(IPC::Connection*, std::unique_ptr<NetworkLoad>&&, ResponseCompletionHandler&&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -36,10 +36,13 @@
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/StoredCredentialsPolicy.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EarlyHintsResourceLoader);
 
 EarlyHintsResourceLoader::EarlyHintsResourceLoader(NetworkResourceLoader& loader)
     : m_loader(&loader)

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "NetworkResourceLoader.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class LinkHeader;
@@ -35,7 +36,7 @@ namespace WebKit {
 
 class EarlyHintsResourceLoader
     : public WebCore::ContentSecurityPolicyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EarlyHintsResourceLoader);
     WTF_MAKE_NONCOPYABLE(EarlyHintsResourceLoader);
 public:
     explicit EarlyHintsResourceLoader(NetworkResourceLoader&);

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -31,6 +31,7 @@
 #include "WebBroadcastChannelRegistryMessages.h"
 #include <WebCore/MessageWithMessagePorts.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -49,6 +50,8 @@ static bool isValidClientOrigin(const WebCore::ClientOrigin& clientOrigin)
 {
     return !clientOrigin.topOrigin.isNull() && !clientOrigin.clientOrigin.isNull();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkBroadcastChannelRegistry);
 
 NetworkBroadcastChannelRegistry::NetworkBroadcastChannelRegistry(NetworkProcess& networkProcess)
     : m_networkProcess(networkProcess)

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
@@ -29,6 +29,7 @@
 #include <WebCore/BroadcastChannelIdentifier.h>
 #include <WebCore/ClientOrigin.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct MessageWithMessagePorts;
@@ -39,7 +40,7 @@ namespace WebKit {
 class NetworkProcess;
 
 class NetworkBroadcastChannelRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkBroadcastChannelRegistry);
 public:
     explicit NetworkBroadcastChannelRegistry(NetworkProcess&);
 

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -35,6 +35,7 @@
 #include "WebErrors.h"
 #include <WebCore/CrossOriginAccessControl.h>
 #include <WebCore/SecurityOrigin.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 #define CORS_CHECKER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkCORSPreflightChecker::" fmt, this, ##__VA_ARGS__)
@@ -42,6 +43,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkCORSPreflightChecker);
 
 NetworkCORSPreflightChecker::NetworkCORSPreflightChecker(NetworkProcess& networkProcess, NetworkResourceLoader* networkResourceLoader, Parameters&& parameters, bool shouldCaptureExtraNetworkLoadMetrics, CompletionCallback&& completionCallback)
     : m_parameters(WTFMove(parameters))

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -33,6 +33,7 @@
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class ResourceError;
@@ -47,7 +48,7 @@ class NetworkProcess;
 class NetworkResourceLoader;
 
 class NetworkCORSPreflightChecker final : private NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkCORSPreflightChecker);
 public:
     struct Parameters {
         WebCore::ResourceRequest originalRequest;

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -41,10 +41,13 @@
 #include <WebCore/SharedBuffer.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkLoad);
 
 NetworkLoad::NetworkLoad(NetworkLoadClient& client, NetworkLoadParameters&& parameters, NetworkSession& networkSession)
     : m_client(client)

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -28,6 +28,7 @@
 #include "DownloadID.h"
 #include "NetworkDataTask.h"
 #include "NetworkLoadParameters.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -50,7 +51,7 @@ class NetworkLoadScheduler;
 class NetworkProcess;
 
 class NetworkLoad final : public NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkLoad);
 public:
     NetworkLoad(NetworkLoadClient&, NetworkLoadParameters&&, NetworkSession&);
     NetworkLoad(NetworkLoadClient&, NetworkSession&, const Function<RefPtr<NetworkDataTask>(NetworkDataTaskClient&)>&);

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/OriginAccessPatterns.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 #define LOAD_CHECKER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkLoadChecker::" fmt, this, ##__VA_ARGS__)
@@ -50,6 +51,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkLoadChecker);
 
 NetworkLoadChecker::NetworkLoadChecker(NetworkProcess& networkProcess, NetworkResourceLoader* networkResourceLoader, NetworkSchemeRegistry* schemeRegistry, FetchOptions&& options, PAL::SessionID sessionID, WebPageProxyIdentifier webPageProxyID, HTTPHeaderMap&& originalRequestHeaders, URL&& url, DocumentURL&& documentURL, RefPtr<SecurityOrigin>&& sourceOrigin, RefPtr<SecurityOrigin>&& topOrigin, RefPtr<SecurityOrigin>&& parentOrigin, PreflightPolicy preflightPolicy, String&& referrer, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, bool shouldCaptureExtraNetworkLoadMetrics, LoadType requestLoadType)
     : m_options(WTFMove(options))

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -33,6 +33,7 @@
 #include <WebCore/NetworkLoadInformation.h>
 #include <pal/SessionID.h>
 #include <variant>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -66,7 +67,7 @@ class NetworkSchemeRegistry;
 using DocumentURL = URL;
 
 class NetworkLoadChecker : public CanMakeWeakPtr<NetworkLoadChecker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkLoadChecker);
 public:
     enum class LoadType : bool { MainFrame, Other };
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "NetworkLoad.h"
 #include <WebCore/ResourceError.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakListHashSet.h>
 
@@ -38,7 +39,7 @@ static constexpr size_t maximumActiveCountForLowPriority = 2;
 static constexpr size_t maximumTrackedHTTP1XOrigins = 128;
 
 class NetworkLoadScheduler::HostContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkLoadScheduler::HostContext);
 public:
     HostContext() = default;
     ~HostContext();
@@ -54,6 +55,8 @@ private:
     WeakHashSet<NetworkLoad> m_activeLoads;
     WeakListHashSet<NetworkLoad> m_pendingLoads;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NetworkLoadSchedulerHostContext, NetworkLoadScheduler::HostContext);
 
 void NetworkLoadScheduler::HostContext::schedule(NetworkLoad& load)
 {
@@ -114,6 +117,8 @@ NetworkLoadScheduler::HostContext::~HostContext()
     for (auto& load : m_pendingLoads)
         start(load);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkLoadScheduler);
 
 NetworkLoadScheduler::NetworkLoadScheduler() = default;
 NetworkLoadScheduler::~NetworkLoadScheduler() = default;

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
@@ -31,6 +31,7 @@
 #include <tuple>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -52,7 +53,7 @@ namespace WebKit {
 class NetworkLoad;
 
 class NetworkLoadScheduler : public CanMakeWeakPtr<NetworkLoadScheduler> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkLoadScheduler);
 public:
     NetworkLoadScheduler();
     ~NetworkLoadScheduler();

--- a/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp
@@ -28,8 +28,11 @@
 
 #include <wtf/Algorithms.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkOriginAccessPatterns);
 
 void NetworkOriginAccessPatterns::allowAccessTo(const WebCore::UserContentURLPattern& pattern)
 {

--- a/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.h
+++ b/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.h
@@ -27,12 +27,13 @@
 
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/UserContentURLPattern.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
 class NetworkOriginAccessPatterns final : public WebCore::OriginAccessPatterns {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkOriginAccessPatterns);
 public:
     void allowAccessTo(const WebCore::UserContentURLPattern&);
 private:

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -100,6 +100,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WTFProcess.h>
@@ -146,6 +147,8 @@ static void callExitSoon(IPC::Connection*)
         terminateProcess(EXIT_FAILURE);
     });
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkProcess);
 
 NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parameters)
     : m_downloadManager(*this)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -59,6 +59,7 @@
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/ASCIILiteral.h>
 
@@ -134,7 +135,7 @@ enum class CacheOption : uint8_t;
 class NetworkProcess final : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>, public CanMakeCheckedPtr<NetworkProcess>
 {
     WTF_MAKE_NONCOPYABLE(NetworkProcess);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkProcess);
 public:
     using RegistrableDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -57,6 +57,7 @@
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/RuntimeApplicationChecks.h>
 #include <WebCore/SWServer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "DefaultWebBrowserChecks.h"
@@ -73,6 +74,9 @@ namespace WebKit {
 using namespace WebCore;
 
 constexpr Seconds cachedNetworkResourceLoaderLifetime { 30_s };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkSession);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NetworkSessionCachedNetworkResourceLoader, NetworkSession::CachedNetworkResourceLoader);
 
 std::unique_ptr<NetworkSession> NetworkSession::create(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
 {

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -49,6 +49,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
@@ -102,7 +103,7 @@ class Cache;
 }
 
 class NetworkSession : public WebCore::SWServerDelegate, public CanMakeCheckedPtr<NetworkSession> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkSession);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSession);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);
@@ -315,7 +316,7 @@ protected:
     HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
 
     class CachedNetworkResourceLoader {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(CachedNetworkResourceLoader);
     public:
         explicit CachedNetworkResourceLoader(Ref<NetworkResourceLoader>&&);
         RefPtr<NetworkResourceLoader> takeLoader();

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -33,9 +33,12 @@
 #include "WebCoreArgumentCoders.h"
 #include "WebSocketChannelMessages.h"
 #include "WebSocketTask.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkSocketChannel);
 
 std::unique_ptr<NetworkSocketChannel> NetworkSocketChannel::create(NetworkConnectionToWebProcess& connection, PAL::SessionID sessionID, const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const WebCore::ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -35,6 +35,7 @@
 #include <WebCore/WebSocketIdentifier.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -58,7 +59,7 @@ class NetworkProcess;
 class NetworkSession;
 
 class NetworkSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkSocketChannel);
 public:
     static std::unique_ptr<NetworkSocketChannel> create(NetworkConnectionToWebProcess&, PAL::SessionID, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -36,9 +36,12 @@
 #include "WebPushDaemonConnectionConfiguration.h"
 #include "WebPushMessage.h"
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkNotificationManager);
 
 NetworkNotificationManager::NetworkNotificationManager(NetworkSession& networkSession, const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
     : m_networkSession(networkSession)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -34,6 +34,7 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/NotificationDirection.h>
 #include <WebCore/PushSubscriptionData.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -50,7 +51,7 @@ enum class MessageType : uint8_t;
 class NetworkSession;
 
 class NetworkNotificationManager : public NotificationManagerMessageHandler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkNotificationManager);
     friend class NetworkSession;
 public:
     NetworkSession& networkSession() const { return m_networkSession; }

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -31,8 +31,11 @@
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
 #include "NetworkSession.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebPushD {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Connection);
 
 Connection::Connection(CString&& machServiceName, NetworkNotificationManager& manager, WebPushDaemonConnectionConfiguration&& configuration)
     : Daemon::ConnectionToMachService<ConnectionTraits>(WTFMove(machServiceName))

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -31,6 +31,7 @@
 #include "MessageSender.h"
 #include "WebPushDaemonConnectionConfiguration.h"
 #include "WebPushDaemonConstants.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Decoder;
@@ -52,7 +53,7 @@ struct ConnectionTraits {
 };
 
 class Connection : public Daemon::ConnectionToMachService<ConnectionTraits>, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Connection);
 public:
     Connection(CString&& machServiceName, NetworkNotificationManager&, WebPushDaemonConnectionConfiguration&&);
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
@@ -28,8 +28,11 @@
 
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::PCM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ClientImpl);
 
 ClientImpl::ClientImpl(NetworkSession& session, NetworkProcess& networkProcess)
     : m_networkSession(session)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h
@@ -27,7 +27,7 @@
 
 #include "PrivateClickMeasurementClient.h"
 #include <pal/SessionID.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +38,7 @@ class NetworkProcess;
 namespace PCM {
 
 class ClientImpl : public Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ClientImpl);
 public:
     ClientImpl(NetworkSession&, NetworkProcess&);
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp
@@ -25,12 +25,15 @@
 
 #include "config.h"
 #include "PrivateClickMeasurementDaemonClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "PCMDaemonConnectionSet.h"
 #endif
 
 namespace WebKit::PCM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DaemonClient);
 
 void DaemonClient::broadcastConsoleMessage(JSC::MessageLevel level, const String& message)
 {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.h
@@ -26,13 +26,13 @@
 #pragma once
 
 #include "PrivateClickMeasurementClient.h"
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit::PCM {
 
 class DaemonClient : public Client, public CanMakeWeakPtr<DaemonClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DaemonClient);
     void broadcastConsoleMessage(JSC::MessageLevel, const String&) final;
     bool featureEnabled() const final;
     bool debugModeEnabled() const final;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/SQLiteStatement.h>
 #include <WebCore/SQLiteStatementAutoResetScope.h>
 #include <WebCore/SQLiteTransaction.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit::PCM {
@@ -81,6 +82,8 @@ static WeakHashSet<Database>& allDatabases()
     static NeverDestroyed<WeakHashSet<Database>> set;
     return set;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Database);
 
 Database::Database(const String& storageDirectory)
     : DatabaseUtilities(FileSystem::pathByAppendingComponent(storageDirectory, "pcm.db"_s))

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
@@ -27,6 +27,7 @@
 
 #include "DatabaseUtilities.h"
 #include <WebCore/PrivateClickMeasurement.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -47,7 +48,7 @@ struct DebugInfo;
 
 // This is created, used, and destroyed on the Store's queue.
 class Database : public DatabaseUtilities, public CanMakeWeakPtr<Database> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Database);
 public:
     Database(const String& storageDirectory);
     virtual ~Database();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/RuntimeApplicationChecks.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringHash.h>
@@ -54,6 +55,8 @@ using AttributionTriggerData = WebCore::PCM::AttributionTriggerData;
 using EphemeralNonce = WebCore::PCM::EphemeralNonce;
 
 constexpr Seconds debugModeSecondsUntilSend { 10_s };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PrivateClickMeasurementManager);
 
 PrivateClickMeasurementManager::PrivateClickMeasurementManager(UniqueRef<PCM::Client>&& client, const String& storageDirectory)
     : m_firePendingAttributionRequestsTimer(RunLoop::main(), this, &PrivateClickMeasurementManager::firePendingAttributionRequests)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -33,6 +33,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -48,7 +49,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::PrivateClickM
 namespace WebKit {
 
 class PrivateClickMeasurementManager : public PCM::ManagerInterface, public CanMakeWeakPtr<PrivateClickMeasurementManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PrivateClickMeasurementManager);
 public:
 
     explicit PrivateClickMeasurementManager(UniqueRef<PCM::Client>&&, const String& storageDirectory);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
@@ -30,8 +30,11 @@
 #include "DaemonEncoder.h"
 #include "PrivateClickMeasurementConnection.h"
 #include "WebCoreArgumentCoders.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::PCM {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ManagerProxy);
 
 template<MessageType messageType, typename... Args>
 void ManagerProxy::sendMessage(Args&&... args) const

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h
@@ -27,7 +27,7 @@
 
 #include "PrivateClickMeasurementConnection.h"
 #include "PrivateClickMeasurementManagerInterface.h"
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace WebKit {
@@ -37,7 +37,7 @@ class NetworkSession;
 namespace PCM {
 
 class ManagerProxy : public ManagerInterface {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ManagerProxy);
 public:
     ManagerProxy(const String& machServiceName, NetworkSession&);
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
@@ -29,10 +29,14 @@
 #include <WebCore/NotImplemented.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceResponse.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::PCM {
 
 #if !PLATFORM(COCOA)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkLoader);
+
 void NetworkLoader::start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, Callback&& completionHandler)
 {
     notImplemented();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h
@@ -28,6 +28,7 @@
 #include <WebCore/PrivateClickMeasurement.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CertificateInfo;
@@ -38,7 +39,7 @@ class ResourceResponse;
 namespace WebKit::PCM {
 
 class NetworkLoader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkLoader);
 public:
     using Callback = CompletionHandler<void(const String&, const RefPtr<JSON::Object>&)>;
     static void start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, Callback&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -34,6 +34,7 @@
 #include "WebErrors.h"
 #include "WebSWContextManagerConnectionMessages.h"
 #include "WebSWServerToContextConnection.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
@@ -45,6 +46,8 @@ static WorkQueue& sharedServiceWorkerDownloadTaskQueue()
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("Shared ServiceWorkerDownloadTask Queue"_s));
     return queue.get();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerDownloadTask);
 
 ServiceWorkerDownloadTask::ServiceWorkerDownloadTask(NetworkSession& session, NetworkDataTaskClient& client, WebSWServerToContextConnection& serviceWorkerConnection, ServiceWorkerIdentifier serviceWorkerIdentifier, SWServerConnectionIdentifier serverConnectionIdentifier, FetchIdentifier fetchIdentifier, const WebCore::ResourceRequest& request, const ResourceResponse& response, DownloadID downloadID)
     : NetworkDataTask(session, client, request, StoredCredentialsPolicy::DoNotUse, false, false)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -32,6 +32,7 @@
 #include <WebCore/FetchIdentifier.h>
 #include <wtf/FileSystem.h>
 #include <wtf/FunctionDispatcher.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class FormDataReference;
@@ -46,7 +47,7 @@ class SandboxExtension;
 class WebSWServerToContextConnection;
 
 class ServiceWorkerDownloadTask : public NetworkDataTask, private FunctionDispatcher, private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerDownloadTask);
 public:
     static Ref<ServiceWorkerDownloadTask> create(NetworkSession& session, NetworkDataTaskClient& client, WebSWServerToContextConnection& connection, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::FetchIdentifier fetchIdentifier, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, DownloadID downloadID)
     {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -44,6 +44,7 @@
 #include "WebSWServerToContextConnection.h"
 #include <WebCore/CrossOriginAccessControl.h>
 #include <WebCore/SWServerRegistration.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define SWFETCH_RELEASE_LOG(fmt, ...) RELEASE_LOG(ServiceWorker, "%p - [fetchIdentifier=%" PRIu64 "] ServiceWorkerFetchTask::" fmt, this, m_fetchIdentifier.toUInt64(), ##__VA_ARGS__)
 #define SWFETCH_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ServiceWorker, "%p - [fetchIdentifier=%" PRIu64 "] ServiceWorkerFetchTask::" fmt, this, m_fetchIdentifier.toUInt64(), ##__VA_ARGS__)
@@ -51,6 +52,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerFetchTask);
 
 Ref<ServiceWorkerFetchTask> ServiceWorkerFetchTask::create(WebSWServerConnection& connection, NetworkResourceLoader& loader, WebCore::ResourceRequest&& request, WebCore::SWServerConnectionIdentifier connectionIdentifier, WebCore::ServiceWorkerIdentifier workerIdentifier, WebCore::SWServerRegistration& registration, NetworkSession* session, bool isWorkerReady)
 {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -32,6 +32,7 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -61,7 +62,7 @@ class WebSWServerConnection;
 class WebSWServerToContextConnection;
 
 class ServiceWorkerFetchTask : public RefCounted<ServiceWorkerFetchTask>, public CanMakeWeakPtr<ServiceWorkerFetchTask> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerFetchTask);
 public:
     static RefPtr<ServiceWorkerFetchTask> fromNavigationPreloader(WebSWServerConnection&, NetworkResourceLoader&, const WebCore::ResourceRequest&, NetworkSession*);
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -34,10 +34,13 @@
 #include "PrivateRelayed.h"
 #include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/NavigationPreloadState.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerNavigationPreloader);
 
 ServiceWorkerNavigationPreloader::ServiceWorkerNavigationPreloader(NetworkSession& session, NetworkLoadParameters&& parameters, const WebCore::NavigationPreloadState& state, bool shouldCaptureExtraNetworkLoadMetric)
     : m_session(session)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -31,6 +31,7 @@
 #include "NetworkLoadParameters.h"
 #include <WebCore/NavigationPreloadState.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -45,7 +46,7 @@ class NetworkLoad;
 class NetworkSession;
 
 class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader>, public CanMakeCheckedPtr<ServiceWorkerNavigationPreloader> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerNavigationPreloader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ServiceWorkerNavigationPreloader);
 public:
     ServiceWorkerNavigationPreloader(NetworkSession&, NetworkLoadParameters&&, const WebCore::NavigationPreloadState&, bool shouldCaptureExtraNetworkLoadMetrics);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -36,10 +36,13 @@
 #include <WebCore/TextResourceDecoder.h>
 #include <WebCore/WorkerFetchResult.h>
 #include <WebCore/WorkerScriptLoader.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerSoftUpdateLoader);
 
 ServiceWorkerSoftUpdateLoader::ServiceWorkerSoftUpdateLoader(NetworkSession& session, ServiceWorkerJobData&& jobData, bool shouldRefreshCache, ResourceRequest&& request, Handler&& completionHandler)
     : m_completionHandler(WTFMove(completionHandler))

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
@@ -33,6 +33,7 @@
 #include <WebCore/ServiceWorkerJobData.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ class NetworkLoad;
 class NetworkSession;
 
 class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader>, public CanMakeCheckedPtr<ServiceWorkerSoftUpdateLoader> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerSoftUpdateLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ServiceWorkerSoftUpdateLoader);
 public:
     using Handler = CompletionHandler<void(WebCore::WorkerFetchResult&&)>;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -58,6 +58,7 @@
 #include <cstdint>
 #include <wtf/Algorithms.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace PAL;
@@ -76,6 +77,8 @@ using namespace WebCore;
         return; \
     } \
 } while (0)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWServerConnection);
 
 WebSWServerConnection::WebSWServerConnection(NetworkConnectionToWebProcess& networkConnectionToWebProcess, SWServer& server, IPC::Connection& connection, ProcessIdentifier processIdentifier)
     : SWServer::Connection(server, processIdentifier)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -39,6 +39,7 @@
 #include <WebCore/SWServer.h>
 #include <pal/SessionID.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -67,7 +68,7 @@ class NetworkResourceLoader;
 class ServiceWorkerFetchTask;
 
 class WebSWServerConnection final : public WebCore::SWServer::Connection, public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSWServerConnection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSWServerConnection);
 public:
     WebSWServerConnection(NetworkConnectionToWebProcess&, WebCore::SWServer&, IPC::Connection&, WebCore::ProcessIdentifier);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -43,11 +43,14 @@
 #include <WebCore/SWServer.h>
 #include <WebCore/SWServerWorker.h>
 #include <WebCore/ServiceWorkerContextData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, &this->ipcConnection())
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWServerToContextConnection);
 
 WebSWServerToContextConnection::WebSWServerToContextConnection(NetworkConnectionToWebProcess& connection, WebPageProxyIdentifier webPageProxyID, RegistrableDomain&& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, SWServer& server)
     : SWServerToContextConnection(server, WTFMove(registrableDomain), serviceWorkerPageIdentifier)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -31,6 +31,7 @@
 #include "ServiceWorkerFetchTask.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/SWServerToContextConnection.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
@@ -57,7 +58,7 @@ class ServiceWorkerDownloadTask;
 class WebSWServerConnection;
 
 class WebSWServerToContextConnection final: public WebCore::SWServerToContextConnection, public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSWServerToContextConnection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSWServerToContextConnection);
 public:
     using WebCore::SWServerToContextConnection::weakPtrFactory;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -41,6 +42,8 @@ static HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>& allWo
     static NeverDestroyed<HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>> allWorkers;
     return allWorkers;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSharedWorker);
 
 WebSharedWorker::WebSharedWorker(WebSharedWorkerServer& server, const WebCore::SharedWorkerKey& key, const WebCore::WorkerOptions& workerOptions)
     : m_server(server)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -35,6 +35,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Identified.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -56,7 +57,7 @@ class WebSharedWorkerServer;
 class WebSharedWorkerServerToContextConnection;
 
 class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker>, public Identified<WebCore::SharedWorkerIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSharedWorker);
 public:
     WebSharedWorker(WebSharedWorkerServer&, const WebCore::SharedWorkerKey&, const WebCore::WorkerOptions&);
     ~WebSharedWorker();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -38,8 +38,11 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/WorkerFetchResult.h>
 #include <WebCore/WorkerOptions.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSharedWorkerServer);
 
 WebSharedWorkerServer::WebSharedWorkerServer(NetworkSession& session)
     : m_session(session)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -33,6 +33,7 @@
 #include <WebCore/SharedWorkerObjectIdentifier.h>
 #include <WebCore/TransferredMessagePort.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -64,7 +65,7 @@ class WebSharedWorkerServerConnection;
 class WebSharedWorkerServerToContextConnection;
 
 class WebSharedWorkerServer : public CanMakeWeakPtr<WebSharedWorkerServer> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSharedWorkerServer);
 public:
     explicit WebSharedWorkerServer(NetworkSession&);
     ~WebSharedWorkerServer();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -37,6 +37,7 @@
 #include "WebSharedWorkerObjectConnectionMessages.h"
 #include "WebSharedWorkerServer.h"
 #include <WebCore/WorkerFetchResult.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -53,6 +54,8 @@ namespace WebKit {
 
 #define CONNECTION_RELEASE_LOG(fmt, ...) RELEASE_LOG(SharedWorker, "%p - [webProcessIdentifier=%" PRIu64 "] WebSharedWorkerServerConnection::" fmt, this, m_webProcessIdentifier.toUInt64(), ##__VA_ARGS__)
 #define CONNECTION_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(SharedWorker, "%p - [webProcessIdentifier=%" PRIu64 "] WebSharedWorkerServerConnection::" fmt, this, m_webProcessIdentifier.toUInt64(), ##__VA_ARGS__)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSharedWorkerServerConnection);
 
 WebSharedWorkerServerConnection::WebSharedWorkerServerConnection(NetworkProcess& networkProcess, WebSharedWorkerServer& server, IPC::Connection& connection, WebCore::ProcessIdentifier webProcessIdentifier)
     : m_contentConnection(connection)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -32,6 +32,7 @@
 #include <WebCore/TransferredMessagePort.h>
 #include <WebCore/WorkerInitializationData.h>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class WebSharedWorkerServerConnection;
@@ -59,7 +60,7 @@ class WebSharedWorkerServerToContextConnection;
 class NetworkSession;
 
 class WebSharedWorkerServerConnection : public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSharedWorkerServerConnection);
 public:
     WebSharedWorkerServerConnection(NetworkProcess&, WebSharedWorkerServer&, IPC::Connection&, WebCore::ProcessIdentifier);
     ~WebSharedWorkerServerConnection();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -40,6 +40,7 @@
 #include "WebSharedWorkerServer.h"
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -48,6 +49,8 @@ namespace WebKit {
 // We terminate the context connection after 5 seconds if it is no longer used by any SharedWorker objects,
 // as a performance optimization.
 constexpr Seconds idleTerminationDelay { 5_s };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSharedWorkerServerToContextConnection);
 
 WebSharedWorkerServerToContextConnection::WebSharedWorkerServerToContextConnection(NetworkConnectionToWebProcess& connection, const WebCore::RegistrableDomain& registrableDomain, WebSharedWorkerServer& server)
     : m_connection(connection)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -34,6 +34,7 @@
 #include <WebCore/Timer.h>
 #include <WebCore/TransferredMessagePort.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class WebSharedWorkerServerToContextConnection;
@@ -59,7 +60,7 @@ class WebSharedWorker;
 class WebSharedWorkerServer;
 
 class WebSharedWorkerServerToContextConnection final : public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSharedWorkerServerToContextConnection);
 public:
     WebSharedWorkerServerToContextConnection(NetworkConnectionToWebProcess&, const WebCore::RegistrableDomain&, WebSharedWorkerServer&);
     ~WebSharedWorkerServerToContextConnection();

--- a/Source/WebKit/NetworkProcess/WebSocketTask.h
+++ b/Source/WebKit/NetworkProcess/WebSocketTask.h
@@ -32,6 +32,7 @@
 #elif USE(CURL)
 #include "WebSocketTaskCurl.h"
 #else
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebSocketTask;
@@ -47,7 +48,7 @@ namespace WebKit {
 struct SessionSet;
 
 class WebSocketTask : public CanMakeWeakPtr<WebSocketTask> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebSocketTask);
 public:
     typedef uint64_t TaskIdentifier;
 

--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(NETWORK_CACHE_STALE_WHILE_REVALIDATE)
 #include <WebCore/CacheValidation.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 namespace NetworkCache {
@@ -53,6 +54,8 @@ static inline WebCore::ResourceRequest constructRevalidationRequest(const Key& k
 
     return revalidationRequest;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AsyncRevalidation);
 
 void AsyncRevalidation::cancel()
 {

--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.h
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.h
@@ -31,6 +31,7 @@
 #include "NetworkCacheEntry.h"
 #include "NetworkCacheSpeculativeLoad.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -56,7 +57,7 @@ class SpeculativeLoad;
 namespace NetworkCache {
 
 class AsyncRevalidation : public CanMakeWeakPtr<AsyncRevalidation> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AsyncRevalidation);
 public:
     enum class Result {
         Failure,

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -47,6 +47,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -58,6 +59,8 @@ namespace WebKit {
 namespace NetworkCache {
 
 using namespace FileSystem;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(CacheRetrieveInfo, Cache::RetrieveInfo);
 
 static const AtomString& resourceType()
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -39,6 +39,7 @@
 #include <wtf/Hasher.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -166,7 +167,7 @@ public:
         Storage::Timings storageTimings;
         bool wasSpeculativeLoad { false };
 
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(RetrieveInfo);
     };
     using RetrieveCompletionHandler = Function<void(std::unique_ptr<Entry>, const RetrieveInfo&)>;
     void retrieve(const WebCore::ResourceRequest&, const GlobalFrameID&, std::optional<NavigatingToAppBoundDomain>, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, RetrieveCompletionHandler&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -32,11 +32,14 @@
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SharedBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebKit {
 namespace NetworkCache {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Entry);
 
 Entry::Entry(const Key& key, const WebCore::ResourceResponse& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& buffer, const Vector<std::pair<String, String>>& varyingRequestHeaders)
     : m_key(key)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -32,6 +32,7 @@
 #include <WebCore/ShareableResource.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ class FragmentedSharedBuffer;
 namespace WebKit::NetworkCache {
 
 class Entry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Entry);
 public:
     Entry(const Key&, const WebCore::ResourceResponse&, PrivateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&&, const Vector<std::pair<String, String>>& varyingRequestHeaders);
     Entry(const Key&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest& redirectRequest, const Vector<std::pair<String, String>>& varyingRequestHeaders);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -37,11 +37,14 @@
 #include <WebCore/NetworkStorageSession.h>
 #include <pal/SessionID.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 namespace NetworkCache {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculativeLoad);
 
 SpeculativeLoad::SpeculativeLoad(Cache& cache, const GlobalFrameID& globalFrameID, const ResourceRequest& request, std::unique_ptr<NetworkCache::Entry> cacheEntryForValidation, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, RevalidationCompletionHandler&& completionHandler)
     : m_cache(cache)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h
@@ -36,6 +36,7 @@
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum class AdvancedPrivacyProtections : uint16_t;
@@ -48,7 +49,7 @@ class NetworkLoad;
 namespace NetworkCache {
 
 class SpeculativeLoad final : public NetworkLoadClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculativeLoad);
 public:
     using RevalidationCompletionHandler = CompletionHandler<void(std::unique_ptr<NetworkCache::Entry>)>;
     SpeculativeLoad(Cache&, const GlobalFrameID&, const WebCore::ResourceRequest&, std::unique_ptr<NetworkCache::Entry>, std::optional<NavigatingToAppBoundDomain>, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, RevalidationCompletionHandler&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -42,6 +42,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -127,7 +128,7 @@ static bool responseNeedsRevalidation(const ResourceResponse& response, WallTime
 }
 
 class SpeculativeLoadManager::ExpiringEntry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculativeLoadManager::ExpiringEntry);
 public:
     explicit ExpiringEntry(WTF::Function<void()>&& expirationHandler)
         : m_lifetimeTimer(WTFMove(expirationHandler))
@@ -139,8 +140,11 @@ private:
     Timer m_lifetimeTimer;
 };
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(SpeculativeLoadManagerExpiringEntry, SpeculativeLoadManager::ExpiringEntry);
+
+
 class SpeculativeLoadManager::PreloadedEntry : private ExpiringEntry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculativeLoadManager::PreloadedEntry);
 public:
     PreloadedEntry(std::unique_ptr<Entry> entry, std::optional<ResourceRequest>&& speculativeValidationRequest, WTF::Function<void()>&& lifetimeReachedHandler)
         : ExpiringEntry(WTFMove(lifetimeReachedHandler))
@@ -161,6 +165,8 @@ private:
     std::unique_ptr<Entry> m_entry;
     std::optional<ResourceRequest> m_speculativeValidationRequest;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(SpeculativeLoadManagerPreloadedEntry, SpeculativeLoadManager::PreloadedEntry);
 
 class SpeculativeLoadManager::PendingFrameLoad : public RefCounted<PendingFrameLoad> {
 public:
@@ -259,6 +265,8 @@ private:
     bool m_didRetrieveExistingEntry { false };
     bool m_didReceiveMainResourceResponse { false };
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculativeLoadManager);
 
 SpeculativeLoadManager::SpeculativeLoadManager(Cache& cache, Storage& storage)
     : m_cache(cache)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
@@ -32,6 +32,7 @@
 #include "NetworkCacheStorage.h"
 #include <WebCore/ResourceRequest.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -60,7 +61,7 @@ class SubresourceInfo;
 class SubresourcesEntry;
 
 class SpeculativeLoadManager : public CanMakeWeakPtr<SpeculativeLoadManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculativeLoadManager);
 public:
     explicit SpeculativeLoadManager(Cache&, Storage&);
     ~SpeculativeLoadManager();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -36,6 +36,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/PriorityQueue.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
@@ -57,7 +58,7 @@ public:
         Data body;
         std::optional<SHA1::Digest> bodyHash;
 
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Record);
     };
 
     struct Timings {
@@ -74,7 +75,7 @@ public:
         bool shrinkInProgressAtDispatch { false };
         bool wasCanceled { false };
 
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Timings);
     };
 
     // This may call completion handler synchronously on failure.

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -31,10 +31,15 @@
 #include "Logging.h"
 #include "NetworkCacheCoders.h"
 #include <WebCore/RegistrableDomain.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/persistence/PersistentEncoder.h>
 
 namespace WebKit {
 namespace NetworkCache {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SubresourceInfo);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SubresourceLoad);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SubresourcesEntry);
 
 bool SubresourceInfo::isFirstParty() const
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
@@ -29,12 +29,13 @@
 
 #include "NetworkCacheStorage.h"
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 
 namespace WebKit::NetworkCache {
 
 class SubresourceInfo {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SubresourceInfo);
 public:
     SubresourceInfo(Key&& key, WallTime lastSeen, WallTime firstSeen)
         : m_key(WTFMove(key))
@@ -85,7 +86,8 @@ private:
 };
 
 struct SubresourceLoad {
-    WTF_MAKE_NONCOPYABLE(SubresourceLoad); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SubresourceLoad);
+    WTF_MAKE_NONCOPYABLE(SubresourceLoad);
 public:
     SubresourceLoad(const WebCore::ResourceRequest& request, const Key& key)
         : request(request)
@@ -97,7 +99,8 @@ public:
 };
 
 class SubresourcesEntry {
-    WTF_MAKE_NONCOPYABLE(SubresourcesEntry); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SubresourcesEntry);
+    WTF_MAKE_NONCOPYABLE(SubresourcesEntry);
 public:
     SubresourcesEntry(Key&&, const Vector<std::unique_ptr<SubresourceLoad>>&);
     explicit SubresourcesEntry(const Storage::Record&);

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -27,8 +27,11 @@
 #include "PrefetchCache.h"
 
 #include <WebCore/HTTPHeaderNames.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PrefetchCache);
 
 PrefetchCache::Entry::Entry(WebCore::ResourceResponse&& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& buffer)
     : response(WTFMove(response))

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
@@ -32,14 +32,15 @@
 #include <WebCore/Timer.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class PrefetchCache {
+    WTF_MAKE_TZONE_ALLOCATED(PrefetchCache);
     WTF_MAKE_NONCOPYABLE(PrefetchCache);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     PrefetchCache();
     ~PrefetchCache();

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -31,11 +31,12 @@
 #include <wtf/Lock.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class LaunchServicesDatabaseObserver : public WebKit::XPCEndpoint, public NetworkProcessSupplement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LaunchServicesDatabaseObserver);
 public:
     LaunchServicesDatabaseObserver(NetworkProcess&);
     virtual ~LaunchServicesDatabaseObserver();

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -29,10 +29,13 @@
 #import "LaunchServicesDatabaseXPCConstants.h"
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LaunchServicesDatabaseObserver);
 
 LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -46,6 +46,7 @@ OBJC_CLASS NSURLCredentialStorage;
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 struct SessionWrapper;
@@ -88,7 +89,7 @@ struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper> {
 };
 
 struct IsolatedSession {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IsolatedSession);
 public:
     SessionWrapper sessionWithCredentialStorage;
     WallTime lastUsed;
@@ -117,7 +118,7 @@ private:
 };
 
 class NetworkSessionCocoa final : public NetworkSession {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkSessionCocoa);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSessionCocoa);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -66,6 +66,7 @@
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -112,6 +113,9 @@ SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_stack_requires_http_protocols, bo
 #import "DeviceManagementSoftLink.h"
 
 using namespace WebKit;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IsolatedSession);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkSessionCocoa);
 
 CFStringRef const WebKit2HTTPProxyDefaultsKey = static_cast<CFStringRef>(@"WebKit2HTTPProxy");
 CFStringRef const WebKit2HTTPSProxyDefaultsKey = static_cast<CFStringRef>(@"WebKit2HTTPSProxy");
@@ -1964,7 +1968,7 @@ void NetworkSessionCocoa::addWebPageNetworkParameters(WebPageProxyIdentifier pag
 // Make NetworkLoad's redirection and challenge handling code pass everything to the NetworkLoadClient
 // and use NetworkLoad and a new NetworkLoadClient instead of BlobDataTaskClient and WKURLSessionTaskDelegate.
 class NetworkSessionCocoa::BlobDataTaskClient final : public NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkSessionCocoa::BlobDataTaskClient);
 public:
     BlobDataTaskClient(WebCore::ResourceRequest&& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, NetworkSessionCocoa& session, IPC::Connection* connection, DataTaskIdentifier identifier)
         : m_task(NetworkDataTaskBlob::create(session, *this, request, session.blobRegistry().filesInBlob(request.url(), topOrigin), topOrigin ? topOrigin->securityOrigin().ptr() : nullptr))
@@ -2015,6 +2019,8 @@ private:
     WeakPtr<NetworkSessionCocoa> m_session;
     const DataTaskIdentifier m_identifier;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NetworkSessionCocoaBlobDataTaskClient, NetworkSessionCocoa::BlobDataTaskClient);
 
 void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& request, WebPageProxyIdentifier pageID, size_t maximumBytesFromNetwork, CompletionHandler<void(std::variant<WebCore::ResourceError, Ref<WebCore::FragmentedSharedBuffer>>&&)>&& completionHandler)
 {

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
@@ -31,6 +31,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSURLSessionWebSocketTask;
@@ -57,7 +58,7 @@ class NetworkSocketChannel;
 struct SessionSet;
 
 class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public NetworkTaskCocoa {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSocketTask);
 public:
     WebSocketTask(NetworkSocketChannel&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WeakPtr<SessionSet>&&, const WebCore::ResourceRequest&, const WebCore::ClientOrigin&, RetainPtr<NSURLSessionWebSocketTask>&&, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     ~WebSocketTask() = default;

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -34,11 +34,14 @@
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/ThreadableWebSocketChannel.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocketTask);
 
 WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, WeakPtr<SessionSet>&& sessionSet, const WebCore::ResourceRequest& request, const WebCore::ClientOrigin& clientOrigin, RetainPtr<NSURLSessionWebSocketTask>&& task, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
     : NetworkTaskCocoa(*channel.session(), shouldRelaxThirdPartyCookieBlocking)

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -33,9 +33,11 @@
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/CurlStreamScheduler.h>
 #include <WebCore/WebSocketHandshake.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocketTask);
 
 WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin& clientOrigin)
     : m_channel(channel)

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
@@ -32,6 +32,7 @@
 #include <WebCore/ThreadableWebSocketChannel.h>
 #include <WebCore/WebSocketDeflateFramer.h>
 #include <WebCore/WebSocketFrame.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class WebSocketTask;
@@ -56,7 +57,7 @@ class NetworkSocketChannel;
 struct SessionSet;
 
 class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public WebCore::CurlStream::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSocketTask);
 public:
     WebSocketTask(NetworkSocketChannel&, WebPageProxyIdentifier, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&);
     virtual ~WebSocketTask();

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -35,9 +35,12 @@
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SoupNetworkSession.h>
 #include <libsoup/soup.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkSessionSoup);
 
 NetworkSessionSoup::NetworkSessionSoup(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
     : NetworkSession(networkProcess, parameters)

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
@@ -28,6 +28,7 @@
 #include "NetworkSession.h"
 #include "SoupCookiePersistentStorageType.h"
 #include "WebPageProxyIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 
 typedef struct _SoupSession SoupSession;
 
@@ -44,7 +45,7 @@ class WebSocketTask;
 struct NetworkSessionCreationParameters;
 
 class NetworkSessionSoup final : public NetworkSession {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkSessionSoup);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSessionSoup);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/SoupVersioning.h>
 #include <WebCore/ThreadableWebSocketChannel.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 #include <wtf/text/StringBuilder.h>
@@ -54,6 +55,8 @@ static inline bool isConnectionError(GError* error, SoupMessage* message)
     return error && !g_error_matches(error, SOUP_WEBSOCKET_ERROR, SOUP_WEBSOCKET_ERROR_NOT_WEBSOCKET);
 #endif
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocketTask);
 
 WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, SoupSession* session, SoupMessage* msg, const String& protocol)
     : m_channel(channel)

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
@@ -28,6 +28,7 @@
 #include <WebCore/ResourceRequest.h>
 #include <libsoup/soup.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 
 namespace WebKit {
@@ -35,7 +36,7 @@ class NetworkSocketChannel;
 struct SessionSet;
 
 class WebSocketTask {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSocketTask);
 public:
     WebSocketTask(NetworkSocketChannel&, const WebCore::ResourceRequest&, SoupSession*, SoupMessage*, const String& protocol);
     ~WebSocketTask();

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -32,6 +32,7 @@
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FileSystem.h>
 #include <wtf/PageBlock.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/MakeString.h>
@@ -46,6 +47,8 @@ static bool shouldUseFileMapping(uint64_t fileSize)
 {
     return fileSize >= pageSize();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetchStoreManager);
 
 String BackgroundFetchStoreManager::createNewStorageIdentifier()
 {

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
@@ -26,8 +26,8 @@
 
 #include <WebCore/BackgroundFetchStore.h>
 #include <WebCore/SharedBuffer.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -47,7 +47,7 @@ class WorkQueue;
 namespace WebKit {
 
 class BackgroundFetchStoreManager : public CanMakeWeakPtr<BackgroundFetchStoreManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackgroundFetchStoreManager);
 public:
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
     BackgroundFetchStoreManager(const String&, Ref<WTF::WorkQueue>&&, QuotaCheckFunction&&);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -35,6 +35,7 @@
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/ResourceError.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -61,6 +62,8 @@ static Ref<CacheStorageStore> createStore(const String& uniqueName, const String
         return CacheStorageMemoryStore::create();
     return CacheStorageDiskStore::create(uniqueName, path, WTFMove(queue));
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CacheStorageCache);
 
 CacheStorageCache::CacheStorageCache(CacheStorageManager& manager, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&& queue)
     : m_manager(manager)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -30,6 +30,7 @@
 #include "NetworkCacheKey.h"
 #include <WebCore/RetrieveRecordsOptions.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
@@ -46,7 +47,7 @@ namespace WebKit {
 class CacheStorageManager;
 
 class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache>, public Identified<WebCore::DOMCacheIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CacheStorageCache);
 public:
     CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
     ~CacheStorageCache();

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/StorageUtilities.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -162,7 +163,9 @@ static FileSystem::Salt readOrMakeSalt(const String& saltPath)
 
     return valueOrDefault(FileSystem::readOrMakeSalt(saltPath));
 }
-    
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CacheStorageManager);
+
 String CacheStorageManager::cacheStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin& origin)
 {
     if (rootDirectory.isEmpty())

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/DOMCacheEngine.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -51,7 +52,7 @@ struct CacheStorageRecordInformation;
 
 
 class CacheStorageManager : public CanMakeWeakPtr<CacheStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CacheStorageManager);
 public:
     static String cacheStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin&);
     static void copySaltFileToOriginDirectory(const String& rootDirectory, const String& originDirectory);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
@@ -27,8 +27,11 @@
 #include "CacheStorageRegistry.h"
 
 #include "CacheStorageCache.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CacheStorageRegistry);
 
 CacheStorageRegistry::CacheStorageRegistry() = default;
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DOMCacheIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -33,7 +34,7 @@ namespace WebKit {
 class CacheStorageCache;
 
 class CacheStorageRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CacheStorageRegistry);
 public:
     CacheStorageRegistry();
     void registerCache(WebCore::DOMCacheIdentifier, CacheStorageCache&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -30,6 +30,7 @@
 #include "FileSystemStorageManager.h"
 #include "SharedFileHandle.h"
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -41,6 +42,8 @@ constexpr char pathSeparator = '/';
 constexpr uint64_t defaultInitialCapacity = 1 * MB;
 constexpr uint64_t defaultMaxCapacityForExponentialGrowth = 256 * MB;
 constexpr uint64_t defaultCapacityStep = 128 * MB;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FileSystemStorageHandle);
 
 std::unique_ptr<FileSystemStorageHandle> FileSystemStorageHandle::create(FileSystemStorageManager& manager, Type type, String&& path, String&& name)
 {

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -30,6 +30,7 @@
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -51,7 +52,7 @@ class FileSystemStorageManager;
 enum class FileSystemStorageError : uint8_t;
 
 class FileSystemStorageHandle : public CanMakeWeakPtr<FileSystemStorageHandle, WeakPtrFactoryInitialization::Eager>, public Identified<WebCore::FileSystemHandleIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FileSystemStorageHandle);
 public:
     enum class Type : uint8_t { File, Directory, Any };
     static std::unique_ptr<FileSystemStorageHandle> create(FileSystemStorageManager&, Type, String&& path, String&& name);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp
@@ -27,8 +27,11 @@
 #include "FileSystemStorageHandleRegistry.h"
 
 #include "FileSystemStorageHandle.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FileSystemStorageHandleRegistry);
 
 FileSystemStorageHandleRegistry::FileSystemStorageHandleRegistry() = default;
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class FileSystemStorageHandle;
 
 class FileSystemStorageHandleRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FileSystemStorageHandleRegistry);
 public:
     FileSystemStorageHandleRegistry();
     void registerHandle(WebCore::FileSystemHandleIdentifier, FileSystemStorageHandle&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -29,8 +29,11 @@
 #include "FileSystemStorageError.h"
 #include "FileSystemStorageHandleRegistry.h"
 #include "WebFileSystemStorageConnectionMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FileSystemStorageManager);
 
 FileSystemStorageManager::FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
     : m_path(WTFMove(path))

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "FileSystemStorageHandle.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class FileSystemStorageManager;
@@ -43,7 +44,7 @@ class FileSystemStorageHandle;
 class FileSystemStorageHandleRegistry;
 
 class FileSystemStorageManager : public CanMakeWeakPtr<FileSystemStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FileSystemStorageManager);
 public:
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
     FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
@@ -32,8 +32,11 @@
 #include <WebCore/IDBRequestData.h>
 #include <WebCore/IDBResultData.h>
 #include <WebCore/UniqueIDBDatabaseConnection.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageConnectionToClient);
 
 IDBStorageConnectionToClient::IDBStorageConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
     : m_connection(connection)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -28,11 +28,12 @@
 #include "Connection.h"
 #include <WebCore/IDBConnectionToClient.h>
 #include <WebCore/IDBConnectionToClientDelegate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class IDBStorageConnectionToClient final : public WebCore::IDBServer::IDBConnectionToClientDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IDBStorageConnectionToClient);
 public:
     IDBStorageConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
     ~IDBStorageConnectionToClient();

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -29,10 +29,13 @@
 #include "IDBStorageConnectionToClient.h"
 #include <WebCore/UniqueIDBDatabaseConnection.h>
 #include <WebCore/UniqueIDBDatabaseTransaction.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 IDBStorageRegistry::IDBStorageRegistry() = default;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageRegistry);
 
 WebCore::IDBServer::IDBConnectionToClient& IDBStorageRegistry::ensureConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
 {

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include <WebCore/IDBDatabaseConnectionIdentifier.h>
 #include <WebCore/IDBResourceIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ namespace WebKit {
 class IDBStorageConnectionToClient;
 
 class IDBStorageRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IDBStorageRegistry);
 public:
     IDBStorageRegistry();
     WebCore::IDBServer::IDBConnectionToClient& ensureConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
@@ -31,6 +31,7 @@
 #include "StorageAreaRegistry.h"
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/FileSystem.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
@@ -60,6 +61,8 @@ static String originToFileName(const WebCore::ClientOrigin& origin)
 {
     return makeString(origin.clientOrigin.databaseIdentifier(), ".localstorage"_s);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalStorageManager);
 
 Vector<WebCore::SecurityOriginData> LocalStorageManager::originsOfLocalStorageData(const String& path)
 {

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include "StorageAreaIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ class StorageAreaBase;
 class StorageAreaRegistry;
 
 class LocalStorageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LocalStorageManager);
 public:
     static Vector<WebCore::SecurityOriginData> originsOfLocalStorageData(const String& path);
     static String localStorageFilePath(const String& directory, const WebCore::ClientOrigin&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -58,6 +58,7 @@
 #include <WebCore/UniqueIDBDatabaseTransaction.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/SuspendableWorkQueue.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
@@ -140,6 +141,8 @@ static void deleteEmptyOriginDirectory(const String& directory)
     FileSystem::deleteEmptyDirectory(directory);
     FileSystem::deleteEmptyDirectory(FileSystem::parentPath(directory));
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkStorageManager);
 
 String NetworkStorageManager::persistedFilePath(const WebCore::ClientOrigin& origin)
 {

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -46,8 +46,8 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <pal/SessionID.h>
 #include <wtf/CheckedPtr.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 
 namespace IPC {
@@ -91,7 +91,7 @@ class StorageAreaBase;
 class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver, public CanMakeCheckedPtr<NetworkStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkStorageManager);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkStorageManager);
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
@@ -27,10 +27,13 @@
 #include "OriginQuotaManager.h"
 
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 static constexpr double defaultReportedQuotaIncreaseFactor = 2.0;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OriginQuotaManager);
 
 Ref<OriginQuotaManager> OriginQuotaManager::create(Parameters&& parameters, GetUsageFunction&& getUsageFunction)
 {

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -28,12 +28,13 @@
 #include "QuotaIncreaseRequestIdentifier.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebKit {
 
 class OriginQuotaManager : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<OriginQuotaManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(OriginQuotaManager);
 public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -44,14 +44,17 @@
 #include <WebCore/SQLiteFileSystem.h>
 #include <WebCore/StorageEstimate.h>
 #include <wtf/FileSystem.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 static constexpr auto originFileName = "origin"_s;
 enum class OriginStorageManager::StorageBucketMode : bool { BestEffort, Persistent };
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OriginStorageManager);
+
 class OriginStorageManager::StorageBucket {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(OriginStorageManager::StorageBucket);
 public:
     enum class StorageType : uint8_t {
         FileSystem,
@@ -123,6 +126,8 @@ private:
     std::unique_ptr<BackgroundFetchStoreManager> m_backgroundFetchManager;
     std::unique_ptr<ServiceWorkerStorageManager> m_serviceWorkerStorageManager;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(OriginStorageManagerStorageBucket, OriginStorageManager::StorageBucket);
 
 OriginStorageManager::StorageBucket::StorageBucket(const String& rootPath, const String& identifier, const String& localStoragePath, const String& idbStoragePath, const String& cacheStoragePath, UnifiedOriginStorageLevel level)
     : m_rootPath(rootPath)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include "OriginQuotaManager.h"
 #include "WebsiteDataType.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -62,7 +63,7 @@ enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
 class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(OriginStorageManager);
 public:
     static String originFileIdentifier();
 

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
@@ -29,8 +29,11 @@
 #include <WebCore/SWRegistrationDatabase.h>
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/ServiceWorkerRegistrationKey.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerStorageManager);
 
 ServiceWorkerStorageManager::ServiceWorkerStorageManager(const String& path)
     : m_path(path)

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
@@ -27,11 +27,12 @@
 
 #include <WebCore/SWRegistrationDatabase.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ServiceWorkerStorageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerStorageManager);
 public:
     explicit ServiceWorkerStorageManager(const String& path);
 

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
@@ -28,8 +28,11 @@
 
 #include "MemoryStorageArea.h"
 #include "StorageAreaRegistry.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SessionStorageManager);
 
 SessionStorageManager::SessionStorageManager(StorageAreaRegistry& registry)
     : m_registry(registry)

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
@@ -29,6 +29,7 @@
 #include "StorageAreaIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
 #include "StorageNamespaceIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct ClientOrigin;
@@ -40,7 +41,7 @@ class MemoryStorageArea;
 class StorageAreaRegistry;
 
 class SessionStorageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SessionStorageManager);
 public:
     explicit SessionStorageManager(StorageAreaRegistry&);
     bool isActive() const;

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
@@ -27,8 +27,11 @@
 #include "StorageAreaBase.h"
 
 #include "StorageAreaMapMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageAreaBase);
 
 uint64_t StorageAreaBase::nextMessageIdentifier()
 {

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
@@ -31,6 +31,7 @@
 #include "StorageAreaMapIdentifier.h"
 #include <WebCore/ClientOrigin.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -56,7 +57,7 @@ enum class StorageError : uint8_t {
 
 class StorageAreaBase : public CanMakeWeakPtr<StorageAreaBase>, public Identified<StorageAreaIdentifier> {
     WTF_MAKE_NONCOPYABLE(StorageAreaBase);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StorageAreaBase);
 public:
     static uint64_t nextMessageIdentifier();
     virtual ~StorageAreaBase();

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.cpp
@@ -27,8 +27,11 @@
 #include "StorageAreaRegistry.h"
 
 #include "StorageAreaBase.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageAreaRegistry);
 
 StorageAreaRegistry::StorageAreaRegistry() = default;
 

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "StorageAreaIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -33,7 +34,7 @@ namespace WebKit {
 class StorageAreaBase;
 
 class StorageAreaRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StorageAreaRegistry);
 public:
     StorageAreaRegistry();
     void registerStorageArea(StorageAreaIdentifier, StorageAreaBase&);

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -36,8 +36,11 @@
 #include "NetworkRTCProvider.h"
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCSocketClient);
 
 LibWebRTCSocketClient::LibWebRTCSocketClient(WebCore::LibWebRTCSocketIdentifier identifier, NetworkRTCProvider& rtcProvider, std::unique_ptr<rtc::AsyncPacketSocket>&& socket, Type type, Ref<IPC::Connection>&& connection)
     : m_identifier(identifier)

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
@@ -39,6 +39,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_COMMA_END
 
+#include <wtf/TZoneMalloc.h>
+
 namespace rtc {
 class AsyncPacketSocket;
 struct SentPacket;
@@ -48,7 +50,7 @@ typedef int64_t PacketTime;
 namespace WebKit {
 
 class LibWebRTCSocketClient final : public NetworkRTCProvider::Socket, public sigslot::has_slots<> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCSocketClient);
 public:
     LibWebRTCSocketClient(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, std::unique_ptr<rtc::AsyncPacketSocket>&&, Type, Ref<IPC::Connection>&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
@@ -29,6 +29,7 @@
 
 #include "NetworkRTCProvider.h"
 #include <Network/Network.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -47,7 +48,7 @@ class SocketAddress;
 namespace WebKit {
 
 class NetworkRTCTCPSocketCocoa final : public NetworkRTCProvider::Socket, public CanMakeWeakPtr<NetworkRTCTCPSocketCocoa> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkRTCTCPSocketCocoa);
 public:
     static std::unique_ptr<NetworkRTCProvider::Socket> createClientTCPSocket(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, const rtc::SocketAddress&, int options, const String& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&, Ref<IPC::Connection>&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -35,6 +35,7 @@
 #include <dispatch/dispatch.h>
 #include <pal/spi/cocoa/NetworkSPI.h>
 #include <wtf/BlockPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 ALLOW_COMMA_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -57,6 +58,8 @@ static dispatch_queue_t tcpSocketQueue()
     });
     return queue;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkRTCTCPSocketCocoa);
 
 std::unique_ptr<NetworkRTCProvider::Socket> NetworkRTCTCPSocketCocoa::createClientTCPSocket(LibWebRTCSocketIdentifier identifier, NetworkRTCProvider& rtcProvider, const rtc::SocketAddress& remoteAddress, int tcpOptions, const String& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain& domain, Ref<IPC::Connection>&& connection)
 {

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
@@ -32,6 +32,7 @@
 #include <limits>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace rtc {
 class SocketAddress;
@@ -58,7 +59,7 @@ namespace WebKit {
 class NetworkRTCUDPSocketCocoaConnections;
 
 class NetworkRTCUDPSocketCocoa final : public NetworkRTCProvider::Socket {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkRTCUDPSocketCocoa);
 public:
     static std::unique_ptr<NetworkRTCProvider::Socket> createUDPSocket(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, const rtc::SocketAddress&, uint16_t minPort, uint16_t maxPort, Ref<IPC::Connection>&&, String&& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -37,11 +37,14 @@
 #include <pal/spi/cocoa/NetworkSPI.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/SoftLinking.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkRTCUDPSocketCocoa);
 
 class NetworkRTCUDPSocketCocoaConnections : public ThreadSafeRefCounted<NetworkRTCUDPSocketCocoaConnections> {
 public:

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "NetworkTransportBidirectionalStream.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportBidirectionalStream);
 
 NetworkTransportBidirectionalStream::NetworkTransportBidirectionalStream(NetworkTransportSession& session)
     : NetworkTransportReceiveStream(session) { }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.h
@@ -27,11 +27,12 @@
 
 #include "NetworkTransportReceiveStream.h"
 #include "NetworkTransportSendStream.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class NetworkTransportBidirectionalStream : public NetworkTransportSendStream, public NetworkTransportReceiveStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkTransportBidirectionalStream);
 public:
     NetworkTransportBidirectionalStream(NetworkTransportSession&);
 };

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp
@@ -27,8 +27,11 @@
 #include "NetworkTransportReceiveStream.h"
 
 #include "NetworkTransportSession.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportReceiveStream);
 
 NetworkTransportReceiveStream::NetworkTransportReceiveStream(NetworkTransportSession& session)
     : m_session(session) { }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -32,7 +33,7 @@ namespace WebKit {
 class NetworkTransportSession;
 
 class NetworkTransportReceiveStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkTransportReceiveStream);
 public:
     NetworkTransportReceiveStream(NetworkTransportSession&);
 private:

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "NetworkTransportSendStream.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportSendStream);
 
 void NetworkTransportSendStream::sendBytes(std::span<const uint8_t>, bool)
 {

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.h
@@ -27,11 +27,12 @@
 
 #include <span>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class NetworkTransportSendStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkTransportSendStream);
 public:
     void sendBytes(std::span<const uint8_t>, bool withFin);
 };

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -32,8 +32,11 @@
 #include "NetworkTransportReceiveStream.h"
 #include "NetworkTransportSendStream.h"
 #include "WebTransportSessionMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkTransportSession);
 
 void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connection, URL&&, CompletionHandler<void(std::unique_ptr<NetworkTransportSession>&&)>&& completionHandler)
 {

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -30,6 +30,7 @@
 #include <WebCore/ProcessQualified.h>
 #include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class NetworkTransportSession;
@@ -54,7 +55,7 @@ using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdenti
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
 class NetworkTransportSession : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<WebTransportSessionIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkTransportSession);
 public:
     static void initialize(NetworkConnectionToWebProcess&, URL&&, CompletionHandler<void(std::unique_ptr<NetworkTransportSession>&&)>&&);
 


### PR DESCRIPTION
#### 93c14025b7e880a3d45bef5c0917e989acd678ff
<pre>
Enable TZone
</pre>
----------------------------------------------------------------------
#### 5a5bde566468c37a22662c8a74459996d82a6e4d
<pre>
[DRAFT][Not For Review] Test WebKit/NetworkProcess
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h:
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp:
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.h:
* Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp:
* Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp:
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/WebSocketTask.h:
* Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp:
* Source/WebKit/NetworkProcess/cache/AsyncRevalidation.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h:
* Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp:
* Source/WebKit/NetworkProcess/cache/PrefetchCache.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h:
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp:
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h:
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h:
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp:
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h:
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93c14025b7e880a3d45bef5c0917e989acd678ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66199 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12764 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50146 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8830 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11165 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11695 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55315 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67929 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61461 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6162 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11292 "Found 1 new test failure: workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57744 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5098 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83225 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37373 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14602 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38457 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39553 "Hash 93c14025 for PR 32059 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->