### PR TITLE
[css-anchor-position-1] Don't attempt to reconstruct layout order during style resolution

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8082,7 +8082,6 @@ webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-c
 # general failures
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-circular.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor names in different tree scopes should not be confused assert_equals: expected 0 but got 200
+PASS Anchor names in different tree scopes should not be confused
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL target1 should scroll with anchor1 assert_equals: expected 40 but got 300
+FAIL target1 should scroll with anchor1 assert_equals: expected 40 but got 50
 FAIL target2 should scroll with anchor2 assert_equals: expected 155 but got 0
 FAIL target3 should scroll with anchor3 assert_equals: expected 270 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Layout is updated on `position-anchor` changes assert_equals: expected 200 but got 0
+PASS Layout is updated on `position-anchor` changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition to a flipped state assert_equals: expected 275 but got 150
-FAIL Transition to an unflipped state assert_equals: expected 250 but got 150
+FAIL Transition to a flipped state assert_equals: expected 275 but got 225
+FAIL Transition to an unflipped state assert_equals: expected 250 but got 300
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-anchor-positioning-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-anchor-positioning-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL CSS Content Visibility: auto still anchors even if the anchor and positioned element are both skipped by the same element assert_equals: #positioned should be anchored because they are both on-screen. expected 209 but got 9
+PASS CSS Content Visibility: auto still anchors even if the anchor and positioned element are both skipped by the same element
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -368,7 +368,7 @@ Length AnchorPositionEvaluator::resolveAnchorValue(const BuilderState& builderSt
     if (!anchorPositionedElementState.finishedCollectingAnchorNames)
         anchorValue.collectAnchorNames(anchorPositionedElementState.anchorNames);
 
-    // An anchor() instance will be ready to be resolved when all anchor-name strings
+    // An anchor() instance will be ready to be resolved when all referenced anchor-names
     // have been mapped to an actual anchor element in the DOM tree. At that point, we
     // should also have layout information for the anchor-positioned element alongside
     // the anchors referenced by the anchor-positioned element. Until then, we cannot

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -144,7 +144,6 @@ private:
     AnchorPositionedElementAction updateAnchorPositioningState(Element&, const RenderStyle*);
     void findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const Element* containingBlock);
     std::optional<Ref<Element>> findLastAcceptableAnchorWithName(String anchorName, const Element* containingBlock);
-    void updateAnchorPositioningStateInInitialContainingBlock();
 
     struct QueryContainerState {
         Change change { Change::None };
@@ -165,8 +164,6 @@ private:
 
     HashSet<Ref<Element>> m_anchorElements;
     HashMap<String, Vector<Ref<Element>>> m_anchorsForAnchorName;
-    HashMap<Ref<Element>, Vector<Ref<Element>>> m_unresolvedAnchorPositionedElementsForContainingBlock;
-    Vector<Ref<Element>> m_unresolvedAnchorPositionedElementsForInitialContainingBlock;
     bool m_hasUnresolvedAnchorPositionedElements { false };
     bool m_canFindAnchorsForNextAnchorPositionedElement { false };
 


### PR DESCRIPTION
#### f83902e89345526a0d5d1271cd108dffa45742ad
<pre>
[css-anchor-position-1] Don&apos;t attempt to reconstruct layout order during style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=277977">https://bugs.webkit.org/show_bug.cgi?id=277977</a>
<a href="https://rdar.apple.com/133710361">rdar://133710361</a>

Reviewed by Antti Koivisto.

The current implementation of style &amp; layout interleaving for anchor
positioning attempts to reproduce the order in which elements are
completely laid out (what I call &quot;layout order&quot;) during style resolution
in TreeResolver. This is an incorrect implementation, and it needs to
be removed.

This patch removes that code, and instead opts to resolve the first
unresolved anchor-positioned element it sees during style resolution.
This is still an incorrect implementation, as valid anchor targets
that come after an anchor-positioned element in tree order will still
be missed.

This patch is simply cleaning up the incorrect code in preparation for
a future patch that will introduce a more spec-compliant implementation.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-anchor-positioning-003-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::popParent):
(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::updateAnchorPositioningStateInInitialContainingBlock): Deleted.
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/282168@main">https://commits.webkit.org/282168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acc3e3ac1d0fa97d0cbe9df72c4974a2e9be8282

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66277 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50191 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30976 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11233 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68007 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6240 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11286 "Found 2 new test failures: media/video-replaces-poster.html workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57564 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57778 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5157 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37451 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39631 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->