### PR TITLE
[JSC] Make DataIC inline code adaptive

### DIFF
--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -651,6 +651,21 @@ CacheableIdentifier GetByStatus::singleIdentifier() const
     return singleIdentifierForICStatus(m_variants);
 }
 
+#if ENABLE(JIT)
+
+CacheType GetByStatus::preferredCacheType() const
+{
+    if (!isSimple())
+        return CacheType::GetByIdSelf;
+    for (const auto& variant : m_variants) {
+        if (variant.conditionSet().isEmpty())
+            return CacheType::GetByIdSelf;
+    }
+    return CacheType::GetByIdPrototype;
+}
+
+#endif
+
 void GetByStatus::dump(PrintStream& out) const
 {
     out.print("(");

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -32,6 +32,7 @@
 #include "ExitFlag.h"
 #include "GetByVariant.h"
 #include "ICStatusMap.h"
+#include "InlineCacheCompiler.h"
 #include "ScopeOffset.h"
 #include "StubInfoSummary.h"
 
@@ -43,6 +44,8 @@ class JSModuleEnvironment;
 class JSModuleNamespaceObject;
 class ModuleNamespaceAccessCase;
 class StructureStubInfo;
+
+enum class CacheType : int8_t;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(GetByStatus);
 
@@ -146,6 +149,10 @@ public:
             return false;
         return m_variants.first().viaGlobalProxy();
     }
+
+#if ENABLE(JIT)
+    CacheType preferredCacheType() const;
+#endif
     
 private:
     void merge(const GetByStatus&);

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -179,10 +179,8 @@ bool InlineAccess::generateSelfPropertyAccess(StructureStubInfo& stubInfo, Struc
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (stubInfo.useDataIC) {
-        // These dynamic slots get filled in by StructureStubInfo. Nothing else to do.
-        return stubInfo.preconfiguredCacheType == CacheType::GetByIdSelf;
-    }
+    if (stubInfo.useDataIC)
+        return false;
 
     CCallHelpers jit;
     
@@ -239,7 +237,7 @@ bool InlineAccess::canGenerateSelfPropertyReplace(StructureStubInfo& stubInfo, P
         return false;
 
     if (stubInfo.useDataIC)
-        return stubInfo.preconfiguredCacheType == CacheType::PutByIdReplace;
+        return false;
 
     if (isInlineOffset(offset))
         return true;
@@ -254,10 +252,8 @@ bool InlineAccess::generateSelfPropertyReplace(StructureStubInfo& stubInfo, Stru
 
     ASSERT(canGenerateSelfPropertyReplace(stubInfo, offset));
 
-    if (stubInfo.useDataIC) {
-        // These dynamic slots get filled in by StructureStubInfo. Nothing else to do.
-        return stubInfo.preconfiguredCacheType == CacheType::PutByIdReplace;
-    }
+    if (stubInfo.useDataIC)
+        return false;
 
     CCallHelpers jit;
 
@@ -347,7 +343,7 @@ bool InlineAccess::generateStringLength(StructureStubInfo& stubInfo)
         return false;
 
     if (stubInfo.useDataIC)
-        return stubInfo.preconfiguredCacheType == CacheType::ArrayLength;
+        return false;
 
     CCallHelpers jit;
 
@@ -382,10 +378,8 @@ bool InlineAccess::generateSelfInAccess(StructureStubInfo& stubInfo, Structure* 
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (stubInfo.useDataIC) {
-        // These dynamic slots get filled in by StructureStubInfo. Nothing else to do.
-        return stubInfo.preconfiguredCacheType == CacheType::InByIdSelf;
-    }
+    if (stubInfo.useDataIC)
+        return false;
 
     GPRReg base = stubInfo.m_baseGPR;
     JSValueRegs value = stubInfo.valueRegs();

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -98,16 +98,6 @@ enum class AccessType : int8_t {
 static constexpr unsigned numberOfAccessTypes = 0 JSC_FOR_EACH_STRUCTURE_STUB_INFO_ACCESS_TYPE(JSC_INCREMENT_ACCESS_TYPE);
 #undef JSC_INCREMENT_ACCESS_TYPE
 
-enum class CacheType : int8_t {
-    Unset,
-    GetByIdSelf,
-    PutByIdReplace,
-    InByIdSelf,
-    Stub,
-    ArrayLength,
-    StringLength,
-};
-
 struct UnlinkedStructureStubInfo;
 struct BaselineUnlinkedStructureStubInfo;
 
@@ -355,13 +345,16 @@ private:
             });
     }
 
-    void replaceHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
+    void setInlinedHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
+    void clearInlinedHandler(CodeBlock*);
+    void initializeWithUnitHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
     void prependHandler(CodeBlock*, Ref<InlineCacheHandler>&&, bool isMegamorphic);
-    void rewireStubAsJumpInAccess(CodeBlock*, InlineCacheHandler&);
+    void rewireStubAsJumpInAccess(CodeBlock*, Ref<InlineCacheHandler>&&);
 
 public:
     static constexpr ptrdiff_t offsetOfByIdSelfOffset() { return OBJECT_OFFSETOF(StructureStubInfo, byIdSelfOffset); }
     static constexpr ptrdiff_t offsetOfInlineAccessBaseStructureID() { return OBJECT_OFFSETOF(StructureStubInfo, m_inlineAccessBaseStructureID); }
+    static constexpr ptrdiff_t offsetOfInlineHolder() { return OBJECT_OFFSETOF(StructureStubInfo, m_inlineHolder); }
     static constexpr ptrdiff_t offsetOfDoneLocation() { return OBJECT_OFFSETOF(StructureStubInfo, doneLocation); }
     static constexpr ptrdiff_t offsetOfSlowPathStartLocation() { return OBJECT_OFFSETOF(StructureStubInfo, slowPathStartLocation); }
     static constexpr ptrdiff_t offsetOfSlowOperation() { return OBJECT_OFFSETOF(StructureStubInfo, m_slowOperation); }
@@ -404,6 +397,7 @@ public:
     CodeOrigin codeOrigin { };
     PropertyOffset byIdSelfOffset;
     WriteBarrierStructureID m_inlineAccessBaseStructureID;
+    JSCell* m_inlineHolder { nullptr };
     CacheableIdentifier m_identifier;
     // This is either the start of the inline IC for *byId caches. or the location of patchable jump for 'instanceof' caches.
     // If useDataIC is true, then it is nullptr.
@@ -419,6 +413,7 @@ public:
     JSGlobalObject* m_globalObject { nullptr };
     std::unique_ptr<PolymorphicAccess> m_stub;
 private:
+    RefPtr<InlineCacheHandler> m_inlinedHandler;
     RefPtr<InlineCacheHandler> m_handler;
     // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.
     // Note that it's always safe to clear this. If we clear it prematurely, then if we see the same

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -4101,13 +4101,9 @@ private:
 
         auto emitPrimordialCheckFor = [&] (JSValue primordialProperty, UniquedStringImpl* propertyUID) {
             m_graph.identifiers().ensure(propertyUID);
-            Node* actualProperty = m_insertionSet.insertNode(
-                m_indexInBlock, SpecNone, TryGetById, node->origin,
-                OpInfo(CacheableIdentifier::createFromImmortalIdentifier(propertyUID)), OpInfo(SpecFunction), Edge(searchRegExp, CellUse));
-
-            m_insertionSet.insertNode(
-                m_indexInBlock, SpecNone, CheckIsConstant, node->origin,
-                OpInfo(m_graph.freeze(primordialProperty)), Edge(actualProperty, CellUse));
+            auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromImmortalIdentifier(propertyUID), CacheType::GetByIdPrototype });
+            Node* actualProperty = m_insertionSet.insertNode(m_indexInBlock, SpecNone, TryGetById, node->origin, OpInfo(data), OpInfo(SpecFunction), Edge(searchRegExp, CellUse));
+            m_insertionSet.insertNode(m_indexInBlock, SpecNone, CheckIsConstant, node->origin, OpInfo(m_graph.freeze(primordialProperty)), Edge(actualProperty, CellUse));
         };
 
         JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -249,6 +249,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         out.print(comma, "id"_s, node->identifierNumber(), "{"_s, identifiers()[node->identifierNumber()], "}"_s);
     if (node->hasCacheableIdentifier() && node->cacheableIdentifier())
         out.print(comma, "cachable-id {"_s, node->cacheableIdentifier(), "}"_s);
+    if (node->hasCacheType())
+        out.print(comma, node->cacheType());
     if (node->hasPromotedLocationDescriptor())
         out.print(comma, node->promotedLocationDescriptor());
     if (node->hasClassInfo())

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1241,6 +1241,7 @@ public:
     Bag<LazyJSValue> m_lazyJSValues;
     Bag<CallDOMGetterData> m_callDOMGetterData;
     Bag<CallCustomAccessorData> m_callCustomAccessorData;
+    Bag<GetByIdData> m_getByIdData;
     Bag<BitVector> m_bitVectors;
     Vector<InlineVariableData, 4> m_inlineVariableData;
     HashMap<CodeBlock*, std::unique_ptr<FullBytecodeLiveness>> m_bytecodeLiveness;

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -376,7 +376,8 @@ void Node::convertToGetByIdMaybeMegamorphic(Graph& graph, CacheableIdentifier id
     children.child1() = Edge(base.node(), CellUse);
     children.child2() = Edge();
     children.child3() = Edge();
-    m_opInfo = identifier;
+    auto* data = graph.m_getByIdData.add(GetByIdData { identifier, CacheType::GetByIdSelf });
+    m_opInfo = data;
 }
 
 void Node::convertToPutByIdMaybeMegamorphic(Graph& graph, CacheableIdentifier identifier)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -51,6 +51,7 @@
 #include "DOMJITSignature.h"
 #include "DeleteByVariant.h"
 #include "GetByVariant.h"
+#include "InlineCacheCompiler.h"
 #include "JSCJSValue.h"
 #include "JSPropertyNameEnumerator.h"
 #include "Operands.h"
@@ -299,6 +300,11 @@ struct CallDOMGetterData {
 struct CallCustomAccessorData {
     CodePtr<CustomAccessorPtrTag> m_customAccessor;
     CacheableIdentifier m_identifier;
+};
+
+struct GetByIdData {
+    CacheableIdentifier m_identifier;
+    CacheType m_cacheType;
 };
 
 enum class BucketOwnerType : uint32_t {
@@ -1167,12 +1173,13 @@ public:
         case TryGetById:
         case GetById:
         case GetByIdFlush:
-        case GetByIdMegamorphic:
         case GetByIdWithThis:
-        case GetByIdWithThisMegamorphic:
         case GetByIdDirect:
         case GetByIdDirectFlush:
         case GetPrivateNameById:
+        case GetByIdMegamorphic:
+        case GetByIdWithThisMegamorphic:
+            return getByIdData().m_identifier;
         case DeleteById:
         case InById:
         case InByIdMegamorphic:
@@ -1207,6 +1214,41 @@ public:
         default:
             return false;
         }
+    }
+
+    bool hasGetByIdData() const
+    {
+        switch (op()) {
+        case TryGetById:
+        case GetById:
+        case GetByIdFlush:
+        case GetByIdWithThis:
+        case GetByIdDirect:
+        case GetByIdDirectFlush:
+        case GetPrivateNameById:
+        case GetByIdMegamorphic:
+        case GetByIdWithThisMegamorphic:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    GetByIdData& getByIdData()
+    {
+        ASSERT(hasGetByIdData());
+        return *m_opInfo.as<GetByIdData*>();
+    }
+
+    bool hasCacheType() const
+    {
+        return hasGetByIdData();
+    }
+
+    CacheType cacheType()
+    {
+        ASSERT(hasCacheType());
+        return getByIdData().m_cacheType;
     }
 
     unsigned identifierNumber()

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -149,7 +149,8 @@ namespace GetByIdWithThis {
     static constexpr GPRReg stubInfoGPR { preferredArgumentGPR<SlowOperation, 2>() };
     static constexpr auto scratchRegisters = allocatedScratchRegisters<GPRInfo, baseJSR, thisJSR, stubInfoGPR, GPRInfo::handlerGPR>;
     static constexpr GPRReg scratch1GPR { scratchRegisters[0] };
-    static_assert(noOverlap(baseJSR, thisJSR, stubInfoGPR, scratch1GPR), "Required for call to slow operation");
+    static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
+    static_assert(noOverlap(baseJSR, thisJSR, stubInfoGPR, scratch1GPR, scratch2GPR), "Required for call to slow operation");
     static_assert(noOverlap(resultJSR, stubInfoGPR));
 }
 

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
@@ -80,10 +80,6 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer,
         CodeLocationLabel<JITStubRoutinePtrTag> start);
 
-#if ENABLE(DFG_JIT)
-    void generateDFGDataICFastPath(DFG::JITCompiler&, StructureStubInfoIndex, GPRReg stubInfoGPR);
-#endif
-
     JSC::UnlinkedStructureStubInfo* m_unlinkedStubInfo { nullptr };
 
     template<typename StubInfo>
@@ -112,7 +108,7 @@ public:
     AccessType accessType() const { return m_accessType; }
 
 protected:
-    void generateBaselineDataICFastPath(JIT&, GPRReg stubInfoGPR);
+    void generateDataICFastPath(CCallHelpers&, GPRReg stubInfoGPR);
 
     StructureStubInfo* m_stubInfo { nullptr };
     AccessType m_accessType;
@@ -187,10 +183,7 @@ public:
         JSValueRegs base, JSValueRegs value, GPRReg stubInfoGPR, AccessType, CacheType);
     
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
-#if ENABLE(DFG_JIT)
-    void generateDFGDataICFastPath(DFG::JITCompiler&, StructureStubInfoIndex, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
-#endif
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -214,10 +207,7 @@ public:
         JSValueRegs value, JSValueRegs base, JSValueRegs thisRegs, GPRReg stubInfoGPR);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
-#if ENABLE(DFG_JIT)
-    void generateDFGDataICFastPath(DFG::JITCompiler&, StructureStubInfoIndex, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
-#endif
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -244,10 +234,7 @@ public:
         JSValueRegs base, JSValueRegs value, GPRReg stubInfoGPR, GPRReg scratch, AccessType);
     
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
-#if ENABLE(DFG_JIT)
-    void generateDFGDataICFastPath(DFG::JITCompiler&, StructureStubInfoIndex, JSValueRegs baseJSR, JSValueRegs valueJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
-#endif
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -280,7 +267,7 @@ public:
     void finalize(LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -336,7 +323,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -384,7 +371,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -416,7 +403,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -458,10 +445,7 @@ public:
         JSValueRegs base, JSValueRegs value, GPRReg stubInfoGPR);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
-#if ENABLE(DFG_JIT)
-    void generateDFGDataICFastPath(DFG::JITCompiler&, StructureStubInfoIndex, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
-#endif
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,
@@ -483,7 +467,7 @@ public:
         bool prototypeIsKnownObject = false);
     
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     CCallHelpers::Jump slowPathJump() const
     {
@@ -540,7 +524,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
     
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     void generateEmptyPath(CCallHelpers&);
 
@@ -596,7 +580,7 @@ public:
     void finalize(LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     void generateEmptyPath(CCallHelpers&);
 
@@ -656,7 +640,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
     
     void generateFastPath(CCallHelpers&);
-    void generateBaselineDataICFastPath(JIT&);
+    void generateDataICFastPath(CCallHelpers&);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo, CodeBlock* codeBlock,

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -176,7 +176,7 @@ void JIT::emit_op_instanceof(const JSInstruction* currentInstruction)
         protoJSR.payloadGPR(),
         stubInfoGPR);
 
-    gen.generateBaselineDataICFastPath(*this);
+    gen.generateDataICFastPath(*this);
 #if USE(JSVALUE32_64)
     boxBoolean(resultJSR.payloadGPR(), resultJSR);
 #endif


### PR DESCRIPTION
#### 9fa6f1a7715e2237d8080660d3d891b3378f3995
<pre>
[JSC] Make DataIC inline code adaptive
<a href="https://bugs.webkit.org/show_bug.cgi?id=277992">https://bugs.webkit.org/show_bug.cgi?id=277992</a>
<a href="https://rdar.apple.com/133724890">rdar://133724890</a>

Reviewed by Keith Miller.

This patch make inlined part of DataIC code adaptive by getting some information from lower tiers.
In Baseline, we use LLInt&apos;s GetByIdMode&apos;s metadata and use GetByIdSelf or GetByIdPrototype.
In DFG, we use GetByStatus&apos; information and pick appropriate one for inline cache code.

Instead of having very special cache for inlined code in DataIC, we use InlineCacheHandler.
We hold this inlined case as m_inlinedHandler so that watchpoint etc. works well: when invariant
gets broken, StructureStubInfo gets cleared.

* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::preferredCacheType const):
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::InlineAccess::generateSelfPropertyAccess):
(JSC::InlineAccess::canGenerateSelfPropertyReplace):
(JSC::InlineAccess::generateSelfPropertyReplace):
(JSC::InlineAccess::generateStringLength):
(JSC::InlineAccess::generateSelfInAccess):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::InlineCacheHandler):
(JSC::m_watchpoint):
(JSC::InlineCacheHandler::create):
(JSC::InlineCacheHandler::createPreCompiled):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::m_next): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::aboutToDie):
(JSC::StructureStubInfo::addAccessCase):
(JSC::StructureStubInfo::reset):
(JSC::StructureStubInfo::visitWeakReferences):
(JSC::StructureStubInfo::callLinkInfoAt):
(JSC::StructureStubInfo::containsPC const):
(JSC::StructureStubInfo::initializeFromUnlinkedStructureStubInfo):
(JSC::StructureStubInfo::initializeFromDFGUnlinkedStructureStubInfo):
(JSC::StructureStubInfo::setInlinedHandler):
(JSC::StructureStubInfo::clearInlinedHandler):
(JSC::StructureStubInfo::initializeWithUnitHandler):
(JSC::StructureStubInfo::prependHandler):
(JSC::StructureStubInfo::rewireStubAsJumpInAccess):
(JSC::StructureStubInfo::resetStubAsJumpInAccess):
(JSC::StructureStubInfo::replaceHandler): Deleted.
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
(JSC::StructureStubInfo::offsetOfInlineHolder):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::handleGetPrivateNameById):
(JSC::DFG::ByteCodeParser::handleDeleteById):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::addStringReplacePrimordialChecks):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToGetByIdMaybeMegamorphic):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::cacheableIdentifier):
(JSC::DFG::Node::hasGetByIdData const):
(JSC::DFG::Node::getByIdData):
(JSC::DFG::Node::hasCacheType const):
(JSC::DFG::Node::cacheType):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::cachedGetById):
(JSC::DFG::SpeculativeJIT::cachedGetByIdWithThis):
(JSC::DFG::SpeculativeJIT::compileGetByVal):
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileGetByValWithThis):
(JSC::DFG::SpeculativeJIT::compileGetById):
(JSC::DFG::SpeculativeJIT::compileDeleteById):
(JSC::DFG::SpeculativeJIT::compileDeleteByVal):
(JSC::DFG::SpeculativeJIT::compileInById):
(JSC::DFG::SpeculativeJIT::compileInByVal):
(JSC::DFG::SpeculativeJIT::compileHasPrivate):
(JSC::DFG::SpeculativeJIT::compilePutByVal):
(JSC::DFG::SpeculativeJIT::compileGetPrivateNameByVal):
(JSC::DFG::SpeculativeJIT::compilePutPrivateName):
(JSC::DFG::SpeculativeJIT::compileCheckPrivateBrand):
(JSC::DFG::SpeculativeJIT::compileSetPrivateBrand):
(JSC::DFG::SpeculativeJIT::compileInstanceOf):
(JSC::DFG::SpeculativeJIT::cachedPutById):
(JSC::DFG::SpeculativeJIT::compileEnumeratorPutByVal):
* Source/JavaScriptCore/jit/BaselineJITRegisters.h:
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_iterator_open):
(JSC::JIT::emit_op_iterator_next):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp:
(JSC::JITInlineCacheGenerator::generateDataICFastPath):
(JSC::generateGetByIdInlineAccessBaselineDataIC):
(JSC::JITGetByIdGenerator::generateDataICFastPath):
(JSC::JITGetByIdWithThisGenerator::generateDataICFastPath):
(JSC::JITPutByIdGenerator::generateDataICFastPath):
(JSC::JITDelByValGenerator::generateDataICFastPath):
(JSC::JITDelByIdGenerator::generateDataICFastPath):
(JSC::JITInByValGenerator::generateDataICFastPath):
(JSC::JITInByIdGenerator::generateDataICFastPath):
(JSC::JITInstanceOfGenerator::generateDataICFastPath):
(JSC::JITGetByValGenerator::generateDataICFastPath):
(JSC::JITGetByValWithThisGenerator::generateDataICFastPath):
(JSC::JITPutByValGenerator::generateDataICFastPath):
(JSC::JITPrivateBrandAccessGenerator::generateDataICFastPath):
(JSC::JITInlineCacheGenerator::generateDFGDataICFastPath): Deleted.
(JSC::JITInlineCacheGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITGetByIdGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITGetByIdGenerator::generateDFGDataICFastPath): Deleted.
(JSC::JITGetByIdWithThisGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITGetByIdWithThisGenerator::generateDFGDataICFastPath): Deleted.
(JSC::JITPutByIdGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITPutByIdGenerator::generateDFGDataICFastPath): Deleted.
(JSC::JITDelByValGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITDelByIdGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITInByValGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITInByIdGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITInByIdGenerator::generateDFGDataICFastPath): Deleted.
(JSC::JITInstanceOfGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITGetByValGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITGetByValWithThisGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITPutByValGenerator::generateBaselineDataICFastPath): Deleted.
(JSC::JITPrivateBrandAccessGenerator::generateBaselineDataICFastPath): Deleted.
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.h:
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_instanceof):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_get_by_val):
(JSC::JIT::emit_op_get_private_name):
(JSC::JIT::emit_op_set_private_brand):
(JSC::JIT::emit_op_check_private_brand):
(JSC::JIT::emit_op_put_by_val):
(JSC::JIT::emit_op_put_private_name):
(JSC::JIT::emit_op_del_by_id):
(JSC::JIT::emit_op_del_by_val):
(JSC::JIT::emit_op_try_get_by_id):
(JSC::JIT::emit_op_get_by_id_direct):
(JSC::JIT::emit_op_get_by_id):
(JSC::JIT::emit_op_get_length):
(JSC::JIT::emit_op_get_by_id_with_this):
(JSC::JIT::emit_op_put_by_id):
(JSC::JIT::emit_op_in_by_id):
(JSC::JIT::emit_op_in_by_val):
(JSC::JIT::emitHasPrivate):
(JSC::JIT::emit_op_get_by_val_with_this):
(JSC::JIT::emit_op_enumerator_get_by_val):
(JSC::JIT::emit_op_enumerator_put_by_val):

Canonical link: <a href="https://commits.webkit.org/282181@main">https://commits.webkit.org/282181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/353c03d4e1ac30a724cd1a0d9fe655db004b5eb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13264 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8928 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65448 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/38790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31039 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11859 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/55476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68092 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61622 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6325 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54053 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5265 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83385 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9386 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14636 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->