### PR TITLE
[DRAFT][Not for review] Test WebKit/WebProcess

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -313,7 +313,7 @@
 #if CPU(ARM64) && OS(DARWIN)
 // Only MacroAssemblerARM64 is known to build.
 // Building with TZONE_MALLOC currently disabled for all platforms.
-#define USE_TZONE_MALLOC 0
+#define USE_TZONE_MALLOC 1
 #else
 #define USE_TZONE_MALLOC 0
 #endif

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -43,9 +43,12 @@
 #include <WebCore/ApplePayShippingMethodUpdate.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/PaymentCoordinator.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPaymentCoordinator);
 
 WebPaymentCoordinator::WebPaymentCoordinator(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -35,6 +35,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -50,7 +51,7 @@ class NetworkProcessConnection;
 class WebPage;
 
 class WebPaymentCoordinator final : public WebCore::PaymentCoordinatorClient, private IPC::MessageReceiver, private IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPaymentCoordinator);
 public:
     friend class NetworkProcessConnection;
     explicit WebPaymentCoordinator(WebPage&);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -63,6 +63,7 @@
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/RenderElement.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 
 #if ENABLE(DATALIST_ELEMENT)
@@ -110,6 +111,8 @@ static inline JSValueRef callPropertyFunction(JSContextRef context, JSObjectRef 
 
     return JSObjectCallAsFunction(context, function, object, argumentCount, arguments, exception);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAutomationSessionProxy);
 
 WebAutomationSessionProxy::WebAutomationSessionProxy(const String& sessionIdentifier)
     : m_sessionIdentifier(sessionIdentifier)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ class WebPage;
 class WebAutomationDOMWindowObserver;
 
 class WebAutomationSessionProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebAutomationSessionProxy);
 public:
     WebAutomationSessionProxy(const String& sessionIdentifier);
     ~WebAutomationSessionProxy();

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -41,9 +41,12 @@
 #include <WebCore/Page.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManager);
 
 MediaKeySystemPermissionRequestManager::MediaKeySystemPermissionRequestManager(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
@@ -34,13 +34,14 @@
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class MediaKeySystemPermissionRequestManager : private WebCore::MediaCanStartListener {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MediaKeySystemPermissionRequestManager);
 public:
     explicit MediaKeySystemPermissionRequestManager(WebPage&);
     ~MediaKeySystemPermissionRequestManager() = default;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -35,10 +35,13 @@
 #include "WebFrame.h"
 #include "WebPage.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionContextProxy);
 
 WebExtensionControllerProxy* WebExtensionContextProxy::extensionControllerProxy() const
 {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -34,6 +34,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -54,7 +55,7 @@ struct WebExtensionTabParameters;
 struct WebExtensionWindowParameters;
 
 class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionContextProxy);
     WTF_MAKE_NONCOPYABLE(WebExtensionContextProxy);
 
 public:

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -34,6 +34,7 @@
 #include "WebFrame.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -44,6 +45,8 @@ static HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionControllerP
     static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionControllerProxy>>> controllers;
     return controllers;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionControllerProxy);
 
 RefPtr<WebExtensionControllerProxy> WebExtensionControllerProxy::get(WebExtensionControllerIdentifier identifier)
 {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -31,6 +31,7 @@
 #include "WebExtensionContextProxy.h"
 #include "WebExtensionControllerParameters.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ class WebFrame;
 class WebPage;
 
 class WebExtensionControllerProxy final : public RefCounted<WebExtensionControllerProxy>, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionControllerProxy);
     WTF_MAKE_NONCOPYABLE(WebExtensionControllerProxy);
 
 public:

--- a/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp
@@ -27,8 +27,11 @@
 
 #if ENABLE(GPU_PROCESS)
 #include "RemoteSharedResourceCacheProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSharedResourceCacheProxy);
 
 Ref<RemoteSharedResourceCacheProxy> RemoteSharedResourceCacheProxy::create()
 {

--- a/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include <wtf/FastMalloc.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebKit {
@@ -36,7 +36,7 @@ namespace WebKit {
 // Class for maintaining view of GPU process RemoteSharedResourceCache state in Web process.
 // Thread-safe.
 class RemoteSharedResourceCacheProxy : public ThreadSafeRefCounted<RemoteSharedResourceCacheProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteSharedResourceCacheProxy);
 public:
     static Ref<RemoteSharedResourceCacheProxy> create();
     virtual ~RemoteSharedResourceCacheProxy();

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
@@ -35,8 +35,11 @@
 #include "StreamClientConnection.h"
 #include "WebProcess.h"
 #include <WebCore/ImageBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::ShapeDetection {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBarcodeDetectorProxy);
 
 Ref<RemoteBarcodeDetectorProxy> RemoteBarcodeDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier, const WebCore::ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions)
 {

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -48,7 +49,7 @@ struct DetectedBarcode;
 namespace WebKit::ShapeDetection {
 
 class RemoteBarcodeDetectorProxy : public WebCore::ShapeDetection::BarcodeDetector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteBarcodeDetectorProxy);
 public:
     static Ref<RemoteBarcodeDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RenderingBackendIdentifier, ShapeDetectionIdentifier, const WebCore::ShapeDetection::BarcodeDetectorOptions&);
 

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -35,8 +35,11 @@
 #include "StreamClientConnection.h"
 #include "WebProcess.h"
 #include <WebCore/ImageBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::ShapeDetection {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFaceDetectorProxy);
 
 Ref<RemoteFaceDetectorProxy> RemoteFaceDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier, const WebCore::ShapeDetection::FaceDetectorOptions& faceDetectorOptions)
 {

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -47,7 +48,7 @@ struct FaceDetectorOptions;
 namespace WebKit::ShapeDetection {
 
 class RemoteFaceDetectorProxy : public WebCore::ShapeDetection::FaceDetector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteFaceDetectorProxy);
 public:
     static Ref<RemoteFaceDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RenderingBackendIdentifier, ShapeDetectionIdentifier, const WebCore::ShapeDetection::FaceDetectorOptions&);
 

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
@@ -35,8 +35,11 @@
 #include "StreamClientConnection.h"
 #include "WebProcess.h"
 #include <WebCore/ImageBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::ShapeDetection {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextDetectorProxy);
 
 Ref<RemoteTextDetectorProxy> RemoteTextDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier)
 {

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -46,7 +47,7 @@ struct DetectedText;
 namespace WebKit::ShapeDetection {
 
 class RemoteTextDetectorProxy : public WebCore::ShapeDetection::TextDetector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteTextDetectorProxy);
 public:
     static Ref<RemoteTextDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RenderingBackendIdentifier, ShapeDetectionIdentifier);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -32,6 +32,7 @@
 #include "RemoteImageBufferSetProxyMessages.h"
 #include "RemoteRenderingBackendProxy.h"
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(GPU_PROCESS)
 
@@ -40,7 +41,7 @@ using namespace WebCore;
 
 class RemoteImageBufferSetProxyFlushFence : public ThreadSafeRefCounted<RemoteImageBufferSetProxyFlushFence> {
     WTF_MAKE_NONCOPYABLE(RemoteImageBufferSetProxyFlushFence);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlushFence);
 public:
     static Ref<RemoteImageBufferSetProxyFlushFence> create(RenderingUpdateID renderingUpdateID)
     {
@@ -86,7 +87,7 @@ private:
 namespace {
 
 class RemoteImageBufferSetProxyFlusher final : public ThreadSafeImageBufferSetFlusher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlusher);
 public:
     RemoteImageBufferSetProxyFlusher(RemoteImageBufferSetIdentifier identifier, Ref<RemoteImageBufferSetProxyFlushFence> flushState, unsigned generation)
         : m_identifier(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -34,6 +34,7 @@
 #include "WorkQueueMessageReceiver.h"
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(GPU_PROCESS)
 
@@ -52,7 +53,7 @@ struct BufferSetBackendHandle;
 // the code that isn't specific to being remote, and this helper belongs
 // there.
 class ThreadSafeImageBufferSetFlusher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ThreadSafeImageBufferSetFlusher);
     WTF_MAKE_NONCOPYABLE(ThreadSafeImageBufferSetFlusher);
 public:
     enum class FlushType {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -31,8 +31,11 @@
 #include "RemoteAdapterMessages.h"
 #include "RemoteDeviceProxy.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAdapterProxy);
 
 RemoteAdapterProxy::RemoteAdapterProxy(String&& name, WebCore::WebGPU::SupportedFeatures& features, WebCore::WebGPU::SupportedLimits& limits, bool isFallbackAdapter, RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : Adapter(WTFMove(name), features, limits, isFallbackAdapter)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUAdapter.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class RemoteGPUProxy;
@@ -41,7 +42,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteAdapterProxy final : public WebCore::WebGPU::Adapter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAdapterProxy);
 public:
     static Ref<RemoteAdapterProxy> create(String&& name, WebCore::WebGPU::SupportedFeatures& features, WebCore::WebGPU::SupportedLimits& limits, bool isFallbackAdapter, RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteBindGroupLayoutMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBindGroupLayoutProxy);
 
 RemoteBindGroupLayoutProxy::RemoteBindGroupLayoutProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUBindGroupLayout.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteBindGroupLayoutProxy final : public WebCore::WebGPU::BindGroupLayout {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteBindGroupLayoutProxy);
 public:
     static Ref<RemoteBindGroupLayoutProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteBindGroupMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBindGroupProxy);
 
 RemoteBindGroupProxy::RemoteBindGroupProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -30,6 +30,7 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUBindGroup.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore::WebGPU {
 class ExternalTexture;
@@ -40,7 +41,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteBindGroupProxy final : public WebCore::WebGPU::BindGroup {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteBindGroupProxy);
 public:
     static Ref<RemoteBindGroupProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteBufferMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteBufferProxy);
 
 RemoteBufferProxy::RemoteBufferProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, bool mappedAtCreation)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -31,13 +31,14 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUBuffer.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteBufferProxy final : public WebCore::WebGPU::Buffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteBufferProxy);
 public:
     static Ref<RemoteBufferProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, bool mappedAtCreation)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteCommandBufferMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCommandBufferProxy);
 
 RemoteCommandBufferProxy::RemoteCommandBufferProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCommandBuffer.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteCommandBufferProxy final : public WebCore::WebGPU::CommandBuffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteCommandBufferProxy);
 public:
     static Ref<RemoteCommandBufferProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -33,8 +33,11 @@
 #include "RemoteComputePassEncoderProxy.h"
 #include "RemoteRenderPassEncoderProxy.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCommandEncoderProxy);
 
 RemoteCommandEncoderProxy::RemoteCommandEncoderProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCommandEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteCommandEncoderProxy final : public WebCore::WebGPU::CommandEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteCommandEncoderProxy);
 public:
     static Ref<RemoteCommandEncoderProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -33,8 +33,11 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/WebGPUTextureFormat.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCompositorIntegrationProxy);
 
 RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -31,6 +31,7 @@
 #include "RemotePresentationContextProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCompositorIntegration.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class ImageBuffer;
@@ -45,7 +46,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteCompositorIntegrationProxy final : public WebCore::WebGPU::CompositorIntegration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteCompositorIntegrationProxy);
 public:
     static Ref<RemoteCompositorIntegrationProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteComputePassEncoderMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoderProxy);
 
 RemoteComputePassEncoderProxy::RemoteComputePassEncoderProxy(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteCommandEncoderProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUComputePassEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteComputePassEncoderProxy final : public WebCore::WebGPU::ComputePassEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteComputePassEncoderProxy);
 public:
     static Ref<RemoteComputePassEncoderProxy> create(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -31,8 +31,11 @@
 #include "RemoteBindGroupLayoutProxy.h"
 #include "RemoteComputePipelineMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteComputePipelineProxy);
 
 RemoteComputePipelineProxy::RemoteComputePipelineProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUComputePipeline.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
@@ -38,7 +39,7 @@ class ConvertToBackingContext;
 class RemoteBindGroupLayoutProxy;
 
 class RemoteComputePipelineProxy final : public WebCore::WebGPU::ComputePipeline {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteComputePipelineProxy);
 public:
     static Ref<RemoteComputePipelineProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -46,8 +46,11 @@
 #include "SharedVideoFrame.h"
 #include "WebGPUCommandEncoderDescriptor.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteDeviceProxy);
 
 RemoteDeviceProxy::RemoteDeviceProxy(Ref<WebCore::WebGPU::SupportedFeatures>&& features, Ref<WebCore::WebGPU::SupportedLimits>&& limits, RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier)
     : Device(WTFMove(features), WTFMove(limits))

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/WebGPUCommandEncoderDescriptor.h>
 #include <WebCore/WebGPUDevice.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
 #include <WebCore/MediaPlayerIdentifier.h>
@@ -44,7 +45,7 @@ class ConvertToBackingContext;
 class RemoteQueueProxy;
 
 class RemoteDeviceProxy final : public WebCore::WebGPU::Device {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteDeviceProxy);
 public:
     static Ref<RemoteDeviceProxy> create(Ref<WebCore::WebGPU::SupportedFeatures>&& features, Ref<WebCore::WebGPU::SupportedLimits>&& limits, RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteExternalTextureMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteExternalTextureProxy);
 
 RemoteExternalTextureProxy::RemoteExternalTextureProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUExternalTexture.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteExternalTextureProxy final : public WebCore::WebGPU::ExternalTexture {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteExternalTextureProxy);
 public:
     static Ref<RemoteExternalTextureProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -43,8 +43,11 @@
 #include <WebCore/WebGPUPresentationContextDescriptor.h>
 #include <WebCore/WebGPUSupportedFeatures.h>
 #include <WebCore/WebGPUSupportedLimits.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGPUProxy);
 
 RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(WebGPU::ConvertToBackingContext& convertToBackingContext, WebPage& page)
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -34,6 +34,7 @@
 #include <WebCore/WebGPU.h>
 #include <WebCore/WebGPUPresentationContext.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
@@ -52,7 +53,7 @@ class DowncastConvertToBackingContext;
 }
 
 class RemoteGPUProxy final : public WebCore::WebGPU::GPU, private IPC::Connection::Client, public ThreadSafeRefCounted<RemoteGPUProxy>, SerialFunctionDispatcher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteGPUProxy);
 public:
     static RefPtr<RemoteGPUProxy> create(WebGPU::ConvertToBackingContext&, WebPage&);
     static RefPtr<RemoteGPUProxy> create(WebGPU::ConvertToBackingContext&, RemoteRenderingBackendProxy&, SerialFunctionDispatcher&);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemotePipelineLayoutMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePipelineLayoutProxy);
 
 RemotePipelineLayoutProxy::RemotePipelineLayoutProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUPipelineLayout.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemotePipelineLayoutProxy final : public WebCore::WebGPU::PipelineLayout {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemotePipelineLayoutProxy);
 public:
     static Ref<RemotePipelineLayoutProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -32,8 +32,11 @@
 #include "RemoteTextureProxy.h"
 #include "WebGPUCanvasConfiguration.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePresentationContextProxy);
 
 RemotePresentationContextProxy::RemotePresentationContextProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <WebCore/WebGPUPresentationContext.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class NativeImage;
@@ -42,7 +43,7 @@ class ConvertToBackingContext;
 class RemoteTextureProxy;
 
 class RemotePresentationContextProxy final : public WebCore::WebGPU::PresentationContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemotePresentationContextProxy);
 public:
     static Ref<RemotePresentationContextProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteQuerySetMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteQuerySetProxy);
 
 RemoteQuerySetProxy::RemoteQuerySetProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUQuerySet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteQuerySetProxy final : public WebCore::WebGPU::QuerySet {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteQuerySetProxy);
 public:
     static Ref<RemoteQuerySetProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteQueueMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteQueueProxy);
 
 RemoteQueueProxy::RemoteQueueProxy(RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -31,13 +31,14 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUQueue.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteQueueProxy final : public WebCore::WebGPU::Queue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteQueueProxy);
 public:
     static Ref<RemoteQueueProxy> create(RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -31,8 +31,11 @@
 #include "RemoteRenderBundleEncoderMessages.h"
 #include "RemoteRenderBundleProxy.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderBundleEncoderProxy);
 
 RemoteRenderBundleEncoderProxy::RemoteRenderBundleEncoderProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderBundleEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteRenderBundleEncoderProxy final : public WebCore::WebGPU::RenderBundleEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteRenderBundleEncoderProxy);
 public:
     static Ref<RemoteRenderBundleEncoderProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteRenderBundleMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderBundleProxy);
 
 RemoteRenderBundleProxy::RemoteRenderBundleProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderBundle.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteRenderBundleProxy final : public WebCore::WebGPU::RenderBundle {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteRenderBundleProxy);
 public:
     static Ref<RemoteRenderBundleProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteRenderPassEncoderMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoderProxy);
 
 RemoteRenderPassEncoderProxy::RemoteRenderPassEncoderProxy(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteCommandEncoderProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderPassEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteRenderPassEncoderProxy final : public WebCore::WebGPU::RenderPassEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteRenderPassEncoderProxy);
 public:
     static Ref<RemoteRenderPassEncoderProxy> create(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -31,8 +31,11 @@
 #include "RemoteBindGroupLayoutProxy.h"
 #include "RemoteRenderPipelineMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRenderPipelineProxy);
 
 RemoteRenderPipelineProxy::RemoteRenderPipelineProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderPipeline.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
@@ -38,7 +39,7 @@ class ConvertToBackingContext;
 class RemoteBindGroupLayoutProxy;
 
 class RemoteRenderPipelineProxy final : public WebCore::WebGPU::RenderPipeline {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteRenderPipelineProxy);
 public:
     static Ref<RemoteRenderPipelineProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteSamplerMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSamplerProxy);
 
 RemoteSamplerProxy::RemoteSamplerProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUSampler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteSamplerProxy final : public WebCore::WebGPU::Sampler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteSamplerProxy);
 public:
     static Ref<RemoteSamplerProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -32,8 +32,11 @@
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUCompilationInfo.h>
 #include <WebCore/WebGPUCompilationMessage.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteShaderModuleProxy);
 
 RemoteShaderModuleProxy::RemoteShaderModuleProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUShaderModule.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteShaderModuleProxy final : public WebCore::WebGPU::ShaderModule {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteShaderModuleProxy);
 public:
     static Ref<RemoteShaderModuleProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -32,8 +32,11 @@
 #include "RemoteTextureViewProxy.h"
 #include "WebGPUConvertToBackingContext.h"
 #include "WebGPUTextureViewDescriptor.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextureProxy);
 
 RemoteTextureProxy::RemoteTextureProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -34,13 +34,14 @@
 #include <WebCore/WebGPUTextureDimension.h>
 #include <WebCore/WebGPUTextureFormat.h>
 #include <WebCore/WebGPUTextureViewDescriptor.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteTextureProxy final : public WebCore::WebGPU::Texture {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteTextureProxy);
 public:
     static Ref<RemoteTextureProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -30,8 +30,11 @@
 
 #include "RemoteTextureViewMessages.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteTextureViewProxy);
 
 RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteTextureProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUTextureView.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteTextureViewProxy final : public WebCore::WebGPU::TextureView {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteTextureViewProxy);
 public:
     static Ref<RemoteTextureViewProxy> create(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
@@ -52,8 +52,11 @@
 #include "RemoteShaderModuleProxy.h"
 #include "RemoteTextureProxy.h"
 #include "RemoteTextureViewProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit::WebGPU {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DowncastConvertToBackingContext);
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Adapter& adapter)
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
@@ -28,11 +28,12 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "WebGPUConvertToBackingContext.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class DowncastConvertToBackingContext final : public ConvertToBackingContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DowncastConvertToBackingContext);
 public:
     static Ref<DowncastConvertToBackingContext> create()
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -34,8 +34,11 @@
 #include "WCUpdateInfo.h"
 #include "WebPage.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteWCLayerTreeHostProxy);
 
 RemoteWCLayerTreeHostProxy::RemoteWCLayerTreeHostProxy(WebPage& page, bool usesOffscreenRendering)
     : m_page(page)

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
@@ -32,6 +32,7 @@
 #include "MessageSender.h"
 #include "UpdateInfo.h"
 #include "WCLayerTreeHostIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -41,7 +42,7 @@ class RemoteWCLayerTreeHostProxy
     : private IPC::MessageSender
     , private GPUProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteWCLayerTreeHostProxy);
 public:
     RemoteWCLayerTreeHostProxy(WebPage&, bool usesOffscreenRendering);
     ~RemoteWCLayerTreeHostProxy();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -32,10 +32,13 @@
 #include "GPUProcessProxy.h"
 #include "RemoteAudioHardwareListenerMessages.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioHardwareListener);
 
 Ref<RemoteAudioHardwareListener> RemoteAudioHardwareListener::create(AudioHardwareListener::Client& client)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -32,6 +32,7 @@
 #include "RemoteAudioHardwareListenerIdentifier.h"
 #include <WebCore/AudioHardwareListener.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -48,7 +49,7 @@ class RemoteAudioHardwareListener final
     , private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAudioHardwareListener);
 public:
     static Ref<RemoteAudioHardwareListener> create(WebCore::AudioHardwareListener::Client&);
     ~RemoteAudioHardwareListener();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -34,10 +34,13 @@
 #include "RemoteAudioSessionProxyMessages.h"
 #include "WebProcess.h"
 #include <WebCore/PlatformMediaSessionManager.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSession);
 
 UniqueRef<RemoteAudioSession> RemoteAudioSession::create()
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioSessionConfiguration.h"
 #include <WebCore/AudioSession.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -47,7 +48,7 @@ class RemoteAudioSession final
     , public GPUProcessConnection::Client
     , IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteAudioSession);
 public:
     static UniqueRef<RemoteAudioSession> create();
     ~RemoteAudioSession();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -32,6 +32,7 @@
 #include "RemoteAudioSourceProviderManagerMessages.h"
 #include "SharedCARingBuffer.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
@@ -113,6 +114,8 @@ void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifi
     }
     iterator->value->audioSamplesAvailable(startFrame, numberOfFrames);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RemoteAudioSourceProviderManagerRemoteAudio, RemoteAudioSourceProviderManager::RemoteAudio);
 
 RemoteAudioSourceProviderManager::RemoteAudio::RemoteAudio(Ref<RemoteAudioSourceProvider>&& provider)
     : m_provider(WTFMove(provider))

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -35,6 +35,7 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <WebCore/WebAudioBufferList.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -61,7 +62,7 @@ private:
     void setConnection(IPC::Connection*);
 
     class RemoteAudio {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(RemoteAudio);
     public:
         explicit RemoteAudio(Ref<RemoteAudioSourceProvider>&&);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -34,10 +34,13 @@
 #include "RemoteCDMInstanceSession.h"
 #include "WebProcess.h"
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCDMFactory);
 
 RemoteCDMFactory::RemoteCDMFactory(WebProcess&)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -33,6 +33,7 @@
 #include "WebProcessSupplement.h"
 #include <WebCore/CDMFactory.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -64,7 +65,7 @@ class RemoteCDMFactory final
     : public WebCore::CDMFactory
     , public WebProcessSupplement
     , public CanMakeWeakPtr<RemoteCDMFactory> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteCDMFactory);
 public:
     explicit RemoteCDMFactory(WebProcess&);
     virtual ~RemoteCDMFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -34,10 +34,13 @@
 #include "RemoteImageDecoderAVFProxyMessages.h"
 #include "SharedBufferReference.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteImageDecoderAVFManager);
 
 RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -35,6 +35,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -45,7 +46,7 @@ class RemoteImageDecoderAVFManager final
     : private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteImageDecoderAVFManager);
 public:
     static Ref<RemoteImageDecoderAVFManager> create();
     virtual ~RemoteImageDecoderAVFManager();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -36,10 +36,13 @@
 #include "WebProcess.h"
 #include <WebCore/LegacyCDM.h>
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLegacyCDMFactory);
 
 RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess&)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -32,6 +32,7 @@
 #include "WebProcessSupplement.h"
 #include <WebCore/LegacyCDM.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -68,7 +69,7 @@ class WebProcess;
 class RemoteLegacyCDMFactory final
     : public WebProcessSupplement
     , public CanMakeWeakPtr<RemoteLegacyCDMFactory> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLegacyCDMFactory);
 public:
     explicit RemoteLegacyCDMFactory(WebProcess&);
     virtual ~RemoteLegacyCDMFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
@@ -36,9 +36,12 @@
 #include <WebCore/MediaDecodingConfiguration.h>
 #include <WebCore/MediaEncodingConfiguration.h>
 #include <WebCore/MediaEngineConfigurationFactory.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaEngineConfigurationFactory);
 
 RemoteMediaEngineConfigurationFactory::RemoteMediaEngineConfigurationFactory(WebProcess&)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
@@ -32,6 +32,7 @@
 #include "WebProcessSupplement.h"
 #include <WebCore/MediaEngineConfigurationFactory.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -56,7 +57,7 @@ class WebProcess;
 class RemoteMediaEngineConfigurationFactory final
     : public WebProcessSupplement
     , public CanMakeWeakPtr<RemoteMediaEngineConfigurationFactory> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaEngineConfigurationFactory);
 public:
     explicit RemoteMediaEngineConfigurationFactory(WebProcess&);
     virtual ~RemoteMediaEngineConfigurationFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -31,10 +31,13 @@
 #include "Logging.h"
 #include "RemoteMediaPlayerManager.h"
 #include "RemoteMediaPlayerManagerProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerMIMETypeCache);
 
 RemoteMediaPlayerMIMETypeCache::RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayerManager& manager, MediaPlayerEnums::MediaEngineIdentifier engineIdentifier)
     : m_manager(manager)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -30,6 +30,7 @@
 #include <WebCore/MediaPlayerEnums.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ namespace WebKit {
 class RemoteMediaPlayerManager;
 
 class RemoteMediaPlayerMIMETypeCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaPlayerMIMETypeCache);
 public:
     RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayerManager&, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
     ~RemoteMediaPlayerMIMETypeCache() = default;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -42,6 +42,7 @@
 #include <wtf/HashFunctions.h>
 #include <wtf/HashMap.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/MediaPlayerPrivateMediaStreamAVFObjC.h>
@@ -102,6 +103,8 @@ private:
     MediaPlayerEnums::MediaEngineIdentifier m_remoteEngineIdentifier;
     RemoteMediaPlayerManager& m_manager;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManager);
 
 Ref<RemoteMediaPlayerManager> RemoteMediaPlayerManager::create()
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -31,6 +31,7 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class MediaPlayerPrivateInterface;
@@ -48,7 +49,7 @@ struct WebProcessCreationParameters;
 class RemoteMediaPlayerManager
     : public GPUProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaPlayerManager);
 public:
     static Ref<RemoteMediaPlayerManager> create();
     ~RemoteMediaPlayerManager();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
@@ -32,8 +32,11 @@
 #include "SharedBufferReference.h"
 #include "WebCoreArgumentCoders.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaResourceProxy);
 
 RemoteMediaResourceProxy::RemoteMediaResourceProxy(Ref<IPC::Connection>&& connection, WebCore::PlatformMediaResource& platformMediaResource, RemoteMediaResourceIdentifier identifier)
     : m_connection(WTFMove(connection))

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
@@ -32,11 +32,12 @@
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/ResourceResponse.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RemoteMediaResourceProxy final : public WebCore::PlatformMediaResourceClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaResourceProxy);
 public:
     RemoteMediaResourceProxy(Ref<IPC::Connection>&&, WebCore::PlatformMediaResource&, RemoteMediaResourceIdentifier);
     ~RemoteMediaResourceProxy();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -33,10 +33,13 @@
 #include "RemoteRemoteCommandListenerMessages.h"
 #include "RemoteRemoteCommandListenerProxyMessages.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteRemoteCommandListener);
 
 Ref<RemoteRemoteCommandListener> RemoteRemoteCommandListener::create(RemoteCommandListenerClient& client)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -32,6 +32,7 @@
 #include "RemoteRemoteCommandListenerIdentifier.h"
 #include <WebCore/RemoteCommandListener.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -48,7 +49,7 @@ class RemoteRemoteCommandListener final
     , private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteRemoteCommandListener);
 public:
     static Ref<RemoteRemoteCommandListener> create(WebCore::RemoteCommandListenerClient&);
     explicit RemoteRemoteCommandListener(WebCore::RemoteCommandListenerClient&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -31,6 +31,7 @@
 #include "LibWebRTCCodecs.h"
 #include "WebProcess.h"
 #include <wtf/StdUnorderedMap.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -56,7 +57,7 @@ private:
 };
 
 class RemoteVideoDecoder : public WebCore::VideoDecoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteVideoDecoder);
 public:
     RemoteVideoDecoder(LibWebRTCCodecs::Decoder&, Ref<RemoteVideoDecoderCallbacks>&&, uint16_t width, uint16_t height);
     ~RemoteVideoDecoder();
@@ -96,7 +97,7 @@ private:
 };
 
 class RemoteVideoEncoder : public WebCore::VideoEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteVideoEncoder);
 public:
     RemoteVideoEncoder(LibWebRTCCodecs::Encoder&, Ref<RemoteVideoEncoderCallbacks>&&);
     ~RemoteVideoEncoder();
@@ -111,6 +112,8 @@ private:
     LibWebRTCCodecs::Encoder& m_internalEncoder;
     Ref<RemoteVideoEncoderCallbacks> m_callbacks;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteVideoCodecFactory);
 
 RemoteVideoCodecFactory::RemoteVideoCodecFactory(WebProcess& process)
 {
@@ -198,6 +201,8 @@ void RemoteVideoCodecFactory::createEncoder(const String& codec, const WebCore::
     });
 }
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteVideoDecoder);
+
 RemoteVideoDecoder::RemoteVideoDecoder(LibWebRTCCodecs::Decoder& decoder, Ref<RemoteVideoDecoderCallbacks>&& callbacks, uint16_t width, uint16_t height)
     : m_internalDecoder(decoder)
     , m_callbacks(WTFMove(callbacks))
@@ -266,6 +271,8 @@ void RemoteVideoDecoderCallbacks::notifyDecodingResult(RefPtr<WebCore::VideoFram
         protectedThis->m_outputCallback(VideoDecoder::DecodedFrame { frame.releaseNonNull(), static_cast<int64_t>(timestamp), duration });
     });
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteVideoEncoder);
 
 RemoteVideoEncoder::RemoteVideoEncoder(LibWebRTCCodecs::Encoder& encoder, Ref<RemoteVideoEncoderCallbacks>&& callbacks)
     : m_internalEncoder(encoder)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
@@ -29,13 +29,14 @@
 
 #include <WebCore/VideoDecoder.h>
 #include <WebCore/VideoEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebProcess;
 
 class RemoteVideoCodecFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteVideoCodecFactory);
 public:
     explicit RemoteVideoCodecFactory(WebProcess&);
     ~RemoteVideoCodecFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -30,6 +30,7 @@
 #include "GPUConnectionToWebProcess.h"
 #include "RemoteVideoFrameObjectHeapMessages.h"
 #include "RemoteVideoFrameObjectHeapProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "WebProcess.h"
@@ -41,6 +42,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteVideoFrameProxy);
 
 RemoteVideoFrameProxy::Properties RemoteVideoFrameProxy::properties(WebKit::RemoteVideoFrameReference reference, const WebCore::VideoFrame& videoFrame)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -32,6 +32,7 @@
 #include "RemoteVideoFrameProxyProperties.h"
 #include <WebCore/VideoFrame.h>
 #include <wtf/ArgumentCoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 #if PLATFORM(COCOA)
@@ -47,7 +48,7 @@ class RemoteVideoFrameObjectHeapProxy;
 // A WebCore::VideoFrame class that points to a concrete WebCore::VideoFrame instance
 // in another process, GPU process.
 class RemoteVideoFrameProxy final : public WebCore::VideoFrame {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteVideoFrameProxy);
     WTF_MAKE_NONCOPYABLE(RemoteVideoFrameProxy);
 public:
     using Properties = RemoteVideoFrameProxyProperties;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/SourceBufferPrivateClient.h>
 #include <wtf/Locker.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebCore {
@@ -50,6 +51,8 @@ extern WTFLogChannel LogMedia;
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceBufferPrivateRemote);
 
 WorkQueue& SourceBufferPrivateRemote::queue()
 {

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -39,6 +39,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -60,7 +61,7 @@ class MediaSourcePrivateRemote;
 class SourceBufferPrivateRemote final
     : public WebCore::SourceBufferPrivate
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SourceBufferPrivateRemote);
 public:
     static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
     virtual ~SourceBufferPrivateRemote();

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -43,11 +43,12 @@
 #include <mach/mach_time.h>
 #include <wtf/Deque.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class AudioMediaStreamTrackRendererInternalUnitManagerProxy final : public WebCore::AudioMediaStreamTrackRendererInternalUnit, public CanMakeWeakPtr<AudioMediaStreamTrackRendererInternalUnitManagerProxy>, public Identified<AudioMediaStreamTrackRendererInternalUnitIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AudioMediaStreamTrackRendererInternalUnitManagerProxy);
 public:
     explicit AudioMediaStreamTrackRendererInternalUnitManagerProxy(Client&);
     ~AudioMediaStreamTrackRendererInternalUnitManagerProxy();
@@ -90,6 +91,8 @@ private:
     bool m_didClose { false };
 };
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioMediaStreamTrackRendererInternalUnitManager);
+
 void AudioMediaStreamTrackRendererInternalUnitManager::add(AudioMediaStreamTrackRendererInternalUnitManagerProxy& proxy)
 {
     m_proxies.add(proxy.identifier(), proxy);
@@ -117,6 +120,8 @@ void AudioMediaStreamTrackRendererInternalUnitManager::restartAllUnits()
     for (auto proxy : proxies.values())
         proxy->reset(AudioMediaStreamTrackRendererInternalUnitManagerProxy::IsClosed::Yes);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioMediaStreamTrackRendererInternalUnitManagerProxy);
 
 AudioMediaStreamTrackRendererInternalUnitManagerProxy::AudioMediaStreamTrackRendererInternalUnitManagerProxy(Client& client)
     : m_client(client)

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
@@ -30,6 +30,7 @@
 #include "AudioMediaStreamTrackRendererInternalUnitIdentifier.h"
 #include <WebCore/AudioMediaStreamTrackRendererInternalUnit.h>
 #include <WebCore/SharedMemory.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -54,7 +55,7 @@ namespace WebKit {
 class AudioMediaStreamTrackRendererInternalUnitManagerProxy;
 
 class AudioMediaStreamTrackRendererInternalUnitManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AudioMediaStreamTrackRendererInternalUnitManager);
 public:
     AudioMediaStreamTrackRendererInternalUnitManager() = default;
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/VP9UtilitiesCocoa.h>
 #include <WebCore/VideoFrameCV.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -86,6 +87,10 @@ static webrtc::WebKitVideoDecoder createVideoDecoder(const webrtc::SdpVideoForma
 
     return { };
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCCodecs);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(LibWebRTCCodecsDecoder, LibWebRTCCodecs::Decoder);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(LibWebRTCCodecsEncoder, LibWebRTCCodecs::Encoder);
 
 std::optional<VideoCodecType> LibWebRTCCodecs::videoCodecTypeFromWebCodec(const String& codec)
 {

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -45,6 +45,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 using CVPixelBufferPoolRef = struct __CVPixelBufferPool*;
 
@@ -68,7 +69,7 @@ namespace WebKit {
 class RemoteVideoFrameObjectHeapProxy;
 
 class LibWebRTCCodecs : public IPC::WorkQueueMessageReceiver, public GPUProcessConnection::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCCodecs);
 public:
     static Ref<LibWebRTCCodecs> create();
     ~LibWebRTCCodecs();
@@ -82,7 +83,7 @@ public:
 
     using DecoderCallback = Function<void(RefPtr<WebCore::VideoFrame>&&, int64_t timestamp)>;
     struct Decoder {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Decoder);
     public:
         struct EncodedFrame {
             int64_t timeStamp { 0 };
@@ -127,7 +128,7 @@ public:
         uint32_t maxFrameRate;
     };
     struct Encoder {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Encoder);
     public:
         VideoEncoderIdentifier identifier;
         VideoCodecType type;

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/RealtimeIncomingVideoSourceCocoa.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/WebAudioBufferList.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>
 
@@ -74,6 +75,8 @@ private:
 
     WeakPtr<MediaRecorderPrivate> m_recorder;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaRecorderPrivate);
 
 MediaRecorderPrivate::MediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
     : m_stream(stream)

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -34,6 +34,7 @@
 #include <WebCore/MediaRecorderPrivate.h>
 #include <wtf/Identified.h>
 #include <wtf/MediaTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -53,7 +54,7 @@ class MediaRecorderPrivate final
     : public WebCore::MediaRecorderPrivate
     , public CanMakeWeakPtr<MediaRecorderPrivate>
     , private Identified<MediaRecorderIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MediaRecorderPrivate);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivate);
 public:
     MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -28,11 +28,14 @@
 
 #include "Decoder.h"
 #include <WebCore/IntSize.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SampleBufferDisplayLayerManager);
 
 void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
@@ -29,6 +29,7 @@
 
 #include "SampleBufferDisplayLayer.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class SampleBufferDisplayLayerManager;
@@ -42,7 +43,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::SampleBufferD
 namespace WebKit {
 
 class SampleBufferDisplayLayerManager : public CanMakeWeakPtr<SampleBufferDisplayLayerManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SampleBufferDisplayLayerManager);
 public:
     SampleBufferDisplayLayerManager() = default;
     ~SampleBufferDisplayLayerManager() = default;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/VideoFrameCV.h>
 #include <WebCore/VideoFrameLibWebRTC.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(LIBWEBRTC)
 
@@ -53,6 +54,8 @@ ALLOW_COMMA_END
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedVideoFrameWriter);
 
 SharedVideoFrameWriter::SharedVideoFrameWriter()
     : m_semaphore(makeUniqueRef<IPC::Semaphore>())
@@ -191,6 +194,8 @@ void SharedVideoFrameWriter::disable()
     m_isDisabled = true;
     m_semaphore->signal();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedVideoFrameReader);
 
 SharedVideoFrameReader::SharedVideoFrameReader(RefPtr<RemoteVideoFrameObjectHeap>&& objectHeap, const ProcessIdentity& resourceOwner, UseIOSurfaceBufferPool useIOSurfaceBufferPool)
     : m_objectHeap(WTFMove(objectHeap))

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -35,6 +35,7 @@
 #include <wtf/MediaTime.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 typedef struct __CVBuffer* CVPixelBufferRef;
@@ -64,7 +65,7 @@ struct SharedVideoFrame {
 };
 
 class SharedVideoFrameWriter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SharedVideoFrameWriter);
 public:
     SharedVideoFrameWriter();
 
@@ -98,7 +99,7 @@ private:
 };
 
 class SharedVideoFrameReader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SharedVideoFrameReader);
 public:
     ~SharedVideoFrameReader();
 

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -41,9 +41,12 @@
 #include <WebCore/LocalFrame.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GeolocationPermissionRequestManager);
 
 GeolocationPermissionRequestManager::GeolocationPermissionRequestManager(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -29,6 +29,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class Geolocation;
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPage;
 
 class GeolocationPermissionRequestManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GeolocationPermissionRequestManager);
 public:
     explicit GeolocationPermissionRequestManager(WebPage&);
     ~GeolocationPermissionRequestManager();

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/GeolocationPositionData.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -47,6 +48,8 @@ static RegistrableDomain registrableDomainForPage(WebPage& page)
         return { };
     return RegistrableDomain { document->url() };
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGeolocationManager);
 
 ASCIILiteral WebGeolocationManager::supplementName()
 {

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -31,6 +31,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 
@@ -45,7 +46,7 @@ class WebProcess;
 class WebPage;
 
 class WebGeolocationManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebGeolocationManager);
     WTF_MAKE_NONCOPYABLE(WebGeolocationManager);
 public:
     explicit WebGeolocationManager(WebProcess&);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class InjectedBundle;
@@ -39,7 +40,7 @@ class Object;
 namespace InjectedBundle {
 
 class Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Client);
 public:
     virtual ~Client() = default;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleEditorClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleEditorClient.h
@@ -28,6 +28,7 @@
 #include <WebCore/EditorInsertAction.h>
 #include <WebCore/TextAffinity.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ namespace API {
 namespace InjectedBundle {
 
 class EditorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EditorClient);
 public:
     virtual ~EditorClient() { }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageContextMenuClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageContextMenuClient.h
@@ -29,6 +29,7 @@
 #if ENABLE(CONTEXT_MENUS)
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class ContextMenuContext;
@@ -49,7 +50,7 @@ class Object;
 namespace InjectedBundle {
 
 class PageContextMenuClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageContextMenuClient);
 public:
     virtual ~PageContextMenuClient() { }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h
@@ -28,6 +28,7 @@
 #include "SameDocumentNavigationType.h"
 #include <WebCore/LayoutMilestone.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
@@ -51,7 +52,7 @@ class Object;
 namespace InjectedBundle {
 
 class PageLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageLoaderClient);
 public:
     virtual ~PageLoaderClient() = default;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageResourceLoadClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageResourceLoadClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/ResourceLoaderIdentifier.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebFrame;
@@ -43,7 +44,7 @@ namespace API {
 namespace InjectedBundle {
 
 class ResourceLoadClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ResourceLoadClient);
 public:
     virtual ~ResourceLoadClient() = default;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageUIClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageUIClient.h
@@ -27,6 +27,7 @@
 
 #include "WebEvent.h"
 #include <JavaScriptCore/ConsoleTypes.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class HitTestResult;
@@ -46,7 +47,7 @@ class SecurityOrigin;
 namespace InjectedBundle {
 
 class PageUIClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageUIClient);
 public:
     virtual ~PageUIClient() { }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/PageOverlay.h>
 #include <WebCore/PlatformMouseEvent.h>
 #include <WebCore/Range.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace API {
 
@@ -56,7 +57,7 @@ template<> struct ClientTraits<WKBundlePageOverlayAccessibilityClientBase> {
 }
 
 class PageOverlayClientImpl : API::Client<WKBundlePageOverlayClientBase>, public WebKit::WebPageOverlay::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageOverlayClientImpl);
 public:
     explicit PageOverlayClientImpl(WKBundlePageOverlayClientBase* client)
     {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
@@ -32,6 +32,7 @@
 #import "PageBanner.h"
 #import "WKAPICast.h"
 #import "WKBundleAPICast.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace API {
 template<> struct ClientTraits<WKBundlePageBannerClientBase> {
@@ -43,7 +44,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class PageBannerClientImpl : API::Client<WKBundlePageBannerClientBase>, public PageBanner::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PageBannerClientImpl);
 public:
     explicit PageBannerClientImpl(WKBundlePageBannerClientBase* client)
     {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 
@@ -80,7 +81,7 @@ static DOMObjectCacheFrameObserverMap& domObjectCacheFrameObservers()
 }
 
 class DOMObjectCacheFrameObserver final: public WebCore::FrameDestructionObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMObjectCacheFrameObserver);
 public:
     DOMObjectCacheFrameObserver(WebCore::LocalFrame& frame)
         : FrameDestructionObserver(&frame)
@@ -109,7 +110,7 @@ public:
 
 private:
     class DOMWindowObserver final : public WebCore::LocalDOMWindowObserver {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMWindowObserver);
     public:
         DOMWindowObserver(WebCore::LocalDOMWindow& window, DOMObjectCacheFrameObserver& frameObserver)
             : m_window(window)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -57,6 +57,7 @@
 #include <glib/gi18n-lib.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -115,7 +116,7 @@ WEBKIT_DEFINE_FINAL_TYPE(WebKitWebPage, webkit_web_page, G_TYPE_OBJECT, GObject)
 static void webFrameDestroyed(WebFrame*);
 
 class WebKitFrameWrapper final: public FrameDestructionObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitFrameWrapper);
 public:
     WebKitFrameWrapper(WebFrame& webFrame)
         : FrameDestructionObserver(webFrame.coreLocalFrame())

--- a/Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h
@@ -27,6 +27,7 @@
 #define APIInjectedBundleFormClient_h
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class Element;
@@ -47,7 +48,7 @@ class Object;
 namespace InjectedBundle {
 
 class FormClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FormClient);
 public:
     virtual ~FormClient() { }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlayController.h>
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/InspectorOverlay.h>
@@ -45,7 +46,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class RepaintIndicatorLayerClient final : public GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RepaintIndicatorLayerClient);
 public:
     RepaintIndicatorLayerClient(WebInspectorClient& inspectorClient)
         : m_inspectorClient(inspectorClient)
@@ -60,6 +61,8 @@ private:
     
     WebInspectorClient& m_inspectorClient;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorClient);
 
 WebInspectorClient::WebInspectorClient(WebPage* page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
@@ -28,6 +28,7 @@
 #include <WebCore/InspectorClient.h>
 #include <WebCore/PageOverlay.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class GraphicsContext;
@@ -42,7 +43,7 @@ class WebPage;
 class RepaintIndicatorLayerClient;
 
 class WebInspectorClient : public WebCore::InspectorClient, private WebCore::PageOverlayClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebInspectorClient);
 friend class RepaintIndicatorLayerClient;
 public:
     WebInspectorClient(WebPage*);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -40,8 +40,11 @@
 #include <WebCore/InspectorFrontendAPIDispatcher.h>
 #include <WebCore/JSDOMGlobalObject.h>
 #include <WebCore/SerializedScriptValue.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorUIExtensionController);
 
 WebInspectorUIExtensionController::WebInspectorUIExtensionController(WebCore::InspectorFrontendClient& inspectorFrontend, WebCore::PageIdentifier pageIdentifier)
     : m_frontendClient(inspectorFrontend)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
@@ -35,6 +35,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -62,7 +63,7 @@ class WebInspectorUI;
 
 class WebInspectorUIExtensionController
     : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebInspectorUIExtensionController);
     WTF_MAKE_NONCOPYABLE(WebInspectorUIExtensionController);
 public:
     WebInspectorUIExtensionController(WebCore::InspectorFrontendClient&, WebCore::PageIdentifier);

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
@@ -30,11 +30,14 @@
 #include "WebPageInspectorTargetFrontendChannel.h"
 #include <WebCore/InspectorController.h>
 #include <WebCore/Page.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInspectorTarget);
 
 WebPageInspectorTarget::WebPageInspectorTarget(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/InspectorTarget.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -35,7 +36,7 @@ class WebPage;
 class WebPageInspectorTargetFrontendChannel;
 
 class WebPageInspectorTarget final : public Inspector::InspectorTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorTarget);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTarget);
 public:
     explicit WebPageInspectorTarget(WebPage&);

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp
@@ -30,8 +30,11 @@
 #include "WebPage.h"
 #include "WebPageInspectorTargetFrontendChannel.h"
 #include "WebPageProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInspectorTargetController);
 
 WebPageInspectorTargetController::WebPageInspectorTargetController(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
@@ -28,6 +28,7 @@
 #include "WebPageInspectorTarget.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPage;
 
 class WebPageInspectorTargetController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorTargetController);
 public:
     WebPageInspectorTargetController(WebPage&);
     ~WebPageInspectorTargetController();

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp
@@ -29,8 +29,11 @@
 #include "MessageSenderInlines.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInspectorTargetFrontendChannel);
 
 WebPageInspectorTargetFrontendChannel::WebPageInspectorTargetFrontendChannel(WebPage& page, const String& targetId, Inspector::FrontendChannel::ConnectionType connectionType)
     : m_page(page)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebPageInspectorTargetFrontendChannel final : public Inspector::FrontendChannel {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorTargetFrontendChannel);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTargetFrontendChannel);
 public:
     WebPageInspectorTargetFrontendChannel(WebPage&, const String& targetId, Inspector::FrontendChannel::ConnectionType);

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
@@ -30,10 +30,13 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/FileSystem.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMediaKeyStorageManager);
 
 void WebMediaKeyStorageManager::setWebsiteDataStore(const WebProcessDataStoreParameters& parameters)
 {

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "WebProcessSupplement.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebProcess;
 
 class WebMediaKeyStorageManager : public WebProcessSupplement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebMediaKeyStorageManager);
     WTF_MAKE_NONCOPYABLE(WebMediaKeyStorageManager);
 public:
     explicit WebMediaKeyStorageManager(WebProcess&) { }

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
@@ -36,6 +36,7 @@
 #include "WebProcess.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -46,6 +47,8 @@ namespace WebKit {
 
 using namespace PAL;
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionCoordinator);
 
 Ref<RemoteMediaSessionCoordinator> RemoteMediaSessionCoordinator::create(WebPage& page, const String& identifier)
 {

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/MediaSessionCoordinatorPrivate.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebPage;
 
 class RemoteMediaSessionCoordinator final : public WebCore::MediaSessionCoordinatorPrivate , public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteMediaSessionCoordinator);
 public:
     static Ref<RemoteMediaSessionCoordinator> create(WebPage&, const String&);
     ~RemoteMediaSessionCoordinator();

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -37,9 +37,12 @@
 #include <WebCore/Page.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaPermissionRequestManager);
 
 UserMediaPermissionRequestManager::UserMediaPermissionRequestManager(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class UserMediaPermissionRequestManager;
@@ -50,7 +51,7 @@ class UserMediaPermissionRequestManager : public WebCore::MediaCanStartListener
                                         , public WebCore::RealtimeMediaSourceCenterObserver
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserMediaPermissionRequestManager);
 public:
     using WebCore::MediaCanStartListener::weakPtrFactory;
     using WebCore::MediaCanStartListener::WeakValueType;

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -33,8 +33,11 @@
 #include "WebPage.h"
 #include <WebCore/ModelPlayerClient.h>
 #include <WebCore/ModelPlayerIdentifier.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerManager);
 
 Ref<ModelProcessModelPlayerManager> ModelProcessModelPlayerManager::create()
 {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
@@ -29,6 +29,7 @@
 
 #include "ModelProcessConnection.h"
 #include <WebCore/ModelPlayerIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class ModelPlayerClient;
@@ -42,7 +43,7 @@ class ModelProcessModelPlayer;
 class ModelProcessModelPlayerManager
     : public ModelProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelProcessModelPlayerManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ModelProcessModelPlayerManager);
 public:
     static Ref<ModelProcessModelPlayerManager> create();
     ~ModelProcessModelPlayerManager();

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -74,6 +74,7 @@
 #include <WebCore/UserContentProvider.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 
 #if USE(QUICK_LOOK)
@@ -99,6 +100,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebLoaderStrategy);
 
 WebLoaderStrategy::WebLoaderStrategy()
     : m_internallyFailedLoadTimer(RunLoop::main(), this, &WebLoaderStrategy::internallyFailedLoadTimerFired)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -34,6 +34,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct FetchOptions;
@@ -47,7 +48,8 @@ class WebPage;
 class WebURLSchemeTaskProxy;
 
 class WebLoaderStrategy final : public WebCore::LoaderStrategy {
-    WTF_MAKE_NONCOPYABLE(WebLoaderStrategy); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebLoaderStrategy);
+    WTF_MAKE_NONCOPYABLE(WebLoaderStrategy);
 public:
     WebLoaderStrategy();
     ~WebLoaderStrategy() final;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
@@ -30,8 +30,11 @@
 
 #include "LibWebRTCNetwork.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCDnsResolverFactory);
 
 std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::CreateAndResolve(const rtc::SocketAddress& address, absl::AnyInvocable<void()> callback)
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h
@@ -33,13 +33,13 @@ ALLOW_COMMA_BEGIN
 #include <webrtc/api/async_dns_resolver.h>
 ALLOW_COMMA_END
 
-#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class LibWebRTCDnsResolverFactory final : public webrtc::AsyncDnsResolverFactoryInterface {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCDnsResolverFactory);
 public:
     class Resolver : public webrtc::AsyncDnsResolverInterface {
     public:

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -31,8 +31,11 @@
 #include "NetworkConnectionToWebProcessMessages.h"
 #include <WebCore/SharedBuffer.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCNetwork);
 
 LibWebRTCNetwork::~LibWebRTCNetwork()
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -33,12 +33,13 @@
 #include "WebRTCResolver.h"
 #include <WebCore/LibWebRTCSocketIdentifier.h>
 #include <wtf/FunctionDispatcher.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
 
 class LibWebRTCNetwork : private FunctionDispatcher, private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCNetwork);
 public:
     static UniqueRef<LibWebRTCNetwork> create() { return UniqueRef { *new LibWebRTCNetwork() }; }
     ~LibWebRTCNetwork();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -38,9 +38,12 @@
 #include <WebCore/LibWebRTCUtils.h>
 #include <WebCore/Page.h>
 #include <wtf/EnumTraits.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCNetworkManager);
 
 LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExecutionContextIdentifier identifier)
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -32,11 +32,12 @@
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/RTCNetworkManager.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class LibWebRTCNetworkManager final : public WebCore::RTCNetworkManager, public rtc::NetworkManagerBase, public webrtc::MdnsResponderInterface, public WebRTCMonitorObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCNetworkManager);
 public:
     static LibWebRTCNetworkManager* getOrCreate(WebCore::ScriptExecutionContextIdentifier);
     ~LibWebRTCNetworkManager();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMallocInlines.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -98,7 +99,7 @@ void LibWebRTCProvider::setVP9HardwareSupportForTesting(std::optional<bool> valu
 #endif
 
 class RTCSocketFactory final : public LibWebRTCProvider::SuspendableSocketFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RTCSocketFactory);
 public:
     RTCSocketFactory(WebPageProxyIdentifier, String&& userAgent, ScriptExecutionContextIdentifier, bool isFirstParty, RegistrableDomain&&);
 
@@ -121,6 +122,8 @@ private:
     bool m_isRelayDisabled { false };
     RegistrableDomain m_domain;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RTCSocketFactory);
 
 RTCSocketFactory::RTCSocketFactory(WebPageProxyIdentifier pageIdentifier, String&& userAgent, ScriptExecutionContextIdentifier identifier, bool isFirstParty, RegistrableDomain&& domain)
     : m_pageIdentifier(pageIdentifier)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -34,8 +34,11 @@
 #include "NetworkRTCProviderMessages.h"
 #include "WebProcess.h"
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCResolver);
 
 void LibWebRTCResolver::sendOnMainThread(Function<void(IPC::Connection&)>&& callback)
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
@@ -31,6 +31,7 @@
 #include "LibWebRTCResolverIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -51,7 +52,7 @@ namespace WebKit {
 class LibWebRTCSocketFactory;
 
 class LibWebRTCResolver final : public LibWebRTCDnsResolverFactory::Resolver, private webrtc::AsyncDnsResolverResult, public CanMakeWeakPtr<LibWebRTCResolver>, public Identified<LibWebRTCResolverIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCResolver);
 public:
     LibWebRTCResolver() = default;
     ~LibWebRTCResolver();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -38,8 +38,11 @@
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Function.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCSocket);
 
 LibWebRTCSocket::LibWebRTCSocket(LibWebRTCSocketFactory& factory, WebCore::ScriptExecutionContextIdentifier contextIdentifier, Type type, const rtc::SocketAddress& localAddress, const rtc::SocketAddress& remoteAddress)
     : m_factory(factory)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -31,6 +31,7 @@
 #include <WebCore/LibWebRTCSocketIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 ALLOW_COMMA_BEGIN
@@ -58,7 +59,7 @@ namespace WebKit {
 class LibWebRTCSocketFactory;
 
 class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeWeakPtr<LibWebRTCSocket>, public Identified<WebCore::LibWebRTCSocketIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LibWebRTCSocket);
 public:
     enum class Type { UDP, ClientTCP, ServerConnectionTCP };
 

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
@@ -32,8 +32,11 @@
 #include "LibWebRTCSocketFactory.h"
 #include <WebCore/LibWebRTCProvider.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebRTCResolver);
 
 WebRTCResolver::WebRTCResolver(LibWebRTCSocketFactory& socketFactory, LibWebRTCResolverIdentifier identifier)
     : m_socketFactory(socketFactory)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
@@ -30,6 +30,7 @@
 #include "LibWebRTCResolverIdentifier.h"
 #include "RTCNetwork.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -41,7 +42,7 @@ namespace WebKit {
 class LibWebRTCSocketFactory;
 
 class WebRTCResolver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebRTCResolver);
 public:
     WebRTCResolver(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -31,6 +31,7 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include "WebProcessCreationParameters.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(NOTIFICATIONS)
 #include "NetworkProcessConnection.h"
@@ -94,6 +95,8 @@ static bool sendNotificationMessageWithAsyncReply(U&& message, WebPage* page, C&
     });
 }
 #endif // ENABLE(NOTIFICATIONS)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebNotificationManager);
 
 ASCIILiteral WebNotificationManager::supplementName()
 {

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -34,6 +34,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
@@ -51,7 +52,7 @@ class WebPage;
 class WebProcess;
 
 class WebNotificationManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebNotificationManager);
     WTF_MAKE_NONCOPYABLE(WebNotificationManager);
 public:
     explicit WebNotificationManager(WebProcess&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -28,6 +28,7 @@
 #if ENABLE(PDF_PLUGIN) && HAVE(INCREMENTAL_PDF_APIS)
 
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -53,7 +54,7 @@ using DataRequestCompletionHandler = Function<void(std::span<const uint8_t>)>;
 enum class CheckValidRanges : bool;
 
 class PDFIncrementalLoader : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFIncrementalLoader> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFIncrementalLoader);
     WTF_MAKE_NONCOPYABLE(PDFIncrementalLoader);
     friend class ByteRangeRequest;
     friend class PDFPluginStreamLoaderClient;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -40,6 +40,7 @@
 #import <wtf/Range.h>
 #import <wtf/RangeSet.h>
 #import <wtf/StdLibExtras.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
 
 #import "PDFKitSoftLink.h"
@@ -53,7 +54,7 @@ using namespace WebCore;
 static const uint32_t nonLinearizedPDFSentinel = std::numeric_limits<uint32_t>::max();
 
 class ByteRangeRequest : public Identified<ByteRangeRequestIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ByteRangeRequest);
 public:
     ByteRangeRequest() = default;
     ByteRangeRequest(uint64_t position, size_t count, DataRequestCompletionHandler&& completionHandler)
@@ -87,6 +88,8 @@ private:
 };
 
 #pragma mark -
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ByteRangeRequest);
 
 void ByteRangeRequest::clearStreamLoader()
 {
@@ -272,6 +275,8 @@ struct PDFIncrementalLoader::RequestData {
 };
 
 #pragma mark -
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFIncrementalLoader);
 
 Ref<PDFIncrementalLoader> PDFIncrementalLoader::create(PDFPluginBase& plugin)
 {

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -34,6 +34,7 @@
 #include <wtf/Range.h>
 #include <wtf/RangeSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -77,7 +78,7 @@ class WebWheelEvent;
 struct WebHitTestResultData;
 
 class PDFPlugin final : public PDFPluginBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFPlugin);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPlugin);
 public:
     static bool pdfKitLayerControllerIsAvailable();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -96,6 +96,7 @@
 #import <pal/spi/mac/NSMenuSPI.h>
 #import <wtf/HexNumber.h>
 #import <wtf/Scope.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/UUID.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WorkQueue.h>
@@ -504,6 +505,8 @@ static WebCore::Cursor::Type toWebCoreCursorType(PDFLayerControllerCursorType cu
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFPlugin);
 
 bool PDFPlugin::pdfKitLayerControllerIsAvailable()
 {

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -45,6 +45,7 @@
 #include <wtf/Range.h>
 #include <wtf/RangeSet.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/WeakPtr.h>
@@ -89,7 +90,7 @@ enum class CheckValidRanges : bool { No, Yes };
 
 class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase>, public CanMakeThreadSafeCheckedPtr<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluatorClient, public Identified<PDFPluginIdentifier> {
     WTF_MAKE_NONCOPYABLE(PDFPluginBase);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFPluginBase);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPluginBase);
     friend class PDFIncrementalLoader;
     friend class PDFPluginChoiceAnnotation;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -67,6 +67,7 @@
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/VoidCallback.h>
 #import <wtf/StdLibExtras.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/VectorCF.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/MakeString.h>
@@ -76,6 +77,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFPluginBase);
 
 PluginInfo PDFPluginBase::pluginInfo()
 {

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
@@ -29,6 +29,7 @@
 
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -55,7 +56,7 @@ public:
 };
 
 class PDFScriptEvaluator : public RefCounted<PDFScriptEvaluator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFScriptEvaluator);
     WTF_MAKE_NONCOPYABLE(PDFScriptEvaluator);
 public:
     static void runScripts(CGPDFDocumentRef, PDFScriptEvaluatorClient&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
@@ -31,6 +31,7 @@
 #import <JavaScriptCore/JSContextRef.h>
 #import <JavaScriptCore/JSObjectRef.h>
 #import <JavaScriptCore/OpaqueJSString.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -135,6 +136,8 @@ static void jsPDFDocFinalize(JSObjectRef object)
     PDFScriptEvaluator* evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(object));
     evaluator->deref();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFScriptEvaluator);
 
 JSClassRef PDFScriptEvaluator::jsPDFDocClass()
 {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -35,6 +35,7 @@
 #include <WebCore/TiledBacking.h>
 #include <wtf/HashMap.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WorkQueue.h>
@@ -93,7 +94,7 @@ using PDFTileRenderIdentifier = ObjectIdentifier<PDFTileRenderType>;
 
 class AsyncPDFRenderer final : public WebCore::TiledBackingClient,
     public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AsyncPDFRenderer> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AsyncPDFRenderer);
     WTF_MAKE_NONCOPYABLE(AsyncPDFRenderer);
 public:
     static Ref<AsyncPDFRenderer> create(PDFPresentationController&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -35,10 +35,13 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AsyncPDFRenderer);
 
 Ref<AsyncPDFRenderer> AsyncPDFRenderer::create(PDFPresentationController& presentationController)
 {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.h
@@ -30,6 +30,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS DDScannerResult;
 OBJC_CLASS PDFPage;
@@ -42,7 +43,7 @@ class FloatRect;
 namespace WebKit {
 
 class PDFDataDetectorItem : public RefCounted<PDFDataDetectorItem> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFDataDetectorItem);
     WTF_MAKE_NONCOPYABLE(PDFDataDetectorItem);
 public:
     static Ref<PDFDataDetectorItem> create(DDScannerResult *, PDFPage *);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
@@ -31,6 +31,7 @@
 #include "PDFKitSPI.h"
 #include <pal/spi/cocoa/DataDetectorsCoreSPI.h>
 #include <pal/spi/mac/DataDetectorsSPI.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/cf/TypeCastsCF.h>
 
 #include "PDFKitSoftlink.h"
@@ -55,6 +56,8 @@ Ref<PDFDataDetectorItem> PDFDataDetectorItem::create(DDScannerResult *dataDetect
 {
     return adoptRef(*new PDFDataDetectorItem(dataDetectorResult, pdfPage));
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFDataDetectorItem);
 
 PDFDataDetectorItem::PDFDataDetectorItem(DDScannerResult *dataDetectorResult, PDFPage *pdfPage)
     : m_result { dataDetectorResult }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -35,6 +35,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ class UnifiedPDFPlugin;
 class WebMouseEvent;
 
 class PDFDataDetectorOverlayController final : private WebCore::PageOverlayClient, WebCore::DataDetectorHighlightClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFDataDetectorOverlayController);
     WTF_MAKE_NONCOPYABLE(PDFDataDetectorOverlayController);
 public:
     explicit PDFDataDetectorOverlayController(UnifiedPDFPlugin&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -47,6 +47,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/cocoa/VectorCocoa.h>
 #include <wtf/text/WTFString.h>
@@ -56,6 +57,8 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFDataDetectorOverlayController);
 
 PDFDataDetectorOverlayController::PDFDataDetectorOverlayController(UnifiedPDFPlugin& plugin)
     : m_plugin(plugin)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -29,6 +29,7 @@
 
 #include "PDFPresentationController.h"
 #include <WebCore/GraphicsLayerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class PlatformWheelEvent;
@@ -49,7 +50,7 @@ enum class PageTransitionState : uint8_t {
 };
 
 class PDFDiscretePresentationController final : public PDFPresentationController, public WebCore::GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFDiscretePresentationController);
     WTF_MAKE_NONCOPYABLE(PDFDiscretePresentationController);
 public:
     PDFDiscretePresentationController(UnifiedPDFPlugin&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -43,6 +43,7 @@
 #include <WebCore/TransformOperations.h>
 #include <WebCore/TransformationMatrix.h>
 #include <pal/spi/mac/NSScrollViewSPI.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -75,6 +76,8 @@ static TextStream& operator<<(TextStream& ts, PageTransitionState state)
     return ts;
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFDiscretePresentationController);
 
 PDFDiscretePresentationController::PDFDiscretePresentationController(UnifiedPDFPlugin& plugin)
     : PDFPresentationController(plugin)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -32,6 +32,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS PDFDocument;
@@ -52,7 +53,7 @@ enum class RepaintRequirement : uint8_t;
 
 class PDFPresentationController : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPresentationController> {
     WTF_MAKE_NONCOPYABLE(PDFPresentationController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFPresentationController);
 public:
     static RefPtr<PDFPresentationController> createForMode(PDFDocumentLayout::DisplayMode, UnifiedPDFPlugin&);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -33,9 +33,12 @@
 #include "PDFKitSPI.h"
 #include "PDFScrollingPresentationController.h"
 #include <WebCore/GraphicsLayer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFPresentationController);
 
 RefPtr<PDFPresentationController> PDFPresentationController::createForMode(PDFDocumentLayout::DisplayMode mode, UnifiedPDFPlugin& plugin)
 {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -30,6 +30,7 @@
 #include "PDFPresentationController.h"
 #include <WebCore/GraphicsLayerClient.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class KeyboardScrollingAnimator;
@@ -38,7 +39,7 @@ class KeyboardScrollingAnimator;
 namespace WebKit {
 
 class PDFScrollingPresentationController final : public PDFPresentationController, public WebCore::GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PDFScrollingPresentationController);
     WTF_MAKE_NONCOPYABLE(PDFScrollingPresentationController);
 public:
     PDFScrollingPresentationController(UnifiedPDFPlugin&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -36,9 +36,12 @@
 #include <WebCore/ScrollAnimator.h>
 #include <WebCore/TiledBacking.h>
 #include <WebCore/TransformationMatrix.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFScrollingPresentationController);
 
 PDFScrollingPresentationController::PDFScrollingPresentationController(UnifiedPDFPlugin& plugin)
     : PDFPresentationController(plugin)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -36,6 +36,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/Timer.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS PDFAction;
 OBJC_CLASS PDFDestination;
@@ -103,7 +104,7 @@ enum class AnnotationSearchDirection : bool {
 };
 
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UnifiedPDFPlugin);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(UnifiedPDFPlugin);
 
     friend class AsyncPDFRenderer;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -92,6 +92,7 @@
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/Algorithms.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextStream.h>
@@ -134,6 +135,8 @@ static constexpr double zoomIncrement = 1.18920;
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UnifiedPDFPlugin);
 
 Ref<UnifiedPDFPlugin> UnifiedPDFPlugin::create(HTMLPlugInElement& pluginElement)
 {

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/SpeechRecognitionCaptureSource.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
@@ -59,7 +60,7 @@ class SpeechRecognitionRealtimeMediaSourceManager::Source final
     , private RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<SpeechRecognitionRealtimeMediaSourceManager::Source>
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SpeechRecognitionRealtimeMediaSourceManager);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Source);
 public:
     Source(RealtimeMediaSourceIdentifier identifier, Ref<RealtimeMediaSource>&& source, Ref<IPC::Connection>&& connection)
@@ -148,6 +149,8 @@ private:
     std::optional<CAAudioStreamDescription> m_description { };
 #endif
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognitionRealtimeMediaSourceManager);
 
 SpeechRecognitionRealtimeMediaSourceManager::SpeechRecognitionRealtimeMediaSourceManager(Ref<IPC::Connection>&& connection)
     : m_connection(WTFMove(connection))

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -32,6 +32,7 @@
 #include "SandboxExtension.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CaptureDevice;
@@ -40,7 +41,7 @@ class CaptureDevice;
 namespace WebKit {
 
 class SpeechRecognitionRealtimeMediaSourceManager final : public IPC::MessageReceiver, private IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionRealtimeMediaSourceManager);
 public:
     explicit SpeechRecognitionRealtimeMediaSourceManager(Ref<IPC::Connection>&&);
     ~SpeechRecognitionRealtimeMediaSourceManager();

--- a/Source/WebKit/WebProcess/Storage/WebSWOriginTable.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWOriginTable.cpp
@@ -28,9 +28,12 @@
 #include "WebSWOriginTable.h"
 
 #include <WebCore/SecurityOrigin.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWOriginTable);
 
 bool WebSWOriginTable::contains(const SecurityOriginData& origin) const
 {

--- a/Source/WebKit/WebProcess/Storage/WebSWOriginTable.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWOriginTable.h
@@ -27,6 +27,7 @@
 
 #include "SharedStringHashTableReadOnly.h"
 #include <WebCore/SharedMemory.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class SecurityOriginData;
@@ -35,7 +36,7 @@ class SecurityOriginData;
 namespace WebKit {
 
 class WebSWOriginTable {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSWOriginTable);
 public:
     WebSWOriginTable() = default;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include <WebCore/AlternativeTextClient.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebAlternativeTextClient final : public WebCore::AlternativeTextClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebAlternativeTextClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAlternativeTextClient);
 public:
     explicit WebAlternativeTextClient(WebPage*);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
@@ -25,12 +25,15 @@
 
 #include "config.h"
 #include "WebAttachmentElementClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 #include "WebPage.h"
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAttachmentElementClient);
 
 WebAttachmentElementClient::WebAttachmentElementClient(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h
@@ -28,13 +28,14 @@
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 #include <WebCore/AttachmentElementClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebAttachmentElementClient final : public WebCore::AttachmentElementClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebAttachmentElementClient);
 public:
     explicit WebAttachmentElementClient(WebPage&);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
@@ -31,8 +31,11 @@
 #include <WebCore/CaptionUserPreferencesMediaAF.h>
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCaptionPreferencesDelegate);
 
 void WebCaptionPreferencesDelegate::setDisplayMode(WebCore::CaptionUserPreferences::CaptionDisplayMode displayMode)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.h
@@ -28,11 +28,12 @@
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 #include <WebCore/CaptionPreferencesDelegate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebCaptionPreferencesDelegate final : public WebCore::CaptionPreferencesDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebCaptionPreferencesDelegate);
 public:
     virtual ~WebCaptionPreferencesDelegate() { }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -103,6 +103,7 @@
 #include <WebCore/TextRecognitionOptions.h>
 #include <WebCore/ViewportConfiguration.h>
 #include <WebCore/WindowFeatures.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
 #import <WebCore/WebGPUCreateImpl.h>
@@ -180,6 +181,8 @@ AXRelayProcessSuspendedNotification::~AXRelayProcessSuspendedNotification()
 #if !PLATFORM(COCOA)
 void AXRelayProcessSuspendedNotification::sendProcessSuspendMessage(bool) { }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebChromeClient);
 
 WebChromeClient::WebChromeClient(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -28,6 +28,7 @@
 
 #include <WebCore/ChromeClient.h>
 #include <WebCore/HTMLVideoElement.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ class WebFrame;
 class WebPage;
 
 class WebChromeClient final : public WebCore::ChromeClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebChromeClient);
 public:
     WebChromeClient(WebPage&);
     ~WebChromeClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -36,9 +36,12 @@
 #include <WebCore/NotImplemented.h>
 #include <WebCore/Page.h>
 #include <WebCore/UserGestureIndicator.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebContextMenuClient);
 
 void WebContextMenuClient::downloadURL(const URL&)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -30,11 +30,12 @@
 
 #include "WebPage.h"
 #include <WebCore/ContextMenuClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebContextMenuClient : public WebCore::ContextMenuClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebContextMenuClient);
 public:
     WebContextMenuClient(WebPage* page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
@@ -32,8 +32,11 @@
 #include "WebProcessProxyMessages.h"
 #include <WebCore/SerializedCryptoKeyWrap.h>
 #include <WebCore/WrappedCryptoKey.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCryptoClient);
 
 std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8_t>& key) const
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/CryptoClient.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebCryptoClient:  public WebCore::CryptoClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebCryptoClient);
 public:
     WebCryptoClient(WebCore::PageIdentifier);
     WebCryptoClient() = default;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
@@ -32,9 +32,12 @@
 #include "WebPageProxyMessages.h"
 #include <WebCore/Page.h>
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDiagnosticLoggingClient);
 
 WebDiagnosticLoggingClient::WebDiagnosticLoggingClient(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
@@ -27,13 +27,14 @@
 #define WebDiagnosticLoggingClient_h
 
 #include <WebCore/DiagnosticLoggingClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebDiagnosticLoggingClient : public WebCore::DiagnosticLoggingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebDiagnosticLoggingClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebDiagnosticLoggingClient);
 public:
     WebDiagnosticLoggingClient(WebPage&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
@@ -29,9 +29,12 @@
 #if ENABLE(DRAG_SUPPORT)
 
 #include "WebPage.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDragClient);
 
 void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, const DragData&)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
@@ -29,13 +29,14 @@
 #if ENABLE(DRAG_SUPPORT)
 
 #include <WebCore/DragClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebDragClient : public WebCore::DragClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebDragClient);
 public:
     WebDragClient(WebPage* page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -62,11 +62,14 @@
 #include <WebCore/UserTypingGestureIndicator.h>
 #include <WebCore/VisibleUnits.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringView.h>
 
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebEditorClient);
 
 bool WebEditorClient::shouldDeleteRange(const std::optional<SimpleRange>& range)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -28,6 +28,7 @@
 #include "WebPage.h"
 #include <WebCore/EditorClient.h>
 #include <WebCore/TextCheckerClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ namespace WebKit {
 class WebPage;
 
 class WebEditorClient final : public WebCore::EditorClient, public WebCore::TextCheckerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebEditorClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEditorClient);
 public:
     WebEditorClient(WebPage* page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -33,9 +33,12 @@
 #include "WebProcess.h"
 #include <WebCore/Geolocation.h>
 #include <WebCore/GeolocationPositionData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGeolocationClient);
 
 WebGeolocationClient::~WebGeolocationClient()
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -27,12 +27,13 @@
 
 #include "WebPage.h"
 #include <WebCore/GeolocationClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
 
 class WebGeolocationClient final : public WebCore::GeolocationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebGeolocationClient);
 public:
     WebGeolocationClient(WebPage& page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
@@ -32,9 +32,12 @@
 #include "WebPage.h"
 #include <WebCore/MediaKeySystemController.h>
 #include <WebCore/MediaKeySystemRequest.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMediaKeySystemClient);
 
 WebMediaKeySystemClient::WebMediaKeySystemClient(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
@@ -28,13 +28,14 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include <WebCore/MediaKeySystemClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebMediaKeySystemClient);
 public:
     WebMediaKeySystemClient(WebPage&);
     ~WebMediaKeySystemClient() { }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -32,9 +32,12 @@
 #include <WebCore/MessagePort.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMessagePortChannelProvider);
 
 WebMessagePortChannelProvider& WebMessagePortChannelProvider::singleton()
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -28,11 +28,12 @@
 #include <WebCore/MessagePortChannelProvider.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebMessagePortChannelProvider final : public WebCore::MessagePortChannelProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebMessagePortChannelProvider);
 public:
     static WebMessagePortChannelProvider& singleton();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
@@ -36,9 +36,12 @@
 #include <WebCore/NotificationData.h>
 #include <WebCore/Page.h>
 #include <WebCore/ScriptExecutionContext.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebNotificationClient);
 
 WebNotificationClient::WebNotificationClient(WebPage* page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
@@ -30,13 +30,14 @@
 #include <WebCore/NotificationClient.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebNotificationClient final : public WebCore::NotificationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebNotificationClient);
 public:
     WebNotificationClient(WebPage*);
     virtual ~WebNotificationClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
@@ -33,9 +33,12 @@
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
 #include <WebCore/ProgressTracker.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProgressTrackerClient);
 
 WebProgressTrackerClient::WebProgressTrackerClient(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h
@@ -27,6 +27,7 @@
 #define WebProgressTrackerClient_h
 
 #include <WebCore/ProgressTrackerClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebProgressTrackerClient : public WebCore::ProgressTrackerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebProgressTrackerClient);
 public:
     explicit WebProgressTrackerClient(WebPage&);
     

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -31,8 +31,11 @@
 #include "WebProcess.h"
 #include "WebScreenOrientationManagerMessages.h"
 #include "WebScreenOrientationManagerProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebScreenOrientationManager);
 
 WebScreenOrientationManager::WebScreenOrientationManager(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/ScreenOrientationManager.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebScreenOrientationManager final : public WebCore::ScreenOrientationManager, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebScreenOrientationManager);
 public:
     explicit WebScreenOrientationManager(WebPage&);
     ~WebScreenOrientationManager();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -31,10 +31,13 @@
 #include "WebPageProxyMessages.h"
 #include "WebSpeechSynthesisVoice.h"
 #include <WebCore/Page.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSpeechSynthesisClient);
 
 const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisClient::voiceList()
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
@@ -30,6 +30,7 @@
 #include <WebCore/PlatformSpeechSynthesisUtterance.h>
 #include <WebCore/PlatformSpeechSynthesisVoice.h>
 #include <WebCore/SpeechSynthesisClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class WebSpeechSynthesisClient;
@@ -45,7 +46,7 @@ namespace WebKit {
 class WebPage;
     
 class WebSpeechSynthesisClient : public WebCore::SpeechSynthesisClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSpeechSynthesisClient);
 public:
     WebSpeechSynthesisClient(WebPage& page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebStorageProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebStorageProvider.h
@@ -28,11 +28,12 @@
 #include "WebStorageConnection.h"
 #include <WebCore/StorageProvider.h>
 #include <WebCore/StorageUtilities.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class WebStorageProvider final : public WebCore::StorageProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebStorageProvider);
 public:
     WebStorageProvider(const String& mediaKeysStorageDirectory, FileSystem::Salt mediaKeysStorageSalt)
         : m_mediaKeysStorageDirectory(mediaKeysStorageDirectory)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
@@ -26,9 +26,12 @@
 #include "WebPage.h"
 #include <WebCore/UserMediaController.h>
 #include <WebCore/UserMediaRequest.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebUserMediaClient);
 
 WebUserMediaClient::WebUserMediaClient(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
@@ -23,13 +23,14 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include <WebCore/UserMediaClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebUserMediaClient : public WebCore::UserMediaClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebUserMediaClient);
 public:
     WebUserMediaClient(WebPage&);
     ~WebUserMediaClient() { }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -34,6 +34,7 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Page.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBGL) && ENABLE(GPU_PROCESS)
 #include "RemoteGraphicsContextGLProxy.h"
@@ -114,6 +115,8 @@ RefPtr<WebCore::WebGPU::GPU> GPUProcessWebWorkerClient::createGPUForWebGPU() con
 #endif
 
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebWorkerClient);
 
 UniqueRef<WebWorkerClient> WebWorkerClient::create(Page& page, SerialFunctionDispatcher& dispatcher)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -29,6 +29,7 @@
 #include "RemoteVideoFrameObjectHeapProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WorkerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class Page;
@@ -43,7 +44,7 @@ namespace WebKit {
 class WebPage;
 
 class WebWorkerClient : public WebCore::WorkerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebWorkerClient);
 public:
     ~WebWorkerClient();
     // Constructed on the main thread, and then transferred to the

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -28,6 +28,7 @@
 
 #include "WebPage.h"
 #include <WebCore/PlatformDisplay.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(WPE_RENDERER)
 #include "AcceleratedSurfaceLibWPE.h"
@@ -45,6 +46,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurface);
 
 std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Client& client)
 {

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/IntSize.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 class RunLoop;
@@ -41,7 +42,8 @@ namespace WebKit {
 class WebPage;
 
 class AcceleratedSurface {
-    WTF_MAKE_NONCOPYABLE(AcceleratedSurface); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(AcceleratedSurface);
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedSurface);
 public:
     class Client {
     public:

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -29,8 +29,8 @@
 
 #include <WebCore/CharacterRange.h>
 #include <WebCore/SimpleRange.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
 
@@ -69,7 +69,7 @@ struct ReplacedRangeAndString {
 };
 
 class TextAnimationController final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextAnimationController);
     WTF_MAKE_NONCOPYABLE(TextAnimationController);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -40,6 +40,7 @@
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TextIterator.h>
 #include <WebCore/WritingToolsTypes.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -50,6 +51,8 @@ static constexpr auto defaultTextAnimationControllerTextIteratorBehaviors = WebC
     WebCore::TextIteratorBehavior::EmitsObjectReplacementCharactersForAttachments
 #endif
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextAnimationController);
 
 TextAnimationController::TextAnimationController(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
@@ -31,6 +31,7 @@
 #include "EditingRange.h"
 #include "MessageReceiver.h"
 #include <WebCore/SimpleRange.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace IPC {
@@ -48,7 +49,7 @@ namespace WebKit {
 class WebPage;
 
 class TextCheckingControllerProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextCheckingControllerProxy);
 public:
     TextCheckingControllerProxy(WebPage&);
     ~TextCheckingControllerProxy();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -43,6 +43,7 @@
 #import <WebCore/RenderedDocumentMarker.h>
 #import <WebCore/TextIterator.h>
 #import <WebCore/VisibleUnits.h>
+#import <wtf/TZoneMallocInlines.h>
 
 // FIXME: Remove this after rdar://problem/48914153 is resolved.
 #if PLATFORM(MACCATALYST)
@@ -54,6 +55,8 @@ typedef NS_ENUM(NSInteger, NSSpellingState) {
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCheckingControllerProxy);
 
 TextCheckingControllerProxy::TextCheckingControllerProxy(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -80,6 +80,7 @@
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 
@@ -782,7 +783,7 @@ static String& replaceSelectionPasteboardName()
 
 class OverridePasteboardForSelectionReplacement {
     WTF_MAKE_NONCOPYABLE(OverridePasteboardForSelectionReplacement);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(OverridePasteboardForSelectionReplacement);
 public:
     OverridePasteboardForSelectionReplacement(const Vector<String>& types, std::span<const uint8_t> data)
         : m_types(types)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -44,6 +44,7 @@
 #include <WebCore/RenderLayerBacking.h>
 #include <WebCore/RenderView.h>
 #include <WebCore/ThreadedScrollingTree.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -51,6 +52,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerTreeHost);
 
 #if HAVE(DISPLAY_LINK)
 LayerTreeHost::LayerTreeHost(WebPage& webPage)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -37,6 +37,7 @@
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 #if !HAVE(DISPLAY_LINK)
 #include "ThreadedDisplayRefreshMonitor.h"
@@ -70,7 +71,7 @@ class LayerTreeHost
 #endif
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LayerTreeHost);
 public:
 #if HAVE(DISPLAY_LINK)
     explicit LayerTreeHost(WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -41,9 +41,12 @@
 #include <WebCore/Settings.h>
 #include <WebCore/TextureMapper.h>
 #include <WebCore/TextureMapperLayer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerTreeHost);
 
 bool LayerTreeHost::prepareForRendering()
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -37,6 +37,7 @@
 #include <WebCore/TextureMapperFPSCounter.h>
 #include <WebCore/Timer.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class GraphicsLayer;
@@ -52,7 +53,7 @@ namespace WebKit {
 class WebPage;
 
 class LayerTreeHost : public WebCore::GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LayerTreeHost);
 public:
     explicit LayerTreeHost(WebPage&);
     ~LayerTreeHost();

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/ScrollView.h>
 #include <WebCore/TiledBacking.h>
 #include <WebCore/TransformationMatrix.h>
+#include <wtf/TZoneMallocInlines.h>
 
 // Subclasses
 #if PLATFORM(COCOA)
@@ -51,6 +52,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DrawingArea);
 
 std::unique_ptr<DrawingArea> DrawingArea::create(WebPage& webPage, const WebPageCreationParameters& parameters)
 {

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -39,6 +39,7 @@
 #include <WebCore/PlatformScreen.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 
 namespace WTF {
@@ -71,7 +72,7 @@ struct WebPageCreationParameters;
 struct WebPreferencesStore;
 
 class DrawingArea : public IPC::MessageReceiver, public WebCore::DisplayRefreshMonitorFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DrawingArea);
     WTF_MAKE_NONCOPYABLE(DrawingArea);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -55,6 +55,7 @@
 #include <WebCore/RenderObject.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/SimpleRange.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/TextIndicatorWindow.h>
@@ -62,6 +63,8 @@
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FindController);
 
 FindController::FindController(WebPage* webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -54,7 +55,7 @@ class PluginView;
 class WebPage;
 
 class FindController final : private WebCore::PageOverlayClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FindController);
     WTF_MAKE_NONCOPYABLE(FindController);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -65,6 +65,7 @@
 #include <wtf/PageBlock.h>
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit::IPCTestingAPI {
@@ -348,7 +349,7 @@ private:
 };
 
 class JSMessageListener final : public IPC::MessageObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSMessageListener);
 public:
     enum class Type { Incoming, Outgoing };
 
@@ -2965,6 +2966,8 @@ JSValueRef JSIPC::processTargets(JSContextRef context, JSObjectRef thisObject, J
     RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
     return toRef(vm, processTargetsObject);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSMessageListener);
 
 JSMessageListener::JSMessageListener(JSIPC& jsIPC, Type type, JSC::JSGlobalObject* globalObject, JSObjectRef callback)
     : m_jsIPC(jsIPC)

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/AnimationFrameRate.h>
 #include <WebCore/Scrollbar.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
@@ -39,6 +40,8 @@ static constexpr Seconds deltaHistoryMaximumAge = 500_ms;
 static constexpr Seconds deltaHistoryMaximumInterval = 150_ms;
 static constexpr WebCore::FramesPerSecond idealCurveFrameRate = 60;
 static constexpr Seconds idealCurveFrameInterval = 1_s / idealCurveFrameRate;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MomentumEventDispatcher);
 
 MomentumEventDispatcher::MomentumEventDispatcher(Client& client)
     : m_client(client)

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -38,6 +38,7 @@
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct DisplayUpdate;
@@ -49,7 +50,7 @@ namespace WebKit {
 
 class MomentumEventDispatcher {
     WTF_MAKE_NONCOPYABLE(MomentumEventDispatcher);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MomentumEventDispatcher);
 public:
     class Client {
     friend class MomentumEventDispatcher;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -35,6 +35,7 @@
 #include <WebCore/LayerPool.h>
 #include <WebCore/PlatformCALayer.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
@@ -47,7 +48,7 @@ class WebPage;
 
 // FIXME: This class doesn't do much now. Roll into RemoteLayerTreeDrawingArea?
 class RemoteLayerTreeContext : public WebCore::GraphicsLayerFactory,  public RefCounted<RemoteLayerTreeContext>, public CanMakeWeakPtr<RemoteLayerTreeContext> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeContext);
 public:
     static Ref<RemoteLayerTreeContext> create(WebPage& webpage)
     {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -42,9 +42,12 @@
 #import <WebCore/Page.h>
 #import <wtf/SetForScope.h>
 #import <wtf/SystemTracing.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeContext);
 
 RemoteLayerTreeContext::RemoteLayerTreeContext(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/Range.h>
 #include <WebCore/RenderView.h>
 #include <WebCore/TextIterator.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "SmartMagnificationControllerMessages.h"
@@ -56,6 +57,8 @@ using namespace WebCore;
 #if PLATFORM(IOS_FAMILY)
 static const double minimumScaleDifferenceForZooming = 0.3;
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewGestureGeometryCollector);
 
 ViewGestureGeometryCollector::ViewGestureGeometryCollector(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
@@ -28,6 +28,7 @@
 
 #include "MessageReceiver.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class FloatPoint;
@@ -40,7 +41,7 @@ namespace WebKit {
 class WebPage;
 
 class ViewGestureGeometryCollector : private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ViewGestureGeometryCollector);
 public:
     ViewGestureGeometryCollector(WebPage&);
     ~ViewGestureGeometryCollector();

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -47,9 +47,12 @@
 #include <WebCore/SimpleRange.h>
 #include <WebCore/TextIterator.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebFoundTextRangeController);
 
 WebFoundTextRangeController::WebFoundTextRangeController(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -36,6 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ namespace WebKit {
 class WebPage;
 
 class WebFoundTextRangeController : private WebCore::PageOverlayClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebFoundTextRangeController);
     WTF_MAKE_NONCOPYABLE(WebFoundTextRangeController);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -36,9 +36,12 @@
 #include <WebCore/FocusController.h>
 #include <WebCore/NotificationController.h>
 #include <WebCore/Page.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageTesting);
 
 WebPageTesting::WebPageTesting(WebPage& page)
     : m_page(page)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -38,7 +39,7 @@ namespace WebKit {
 class WebPage;
 
 class WebPageTesting : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPageTesting);
     WTF_MAKE_NONCOPYABLE(WebPageTesting);
 public:
     explicit WebPageTesting(WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(GBM)
 #include <WebCore/DRMDeviceManager.h>
@@ -95,6 +96,8 @@ static uint64_t generateTargetID()
     static uint64_t identifier = 0;
     return ++identifier;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(AcceleratedSurfaceDMABufRenderTarget, AcceleratedSurfaceDMABuf::RenderTarget);
 
 AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget(uint64_t surfaceID, const WebCore::IntSize& size)
     : m_id(generateTargetID())

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -33,6 +33,7 @@
 #include "MessageReceiver.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 #if USE(GBM)
@@ -96,7 +97,7 @@ private:
     void releaseUnusedBuffersTimerFired();
 
     class RenderTarget {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(RenderTarget);
     public:
         virtual ~RenderTarget();
 

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/ResourceError.h>
 #include <gtk/gtk.h>
 #include <memory>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -55,6 +56,8 @@
 #endif
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPrintOperationGtk);
 
 WebPrintOperationGtk::PrintPagesData::PrintPagesData(WebPrintOperationGtk* printOperation)
     : printOperation(printOperation)

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
@@ -29,6 +29,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 
@@ -54,7 +55,7 @@ class ResourceError;
 namespace WebKit {
 
 class WebPrintOperationGtk {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebPrintOperationGtk);
 public:
     explicit WebPrintOperationGtk(const PrintInfo&);
     ~WebPrintOperationGtk();

--- a/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorOverlayClientIOS.h
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindIndicatorOverlayClientIOS.h
@@ -30,11 +30,12 @@
 #import <WebCore/LocalFrame.h>
 #import <WebCore/PageOverlay.h>
 #import <WebCore/TextIndicator.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class FindIndicatorOverlayClientIOS : public WebCore::PageOverlayClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(FindIndicatorOverlayClientIOS);
 public:
     FindIndicatorOverlayClientIOS(WebCore::LocalFrame& frame, WebCore::TextIndicator* textIndicator)
         : m_frame(frame)

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -31,10 +31,13 @@
 #include "WebPage.h"
 #include <WebCore/PlatformDisplayLibWPE.h>
 #include <wpe/wpe-egl.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniStdExtras.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurfaceLibWPE);
 
 std::unique_ptr<AcceleratedSurfaceLibWPE> AcceleratedSurfaceLibWPE::create(WebPage& webPage, Client& client)
 {

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -28,6 +28,7 @@
 #if USE(WPE_RENDERER)
 
 #include "AcceleratedSurface.h"
+#include <wtf/TZoneMalloc.h>
 
 struct wpe_renderer_backend_egl_target;
 
@@ -36,7 +37,8 @@ namespace WebKit {
 class WebPage;
 
 class AcceleratedSurfaceLibWPE final : public AcceleratedSurface {
-    WTF_MAKE_NONCOPYABLE(AcceleratedSurfaceLibWPE); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(AcceleratedSurfaceLibWPE);
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedSurfaceLibWPE);
 public:
     static std::unique_ptr<AcceleratedSurfaceLibWPE> create(WebPage&, Client&);
     ~AcceleratedSurfaceLibWPE();

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -33,12 +33,13 @@
 #include "WCTileGrid.h"
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/TransformState.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 class WCTiledBacking final : public TiledBacking {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WCTiledBacking);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WCTiledBacking);
 public:
     WCTiledBacking(GraphicsLayerWC& owner)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.cpp
@@ -30,8 +30,11 @@
 
 #include "ImageBufferBackendHandleSharing.h"
 #include <WebCore/ShareableBitmap.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WCBackingStore);
 
 WCBackingStore::WCBackingStore(std::optional<ImageBufferBackendHandle>&& handle)
 {

--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
@@ -29,11 +29,12 @@
 
 #include "ImageBufferBackendHandle.h"
 #include <WebCore/ImageBuffer.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WCBackingStore {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WCBackingStore);
 public:
     WCBackingStore() { }
     WebCore::ImageBuffer* imageBuffer() { return m_imageBuffer.get(); }

--- a/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.cpp
@@ -28,7 +28,11 @@
 
 #if USE(GRAPHICS_LAYER_WC)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WCTileGridTile, WCTileGrid::Tile);
 
 WCTileGrid::Tile::Tile(WebCore::IntRect rect)
     : m_tileRect(rect)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/IntRect.h>
 #include <WebCore/TextureMapperSparseBackingStore.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ public:
     using TileIndex = WebCore::TextureMapperSparseBackingStore::TileIndex;
 
     class Tile {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(WCTileGrid);
         WTF_MAKE_NONCOPYABLE(Tile);
     public:
         Tile(WebCore::IntRect);

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
@@ -30,8 +30,11 @@
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSleepDisablerClient);
 
 void WebSleepDisablerClient::didCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, const String& reason, bool display, std::optional<WebCore::PageIdentifier> pageID)
 {

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.h
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include <WebCore/SleepDisablerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebSleepDisablerClient final : public WebCore::SleepDisablerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSleepDisablerClient);
 public:
     void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String&, bool display, std::optional<WebCore::PageIdentifier>) final;
     void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier, std::optional<WebCore::PageIdentifier>) final;

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -46,9 +46,12 @@
 #include <WebCore/StorageEventDispatcher.h>
 #include <WebCore/StorageMap.h>
 #include <WebCore/StorageType.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageAreaMap);
 
 StorageAreaMap::StorageAreaMap(StorageNamespaceImpl& storageNamespace, Ref<const WebCore::SecurityOrigin>&& securityOrigin)
     : m_namespace(storageNamespace)

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -36,6 +36,7 @@
 #include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -59,7 +60,7 @@ class StorageAreaImpl;
 class StorageNamespaceImpl;
 
 class StorageAreaMap final : public IPC::MessageReceiver, public Identified<StorageAreaMapIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StorageAreaMap);
 public:
     StorageAreaMap(StorageNamespaceImpl&, Ref<const WebCore::SecurityOrigin>&&);
     ~StorageAreaMap();

--- a/Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp
@@ -28,8 +28,11 @@
 
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSystemSoundDelegate);
 
 void WebSystemSoundDelegate::systemBeep()
 {

--- a/Source/WebKit/WebProcess/WebSystemSoundDelegate.h
+++ b/Source/WebKit/WebProcess/WebSystemSoundDelegate.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include <WebCore/SystemSoundDelegate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebSystemSoundDelegate final : public WebCore::SystemSoundDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebSystemSoundDelegate);
 public:
     void systemBeep() final;
 };

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -32,10 +32,13 @@
 #include "AudioSessionRoutingArbitratorProxyMessages.h"
 #include "WebProcess.h"
 #include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioSessionRoutingArbitrator);
 
 AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process)
     : m_observer([this] (AudioSession& session) { session.setRoutingArbitrationClient(*this); })

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -29,6 +29,7 @@
 
 #include "WebProcessSupplement.h"
 #include <WebCore/AudioSession.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ class WebProcess;
 class AudioSessionRoutingArbitrator final
     : public WebProcessSupplement
     , public WebCore::AudioSessionRoutingArbitrationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AudioSessionRoutingArbitrator);
 public:
     explicit AudioSessionRoutingArbitrator(WebProcess&);
     virtual ~AudioSessionRoutingArbitrator();

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -39,6 +39,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace IPC {
@@ -61,7 +62,7 @@ class PlaybackSessionInterfaceContext final
     : public RefCounted<PlaybackSessionInterfaceContext>
     , public WebCore::PlaybackSessionModelClient
     , public CanMakeCheckedPtr<PlaybackSessionInterfaceContext> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PlaybackSessionInterfaceContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceContext);
 public:
     static Ref<PlaybackSessionInterfaceContext> create(PlaybackSessionManager& manager, PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -46,11 +46,14 @@
 #import <WebCore/UserGestureIndicator.h>
 #import <mach/mach_port.h>
 #import <wtf/LoggerHelper.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 #pragma mark - PlaybackSessionInterfaceContext
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlaybackSessionInterfaceContext);
 
 PlaybackSessionInterfaceContext::PlaybackSessionInterfaceContext(PlaybackSessionManager& manager, PlaybackSessionContextIdentifier contextId)
     : m_manager(&manager)

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -36,11 +36,14 @@
 #include <WebCore/NativeImage.h>
 #include <WebCore/VideoFrameCV.h>
 #include <WebCore/WebAudioBufferList.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteCaptureSampleManager);
 
 RemoteCaptureSampleManager::RemoteCaptureSampleManager()
     : m_queue(WorkQueue::create("RemoteCaptureSampleManager"_s, WorkQueue::QOS::UserInteractive))
@@ -170,6 +173,8 @@ void RemoteCaptureSampleManager::videoFrameAvailableCV(RealtimeMediaSourceIdenti
     auto videoFrame = VideoFrameCV::create(presentationTime, mirrored, rotation, WTFMove(pixelBuffer));
     iterator->value->remoteVideoFrameAvailable(videoFrame.get(), metadata);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(RemoteCaptureSampleManagerRemoteAudio, RemoteCaptureSampleManager::RemoteAudio);
 
 RemoteCaptureSampleManager::RemoteAudio::RemoteAudio(Ref<RemoteRealtimeAudioSource>&& source)
     : m_source(WTFMove(source))

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -41,6 +41,7 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebCore {
@@ -52,7 +53,7 @@ namespace WebKit {
 class RemoteVideoFrameObjectHeapProxy;
 
 class RemoteCaptureSampleManager : public IPC::WorkQueueMessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteCaptureSampleManager);
 public:
     RemoteCaptureSampleManager();
     ~RemoteCaptureSampleManager();
@@ -79,7 +80,7 @@ private:
     void setConnection(RefPtr<IPC::Connection>&&);
 
     class RemoteAudio {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(RemoteAudio);
     public:
         explicit RemoteAudio(Ref<RemoteRealtimeAudioSource>&&);
         ~RemoteAudio();

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -41,10 +41,13 @@
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/RealtimeMediaSourceCenter.h>
 #include <wtf/Assertions.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaCaptureManager);
 
 UserMediaCaptureManager::UserMediaCaptureManager(WebProcess& process)
     : m_audioFactory(*this)

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -35,6 +35,7 @@
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CAAudioStreamDescription;
@@ -47,7 +48,7 @@ class RemoteRealtimeVideoSource;
 class WebProcess;
 
 class UserMediaCaptureManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserMediaCaptureManager);
 public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -39,6 +39,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 
 namespace IPC {
@@ -69,7 +70,7 @@ class VideoPresentationInterfaceContext final
     : public RefCounted<VideoPresentationInterfaceContext>
     , public WebCore::VideoPresentationModelClient
     , public CanMakeCheckedPtr<VideoPresentationInterfaceContext> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VideoPresentationInterfaceContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceContext);
 public:
     static Ref<VideoPresentationInterfaceContext> create(VideoPresentationManager& manager, PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -60,6 +60,7 @@
 #import <mach/mach_port.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/MachSendRight.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -87,6 +88,8 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
 }
 
 #pragma mark - VideoPresentationInterfaceContext
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoPresentationInterfaceContext);
 
 VideoPresentationInterfaceContext::VideoPresentationInterfaceContext(VideoPresentationManager& manager, PlaybackSessionContextIdentifier contextId)
     : m_manager(manager)

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -34,9 +34,12 @@
 #include <WebCore/MediaDeviceHashSalts.h>
 #include <WebCore/MediaStreamRequest.h>
 #include <WebCore/RealtimeMediaSourceCenter.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaCaptureManager);
 
 UserMediaCaptureManager::UserMediaCaptureManager(WebProcess& process)
 {

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "WebProcessSupplement.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CaptureDevice;
@@ -45,7 +46,7 @@ namespace WebKit {
 class WebProcess;
 
 class UserMediaCaptureManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserMediaCaptureManager);
     WTF_MAKE_NONCOPYABLE(UserMediaCaptureManager);
 public:
     explicit UserMediaCaptureManager(WebProcess&);


### PR DESCRIPTION
#### a1ed55a9bdd86add8a763d76ae35d345c24459e9
<pre>
[DRAFT][Not for review] Test WebKit/WebProcess

Reviewed by NOBODY (OOPS!).

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp:
* Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h:
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleEditorClient.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageContextMenuClient.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageResourceLoadClient.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageUIClient.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h:
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp:
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/WebSWOriginTable.cpp:
* Source/WebKit/WebProcess/Storage/WebSWOriginTable.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h:
* Source/WebKit/WebProcess/WebPage/ios/FindIndicatorOverlayClientIOS.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
* Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.cpp:
* Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h:
* Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.cpp:
* Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h:
* Source/WebKit/WebProcess/WebSleepDisablerClient.cpp:
* Source/WebKit/WebProcess/WebSleepDisablerClient.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp:
* Source/WebKit/WebProcess/WebSystemSoundDelegate.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1ed55a9bdd86add8a763d76ae35d345c24459e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50183 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8864 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11756 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67990 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6223 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11271 "Found 2 new test failures: webrtc/vp8-then-h264.html workers/worker-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57555 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57770 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5149 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37434 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14616 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38518 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39614 "Hash a1ed55a9 for PR 32084 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->