### PR TITLE
[DRAFT][Not for review] Test WebKit/Shared: Convert FastMalloc to TZone

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -313,7 +313,7 @@
 #if CPU(ARM64) && OS(DARWIN)
 // Only MacroAssemblerARM64 is known to build.
 // Building with TZONE_MALLOC currently disabled for all platforms.
-#define USE_TZONE_MALLOC 0
+#define USE_TZONE_MALLOC 1
 #else
 #define USE_TZONE_MALLOC 0
 #endif

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIDictionary.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace IPC {
@@ -38,7 +39,7 @@ namespace WebKit {
 class RemoteObjectInvocation {
 public:
     struct ReplyInfo {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteObjectInvocation);
     public:
         ReplyInfo(uint64_t replyID, String&& blockSignature)
             : replyID(replyID)

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
@@ -29,6 +29,7 @@
 #include "ProcessThrottler.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,7 +43,7 @@ class WebPage;
 class WebProcessProxy;
 
 class RemoteObjectRegistry : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteObjectRegistry);
 public:
     virtual ~RemoteObjectRegistry();
 

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
@@ -33,8 +33,11 @@
 #import "WebPage.h"
 #import "WebProcessProxy.h"
 #import "_WKRemoteObjectRegistryInternal.h"
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteObjectRegistry);
 
 RemoteObjectRegistry::RemoteObjectRegistry(_WKRemoteObjectRegistry *remoteObjectRegistry)
     : m_remoteObjectRegistry(remoteObjectRegistry)

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
@@ -40,10 +40,13 @@
 #include <WebCore/ApplePayPaymentMethodUpdate.h>
 #include <WebCore/ApplePayShippingContactUpdate.h>
 #include <WebCore/ApplePayShippingMethodUpdate.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, messageSenderConnection())
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPaymentCoordinatorProxy);
 
 static WeakPtr<WebPaymentCoordinatorProxy>& activePaymentCoordinatorProxy()
 {

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -35,6 +35,7 @@
 #include <WebCore/PaymentHeaders.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
@@ -90,7 +91,7 @@ class WebPaymentCoordinatorProxy
     : public IPC::MessageReceiver
     , private IPC::MessageSender
     , public PaymentAuthorizationPresenter::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPaymentCoordinatorProxy);
 public:
     struct Client {
         virtual ~Client() = default;

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
@@ -39,6 +39,7 @@
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include <WebCore/AuthenticationChallenge.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -48,6 +49,8 @@ static bool canCoalesceChallenge(const WebCore::AuthenticationChallenge& challen
     // Do not coalesce server trust evaluation requests because ProtectionSpace comparison does not evaluate server trust (e.g. certificate).
     return challenge.protectionSpace().authenticationScheme() != ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticationManager);
 
 ASCIILiteral AuthenticationManager::supplementName()
 {

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.h
@@ -37,6 +37,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -73,7 +74,7 @@ enum class AuthenticationChallengeDisposition : uint8_t;
 using ChallengeCompletionHandler = CompletionHandler<void(AuthenticationChallengeDisposition, const WebCore::Credential&)>;
 
 class AuthenticationManager : public NetworkProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AuthenticationManager);
     WTF_MAKE_NONCOPYABLE(AuthenticationManager);
 public:
     explicit AuthenticationManager(NetworkProcess&);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
@@ -31,13 +31,14 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/KeyValuePair.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
 class CoreIPCDictionary {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCDictionary);
 public:
     CoreIPCDictionary(NSDictionary *);
     CoreIPCDictionary(const RetainPtr<NSDictionary>&);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -25,12 +25,15 @@
 
 #import "config.h"
 #import "CoreIPCDictionary.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 
 #import "CoreIPCTypes.h"
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCDictionary);
 
 CoreIPCDictionary::CoreIPCDictionary(NSDictionary *dictionary)
 {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA)
 
 #import <CoreFoundation/CoreFoundation.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/text/WTFString.h>
 
 OBJC_CLASS NSError;
@@ -35,7 +36,7 @@ OBJC_CLASS NSError;
 namespace WebKit {
 
 class CoreIPCError {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCError);
 public:
     static bool hasValidUserInfo(const RetainPtr<CFDictionaryRef>&);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -26,9 +26,12 @@
 #import "config.h"
 #import "CoreIPCError.h"
 
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCError);
 
 bool CoreIPCError::hasValidUserInfo(const RetainPtr<CFDictionaryRef>& userInfo)
 {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -37,6 +37,7 @@
 #import "CoreIPCURL.h"
 
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 
 OBJC_CLASS NSURLRequest;
@@ -148,7 +149,7 @@ struct CoreIPCNSURLRequestData {
 };
 
 class CoreIPCNSURLRequest {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCNSURLRequest);
 public:
     CoreIPCNSURLRequest(NSURLRequest *);
     CoreIPCNSURLRequest(CoreIPCNSURLRequestData&&);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -27,6 +27,7 @@
 #import "CoreIPCNSURLRequest.h"
 
 #import "GeneratedSerializers.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #if PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLREQUEST)
@@ -63,6 +64,8 @@ namespace WebKit {
 
 #define SET_DICT_FROM_PRIMITIVE(KEY, CLASS, PRIMITIVE) \
     [dict setObject:[NSNumber numberWith##PRIMITIVE:m_data.KEY] forKey:@#KEY]
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCNSURLRequest);
 
 CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
 {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h
@@ -29,12 +29,13 @@
 
 #include "ArgumentCodersCocoa.h"
 #include <Foundation/Foundation.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class CoreIPCPersonNameComponents {
-WTF_MAKE_FAST_ALLOCATED;
+WTF_MAKE_TZONE_ALLOCATED(CoreIPCPersonNameComponents);
 public:
     CoreIPCPersonNameComponents(NSPersonNameComponents *);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
@@ -29,8 +29,11 @@
 #if PLATFORM(COCOA)
 
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCPersonNameComponents);
 
 CoreIPCPersonNameComponents::CoreIPCPersonNameComponents(NSPersonNameComponents *components)
     : m_namePrefix(components.namePrefix)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h
@@ -31,13 +31,14 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/KeyValuePair.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
 class CoreIPCPlistDictionary {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCPlistDictionary);
 public:
     CoreIPCPlistDictionary(NSDictionary *);
     CoreIPCPlistDictionary(const RetainPtr<NSDictionary>&);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm
@@ -35,8 +35,11 @@
 #import "CoreIPCPlistObject.h"
 #import "CoreIPCString.h"
 #import <wtf/Assertions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCPlistDictionary);
 
 CoreIPCPlistDictionary::CoreIPCPlistDictionary(NSDictionary *dictionary)
 {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA)
 
 #include <wtf/ArgumentCoder.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -36,7 +37,7 @@ OBJC_CLASS NSPresentationIntent;
 namespace WebKit {
 
 class CoreIPCPresentationIntent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCPresentationIntent);
 public:
     CoreIPCPresentationIntent(NSPresentationIntent *);
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm
@@ -30,8 +30,11 @@
 
 #import <Foundation/Foundation.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCPresentationIntent);
 
 CoreIPCPresentationIntent::CoreIPCPresentationIntent(NSPresentationIntent *intent)
     : m_intentKind(intent.intentKind)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
@@ -29,6 +29,7 @@
 
 #include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 #ifdef __OBJC__
 @interface NSObject (WebKitSecureCoding)
@@ -51,7 +52,7 @@ void applyProcessCreationParameters(const AuxiliaryProcessCreationParameters&);
 #ifdef __OBJC__
 
 class CoreIPCSecureCoding {
-WTF_MAKE_FAST_ALLOCATED;
+WTF_MAKE_TZONE_ALLOCATED(CoreIPCSecureCoding);
 public:
     CoreIPCSecureCoding(id);
     CoreIPCSecureCoding(const RetainPtr<NSObject<NSSecureCoding>>& object)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -32,6 +32,7 @@
 #import "AuxiliaryProcessCreationParameters.h"
 #import "WKCrashReporter.h"
 #import <WebCore/RuntimeApplicationChecks.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/StringHash.h>
 
 namespace WebKit {
@@ -82,6 +83,8 @@ void applyProcessCreationParameters(const AuxiliaryProcessCreationParameters& pa
 }
 
 } // namespace SecureCoding
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCSecureCoding);
 
 bool CoreIPCSecureCoding::conformsToWebKitSecureCoding(id object)
 {

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
@@ -30,6 +30,7 @@
 
 #include <wtf/HashMap.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -38,6 +39,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CompositingRunLoop);
 
 CompositingRunLoop::CompositingRunLoop(Function<void ()>&& updateFunction)
     : m_runLoop(RunLoop::create("org.webkit.ThreadedCompositor"_s, ThreadType::Graphics))

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
@@ -29,18 +29,18 @@
 
 #include <wtf/Atomics.h>
 #include <wtf/Condition.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class CompositingRunLoop {
     WTF_MAKE_NONCOPYABLE(CompositingRunLoop);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CompositingRunLoop);
 public:
     CompositingRunLoop(Function<void ()>&&);
     ~CompositingRunLoop();

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -54,6 +55,8 @@ using namespace WebCore;
 #if !HAVE(DISPLAY_LINK)
 static constexpr unsigned c_defaultRefreshRate = 60000;
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadedCompositor);
 
 #if HAVE(DISPLAY_LINK)
 Ref<ThreadedCompositor> ThreadedCompositor::create(Client& client, PlatformDisplayID displayID, const IntSize& viewportSize, float scaleFactor, bool flipY, DamagePropagation damagePropagation)

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -33,8 +33,8 @@
 #include <WebCore/GLContext.h>
 #include <WebCore/IntSize.h>
 #include <wtf/Atomics.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 #if !HAVE(DISPLAY_LINK)
@@ -48,8 +48,8 @@ class Damage;
 namespace WebKit {
 
 class ThreadedCompositor : public CoordinatedGraphicsSceneClient, public ThreadSafeRefCounted<ThreadedCompositor> {
+    WTF_MAKE_TZONE_ALLOCATED(ThreadedCompositor);
     WTF_MAKE_NONCOPYABLE(ThreadedCompositor);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class DamagePropagation : uint8_t {
         None,

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -36,6 +36,7 @@
 #include <WebCore/Region.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS CALayer;
@@ -82,8 +83,8 @@ enum class LayerContentsType : uint8_t {
 };
 
 class RemoteLayerBackingStore : public CanMakeWeakPtr<RemoteLayerBackingStore> {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerBackingStore);
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStore);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     RemoteLayerBackingStore(PlatformCALayerRemote&);
     virtual ~RemoteLayerBackingStore();
@@ -222,8 +223,8 @@ protected:
 // The subset of RemoteLayerBackingStore that gets serialized into the UI
 // process, and gets applied to the CALayer.
 class RemoteLayerBackingStoreProperties {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerBackingStoreProperties);
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStoreProperties);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     RemoteLayerBackingStoreProperties() = default;
     RemoteLayerBackingStoreProperties(RemoteLayerBackingStoreProperties&&) = default;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -59,8 +59,8 @@
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <WebCore/WebLayer.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
-#import <wtf/FastMalloc.h>
 #import <wtf/Noncopyable.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/TextStream.h>
 
@@ -72,7 +72,7 @@ using namespace WebCore;
 namespace {
 
 class DelegatedContentsFenceFlusher final : public ThreadSafeImageBufferSetFlusher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DelegatedContentsFenceFlusher);
     WTF_MAKE_NONCOPYABLE(DelegatedContentsFenceFlusher);
 public:
     static std::unique_ptr<DelegatedContentsFenceFlusher> create(Ref<PlatformCALayerDelegatedContentsFence> fence)
@@ -93,7 +93,11 @@ private:
     Ref<PlatformCALayerDelegatedContentsFence> m_fence;
 };
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DelegatedContentsFenceFlusher);
+
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerBackingStore);
 
 std::unique_ptr<RemoteLayerBackingStore> RemoteLayerBackingStore::createForLayer(PlatformCALayerRemote& layer)
 {
@@ -194,6 +198,8 @@ void RemoteLayerBackingStore::encode(IPC::Encoder& encoder) const
     encoder << displayListHandle();
 #endif
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerBackingStoreProperties);
 
 void RemoteLayerBackingStoreProperties::dump(TextStream& ts) const
 {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -29,6 +29,7 @@
 #import <wtf/HashSet.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/OptionSet.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
@@ -61,8 +62,8 @@ enum class BufferInSetType : uint8_t;
 enum class SwapBuffersDisplayRequirement : uint8_t;
 
 class RemoteLayerBackingStoreCollection : public CanMakeWeakPtr<RemoteLayerBackingStoreCollection> {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerBackingStoreCollection);
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStoreCollection);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     RemoteLayerBackingStoreCollection(RemoteLayerTreeContext&);
     virtual ~RemoteLayerBackingStoreCollection();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -39,11 +39,14 @@
 #import "SwapBuffersDisplayRequirement.h"
 #import <WebCore/IOSurfacePool.h>
 #import <WebCore/ImageBuffer.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/TextStream.h>
 
 const Seconds volatilityTimerInterval = 200_ms;
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerBackingStoreCollection);
 
 RemoteLayerBackingStoreCollection::RemoteLayerBackingStoreCollection(RemoteLayerTreeContext& layerTreeContext)
     : m_layerTreeContext(layerTreeContext)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -42,6 +42,7 @@
 #include <WebCore/ScrollTypes.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -75,7 +76,7 @@ struct ChangedLayers {
 };
 
 class RemoteLayerTreeTransaction {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeTransaction);
 public:
     struct LayerCreationProperties {
         struct NoAdditionalData { };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -36,11 +36,14 @@
 #import <WebCore/Model.h>
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/TimingFunction.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/TextStream.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeTransaction);
 
 RemoteLayerTreeTransaction::RemoteLayerTreeTransaction(RemoteLayerTreeTransaction&&) = default;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -40,6 +40,7 @@
 #import <WebCore/ImageBufferPixelFormat.h>
 #import <WebCore/PlatformCALayerClient.h>
 #import <wtf/Scope.h>
+#import <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -142,7 +143,7 @@ void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContent
 }
 
 class ImageBufferBackingStoreFlusher final : public ThreadSafeImageBufferSetFlusher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ImageBufferBackingStoreFlusher);
     WTF_MAKE_NONCOPYABLE(ImageBufferBackingStoreFlusher);
 public:
     static std::unique_ptr<ImageBufferBackingStoreFlusher> create(std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher> imageBufferFlusher)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
@@ -27,6 +27,7 @@
 
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Decoder;
@@ -47,7 +48,7 @@ enum class RemoteScrollingUIStateChanges : uint8_t {
 };
 
 class RemoteScrollingUIState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteScrollingUIState);
 public:
     using Changes = RemoteScrollingUIStateChanges;
 

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -32,6 +32,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -54,7 +55,7 @@ enum class SandboxExtensionType : uint8_t {
 
 #if ENABLE(SANDBOX_EXTENSIONS)
 class SandboxExtensionImpl {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SandboxExtensionImpl);
 public:
     static std::unique_ptr<SandboxExtensionImpl> create(const char* path, SandboxExtensionType, std::optional<audit_token_t> = std::nullopt, OptionSet<SandboxExtensionFlags> = SandboxExtensionFlags::Default);
     SandboxExtensionImpl(std::span<const uint8_t>);

--- a/Source/WebKit/Shared/WebEvent.cpp
+++ b/Source/WebKit/Shared/WebEvent.cpp
@@ -31,9 +31,12 @@
 #include "WebCoreArgumentCoders.h"
 #include "WebKeyboardEvent.h"
 #include <WebCore/WindowsKeyboardCodes.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebEvent);
 
 WebEvent::WebEvent(WebEventType type, OptionSet<WebEventModifier> modifiers, WallTime timestamp, WTF::UUID authorizationToken)
     : m_type(type)

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -35,6 +35,7 @@
 
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
@@ -47,7 +48,7 @@ class Encoder;
 namespace WebKit {
 
 class WebEvent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebEvent);
 public:
     WebEvent(WebEventType, OptionSet<WebEventModifier>, WallTime timestamp, WTF::UUID authorizationToken);
     WebEvent(WebEventType, OptionSet<WebEventModifier>, WallTime timestamp);

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "NativeWebWheelEvent.h"
 #include "WebEventConversion.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebKit {
@@ -43,6 +44,8 @@ static TextStream& operator<<(TextStream& ts, const NativeWebWheelEvent& nativeW
     return ts;
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebWheelEventCoalescer);
 
 bool WebWheelEventCoalescer::canCoalesce(const WebWheelEvent& a, const WebWheelEvent& b)
 {

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.h
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.h
@@ -27,12 +27,12 @@
 
 #include "NativeWebWheelEvent.h"
 #include <wtf/Deque.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebWheelEventCoalescer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebWheelEventCoalescer);
 public:
     // If this returns true, use nextEventToDispatch() to get the event to dispatch.
     bool shouldDispatchEvent(const NativeWebWheelEvent&);

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -31,8 +31,11 @@
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebsitePoliciesData);
 
 void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePolicies, WebCore::DocumentLoader& documentLoader)
 {

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -40,6 +40,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Decoder;
@@ -53,7 +54,7 @@ class DocumentLoader;
 namespace WebKit {
 
 struct WebsitePoliciesData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebsitePoliciesData);
 public:
     static void applyToDocumentLoader(WebsitePoliciesData&&, WebCore::DocumentLoader&);
 

--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WebContextMenuItemGlib.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 #if ENABLE(CONTEXT_MENUS)
 #include "APIObject.h"
 #include <gio/gio.h>
@@ -36,6 +38,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebContextMenuItemGlib);
 
 WebContextMenuItemGlib::WebContextMenuItemGlib(ContextMenuItemType type, ContextMenuAction action, const String& title, bool enabled, bool checked)
     : WebContextMenuItemData(type, action, String { title }, enabled, checked)

--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.h
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemData.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -38,7 +39,7 @@ typedef struct _GAction GAction;
 namespace WebKit {
 
 class WebContextMenuItemGlib final : public WebContextMenuItemData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebContextMenuItemGlib);
 public:
     WebContextMenuItemGlib(WebCore::ContextMenuItemType, WebCore::ContextMenuAction, const String& title, bool enabled = true, bool checked = false);
     WebContextMenuItemGlib(const WebContextMenuItemData&);


### PR DESCRIPTION
#### c82829e4f19355f7bb21c05f492520a932b9d3dd
<pre>
[DRAFT][Not for review] Test WebKit/Shared: Convert FastMalloc to TZone

Reviewed by NOBODY (OOPS!).

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/Authentication/AuthenticationManager.cpp:
* Source/WebKit/Shared/Authentication/AuthenticationManager.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCError.h:
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h:
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/Shared/WebEvent.cpp:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/WebWheelEventCoalescer.cpp:
* Source/WebKit/Shared/WebWheelEventCoalescer.h:
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp:
* Source/WebKit/Shared/glib/WebContextMenuItemGlib.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c82829e4f19355f7bb21c05f492520a932b9d3dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12822 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50179 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8856 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11218 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11753 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55373 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67987 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61519 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57767 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5146 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37431 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14614 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38515 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39611 "Hash c82829e4 for PR 32082 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->