### PR TITLE
Remove subscriptions associated with uninstalled web clips at webpushd startup time

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -68,6 +68,15 @@ struct RemovedPushRecord {
     WEBCORE_EXPORT RemovedPushRecord isolatedCopy() &&;
 };
 
+struct PushSubscriptionSetRecord {
+    PushSubscriptionSetIdentifier identifier;
+    String securityOrigin;
+    bool enabled;
+
+    WEBCORE_EXPORT PushSubscriptionSetRecord isolatedCopy() const &;
+    WEBCORE_EXPORT PushSubscriptionSetRecord isolatedCopy() &&;
+};
+
 struct PushTopics {
     Vector<String> enabledTopics;
     Vector<String> ignoredTopics;
@@ -93,6 +102,7 @@ public:
     WEBCORE_EXPORT void getRecordByTopic(const String& topic, CompletionHandler<void(std::optional<PushRecord>&&)>&&);
     WEBCORE_EXPORT void getRecordBySubscriptionSetAndScope(const PushSubscriptionSetIdentifier&, const String& scope, CompletionHandler<void(std::optional<PushRecord>&&)>&&);
     WEBCORE_EXPORT void getIdentifiers(CompletionHandler<void(HashSet<PushSubscriptionIdentifier>&&)>&&);
+    WEBCORE_EXPORT void getPushSubscriptionSetRecords(CompletionHandler<void(Vector<PushSubscriptionSetRecord>&&)>&&);
     WEBCORE_EXPORT void getTopics(CompletionHandler<void(PushTopics&&)>&&);
 
     WEBCORE_EXPORT void incrementSilentPushCount(const PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
@@ -100,6 +110,7 @@ public:
     WEBCORE_EXPORT void removeRecordsBySubscriptionSet(const PushSubscriptionSetIdentifier&, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
     WEBCORE_EXPORT void removeRecordsBySubscriptionSetAndSecurityOrigin(const PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
 
+    WEBCORE_EXPORT void setPushesEnabled(const PushSubscriptionSetIdentifier&, bool, CompletionHandler<void(bool recordsChanged)>&&);
     WEBCORE_EXPORT void setPushesEnabledForOrigin(const PushSubscriptionSetIdentifier&, const String& securityOrigin, bool, CompletionHandler<void(bool recordsChanged)>&&);
 
 private:
@@ -109,8 +120,6 @@ private:
     template<typename... Args> WebCore::SQLiteStatementAutoResetScope bindStatementOnQueue(ASCIILiteral query, Args&&...);
 
     void dispatchOnWorkQueue(Function<void()>&&);
-
-    enum class SubscriptionSetState { Enabled, Ignored };
 
     Ref<WorkQueue> m_queue;
     UniqueRef<WebCore::SQLiteDatabase> m_db;

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -148,6 +148,8 @@
 
 @interface UIWebClip : NSObject
 + (UIWebClip *)webClipWithIdentifier:(NSString *)identifier;
++ (NSArray *)webClips;
+@property (copy) NSString *identifier;
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, retain) NSURL *pageURL;
 @end

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
@@ -187,6 +187,17 @@
 (allow file-read*
     (home-subpath "/Library/WebClips"))
 
+;; Web Clip notifications.
+(define (notifyd-message-numbers) (message-number 1002 1011 1012 1016 1017 1018 1021 1025 1026 1028 1029 1030 1031 1032))
+(define (allow-notifyd)
+    (allow ipc-posix-shm-read* (ipc-posix-name "apple.shm.notification_center"))
+    (allow mach-lookup (global-name "com.apple.system.notification_center")
+        (apply-message-filter
+            (deny mach-message-send)
+            (deny mach-message-send (with no-report) (message-number 1023))
+            (allow mach-message-send (notifyd-message-numbers)))))
+(allow-notifyd)
+
 ;; Support for looking up host apps from extensions.
 (allow mach-lookup
     (global-name "com.apple.runningboard"))

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -34,6 +34,8 @@
 #import <WebCore/PushMessageCrypto.h>
 #import <WebCore/SecurityOrigin.h>
 #import <notify.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/CallbackAggregator.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -46,20 +48,29 @@
 #import <pal/spi/ios/MobileKeyBagSPI.h>
 #endif
 
+#if PLATFORM(IOS) || PLATFORM(VISION)
+#import "UIKitSPI.h"
+#endif
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/PushServiceAdditions.mm>)
+#import <WebKitAdditions/PushServiceAdditions.mm>
+#endif
+
+#if !defined(PUSH_SERVICE_CONSTRUCTOR_ADDITIONS)
+#define PUSH_SERVICE_CONSTRUCTOR_ADDITIONS
+#endif
+
+#if !defined(UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_1)
+#define UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_1
+#endif
+
+#if !defined(UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_2)
+#define UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_2
+#endif
+
 namespace WebPushD {
 using namespace WebKit;
 using namespace WebCore;
-
-static void updateTopicLists(PushServiceConnection& connection, PushDatabase& database, CompletionHandler<void()> completionHandler)
-{
-    database.getTopics([&connection, completionHandler = WTFMove(completionHandler)](auto&& topics) mutable {
-        PushServiceConnection::TopicLists topicLists;
-        topicLists.enabledTopics = WTFMove(topics.enabledTopics);
-        topicLists.ignoredTopics = WTFMove(topics.ignoredTopics);
-        connection.setTopicLists(WTFMove(topicLists));
-        completionHandler();
-    });
-}
 
 #if HAVE(APPLE_PUSH_SERVICE_URL_TOKEN_SUPPORT)
 
@@ -144,15 +155,16 @@ void PushService::create(const String& incomingPushServiceName, const String& da
             auto database = makeUniqueRefFromNonNullUniquePtr(WTFMove(databaseResult));
             UniqueRef<PushService> service(*new PushService(WTFMove(connection), WTFMove(database), WTFMove(messageHandler)));
 
-            auto& connectionRef = service->connection();
-            auto& databaseRef = service->database();
-
             // Only provide the service object back to the caller after we've synced the topic lists in
             // the database with the PushServiceConnection/APSConnection. This ensures that we won't
             // service any calls to subscribe/unsubscribe/etc. until after the topic lists are up to
             // date, which APSConnection cares about.
-            updateTopicLists(connectionRef, databaseRef, [transaction, service = WTFMove(service), creationHandler = WTFMove(creationHandler)]() mutable {
-                creationHandler(service.moveToUniquePtr());
+            auto& serviceRef = service.get();
+            serviceRef.updateTopicLists([transaction, service = WTFMove(service), creationHandler = WTFMove(creationHandler)]() mutable {
+                auto& serviceRef = service.get();
+                serviceRef.updateSubscriptionSetState([transaction, service = WTFMove(service), creationHandler = WTFMove(creationHandler)]() mutable {
+                    creationHandler(service.moveToUniquePtr());
+                });
             });
         });
     });
@@ -185,19 +197,30 @@ PushService::PushService(UniqueRef<PushServiceConnection>&& pushServiceConnectio
     : m_connection(WTFMove(pushServiceConnection))
     , m_database(WTFMove(pushDatabase))
     , m_incomingPushMessageHandler(WTFMove(incomingPushMessageHandler))
+    , m_notifyToken(NOTIFY_TOKEN_INVALID)
 {
     RELEASE_ASSERT(m_incomingPushMessageHandler);
 
-    m_connection->startListeningForPublicToken([this](auto&& token) {
+    m_connection->startListeningForPublicToken([this, weakThis = WeakPtr { *this }](auto&& token) mutable {
+        if (!weakThis)
+            return;
         didReceivePublicToken(WTFMove(token));
     });
 
-    m_connection->startListeningForPushMessages([this](NSString *topic, NSDictionary *userInfo) {
+    m_connection->startListeningForPushMessages([this, weakThis = WeakPtr { *this }](NSString *topic, NSDictionary *userInfo) mutable {
+        if (!weakThis)
+            return;
         didReceivePushMessage(topic, userInfo);
     });
+
+    PUSH_SERVICE_CONSTRUCTOR_ADDITIONS;
 }
 
-PushService::~PushService() = default;
+PushService::~PushService()
+{
+    if (m_notifyToken != NOTIFY_TOKEN_INVALID)
+        notify_cancel(m_notifyToken);
+}
 
 static PushSubscriptionData makePushSubscriptionFromRecord(PushRecord&& record)
 {
@@ -211,7 +234,7 @@ static PushSubscriptionData makePushSubscriptionFromRecord(PushRecord&& record)
     };
 }
 
-class PushServiceRequest {
+class PushServiceRequest : public CanMakeWeakPtr<PushServiceRequest> {
 public:
     virtual ~PushServiceRequest() = default;
 
@@ -236,9 +259,12 @@ protected:
 
     virtual void finish() = 0;
 
+    // PushServiceRequest is owned by PushService, so these references are valid for the lifetime of
+    // PushServiceRequest.
     PushService& m_service;
     PushServiceConnection& m_connection;
     PushDatabase& m_database;
+
     PushSubscriptionSetIdentifier m_identifier;
     String m_scope;
     CompletionHandler<void(PushServiceRequest&)> m_completionHandler;
@@ -318,7 +344,10 @@ GetSubscriptionRequest::GetSubscriptionRequest(PushService& service, const PushS
 // Implements the webpushd side of PushManager.getSubscription.
 void GetSubscriptionRequest::startInternal()
 {
-    m_database.getRecordBySubscriptionSetAndScope(m_identifier, m_scope, [this](auto&& result) mutable {
+    m_database.getRecordBySubscriptionSetAndScope(m_identifier, m_scope, [this, weakThis = WeakPtr { *this }](auto&& result) mutable {
+        if (!weakThis)
+            return;
+
         if (!result) {
             fulfill(std::optional<WebCore::PushSubscriptionData> { });
             return;
@@ -355,7 +384,10 @@ SubscribeRequest::SubscribeRequest(PushService& service, const PushSubscriptionS
 // Implements the webpushd side of PushManager.subscribe().
 void SubscribeRequest::startImpl(IsRetry isRetry)
 {
-    m_database.getRecordBySubscriptionSetAndScope(m_identifier, m_scope, [this, isRetry](auto&& result) mutable {
+    m_database.getRecordBySubscriptionSetAndScope(m_identifier, m_scope, [this, weakThis = WeakPtr { *this }, isRetry](auto&& result) mutable {
+        if (!weakThis)
+            return;
+
         if (result) {
             if (m_vapidPublicKey != result->serverVAPIDPublicKey)
                 reject(WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, "Provided applicationServerKey does not match the key in the existing subscription."_s });
@@ -365,7 +397,10 @@ void SubscribeRequest::startImpl(IsRetry isRetry)
         }
 
         auto topic = makePushTopic(m_identifier, m_scope);
-        m_connection.subscribe(topic, m_vapidPublicKey, [this, isRetry, topic](NSString *endpoint, NSError *error) mutable {
+        m_connection.subscribe(topic, m_vapidPublicKey, [this, weakThis = WeakPtr { *this }, isRetry, topic](NSString *endpoint, NSError *error) mutable {
+            if (!weakThis)
+                return;
+
             if (error) {
 #if !HAVE(APPLE_PUSH_SERVICE_URL_TOKEN_SUPPORT)
                 UNUSED_PARAM(isRetry);
@@ -395,16 +430,19 @@ void SubscribeRequest::startImpl(IsRetry isRetry)
                 .sharedAuthSecret = WTFMove(clientKeys.sharedAuthSecret)
             };
 
-            m_database.insertRecord(record, [this](auto&& result) mutable {
+            m_database.insertRecord(record, [this, weakThis = WeakPtr { *this }](auto&& result) mutable {
+                if (!weakThis)
+                    return;
+
                 if (!result) {
                     RELEASE_LOG_ERROR(Push, "PushManager.subscribe(%{public}s, scope: %{sensitive}s) failed with database error", m_identifier.debugDescription().utf8().data(), m_scope.utf8().data());
                     reject(WebCore::ExceptionData { WebCore::ExceptionCode::AbortError, "Failed due to internal database error"_s });
                     return;
                 }
 
-                // FIXME: support partial topic list updates.
-                updateTopicLists(m_connection, m_database, [this, record = WTFMove(*result)]() mutable {
-                    fulfill(makePushSubscriptionFromRecord(WTFMove(record)));
+                m_service.updateTopicLists([this, weakThis = WeakPtr { *this }, record = WTFMove(*result)]() mutable {
+                    if (weakThis)
+                        fulfill(makePushSubscriptionFromRecord(WTFMove(record)));
                 });
             });
         });
@@ -417,7 +455,10 @@ void SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError(String&& to
 #if !HAVE(APPLE_PUSH_SERVICE_URL_TOKEN_SUPPORT)
     UNUSED_PARAM(topic);
 #else
-    WorkQueue::main().dispatch([this, topic = WTFMove(topic)]() mutable {
+    WorkQueue::main().dispatch([this, weakThis = WeakPtr { *this }, topic = WTFMove(topic)]() mutable {
+        if (!weakThis)
+            return;
+
         // This takes ownership of the paused topic and tells apsd to forget about the topic.
         auto originalTopics = m_connection.ignoredTopics();
         auto augmentedTopics = originalTopics;
@@ -425,7 +466,10 @@ void SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError(String&& to
         m_connection.setIgnoredTopics(WTFMove(augmentedTopics));
         m_connection.setIgnoredTopics(WTFMove(originalTopics));
 
-        WorkQueue::main().dispatch([this]() mutable {
+        WorkQueue::main().dispatch([this, weakThis = WeakPtr { *this }]() mutable {
+            if (!weakThis)
+                return;
+
             startImpl(IsRetry::Yes);
         });
     });
@@ -456,25 +500,35 @@ UnsubscribeRequest::UnsubscribeRequest(PushService& service, const PushSubscript
 // Implements the webpushd side of PushSubscription.unsubscribe.
 void UnsubscribeRequest::startInternal()
 {
-    m_database.getRecordBySubscriptionSetAndScope(m_identifier, m_scope, [this](auto&& result) mutable {
+    m_database.getRecordBySubscriptionSetAndScope(m_identifier, m_scope, [this, weakThis = WeakPtr { *this }](auto&& result) mutable {
+        if (!weakThis)
+            return;
+
         if (!result || (m_subscriptionIdentifier && *m_subscriptionIdentifier != result->identifier)) {
             fulfill(false);
             return;
         }
         
-        m_database.removeRecordByIdentifier(result->identifier, [this, serverVAPIDPublicKey = result->serverVAPIDPublicKey](bool removed) mutable {
+        m_database.removeRecordByIdentifier(result->identifier, [this, weakThis = WeakPtr { *this }, serverVAPIDPublicKey = result->serverVAPIDPublicKey](bool removed) mutable {
+            if (!weakThis)
+                return;
+
             if (!removed) {
                 fulfill(false);
                 return;
             }
 
             // FIXME: support partial topic list updates.
-            updateTopicLists(m_connection, m_database, [this]() mutable {
-                fulfill(true);
+            m_service.updateTopicLists([this, weakThis = WeakPtr { *this }]() mutable {
+                if (weakThis)
+                    fulfill(true);
             });
 
             auto topic = makePushTopic(m_identifier, m_scope);
-            m_connection.unsubscribe(topic, serverVAPIDPublicKey, [this](bool unsubscribed, NSError *error) mutable {
+            m_connection.unsubscribe(topic, serverVAPIDPublicKey, [this, weakThis = WeakPtr { *this }](bool unsubscribed, NSError *error) mutable {
+                if (!weakThis)
+                    return;
+
                 RELEASE_LOG_ERROR_IF(!unsubscribed, Push, "PushSubscription.unsubscribe(%{public}s scope: %{sensitive}s) failed with domain: %{public}s code: %lld)", m_identifier.debugDescription().utf8().data(), m_scope.utf8().data(), error.domain.UTF8String ?: "none", static_cast<int64_t>(error.code));
             });
         });
@@ -579,7 +633,10 @@ void PushService::incrementSilentPushCount(const PushSubscriptionSetIdentifier& 
         return;
     }
 
-    m_database->incrementSilentPushCount(identifier, securityOrigin, [this, identifier, securityOrigin, handler = WTFMove(handler)](unsigned silentPushCount) mutable {
+    m_database->incrementSilentPushCount(identifier, securityOrigin, [this, weakThis = WeakPtr { *this }, identifier, securityOrigin, handler = WTFMove(handler)](unsigned silentPushCount) mutable {
+        if (!weakThis)
+            return handler(0);
+
         if (silentPushCount < WebKit::WebPushD::maxSilentPushCount) {
             handler(silentPushCount);
             return;
@@ -600,10 +657,10 @@ void PushService::setPushesEnabledForSubscriptionSetAndOrigin(const PushSubscrip
         return handler();
     }
 
-    m_database->setPushesEnabledForOrigin(identifier, securityOrigin, enabled, [this, handler = WTFMove(handler)](bool recordsChanged) mutable {
-        if (!recordsChanged)
+    m_database->setPushesEnabledForOrigin(identifier, securityOrigin, enabled, [this, weakThis = WeakPtr { *this }, handler = WTFMove(handler)](bool recordsChanged) mutable {
+        if (!weakThis || !recordsChanged)
             return handler();
-        updateTopicLists(m_connection, m_database, WTFMove(handler));
+        updateTopicLists(WTFMove(handler));
     });
 }
 
@@ -627,14 +684,17 @@ void PushService::removeRecordsImpl(const PushSubscriptionSetIdentifier& identif
         return;
     }
 
-    auto removedRecordsHandler = [this, identifier, securityOrigin, handler = WTFMove(handler)](Vector<RemovedPushRecord>&& removedRecords) mutable {
+    auto removedRecordsHandler = [this, weakThis = WeakPtr { *this }, identifier, securityOrigin, handler = WTFMove(handler)](Vector<RemovedPushRecord>&& removedRecords) mutable {
+        if (!weakThis)
+            return handler(removedRecords.size());
+
         for (auto& record : removedRecords) {
             m_connection->unsubscribe(record.topic, record.serverVAPIDPublicKey, [topic = record.topic](bool unsubscribed, NSError* error) {
                 RELEASE_LOG_ERROR_IF(!unsubscribed, Push, "removeRecordsImpl couldn't remove subscription for topic %{sensitive}s: %{public}s code: %lld)", topic.utf8().data(), error.domain.UTF8String ?: "none", static_cast<int64_t>(error.code));
             });
         }
 
-        updateTopicLists(m_connection, m_database, [count = removedRecords.size(), handler = WTFMove(handler)]() mutable {
+        updateTopicLists([count = removedRecords.size(), handler = WTFMove(handler)]() mutable {
             handler(count);
         });
     };
@@ -643,6 +703,87 @@ void PushService::removeRecordsImpl(const PushSubscriptionSetIdentifier& identif
         m_database->removeRecordsBySubscriptionSetAndSecurityOrigin(identifier, *securityOrigin, WTFMove(removedRecordsHandler));
     else
         m_database->removeRecordsBySubscriptionSet(identifier, WTFMove(removedRecordsHandler));
+}
+
+void PushService::updateSubscriptionSetState(CompletionHandler<void()>&& completionHandler)
+{
+#if !PLATFORM(IOS) && !PLATFORM(VISION)
+    completionHandler();
+#else
+    RetainPtr<NSMutableSet> installedWebClipIdentifiers;
+
+    @autoreleasepool {
+        NSArray *webClips = [UIWebClip webClips];
+        installedWebClipIdentifiers = adoptNS([[NSMutableSet alloc] initWithCapacity:webClips.count]);
+
+        for (UIWebClip *webClip in webClips) {
+            if (NSString *identifier = [webClip identifier])
+                [installedWebClipIdentifiers addObject:identifier];
+        }
+    }
+
+    RELEASE_LOG(Push, "Found %zu web clips", [installedWebClipIdentifiers count]);
+
+    m_database->getPushSubscriptionSetRecords([this, weakThis = WeakPtr { *this }, installedWebClipIdentifiers = WTFMove(installedWebClipIdentifiers), completionHandler = WTFMove(completionHandler)](auto&& records) mutable {
+        if (!weakThis)
+            return completionHandler();
+
+        HashSet<PushSubscriptionSetIdentifier> identifiersToRemove;
+
+        UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_1;
+
+        for (const auto& record : records) {
+            NSString *webClipIdentifier = (NSString *)record.identifier.pushPartition;
+            if (![installedWebClipIdentifiers containsObject:webClipIdentifier]) {
+                identifiersToRemove.add(record.identifier);
+                continue;
+            }
+
+            UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_2;
+        }
+
+        if (identifiersToRemove.isEmpty()) {
+            RELEASE_LOG(Push, "All push subscriptions are associated with existing web clips");
+            return completionHandler();
+        }
+
+        Ref aggregator = MainRunLoopCallbackAggregator::create([this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+            if (!weakThis)
+                return completionHandler();
+
+            // Set the APS topics filter again so that the topics we just unsubscribed from are no longer in the filter.
+            updateTopicLists(WTFMove(completionHandler));
+        });
+
+        for (const auto& identifier : identifiersToRemove) {
+            RELEASE_LOG(Push, "No web clip matching push subscription set identifier %{public}s; removing", identifier.debugDescription().utf8().data());
+            m_database->removeRecordsBySubscriptionSet(identifier, [this, weakThis = WeakPtr { *this }, aggregator](auto&& records) {
+                if (!weakThis)
+                    return;
+
+                for (auto& record : records) {
+                    m_connection->unsubscribe(record.topic, record.serverVAPIDPublicKey, [topic = record.topic](bool unsubscribed, NSError* error) {
+                        RELEASE_LOG_ERROR_IF(!unsubscribed, Push, "couldn't remove subscription for topic %{sensitive}s: %{public}s code: %lld)", topic.utf8().data(), error.domain.UTF8String ?: "none", static_cast<int64_t>(error.code));
+                    });
+                }
+            });
+        }
+    });
+#endif
+}
+
+void PushService::updateTopicLists(CompletionHandler<void()>&& completionHandler)
+{
+    m_database->getTopics([this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](auto&& topics) mutable {
+        if (!weakThis)
+            return completionHandler();
+
+        PushServiceConnection::TopicLists topicLists;
+        topicLists.enabledTopics = WTFMove(topics.enabledTopics);
+        topicLists.ignoredTopics = WTFMove(topics.ignoredTopics);
+        m_connection->setTopicLists(WTFMove(topicLists));
+        completionHandler();
+    });
 }
 
 enum class ContentEncoding {
@@ -733,14 +874,17 @@ void PushService::setPublicTokenForTesting(Vector<uint8_t>&& token)
 
 void PushService::didReceivePublicToken(Vector<uint8_t>&& token)
 {
-    m_database->updatePublicToken(token, [this](auto result) mutable {
+    m_database->updatePublicToken(token, [this, weakThis = WeakPtr { *this }](auto result) mutable {
+        if (!weakThis)
+            return;
+
         if (result == PushDatabase::PublicTokenChanged::No) {
             RELEASE_LOG(Push, "Received expected public token");
             return;
         }
 
         RELEASE_LOG_ERROR(Push, "Public token changed; invalidated all existing push subscriptions");
-        updateTopicLists(m_connection, m_database, []() { });
+        updateTopicLists([]() { });
     });
 }
 
@@ -752,7 +896,10 @@ void PushService::didReceivePushMessage(NSString* topic, NSDictionary* userInfo,
     if (!messageResult)
         return;
 
-    m_database->getRecordByTopic(topic, [this, message = WTFMove(*messageResult), completionHandler = WTFMove(completionHandler), transaction = WTFMove(transaction)](auto&& recordResult) mutable {
+    m_database->getRecordByTopic(topic, [this, weakThis = WeakPtr { *this }, message = WTFMove(*messageResult), completionHandler = WTFMove(completionHandler), transaction = WTFMove(transaction)](auto&& recordResult) mutable {
+        if (!weakThis)
+            return completionHandler();
+
         if (!recordResult) {
             RELEASE_LOG_ERROR(Push, "Dropping incoming push sent to unknown topic: %{sensitive}s", message.topic.utf8().data());
             completionHandler();

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -53,6 +53,26 @@ static bool operator==(const PushRecord& a, const PushRecord& b)
         && a.expirationTime == b.expirationTime;
 }
 
+static bool operator==(const PushSubscriptionSetRecord& a, const PushSubscriptionSetRecord& b)
+{
+    return a.identifier == b.identifier && a.securityOrigin == b.securityOrigin && a.enabled == b.enabled;
+}
+
+static bool operator==(const Vector<PushSubscriptionSetRecord>& a, const Vector<PushSubscriptionSetRecord>& b)
+{
+    if (a.size() != b.size())
+        return false;
+
+    // Not efficient, but ok for the sizes in this test.
+    auto bCopy = b;
+    for (auto& record : a) {
+        if (!bCopy.removeFirst(record))
+            return false;
+    }
+
+    return true;
+}
+
 static bool operator==(PushTopics a, PushTopics b)
 {
     auto lessThan = [](const String& lhs, const String& rhs) {
@@ -154,6 +174,20 @@ static HashSet<uint64_t> getRowIdentifiersSync(PushDatabase& database)
     Util::run(&done);
 
     return rowIdentifiers;
+}
+
+static Vector<PushSubscriptionSetRecord> getPushSubscriptionSetsSync(PushDatabase& database)
+{
+    bool done = false;
+    Vector<PushSubscriptionSetRecord> result;
+
+    database.getPushSubscriptionSetRecords([&done, &result](auto&& records) {
+        result = WTFMove(records);
+        done = true;
+    });
+    Util::run(&done);
+
+    return result;
 }
 
 static PushTopics getTopicsSync(PushDatabase& database)
@@ -272,6 +306,28 @@ public:
     std::optional<PushRecord> insertResult5;
     std::optional<PushRecord> insertResult6;
     std::optional<PushRecord> insertResult7;
+    Vector<PushSubscriptionSetRecord> expectedSubscriptionSets {
+        // from record1
+        { { "com.apple.webapp"_s, emptyString(), std::nullopt }, "https://www.apple.com"_s, true },
+
+        // from record2
+        { { "com.apple.Safari"_s, emptyString(), std::nullopt }, "https://www.webkit.org"_s, true },
+
+        // from record3 and record4
+        { { "com.apple.Safari"_s, emptyString(), std::nullopt }, "https://www.apple.com"_s, true },
+
+        // from record5
+        { { "com.apple.webapp"_s, emptyString(), WTF::UUID::parse("c1d79454-1f1a-4135-8764-e71d0de4b02e"_s)
+        }, "https://www.webkit.org"_s, true },
+
+        // from record6
+        { { "com.apple.webapp"_s, emptyString(), WTF::UUID::parse("c1d79454-1f1a-4135-8764-e71d0de4b02e"_s)
+        }, "https://www.apple.com"_s, true },
+
+        // from record7
+        { { "com.apple.webapp"_s, "partition"_s, WTF::UUID::parse("c1d79454-1f1a-4135-8764-e71d0de4b02e"_s)
+        }, "https://www.apple.com"_s, true },
+    };
 
     Vector<uint8_t> getPublicToken()
     {
@@ -335,6 +391,11 @@ public:
         return getRowIdentifiersSync(*db);
     }
 
+    Vector<PushSubscriptionSetRecord> getPushSubscriptionSets()
+    {
+        return getPushSubscriptionSetsSync(*db);
+    }
+
     PushTopics getTopics()
     {
         return getTopicsSync(*db);
@@ -382,6 +443,20 @@ public:
         return count;
     }
 
+    bool setPushesEnabled(const PushSubscriptionSetIdentifier& subscriptionSetIdentifier, bool enabled)
+    {
+        bool done = false;
+        bool result = false;
+
+        db->setPushesEnabled(subscriptionSetIdentifier, enabled, [&done, &result](bool recordsChanged) {
+            result = recordsChanged;
+            done = true;
+        });
+        Util::run(&done);
+
+        return result;
+    }
+
     bool setPushesEnabledForOrigin(const PushSubscriptionSetIdentifier& subscriptionSetIdentifier, const String& securityOrigin, bool enabled)
     {
         bool done = false;
@@ -407,6 +482,7 @@ public:
         ASSERT_TRUE(insertResult5 = insertRecord(record5));
         ASSERT_TRUE(insertResult6 = insertRecord(record6));
         ASSERT_TRUE(insertResult7 = insertRecord(record7));
+
     }
 };
 
@@ -435,6 +511,7 @@ TEST_F(PushDatabaseTest, UpdatePublicToken)
     auto updateResult3 = updatePublicToken(modifiedToken);
     EXPECT_EQ(updateResult3, PushDatabase::PublicTokenChanged::Yes);
     EXPECT_TRUE(getRowIdentifiers().isEmpty());
+    EXPECT_TRUE(getPushSubscriptionSets().isEmpty());
 
     auto getResult3 = getPublicToken();
     EXPECT_EQ(getResult3, modifiedToken);
@@ -470,6 +547,8 @@ TEST_F(PushDatabaseTest, InsertRecord)
     expectedRecord7.identifier = ObjectIdentifier<PushSubscriptionIdentifierType>(7);
     EXPECT_TRUE(expectedRecord7 == *insertResult7);
 
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
     // Inserting a record with the same (subscriptionSetIdentifier, scope) as record 1 should fail.
     PushRecord record8 = record1;
     record8.topic = "topic8"_s;
@@ -480,7 +559,7 @@ TEST_F(PushDatabaseTest, InsertRecord)
     record9.subscriptionSetIdentifier.dataStoreIdentifier = WTF::UUID::createVersion4Weak();
     record9.topic = "topic9"_s;
     EXPECT_TRUE(insertRecord(WTFMove(record9)));
-    
+
     // Inserting a record that has a different pushPartition should succeed.
     PushRecord record10 = record1;
     record10.subscriptionSetIdentifier.pushPartition = "foobar"_s;
@@ -488,6 +567,10 @@ TEST_F(PushDatabaseTest, InsertRecord)
     EXPECT_TRUE(insertRecord(WTFMove(record10)));
 
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
+
+    expectedSubscriptionSets.append({ record9.subscriptionSetIdentifier, record9.securityOrigin, true });
+    expectedSubscriptionSets.append({ record10.subscriptionSetIdentifier, record10.securityOrigin, true });
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
 }
 
 TEST_F(PushDatabaseTest, RemoveRecord)
@@ -495,6 +578,10 @@ TEST_F(PushDatabaseTest, RemoveRecord)
     EXPECT_TRUE(removeRecordByRowIdentifier(1));
     EXPECT_FALSE(removeRecordByRowIdentifier(1));
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 2, 3, 4, 5, 6, 7 }));
+
+    auto removeResult = expectedSubscriptionSets.removeFirst(PushSubscriptionSetRecord { record1.subscriptionSetIdentifier, record1.securityOrigin, true });
+    EXPECT_TRUE(removeResult);
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
 }
 
 TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSet)
@@ -505,14 +592,14 @@ TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSet)
     EXPECT_EQ(getTopicsFromRecords(removedRecords), expected);
     EXPECT_EQ(removedRecords.size(), 3u);
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 5, 6, 7 }));
-    
+
     // record5 and record6 have the same subscriptionSetIdentifier.
     removedRecords = removeRecordsBySubscriptionSet(record5.subscriptionSetIdentifier);
     expected = HashSet<String> { record5.topic, record6.topic };
     EXPECT_EQ(getTopicsFromRecords(removedRecords), expected);
     EXPECT_EQ(removedRecords.size(), 2u);
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 7 }));
-    
+
     // record7 has its own subscriptionSetIdentifier.
     removedRecords = removeRecordsBySubscriptionSet(record7.subscriptionSetIdentifier);
     expected = HashSet<String> { record7.topic };
@@ -521,11 +608,17 @@ TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSet)
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1 }));
 
     // Inserting a new record should produce a new identifier.
-    PushRecord record5 = record3;
-    auto insertResult = insertRecord(WTFMove(record5));
+    PushRecord record8 = record3;
+    auto insertResult = insertRecord(WTFMove(record8));
     EXPECT_TRUE(insertResult);
     EXPECT_EQ(insertResult->identifier, ObjectIdentifier<PushSubscriptionIdentifierType>(8));
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 8 }));
+
+    Vector<PushSubscriptionSetRecord> expectedSubscriptionSets {
+        { record1.subscriptionSetIdentifier, record1.securityOrigin, true },
+        { record8.subscriptionSetIdentifier, record8.securityOrigin, true }
+    };
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
 }
 
 TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSetAndSecurityOrigin)
@@ -536,14 +629,14 @@ TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSetAndSecurityOrigin)
     EXPECT_EQ(getTopicsFromRecords(removedRecords), expected);
     EXPECT_EQ(removedRecords.size(), 2u);
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 5, 6, 7 }));
-    
-    // record6 has a distinct subscriptionSetIdentifier.
+
+    // record5 and record6 have the same subscriptionSetIdentifier.
     removedRecords = removeRecordsBySubscriptionSetAndSecurityOrigin(record6.subscriptionSetIdentifier, record6.securityOrigin);
     expected = HashSet<String> { record6.topic };
     EXPECT_EQ(getTopicsFromRecords(removedRecords), expected);
     EXPECT_EQ(removedRecords.size(), 1u);
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 5, 7 }));
-    
+
     // record7 has a distinct subscriptionSetIdentifier.
     removedRecords = removeRecordsBySubscriptionSetAndSecurityOrigin(record7.subscriptionSetIdentifier, record7.securityOrigin);
     expected = HashSet<String> { record7.topic };
@@ -557,6 +650,14 @@ TEST_F(PushDatabaseTest, RemoveRecordsBySubscriptionSetAndSecurityOrigin)
     EXPECT_TRUE(insertResult);
     EXPECT_EQ(insertResult->identifier, ObjectIdentifier<PushSubscriptionIdentifierType>(8));
     EXPECT_EQ(getRowIdentifiers(), (HashSet<uint64_t> { 1, 2, 5, 8 }));
+
+    Vector<PushSubscriptionSetRecord> expectedSubscriptionSets {
+        { record1.subscriptionSetIdentifier, record1.securityOrigin, true },
+        { record2.subscriptionSetIdentifier, record2.securityOrigin, true },
+        { record5.subscriptionSetIdentifier, record5.securityOrigin, true },
+        { record8.subscriptionSetIdentifier, record8.securityOrigin, true }
+    };
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
 }
 
 TEST_F(PushDatabaseTest, GetRecordByTopic)
@@ -629,6 +730,59 @@ TEST_F(PushDatabaseTest, IncrementSilentPushCount)
     EXPECT_EQ(count, 0u);
 }
 
+TEST_F(PushDatabaseTest, SetPushesEnabled)
+{
+    // topic2, topic3, topic4 have the same subscription set identifier.
+    bool result = setPushesEnabled(record3.subscriptionSetIdentifier, false);
+    EXPECT_TRUE(result);
+
+    auto topics = getTopics();
+    auto expectedTopics = PushTopics { { "topic1"_s, "topic5"_s, "topic6"_s, "topic7"_s }, { "topic2"_s, "topic3"_s, "topic4"_s } };
+    EXPECT_EQ(topics, expectedTopics);
+
+    expectedSubscriptionSets.at(1).enabled = false;
+    expectedSubscriptionSets.at(2).enabled = false;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
+    result = setPushesEnabled(record3.subscriptionSetIdentifier, true);
+    EXPECT_TRUE(result);
+
+    topics = getTopics();
+    expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic3"_s, "topic4"_s, "topic5"_s, "topic6"_s, "topic7"_s }, { } };
+    EXPECT_EQ(topics, expectedTopics);
+
+    expectedSubscriptionSets.at(1).enabled = true;
+    expectedSubscriptionSets.at(2).enabled = true;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
+    // topic7 has a distinct subscriptionSetIdentifier.
+    result = setPushesEnabled(record7.subscriptionSetIdentifier, false);
+    EXPECT_TRUE(result);
+
+    topics = getTopics();
+    expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic3"_s, "topic4"_s, "topic5"_s, "topic6"_s }, { "topic7"_s } };
+    EXPECT_EQ(topics, expectedTopics);
+
+    expectedSubscriptionSets.at(5).enabled = false;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
+    result = setPushesEnabledForOrigin(record7.subscriptionSetIdentifier, record7.securityOrigin, true);
+    EXPECT_TRUE(result);
+
+    topics = getTopics();
+    expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic3"_s, "topic4"_s, "topic5"_s, "topic6"_s, "topic7"_s }, { } };
+    EXPECT_EQ(topics, expectedTopics);
+
+    expectedSubscriptionSets.at(5).enabled = true;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
+    result = setPushesEnabledForOrigin(PushSubscriptionSetIdentifier { "foobar"_s, emptyString(), std::nullopt }, "https://www.apple.com"_s, false);
+    EXPECT_FALSE(result);
+
+    EXPECT_EQ(topics, expectedTopics);
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+}
+
 TEST_F(PushDatabaseTest, SetPushesEnabledForOrigin)
 {
     // topic3 and topic4 both have the same subscriptionSetIdentifier and origin.
@@ -639,12 +793,18 @@ TEST_F(PushDatabaseTest, SetPushesEnabledForOrigin)
     auto expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic5"_s, "topic6"_s, "topic7"_s }, { "topic3"_s, "topic4"_s } };
     EXPECT_EQ(topics, expectedTopics);
 
+    expectedSubscriptionSets.at(2).enabled = false;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
     result = setPushesEnabledForOrigin(record3.subscriptionSetIdentifier, record3.securityOrigin, true);
     EXPECT_TRUE(result);
 
     topics = getTopics();
     expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic3"_s, "topic4"_s, "topic5"_s, "topic6"_s, "topic7"_s }, { } };
     EXPECT_EQ(topics, expectedTopics);
+
+    expectedSubscriptionSets.at(2).enabled = true;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
 
     // topic7 has a distinct subscriptionSetIdentifier and origin.
     result = setPushesEnabledForOrigin(record7.subscriptionSetIdentifier, record7.securityOrigin, false);
@@ -654,6 +814,9 @@ TEST_F(PushDatabaseTest, SetPushesEnabledForOrigin)
     expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic3"_s, "topic4"_s, "topic5"_s, "topic6"_s }, { "topic7"_s } };
     EXPECT_EQ(topics, expectedTopics);
 
+    expectedSubscriptionSets.at(5).enabled = false;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
     result = setPushesEnabledForOrigin(record7.subscriptionSetIdentifier, record7.securityOrigin, true);
     EXPECT_TRUE(result);
 
@@ -661,8 +824,14 @@ TEST_F(PushDatabaseTest, SetPushesEnabledForOrigin)
     expectedTopics = PushTopics { { "topic1"_s, "topic2"_s, "topic3"_s, "topic4"_s, "topic5"_s, "topic6"_s, "topic7"_s }, { } };
     EXPECT_EQ(topics, expectedTopics);
 
+    expectedSubscriptionSets.at(5).enabled = true;
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
+
     result = setPushesEnabledForOrigin(PushSubscriptionSetIdentifier { "foobar"_s, emptyString(), std::nullopt }, "https://www.apple.com"_s, false);
     EXPECT_FALSE(result);
+
+    EXPECT_EQ(topics, expectedTopics);
+    EXPECT_EQ(getPushSubscriptionSets(), expectedSubscriptionSets);
 }
 
 TEST(PushDatabase, ManyInFlightOps)


### PR DESCRIPTION
#### 5f2a2afa9207ac4f567654e640d5edae3059c984
<pre>
Remove subscriptions associated with uninstalled web clips at webpushd startup time
<a href="https://bugs.webkit.org/show_bug.cgi?id=277993">https://bugs.webkit.org/show_bug.cgi?id=277993</a>
<a href="https://rdar.apple.com/133725266">rdar://133725266</a>

Reviewed by Brady Eidson.

On iOS, every web push subscription must be associated with a web clip. Enforce this with a check at
startup time by making sure that each subscription is associated with a web clip identifier, and
remove any subscriptions that are no longer associated with a web clip identifier.

The main logic changed here is in PushService::create. This now calls updateSubscriptionSetState,
which is what intersects the list of web clips with the list of push subscriptions, cleaning up as
necessary.

I also changed both PushService and PushServiceRequest so that we can make weak pointers out of them
and had various lambdas that capture those objects use weak pointers as necessary. This isn&apos;t
actually necessary because PushService is constructed and never destructed by the WebPushDaemon
singleton. But I think it makes it easier to review PushService code in isolation.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushSubscriptionSetRecord::isolatedCopy const):
(WebCore::PushSubscriptionSetRecord::isolatedCopy):
(WebCore::PushDatabase::getTopics):
(WebCore::PushDatabase::getPushSubscriptionSetRecords):
(WebCore::PushDatabase::setPushesEnabled):
(WebCore::PushDatabase::setPushesEnabledForOrigin):
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::create):
(WebPushD::PushService::PushService):
(WebPushD::GetSubscriptionRequest::startInternal):
(WebPushD::SubscribeRequest::startImpl):
(WebPushD::SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError):
(WebPushD::UnsubscribeRequest::startInternal):
(WebPushD::PushService::incrementSilentPushCount):
(WebPushD::PushService::setPushesEnabledForSubscriptionSetAndOrigin):
(WebPushD::PushService::removeRecordsImpl):
(WebPushD::PushService::updateSubscriptionSetState):
(WebPushD::PushService::updateTopicLists):
(WebPushD::PushService::didReceivePublicToken):
(WebPushD::PushService::didReceivePushMessage):
(WebPushD::updateTopicLists): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(WebCore::operator==):
(TestWebKitAPI::getPushSubscriptionSetsSync):
(TestWebKitAPI::PushDatabaseTest::getPushSubscriptionSets):
(TestWebKitAPI::PushDatabaseTest::setPushesEnabled):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/282260@main">https://commits.webkit.org/282260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c943bec03c464240c9a71ec9c069cd62bcd4600d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62613 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39003 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35725 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12093 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6559 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58024 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13898 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5473 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->