### PR TITLE
[webkitbugspy] Fix some radar models

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -121,8 +121,8 @@ class RadarModel(object):
             self.name = name
 
     class Tentpole(object):
-        def __init__(self, name):
-            self.name = name
+        def __init__(self, args):
+            self.name = args['name']
 
     class MilestoneAssociations(object):
         def __init__(self, milestone):
@@ -182,7 +182,7 @@ class RadarModel(object):
         event = issue.get('event')
         self.event = RadarModel.Event(event) if event else None
         tentpole = issue.get('tentpole')
-        self.tentpole = RadarModel.Tentpole(tentpole) if tentpole else None
+        self.tentpole = RadarModel.Tentpole(dict(name=tentpole)) if tentpole else None
 
         components = []
         if issue.get('project') and issue.get('component') and issue.get('version'):
@@ -437,6 +437,7 @@ class Radar(Base, ContextStack):
     top = None
 
     Person = RadarModel.Person
+    Tentpole = RadarModel.Tentpole
 
     class AuthenticationStrategySystemAccount(object):
         def __init__(self, username, __, ___, ____):
@@ -536,7 +537,7 @@ class Radar(Base, ContextStack):
             self._events = [RadarModel.Event(event) for event in (events or [])]
 
             self._isTentpoleRequired = isTentpoleRequired
-            self._tentpoles = [RadarModel.Tentpole(tentpole) for tentpole in (tentpoles or [])]
+            self._tentpoles = [RadarModel.Tentpole(dict(name=tentpole)) for tentpole in (tentpoles or [])]
 
     class Category(object):
         def __init__(self, name):


### PR DESCRIPTION
#### e56ee1e93fd1a4d8ab767f00aea5b4c4c307d876
<pre>
[webkitbugspy] Fix some radar models
<a href="https://bugs.webkit.org/show_bug.cgi?id=277978">https://bugs.webkit.org/show_bug.cgi?id=277978</a>
<a href="https://rdar.apple.com/131631006">rdar://131631006</a>

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.Tentpole.__init__): Accept dictionary.
(Radar): Export RadarModel.Tentpole.

Canonical link: <a href="https://commits.webkit.org/282250@main">https://commits.webkit.org/282250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1082a65c16baeadee4d80c0c8fdca0bbc62a25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50176 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30963 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/61783 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11208 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67982 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57546 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57762 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5136 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9419 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37426 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->