### PR TITLE
[CSS]  Allow {} only as whole value of a property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/var-with-blocks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/var-with-blocks-expected.txt
@@ -2,10 +2,10 @@
 PASS Plain var()
 PASS Whole-value block with var()
 PASS Whole-value block with var() (spaces)
-FAIL Trailing block, leading var() assert_equals: expected "rgb(2, 2, 2)" but got "var(--x) { }"
-FAIL Leading block, trailing var() assert_equals: expected "rgb(2, 2, 2)" but got "{ } var(--x)"
-FAIL In-block var() with trailing token assert_equals: expected "rgb(2, 2, 2)" but got "{ var(--x) } A"
-FAIL In-block var() with leading token assert_equals: expected "rgb(2, 2, 2)" but got "A { var(--x) }"
+PASS Trailing block, leading var()
+PASS Leading block, trailing var()
+PASS In-block var() with trailing token
+PASS In-block var() with leading token
 PASS Plain var() (custom property)
 PASS Whole-value block with var() (custom property)
 PASS Whole-value block with var() (spaces, custom property)

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -35,6 +35,7 @@
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParser.h"
+#include "CSSTokenizer.h"
 
 namespace WebCore {
 
@@ -54,9 +55,22 @@ static bool isValidConstantName(const CSSParserToken& token)
 static bool isValidVariableReference(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidConstantReference(CSSParserTokenRange, const CSSParserContext&);
 
-static bool classifyBlock(CSSParserTokenRange range, bool& hasReferences, const CSSParserContext& parserContext, bool isTopLevelBlock = true)
+static bool classifyBlock(CSSParserTokenRange range, bool& hasReferences, bool& hasTopLevelBraceBlockMixedWithOtherValues, const CSSParserContext& parserContext, bool isTopLevelBlock = true)
 {
+    unsigned topLevelBraceBlocks = 0;
+    bool hasOtherValuesThanTopLevelBraceBlock = false;
+
     while (!range.atEnd()) {
+        if (isTopLevelBlock) {
+            auto tokenType = range.peek().type();
+            if (!CSSTokenizer::isWhitespace(tokenType)) {
+                if (tokenType == LeftBraceToken)
+                    topLevelBraceBlocks++;
+                else
+                    hasOtherValuesThanTopLevelBraceBlock = true;
+            }
+        }
+
         if (range.peek().getBlockType() == CSSParserToken::BlockStart) {
             const CSSParserToken& token = range.peek();
             CSSParserTokenRange block = range.consumeBlock();
@@ -72,7 +86,7 @@ static bool classifyBlock(CSSParserTokenRange range, bool& hasReferences, const 
                 hasReferences = true;
                 continue;
             }
-            if (!classifyBlock(block, hasReferences, parserContext, false))
+            if (!classifyBlock(block, hasReferences, hasTopLevelBraceBlockMixedWithOtherValues, parserContext, false))
                 return false;
             continue;
         }
@@ -102,6 +116,11 @@ static bool classifyBlock(CSSParserTokenRange range, bool& hasReferences, const 
             break;
         }
     }
+
+    // If there is a top level brace block, the value should contains only that.
+    if (topLevelBraceBlocks > 1 || (topLevelBraceBlocks == 1 && hasOtherValuesThanTopLevelBraceBlock))
+        hasTopLevelBraceBlockMixedWithOtherValues = true;
+
     return true;
 }
 
@@ -119,7 +138,8 @@ bool isValidVariableReference(CSSParserTokenRange range, const CSSParserContext&
         return true;
 
     bool hasReferences = false;
-    return classifyBlock(range, hasReferences, parserContext);
+    bool hasTopLevelBraceBlock = false;
+    return classifyBlock(range, hasReferences, hasTopLevelBraceBlock, parserContext);
 }
 
 bool isValidConstantReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
@@ -136,25 +156,31 @@ bool isValidConstantReference(CSSParserTokenRange range, const CSSParserContext&
         return true;
 
     bool hasReferences = false;
-    return classifyBlock(range, hasReferences, parserContext);
+    bool hasTopLevelBraceBlock = false;
+    return classifyBlock(range, hasReferences, hasTopLevelBraceBlock, parserContext);
 }
 
 struct VariableType {
     std::optional<CSSValueID> cssWideKeyword { };
     bool hasReferences { false };
+    bool hasTopLevelBraceBlockWithOtherValues { false };
 };
 
 static std::optional<VariableType> classifyVariableRange(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     range.consumeWhitespace();
+
     if (range.peek().type() == IdentToken) {
+        auto rangeCopy = range;
         CSSValueID id = range.consumeIncludingWhitespace().id();
         if (range.atEnd() && isCSSWideKeyword(id))
             return VariableType { id };
+        // No fast path, restart with the complete range.
+        range = rangeCopy;
     }
 
     VariableType type;
-    if (!classifyBlock(range, type.hasReferences, parserContext))
+    if (!classifyBlock(range, type.hasReferences, type.hasTopLevelBraceBlockWithOtherValues, parserContext))
         return { };
 
     return type;
@@ -163,7 +189,10 @@ static std::optional<VariableType> classifyVariableRange(CSSParserTokenRange ran
 bool CSSVariableParser::containsValidVariableReferences(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     auto type = classifyVariableRange(range, parserContext);
-    return type && type->hasReferences;
+    if (!type)
+        return false;
+
+    return type->hasReferences && !type->hasTopLevelBraceBlockWithOtherValues;
 }
 
 RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext)


### PR DESCRIPTION
#### 321f676e35e6f1c729b0aeb26f866fafca2e6b2e
<pre>
[CSS]  Allow {} only as whole value of a property
<a href="https://bugs.webkit.org/show_bug.cgi?id=276825">https://bugs.webkit.org/show_bug.cgi?id=276825</a>
<a href="https://rdar.apple.com/132102189">rdar://132102189</a>

Reviewed by Antti Koivisto.

<a href="https://github.com/w3c/csswg-drafts/commit/77e96017716572ffdc84da087fc10c9929a0d54e">https://github.com/w3c/csswg-drafts/commit/77e96017716572ffdc84da087fc10c9929a0d54e</a>

This only applies to regular properties. Custom properties
can still include whatever.

* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/var-with-blocks-expected.txt:
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::classifyBlock):
(WebCore::isValidVariableReference):
(WebCore::isValidConstantReference):
(WebCore::classifyVariableRange):
(WebCore::CSSVariableParser::containsValidVariableReferences):

Canonical link: <a href="https://commits.webkit.org/282382@main">https://commits.webkit.org/282382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3770ec1831280279b9a4b6c3ab22f45ac8e779d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66997 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50764 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9373 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11878 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68692 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58080 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58284 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5773 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38152 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->