### PR TITLE
Fix RenderTreeBuilder::move() to clear percent height map

### DIFF
--- a/LayoutTests/fast/inline/inline-split-percent-height-object-crash-expected.txt
+++ b/LayoutTests/fast/inline/inline-split-percent-height-object-crash-expected.txt
@@ -1,0 +1,3 @@
+Test passes if it does not crash.
+
+

--- a/LayoutTests/fast/inline/inline-split-percent-height-object-crash.html
+++ b/LayoutTests/fast/inline/inline-split-percent-height-object-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+.CLASS8 {
+    display: inline-block;
+    max-height: 3.5%;
+}
+</style>
+<p>Test passes if it does not crash.</p>
+<span><div id="inner" style="display:none"></div></span>
+<div class="CLASS8"></div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+document.documentElement.offsetTop;
+document.getElementById("inner").style.display = "";
+</script>

--- a/LayoutTests/fast/table/table-split-percent-height-expected.html
+++ b/LayoutTests/fast/table/table-split-percent-height-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<p>There should be a blue square below.</p>
+<div style="display:table; height:450px;">
+    <div style="display:table-row-group;">
+        <div></div>
+        <div id="splitter" style="display: table-row;"></div>
+        <div style="width:75px; height:50%; background:blue;"></div>
+    </div>
+</div>

--- a/LayoutTests/fast/table/table-split-percent-height.html
+++ b/LayoutTests/fast/table/table-split-percent-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<p>There should be a blue square below.</p>
+<div style="display:table; height:450px;">
+    <div style="display:table-row-group;">
+        <div></div>
+        <div id="splitter" style="display:none;"></div>
+        <div style="width:75px; height:50%; background:blue;"></div>
+    </div>
+</div>
+<script>
+    document.body.offsetTop;
+    document.getElementById("splitter").style.display = "table-row";
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -503,6 +504,8 @@ void RenderTreeBuilder::move(RenderBoxModelObject& from, RenderBoxModelObject& t
 
     ASSERT(&from == child.parent());
     ASSERT(!beforeChild || &to == beforeChild->parent());
+    if (normalizeAfterInsertion == NormalizeAfterInsertion::Yes && is<RenderBlock>(from) && child.isRenderBox())
+        RenderBlock::removePercentHeightDescendantIfNeeded(downcast<RenderBox>(child));
     if (normalizeAfterInsertion == NormalizeAfterInsertion::Yes && (to.isRenderBlock() || to.isRenderInline())) {
         // Takes care of adding the new child correctly if toBlock and fromBlock
         // have different kind of children (block vs inline).
@@ -559,6 +562,7 @@ void RenderTreeBuilder::moveChildren(RenderBoxModelObject& from, RenderBoxModelO
     if (normalizeAfterInsertion == NormalizeAfterInsertion::Yes) {
         if (CheckedPtr blockFlow = dynamicDowncast<RenderBlock>(from)) {
             blockFlow->removePositionedObjects(nullptr);
+            RenderBlock::removePercentHeightDescendantIfNeeded(*blockFlow);
             removeFloatingObjects(*blockFlow);
         }
     }


### PR DESCRIPTION
#### 1223895a9c1b04cb71cfcebf00498992302f64fe
<pre>
Fix RenderTreeBuilder::move() to clear percent height map

<a href="https://bugs.webkit.org/show_bug.cgi?id=274011">https://bugs.webkit.org/show_bug.cgi?id=274011</a>
<a href="https://rdar.apple.com/128289804">rdar://128289804</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/7afb0474da50c93fa2360fc70ccbb73a313a45f7">https://chromium.googlesource.com/chromium/src.git/+/7afb0474da50c93fa2360fc70ccbb73a313a45f7</a>

This patch fixes RenderTreeBuilder::clear() to clear the
moving children from the global percent height map.

* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::move):
(WebCore::RenderTreeBuilder::moveChildren):
* LayoutTests/fast/inline/inline-split-percent-height-object-crash-expected.txt:
* LayoutTests/fast/inline/inline-split-percent-height-object-crash.html:
* LayoutTests/fast/table/table-split-percent-height-expected.html:
* LayoutTests/fast/table/table-split-percent-height.html:

Canonical link: <a href="https://commits.webkit.org/282160@main">https://commits.webkit.org/282160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761eec570ea4087fd5555a82e3d585d1604d4082

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66211 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50155 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8836 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67941 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11233 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html media/video-replaces-poster.html workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5101 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37385 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38469 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->