### PR TITLE
[TZone] WebKitLegacy: Convert FastMalloc to TZone

### DIFF
--- a/Source/WebKitLegacy/Storage/StorageTracker.cpp
+++ b/Source/WebKitLegacy/Storage/StorageTracker.cpp
@@ -36,6 +36,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -52,7 +53,9 @@ static StorageTracker* storageTracker = nullptr;
 // If there is no document referencing a storage database, close the underlying database
 // after it has been idle for m_StorageDatabaseIdleInterval seconds.
 static const Seconds defaultStorageDatabaseIdleInterval { 300_s };
-    
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageTracker);
+
 void StorageTracker::initializeTracker(const String& storagePath, StorageTrackerClient* client)
 {
     ASSERT(isMainThread());

--- a/Source/WebKitLegacy/Storage/StorageTracker.h
+++ b/Source/WebKitLegacy/Storage/StorageTracker.h
@@ -28,6 +28,7 @@
 #include <WebCore/SQLiteDatabase.h>
 #include <wtf/HashSet.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -43,7 +44,7 @@ namespace WebKit {
 
 class StorageTracker {
     WTF_MAKE_NONCOPYABLE(StorageTracker);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StorageTracker);
 public:
     static void initializeTracker(const String& storagePath, WebCore::StorageTrackerClient*);
     static StorageTracker& tracker();

--- a/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
@@ -34,13 +34,15 @@
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 // This class triggers asynchronous loads independent of the networking context staying alive (i.e., auditing pingbacks).
 // The object just needs to live long enough to ensure the message was actually sent.
 // As soon as any callback is received from the ResourceHandle, this class will cancel the load and delete itself.
 
 class PingHandle final : private WebCore::ResourceHandleClient {
-    WTF_MAKE_NONCOPYABLE(PingHandle); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PingHandle);
+    WTF_MAKE_NONCOPYABLE(PingHandle);
 public:
     PingHandle(WebCore::NetworkingContext* networkingContext, const WebCore::ResourceRequest& request, bool shouldUseCredentialStorage, bool shouldFollowRedirects, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&& completionHandler)
         : m_currentRequest(request)

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h
@@ -27,10 +27,11 @@
 
 #import "WebView.h"
 #import <WebCore/CryptoClient.h>
+#import <wtf/TZoneMalloc.h>
 
 
 class WebCryptoClient:  public WebCore::CryptoClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebCryptoClient);
 public:
     WebCryptoClient() = default;
     ~WebCryptoClient() = default;

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
@@ -30,7 +30,10 @@
 #import <WebCore/SerializedCryptoKeyWrap.h>
 #import <WebCore/WrappedCryptoKey.h>
 #import <optional>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCryptoClient);
 
 std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8_t>& key) const
 {

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/SubresourceLoader.h>
 #include <wtf/MainThread.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/text/CString.h>
 
@@ -60,6 +61,8 @@ WebResourceLoadScheduler& webResourceLoadScheduler()
 {
     return static_cast<WebResourceLoadScheduler&>(*platformStrategies()->loaderStrategy());
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebResourceLoadScheduler);
 
 auto WebResourceLoadScheduler::hostForURL(const URL& url, CreateHostPolicy createHostPolicy) -> CheckedPtr<HostInformation>
 {
@@ -320,6 +323,8 @@ void WebResourceLoadScheduler::requestTimerFired()
 {
     servePendingRequests();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WebResourceLoadSchedulerHostInformation, WebResourceLoadScheduler::HostInformation);
 
 WebResourceLoadScheduler::HostInformation::HostInformation(const String& name, unsigned maxRequestsInFlight)
     : m_name(name)

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -33,6 +33,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -42,7 +43,8 @@ class WebResourceLoadScheduler;
 WebResourceLoadScheduler& webResourceLoadScheduler();
 
 class WebResourceLoadScheduler final : public WebCore::LoaderStrategy {
-    WTF_MAKE_NONCOPYABLE(WebResourceLoadScheduler); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebResourceLoadScheduler);
+    WTF_MAKE_NONCOPYABLE(WebResourceLoadScheduler);
 public:
     WebResourceLoadScheduler();
 
@@ -85,7 +87,7 @@ private:
 
     class HostInformation final : public CanMakeWeakPtr<HostInformation>, public CanMakeCheckedPtr<HostInformation> {
         WTF_MAKE_NONCOPYABLE(HostInformation);
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(HostInformation);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HostInformation);
     public:
         HostInformation(const String&, unsigned);

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -55,13 +55,15 @@
 #include <WebCore/UserContentProvider.h>
 #include <WebCore/WebSocketChannelClient.h>
 #include <WebCore/WebSocketHandshake.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 const Seconds TCPMaximumSegmentLifetime { 2_min };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocketChannel);
 
 WebSocketChannel::WebSocketChannel(Document& document, WebSocketChannelClient& client, SocketProvider& provider)
     : m_document(document)

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -43,6 +43,7 @@
 #include <wtf/Forward.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
@@ -63,7 +64,7 @@ using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 
 class WebSocketChannel final : public RefCounted<WebSocketChannel>, public SocketStreamHandleClient, public ThreadableWebSocketChannel, public FileReaderLoaderClient
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSocketChannel);
 public:
     static Ref<WebSocketChannel> create(Document& document, WebSocketChannelClient& client, SocketProvider& provider) { return adoptRef(*new WebSocketChannel(document, client, provider)); }
     virtual ~WebSocketChannel();

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -26,9 +26,10 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "WebChromeClient.h"
+#import <wtf/TZoneMalloc.h>
 
 class WebChromeClientIOS final : public WebChromeClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebChromeClientIOS);
 public:
     WebChromeClientIOS(WebView* webView)
         : WebChromeClient(webView)

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
@@ -63,6 +63,7 @@
 #import <WebCore/WebCoreThreadMessage.h>
 #import <wtf/HashMap.h>
 #import <wtf/RefPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 NSString * const WebOpenPanelConfigurationAllowMultipleFilesKey = @"WebOpenPanelConfigurationAllowMultipleFilesKey";
@@ -89,6 +90,8 @@ static WebMediaCaptureType webMediaCaptureType(MediaCaptureType type)
 }
 
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebChromeClientIOS);
 
 void WebChromeClientIOS::setWindowRect(const WebCore::FloatRect& r)
 {

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
@@ -31,6 +31,7 @@
 #import <WebCore/SecurityOrigin.h>
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <WebCore/WebCoreThread.h>
@@ -96,7 +97,7 @@ WebDatabaseManagerClient::~WebDatabaseManagerClient()
 }
 
 class DidModifyOriginData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DidModifyOriginData);
 public:
     static void dispatchToMainThread(WebDatabaseManagerClient& client, const SecurityOriginData& origin)
     {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.h
@@ -25,11 +25,12 @@
 
 #import "CorrectionPanel.h"
 #import <WebCore/AlternativeTextClient.h>
+#import <wtf/TZoneMalloc.h>
 
 @class WebView;
 
 class WebAlternativeTextClient : public WebCore::AlternativeTextClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebAlternativeTextClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAlternativeTextClient);
 public:
     explicit WebAlternativeTextClient(WebView *);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
@@ -26,8 +26,11 @@
 #import "WebAlternativeTextClient.h"
 
 #import "WebViewInternal.h"
+#import <wtf/TZoneMallocInlines.h>
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAlternativeTextClient);
 
 WebAlternativeTextClient::WebAlternativeTextClient(WebView* webView)
     : m_webView(webView)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebCachedFramePlatformData.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebCachedFramePlatformData.h
@@ -30,9 +30,10 @@
 #import <WebCore/CachedFramePlatformData.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 class WebCachedFramePlatformData : public WebCore::CachedFramePlatformData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebCachedFramePlatformData);
 public:
     WebCachedFramePlatformData(id webDocumentView) : m_webDocumentView(webDocumentView) { }
     

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -30,6 +30,7 @@
 #import <WebCore/ChromeClient.h>
 #import <WebCore/FocusDirection.h>
 #import <wtf/Forward.h>
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class HTMLImageElement;
@@ -41,7 +42,7 @@ class HTMLImageElement;
 // base class of the concrete class, WebChromeClientIOS. Because of that, this class and
 // many of its functions are not marked final. That is messy way to organize things.
 class WebChromeClient : public WebCore::ChromeClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebChromeClient);
 public:
     WebChromeClient(WebView*);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -91,6 +91,7 @@
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/RefPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
@@ -157,6 +158,8 @@ NSString *WebConsoleMessageErrorMessageLevel = @"ErrorMessageLevel";
 
 using namespace WebCore;
 using namespace HTMLNames;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebChromeClient);
 
 WebChromeClient::WebChromeClient(WebView *webView) 
     : m_webView(webView)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
@@ -31,6 +31,7 @@
 #import "WebSharingServicePickerController.h"
 #import <WebCore/ContextMenuClient.h>
 #import <WebCore/IntRect.h>
+#import <wtf/TZoneMalloc.h>
 
 @class WebSharingServicePickerController;
 @class WebView;
@@ -44,7 +45,7 @@ class WebContextMenuClient : public WebCore::ContextMenuClient
     , public WebSharingServicePickerClient
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebContextMenuClient);
 public:
     WebContextMenuClient(WebView *webView);
     virtual ~WebContextMenuClient();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -57,6 +57,7 @@
 #import <WebCore/SimpleRange.h>
 #import <WebKitLegacy/DOMPrivate.h>
 #import <pal/spi/mac/NSSharingServicePickerSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 
 using namespace WebCore;
@@ -66,6 +67,8 @@ using namespace WebCore;
 - (void)speakString:(NSString *)string;
 - (void)stopSpeaking:(id)sender;
 @end
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebContextMenuClient);
 
 WebContextMenuClient::WebContextMenuClient(WebView *webView)
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h
@@ -26,11 +26,12 @@
 #if ENABLE(DRAG_SUPPORT)
 
 #import <WebCore/DragClient.h>
+#import <wtf/TZoneMalloc.h>
 
 @class WebView;
 
 class WebDragClient : public WebCore::DragClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebDragClient);
 public:
     WebDragClient(WebView*);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -59,9 +59,12 @@
 #import <WebCore/PagePasteboardContext.h>
 #import <WebCore/Pasteboard.h>
 #import <WebCore/PasteboardWriter.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDragClient);
 
 WebDragClient::WebDragClient(WebView* webView)
     : m_webView(webView) 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -34,6 +34,7 @@
 #import <wtf/Forward.h>
 #import <wtf/Ref.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/text/StringView.h>
@@ -46,7 +47,7 @@
 @class WebEditorUndoTarget;
 
 class WebEditorClient final : public WebCore::EditorClient, public WebCore::TextCheckerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebEditorClient);
 public:
     WebEditorClient(WebView *);
     virtual ~WebEditorClient();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -85,6 +85,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/WTFString.h>
 
@@ -190,6 +191,8 @@ static WebViewInsertAction kit(EditorInsertAction action)
 }
 
 @end
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebEditorClient);
 
 WebEditorClient::WebEditorClient(WebView *webView)
     : m_webView(webView)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.h
@@ -24,6 +24,7 @@
  */
 
 #import <WebCore/GeolocationClient.h>
+#import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class Geolocation;
@@ -33,7 +34,7 @@ class GeolocationPositionData;
 @class WebView;
 
 class WebGeolocationClient : public WebCore::GeolocationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebGeolocationClient);
 public:
     WebGeolocationClient(WebView *);
     WebView *webView() { return m_webView; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.mm
@@ -39,6 +39,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/NakedPtr.h>
 #import <wtf/NakedRef.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <WebCore/WAKResponder.h>
@@ -72,6 +73,8 @@ using namespace WebCore;
 - (id)initWithGeolocation:(NakedRef<Geolocation>)geolocation;
 @end
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGeolocationClient);
 
 WebGeolocationClient::WebGeolocationClient(WebView *webView)
     : m_webView(webView)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -34,6 +34,7 @@
 #import <wtf/Forward.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/text/StringHash.h>
@@ -54,7 +55,7 @@ class Page;
 class WebInspectorFrontendClient;
 
 class WebInspectorClient final : public WebCore::InspectorClient, public Inspector::FrontendChannel {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebInspectorClient);
 public:
     explicit WebInspectorClient(WebView *inspectedWebView);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
@@ -26,9 +26,10 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #import <WebCore/MediaKeySystemClient.h>
+#import <wtf/TZoneMalloc.h>
 
 class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebMediaKeySystemClient);
 public:
     static WebMediaKeySystemClient& singleton();
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
@@ -30,8 +30,11 @@
 #import <WebCore/MediaKeySystemRequest.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMediaKeySystemClient);
 
 WebMediaKeySystemClient& WebMediaKeySystemClient::singleton()
 {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h
@@ -31,6 +31,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/UUID.h>
 
 @class WebNotification;
@@ -38,7 +39,7 @@
 @class WebView;
 
 class WebNotificationClient final : public WebCore::NotificationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebNotificationClient);
 public:
     WebNotificationClient(WebView *);
     WebView *webView() { return m_webView; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
@@ -38,6 +38,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/Scope.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 using namespace WebCore;
@@ -48,6 +49,8 @@ using namespace WebCore;
 }
 - (id)initWithPermissionHandler:(NotificationClient::PermissionHandler&&)permissionHandler;
 @end
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebNotificationClient);
 
 WebNotificationClient::WebNotificationClient(WebView *webView)
     : m_webView(webView)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.h
@@ -29,8 +29,10 @@
 
 #if ENABLE(APPLE_PAY)
 
+#import <wtf/TZoneMalloc.h>
+
 class WebPaymentCoordinatorClient final : public WebCore::PaymentCoordinatorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPaymentCoordinatorClient);
 public:
     WebPaymentCoordinatorClient();
     ~WebPaymentCoordinatorClient();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
@@ -29,7 +29,10 @@
 
 #import <wtf/CompletionHandler.h>
 #import <wtf/MainThread.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPaymentCoordinatorClient);
 
 // FIXME: Why is this distinct from EmptyPaymentCoordinatorClient?
 WebPaymentCoordinatorClient::WebPaymentCoordinatorClient()

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.h
@@ -30,6 +30,7 @@
 
 #import "WebSharingServicePickerController.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
@@ -43,7 +44,7 @@ class IntPoint;
 }
 
 class WebSelectionServiceController : public WebSharingServicePickerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSelectionServiceController);
 public:
     WebSelectionServiceController(WebView*);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
@@ -32,8 +32,11 @@
 #import <WebCore/HTMLConverter.h>
 #import <WebCore/Range.h>
 #import <pal/spi/mac/NSSharingServiceSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSelectionServiceController);
 
 WebSelectionServiceController::WebSelectionServiceController(WebView *webView) 
     : WebSharingServicePickerClient(webView)

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
@@ -31,6 +31,7 @@
 #include <WebCore/MediaPlaybackTargetContext.h>
 #include <WebCore/WebMediaSessionManagerClient.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,7 +44,7 @@ class Page;
 }
 
 class WebMediaPlaybackTargetPicker : public WebCore::WebMediaSessionManagerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebMediaPlaybackTargetPicker);
 public:
     static std::unique_ptr<WebMediaPlaybackTargetPicker> create(WebView *, WebCore::Page&);
 

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
@@ -31,6 +31,9 @@
 #import <WebCore/MediaPlaybackTarget.h>
 #import <WebCore/Page.h>
 #import <WebCore/WebMediaSessionManager.h>
+#import <wtf/TZoneMallocInlines.h>
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMediaPlaybackTargetPicker);
 
 std::unique_ptr<WebMediaPlaybackTargetPicker> WebMediaPlaybackTargetPicker::create(WebView *webView, WebCore::Page& page)
 {

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
@@ -25,13 +25,13 @@
 
 #import <WebCore/RunLoopObserver.h>
 #import <wtf/CheckedPtr.h>
-#import <wtf/FastMalloc.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
 @class WebView;
 
 class WebViewRenderingUpdateScheduler : public CanMakeWeakPtr<WebViewRenderingUpdateScheduler>, public CanMakeCheckedPtr<WebViewRenderingUpdateScheduler> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebViewRenderingUpdateScheduler);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebViewRenderingUpdateScheduler);
 public:
     explicit WebViewRenderingUpdateScheduler(WebView*);

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -28,12 +28,15 @@
 
 #import "WebViewInternal.h"
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/WebCoreThread.h>
 #import <WebCore/WebCoreThreadInternal.h>
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewRenderingUpdateScheduler);
 
 WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webView)
     : m_webView(webView)


### PR DESCRIPTION
#### f25e56e5701c437fd282fda0ba5ab61db5b93697
<pre>
[TZone] WebKitLegacy: Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=277987">https://bugs.webkit.org/show_bug.cgi?id=277987</a>
<a href="https://rdar.apple.com/133721126">rdar://133721126</a>

Reviewed by Michael Saboff.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebKitLegacy/Storage/StorageTracker.cpp:
* Source/WebKitLegacy/Storage/StorageTracker.h:
* Source/WebKitLegacy/WebCoreSupport/PingHandle.h:
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.h:
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm:
* Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebCachedFramePlatformData.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPaymentCoordinatorClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm:

Canonical link: <a href="https://commits.webkit.org/282191@main">https://commits.webkit.org/282191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc25f65e90bfcfeacc0bf184ad810ecd619a4ed3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66360 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13261 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8923 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6322 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5261 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37531 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->