### PR TITLE
REGRESSION(282017@main): [ iOS, visionOS ] fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.html is a constant text failure

### DIFF
--- a/LayoutTests/fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields-expected.txt
+++ b/LayoutTests/fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields-expected.txt
@@ -22,6 +22,9 @@ PASS: movementY is correct.
 pointermove fired.
 PASS: movementX is correct.
 PASS: movementY is correct.
+pointermove fired.
+PASS: movementX is correct.
+PASS: movementY is correct.
 pointerup fired.
 PASS: movementX is correct.
 PASS: movementY is correct.


### PR DESCRIPTION
#### bdce95d0568785f26cff355d2e1b89df71662634
<pre>
REGRESSION(282017@main): [ iOS, visionOS ] fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=277994">https://bugs.webkit.org/show_bug.cgi?id=277994</a>
<a href="https://rdar.apple.com/133726249">rdar://133726249</a>

Unreviewed test expectation gardening.

We&apos;ve progressed this test in 282017@main, but failed to update the test
expectations earlier since it only runs in internal test queues.

* LayoutTests/fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields-expected.txt:

Canonical link: <a href="https://commits.webkit.org/282153@main">https://commits.webkit.org/282153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7006eeb1f0c3a76e6e6a13f198ea69891f76a89b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12830 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13170 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53943 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/30968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11761 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6228 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53936 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5151 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9374 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->