### PR TITLE
[Writing Tools] Remove unnecessary infrastructure to support concurrent Writing Tools sessions

### DIFF
--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -127,7 +127,6 @@ public:
 
         String originalText;
         WritingTools::TextSuggestionID suggestionID;
-        WritingTools::SessionID sessionID;
         State state { State::Accepted };
     };
 #endif

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -674,23 +674,23 @@ public:
     virtual double baseViewportLayoutSizeScaleFactor() const { return 1; }
 
 #if ENABLE(WRITING_TOOLS)
-    virtual void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WritingTools::SessionID&, const WritingTools::TextSuggestionID&, IntRect) { }
+    virtual void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WritingTools::TextSuggestionID&, IntRect) { }
 
-    virtual void proofreadingSessionUpdateStateForSuggestionWithID(const WritingTools::SessionID&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestionID&) { }
+    virtual void proofreadingSessionUpdateStateForSuggestionWithID(WritingTools::TextSuggestionState, const WritingTools::TextSuggestionID&) { }
 
     virtual void removeTextAnimationForAnimationID(const WTF::UUID&) { }
 
-    virtual void removeTransparentMarkersForSessionID(const WritingTools::SessionID&) { }
+    virtual void removeTransparentMarkersForActiveWritingToolsSession() { }
 
-    virtual void removeInitialTextAnimation(const WritingTools::SessionID&) { }
+    virtual void removeInitialTextAnimationForActiveWritingToolsSession() { }
 
-    virtual void addInitialTextAnimation(const WritingTools::SessionID&) { }
+    virtual void addInitialTextAnimationForActiveWritingToolsSession() { }
 
-    virtual void addSourceTextAnimation(const WritingTools::SessionID&, const CharacterRange&, const String&, CompletionHandler<void(TextAnimationRunMode)>&&) { }
+    virtual void addSourceTextAnimationForActiveWritingToolsSession(const CharacterRange&, const String&, CompletionHandler<void(TextAnimationRunMode)>&&) { }
 
-    virtual void addDestinationTextAnimation(const WritingTools::SessionID&, const std::optional<CharacterRange>&, const String&) { }
+    virtual void addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<CharacterRange>&, const String&) { }
 
-    virtual void clearAnimationsForSessionID(const WritingTools::SessionID&) { };
+    virtual void clearAnimationsForActiveWritingToolsSession() { };
 #endif
 
     virtual void hasActiveNowPlayingSessionChanged(bool) { }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4946,6 +4946,11 @@ void Page::compositionSessionDidReceiveTextWithReplacementRange(const WritingToo
     m_writingToolsController->compositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
 }
 
+void Page::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WritingTools::Action action)
+{
+    m_writingToolsController->writingToolsSessionDidReceiveAction(session, action);
+}
+
 void Page::updateStateForSelectedSuggestionIfNeeded()
 {
     m_writingToolsController->updateStateForSelectedSuggestionIfNeeded();
@@ -4961,19 +4966,14 @@ void Page::respondToReappliedWritingToolsEditing(EditCommandComposition* command
     m_writingToolsController->respondToReappliedEditing(command);
 }
 
-std::optional<SimpleRange> Page::contextRangeForSessionWithID(const WritingTools::Session::ID& sessionID) const
+std::optional<SimpleRange> Page::contextRangeForActiveWritingToolsSession() const
 {
-    return m_writingToolsController->contextRangeForSessionWithID(sessionID);
+    return m_writingToolsController->activeSessionRange();
 }
 
-void Page::showSelectionForWritingToolsSessionWithID(const WritingTools::Session::ID& sessionID) const
+void Page::showSelectionForActiveWritingToolsSession() const
 {
-    return m_writingToolsController->showSelectionForWritingToolsSessionWithID(sessionID);
-}
-
-void Page::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WritingTools::Action action)
-{
-    m_writingToolsController->writingToolsSessionDidReceiveAction(session, action);
+    return m_writingToolsController->showSelection();
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1184,8 +1184,8 @@ public:
     void respondToUnappliedWritingToolsEditing(EditCommandComposition*);
     void respondToReappliedWritingToolsEditing(EditCommandComposition*);
 
-    WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::SessionID&) const;
-    WEBCORE_EXPORT void showSelectionForWritingToolsSessionWithID(const WritingTools::SessionID&) const;
+    WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForActiveWritingToolsSession() const;
+    WEBCORE_EXPORT void showSelectionForActiveWritingToolsSession() const;
 #endif
 
     bool hasActiveNowPlayingSession() const { return m_hasActiveNowPlayingSession; }

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -77,23 +77,25 @@ public:
 
     // FIXME: Refactor `TextAnimationController` in such a way so as to not explicitly depend on `WritingToolsController`,
     // and then remove these methods after doing so.
-    std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::Session::ID&) const;
-    void showSelectionForWritingToolsSessionWithID(const WritingTools::Session::ID&) const;
+    std::optional<SimpleRange> activeSessionRange() const;
+    void showSelection() const;
 
 private:
     struct CompositionState : CanMakeCheckedPtr<CompositionState> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(CompositionState);
 
-        CompositionState(const Vector<Ref<WritingToolsCompositionCommand>>& unappliedCommands, const Vector<Ref<WritingToolsCompositionCommand>>& reappliedCommands)
+        CompositionState(const Vector<Ref<WritingToolsCompositionCommand>>& unappliedCommands, const Vector<Ref<WritingToolsCompositionCommand>>& reappliedCommands, const WritingTools::Session& session)
             : unappliedCommands(unappliedCommands)
             , reappliedCommands(reappliedCommands)
+            , session(session)
         {
         }
 
         // These two vectors should never have the same command in both of them.
         Vector<Ref<WritingToolsCompositionCommand>> unappliedCommands;
         Vector<Ref<WritingToolsCompositionCommand>> reappliedCommands;
+        WritingTools::Session session;
         std::optional<SimpleRange> currentRange;
     };
 
@@ -101,13 +103,15 @@ private:
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProofreadingState);
 
-        ProofreadingState(const Ref<Range>& contextRange, int replacementLocationOffset)
+        ProofreadingState(const Ref<Range>& contextRange, const WritingTools::Session& session, int replacementLocationOffset)
             : contextRange(contextRange)
+            , session(session)
             , replacementLocationOffset(replacementLocationOffset)
         {
         }
 
         Ref<Range> contextRange;
+        WritingTools::Session session;
         int replacementLocationOffset { 0 };
     };
 
@@ -141,7 +145,7 @@ private:
     static String plainText(const SimpleRange&);
 
     template<WritingTools::Session::Type Type>
-    StateFromSessionType<Type>::Value* stateForSession(const WritingTools::Session&);
+    StateFromSessionType<Type>::Value* currentState();
 
     std::optional<std::tuple<Node&, DocumentMarker&>> findTextSuggestionMarkerContainingRange(const SimpleRange&) const;
     std::optional<std::tuple<Node&, DocumentMarker&>> findTextSuggestionMarkerByID(const SimpleRange& outerRange, const WritingTools::TextSuggestion::ID&) const;
@@ -149,26 +153,26 @@ private:
     void replaceContentsOfRangeInSession(ProofreadingState&, const SimpleRange&, const String&);
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, const AttributedString&, WritingToolsCompositionCommand::State);
 
-    void compositionSessionDidFinishReplacement(const WritingTools::Session&);
-    void compositionSessionDidFinishReplacement(const WritingTools::Session&, const CharacterRange&, const String&);
+    void compositionSessionDidFinishReplacement();
+    void compositionSessionDidFinishReplacement(const CharacterRange&, const String&);
 
-    void compositionSessionDidReceiveTextWithReplacementRangeAsync(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
+    void compositionSessionDidReceiveTextWithReplacementRangeAsync(const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
 
-    void showOriginalCompositionForSession(const WritingTools::Session&);
-    void showRewrittenCompositionForSession(const WritingTools::Session&);
-    void restartCompositionForSession(const WritingTools::Session&);
-
-    template<WritingTools::Session::Type Type>
-    void writingToolsSessionDidReceiveAction(const WritingTools::Session&, WritingTools::Action);
+    void showOriginalCompositionForSession();
+    void showRewrittenCompositionForSession();
+    void restartCompositionForSession();
 
     template<WritingTools::Session::Type Type>
-    void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
+    void writingToolsSessionDidReceiveAction(WritingTools::Action);
+
+    template<WritingTools::Session::Type Type>
+    void didEndWritingToolsSession(bool accepted);
 
     RefPtr<Document> document() const;
 
     SingleThreadWeakPtr<Page> m_page;
 
-    HashMap<WritingTools::Session::ID, std::variant<std::monostate, ProofreadingState, CompositionState>> m_states;
+    std::variant<std::monostate, ProofreadingState, CompositionState> m_state;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -445,7 +445,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    _writingToolsSessions = [NSMapTable strongToWeakObjectsMapTable];
+    _activeWritingToolsSession = nil;
     _writingToolsTextSuggestions = [NSMapTable strongToWeakObjectsMapTable];
 #endif
 }
@@ -2141,7 +2141,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     auto webSession = WebKit::convertToWebSession(session);
 
     if (session) {
-        [_writingToolsSessions setObject:session forKey:session.uuid];
+        _activeWritingToolsSession = session;
         _page->setWritingToolsActive(true);
     }
 
@@ -2246,7 +2246,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
         return;
     }
 
-    [_writingToolsSessions removeObjectForKey:session.uuid];
+    _activeWritingToolsSession = nil;
     [_writingToolsTextSuggestions removeAllObjects];
 
     _page->setWritingToolsActive(false);
@@ -2298,13 +2298,12 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
 #pragma mark - WTTextViewDelegate invoking methods
 
-- (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID showDetailsForSuggestionWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect
+- (void)_proofreadingSessionShowDetailsForSuggestionWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect
 {
-    WTSession *session = [_writingToolsSessions objectForKey:sessionUUID];
-    if (!session)
+    if (!_activeWritingToolsSession)
         return;
 
-    auto textViewDelegate = (NSObject<WTTextViewDelegate> *)session.textViewDelegate;
+    auto textViewDelegate = (NSObject<WTTextViewDelegate> *)[_activeWritingToolsSession textViewDelegate];
 
     if (![textViewDelegate respondsToSelector:@selector(proofreadingSessionWithUUID:showDetailsForSuggestionWithUUID:relativeToRect:inView:)])
         return;
@@ -2315,21 +2314,20 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     RetainPtr view = _contentView;
 #endif
 
-    [textViewDelegate proofreadingSessionWithUUID:session.uuid showDetailsForSuggestionWithUUID:replacementUUID relativeToRect:rect inView:view.get()];
+    [textViewDelegate proofreadingSessionWithUUID:[_activeWritingToolsSession uuid] showDetailsForSuggestionWithUUID:replacementUUID relativeToRect:rect inView:view.get()];
 }
 
-- (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID updateState:(WebCore::WritingTools::TextSuggestion::State)state forSuggestionWithUUID:(NSUUID *)replacementUUID
+- (void)_proofreadingSessionUpdateState:(WebCore::WritingTools::TextSuggestion::State)state forSuggestionWithUUID:(NSUUID *)replacementUUID
 {
-    WTSession *session = [_writingToolsSessions objectForKey:sessionUUID];
-    if (!session)
+    if (!_activeWritingToolsSession)
         return;
 
-    auto textViewDelegate = (NSObject<WTTextViewDelegate> *)session.textViewDelegate;
+    auto textViewDelegate = (NSObject<WTTextViewDelegate> *)[_activeWritingToolsSession textViewDelegate];
 
     if (![textViewDelegate respondsToSelector:@selector(proofreadingSessionWithUUID:updateState:forSuggestionWithUUID:)])
         return;
 
-    [textViewDelegate proofreadingSessionWithUUID:session.uuid updateState:WebKit::convertToPlatformTextSuggestionState(state) forSuggestionWithUUID:replacementUUID];
+    [textViewDelegate proofreadingSessionWithUUID:[_activeWritingToolsSession uuid] updateState:WebKit::convertToPlatformTextSuggestionState(state) forSuggestionWithUUID:replacementUUID];
 }
 
 #endif
@@ -3169,7 +3167,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
         return nil;
 
 #if ENABLE(WRITING_TOOLS_UI)
-    _page->enableSourceTextAnimationAfterElementWithID(elementID, *uuid);
+    _page->enableSourceTextAnimationAfterElementWithID(elementID);
 
 #if PLATFORM(IOS_FAMILY)
     [_contentView addTextAnimationForAnimationID:nsUUID.get() withStyleType:WKTextAnimationTypeInitial];
@@ -3191,7 +3189,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
         return nil;
 
 #if ENABLE(WRITING_TOOLS_UI)
-    _page->enableTextAnimationTypeForElementWithID(elementID, *uuid);
+    _page->enableTextAnimationTypeForElementWithID(elementID);
 
 #if PLATFORM(IOS_FAMILY)
     [_contentView addTextAnimationForAnimationID:nsUUID.get() withStyleType:WKTextAnimationTypeFinal];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -249,7 +249,7 @@ struct PerWebProcessState {
 
 #if ENABLE(WRITING_TOOLS)
     RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _writingToolsTextSuggestions;
-    RetainPtr<NSMapTable<NSUUID *, WTSession *>> _writingToolsSessions;
+    RetainPtr<WTSession> _activeWritingToolsSession;
 #endif
 
 #if PLATFORM(MAC)
@@ -407,9 +407,9 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-- (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID showDetailsForSuggestionWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect;
+- (void)_proofreadingSessionShowDetailsForSuggestionWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect;
 
-- (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID updateState:(WebCore::WritingTools::TextSuggestionState)state forSuggestionWithUUID:(NSUUID *)replacementUUID;
+- (void)_proofreadingSessionUpdateState:(WebCore::WritingTools::TextSuggestionState)state forSuggestionWithUUID:(NSUUID *)replacementUUID;
 
 #if PLATFORM(MAC)
 // FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -120,9 +120,9 @@ public:
     WindowKind windowKind() final;
 
 #if ENABLE(WRITING_TOOLS)
-    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
 
-    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WTF::UUID& replacementUUID) final;
+    void proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestionState, const WTF::UUID& replacementUUID) final;
 
     void writingToolsActiveWillChange() final;
     void writingToolsActiveDidChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -293,14 +293,14 @@ WindowKind PageClientImplCocoa::windowKind()
 }
 
 #if ENABLE(WRITING_TOOLS)
-void PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    [m_webView _proofreadingSessionWithUUID:sessionID showDetailsForSuggestionWithUUID:replacementID relativeToRect:selectionBoundsInRootView];
+    [m_webView _proofreadingSessionShowDetailsForSuggestionWithUUID:replacementID relativeToRect:selectionBoundsInRootView];
 }
 
-void PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    [m_webView _proofreadingSessionWithUUID:sessionID updateState:state forSuggestionWithUUID:replacementID];
+    [m_webView _proofreadingSessionUpdateState:state forSuggestionWithUUID:replacementID];
 }
 
 static NSString *writingToolsActiveKey = @"writingToolsActive";

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1223,20 +1223,20 @@ void WebPageProxy::writingToolsSessionDidReceiveAction(const WebCore::WritingToo
 
 #if ENABLE(WRITING_TOOLS_UI)
 
-void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID& uuid)
+void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& elementID)
 {
     if (!hasRunningProcess())
         return;
 
-    legacyMainFrameProcess().send(Messages::WebPage::EnableSourceTextAnimationAfterElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().send(Messages::WebPage::EnableSourceTextAnimationAfterElementWithID(elementID), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID& uuid)
+void WebPageProxy::enableTextAnimationTypeForElementWithID(const String& elementID)
 {
     if (!hasRunningProcess())
         return;
 
-    legacyMainFrameProcess().send(Messages::WebPage::EnableTextAnimationTypeForElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().send(Messages::WebPage::EnableTextAnimationTypeForElementWithID(elementID), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::addTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid, const WebCore::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
@@ -1288,20 +1288,12 @@ void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::U
     legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::UpdateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID& animationID)
+void WebPageProxy::showSelectionForActiveWritingToolsSession()
 {
     if (!hasRunningProcess())
         return;
 
-    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForWritingToolsSessionAssociatedWithAnimationID(animationID), webPageIDInMainFrameProcess());
-}
-
-void WebPageProxy::showSelectionForWritingToolsSessionWithID(const WebCore::WritingTools::Session::ID& sessionID)
-{
-    if (!hasRunningProcess())
-        return;
-
-    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForWritingToolsSessionWithID(sessionID), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForActiveWritingToolsSession(), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&)
@@ -1320,18 +1312,14 @@ void WebPageProxy::removeTextAnimationForAnimationID(IPC::Connection& connection
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(IPC::Connection& connection, const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(IPC::Connection& connection, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    MESSAGE_CHECK(sessionID.isValid());
-
-    protectedPageClient()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
+    protectedPageClient()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(replacementID, selectionBoundsInRootView);
 }
 
-void WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID(IPC::Connection& connection, const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID(IPC::Connection& connection, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    MESSAGE_CHECK(sessionID.isValid());
-
-    protectedPageClient()->proofreadingSessionUpdateStateForSuggestionWithID(sessionID, state, replacementID);
+    protectedPageClient()->proofreadingSessionUpdateStateForSuggestionWithID(state, replacementID);
 }
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -756,9 +756,9 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    virtual void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) = 0;
+    virtual void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) = 0;
 
-    virtual void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) = 0;
+    virtual void proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) = 0;
 
     virtual void writingToolsActiveWillChange() = 0;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2425,22 +2425,21 @@ public:
 
     bool isWritingToolsActive() const { return m_isWritingToolsActive; }
 
-    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(IPC::Connection&, const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView);
-    void proofreadingSessionUpdateStateForSuggestionWithID(IPC::Connection&, const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(IPC::Connection&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView);
+    void proofreadingSessionUpdateStateForSuggestionWithID(IPC::Connection&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)
     void addTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&, const WebCore::TextAnimationData&, const WebCore::TextIndicatorData&, WTF::CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
     void removeTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&);
-    void enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID&);
-    void enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID&);
+    void enableSourceTextAnimationAfterElementWithID(const String& elementID);
+    void enableTextAnimationTypeForElementWithID(const String& elementID);
 
     void callCompletionHandlerForAnimationID(const WTF::UUID&, WebCore::TextAnimationRunMode);
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
 
-    void showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID&);
-    void showSelectionForWritingToolsSessionWithID(const WebCore::WritingTools::SessionID&);
+    void showSelectionForActiveWritingToolsSession();
     void didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&);
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -234,9 +234,9 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(struct WebCore::WritingTools::Session::ID sessionID, struct WebCore::WritingTools::TextSuggestion::ID replacementID, WebCore::IntRect selectionBoundsInRootView)
+    ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(struct WebCore::WritingTools::TextSuggestion::ID replacementID, WebCore::IntRect selectionBoundsInRootView)
 
-    ProofreadingSessionUpdateStateForSuggestionWithID(struct WebCore::WritingTools::Session::ID sessionID, enum:uint8_t WebCore::WritingTools::TextSuggestionState state, struct WebCore::WritingTools::TextSuggestion::ID replacementID)
+    ProofreadingSessionUpdateStateForSuggestionWithID(enum:uint8_t WebCore::WritingTools::TextSuggestionState state, struct WebCore::WritingTools::TextSuggestion::ID replacementID)
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -128,7 +128,7 @@
             if (strongWebView->isIntelligenceTextPonderingAnimationFinished() && strongWebView->isWritingToolsTextReplacementsFinished()) {
                 // If the entire replacement has already been completed, and this is the end of the last animation,
                 // then reveal the selection.
-                strongWebView->page().showSelectionForWritingToolsSessionAssociatedWithAnimationID(*animationID);
+                strongWebView->page().showSelectionForActiveWritingToolsSession();
             }
 
             strongWebView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, true);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1872,14 +1872,14 @@ void WebChromeClient::gamepadsRecentlyAccessed()
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    protectedPage()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
+    protectedPage()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(replacementID, selectionBoundsInRootView);
 }
 
-void WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID(const WritingTools::Session::ID& sessionID, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion::ID& replacementID)
+void WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID(WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion::ID& replacementID)
 {
-    protectedPage()->proofreadingSessionUpdateStateForSuggestionWithID(sessionID, state, replacementID);
+    protectedPage()->proofreadingSessionUpdateStateForSuggestionWithID(state, replacementID);
 }
 
 #endif
@@ -1891,34 +1891,34 @@ void WebChromeClient::removeTextAnimationForAnimationID(const WTF::UUID& animati
     protectedPage()->removeTextAnimationForAnimationID(animationID);
 }
 
-void WebChromeClient::removeTransparentMarkersForSessionID(const WritingTools::Session::ID& sessionID)
+void WebChromeClient::removeTransparentMarkersForActiveWritingToolsSession()
 {
-    protectedPage()->removeTransparentMarkersForSessionID(sessionID);
+    protectedPage()->removeTransparentMarkersForActiveWritingToolsSession();
 }
 
-void WebChromeClient::removeInitialTextAnimation(const WritingTools::Session::ID& sessionID)
+void WebChromeClient::removeInitialTextAnimationForActiveWritingToolsSession()
 {
-    protectedPage()->removeInitialTextAnimation(sessionID);
+    protectedPage()->removeInitialTextAnimationForActiveWritingToolsSession();
 }
 
-void WebChromeClient::addInitialTextAnimation(const WritingTools::Session::ID& sessionID)
+void WebChromeClient::addInitialTextAnimationForActiveWritingToolsSession()
 {
-    protectedPage()->addInitialTextAnimation(sessionID);
+    protectedPage()->addInitialTextAnimationForActiveWritingToolsSession();
 }
 
-void WebChromeClient::addSourceTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+void WebChromeClient::addSourceTextAnimationForActiveWritingToolsSession(const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
-    protectedPage()->addSourceTextAnimation(sessionID, range, string, WTFMove(completionHandler));
+    protectedPage()->addSourceTextAnimationForActiveWritingToolsSession(range, string, WTFMove(completionHandler));
 }
 
-void WebChromeClient::addDestinationTextAnimation(const WritingTools::Session::ID& sessionID, const std::optional<CharacterRange>& range, const String& string)
+void WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<CharacterRange>& range, const String& string)
 {
-    protectedPage()->addDestinationTextAnimation(sessionID, range, string);
+    protectedPage()->addDestinationTextAnimationForActiveWritingToolsSession(range, string);
 }
 
-void WebChromeClient::clearAnimationsForSessionID(const WritingTools::Session::ID& sessionID)
+void WebChromeClient::clearAnimationsForActiveWritingToolsSession()
 {
-    protectedPage()->clearAnimationsForSessionID(sessionID);
+    protectedPage()->clearAnimationsForActiveWritingToolsSession();
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -515,26 +515,25 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
 
-    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) final;
+    void proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) final;
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
     void removeTextAnimationForAnimationID(const WTF::UUID&) final;
 
-    void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&) final;
+    void removeInitialTextAnimationForActiveWritingToolsSession() final;
 
-    void addInitialTextAnimation(const WebCore::WritingTools::SessionID&) final;
+    void addInitialTextAnimationForActiveWritingToolsSession() final;
 
-    void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&) final;
+    void removeTransparentMarkersForActiveWritingToolsSession() final;
 
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&) final;
+    void addSourceTextAnimationForActiveWritingToolsSession(const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&) final;
 
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const std::optional<WebCore::CharacterRange>&, const String&) final;
+    void addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<WebCore::CharacterRange>&, const String&) final;
 
-    void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&) final;
-
+    void clearAnimationsForActiveWritingToolsSession() final;
 #endif
 
     void hasActiveNowPlayingSessionChanged(bool) final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -43,10 +43,6 @@ struct TextIndicatorData;
 enum class TextIndicatorOption : uint16_t;
 enum class TextAnimationRunMode : uint8_t;
 
-namespace WritingTools {
-using SessionID = WTF::UUID;
-}
-
 }
 
 namespace WebKit {
@@ -75,39 +71,37 @@ class TextAnimationController final {
 public:
     explicit TextAnimationController(WebPage&);
 
-    void removeTransparentMarkersForSessionID(const WTF::UUID& sessionUUID);
+    void removeTransparentMarkersForActiveWritingToolsSession();
     void removeTransparentMarkersForTextAnimationID(const WTF::UUID&);
 
-    void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&);
-    void addInitialTextAnimation(const WebCore::WritingTools::SessionID&);
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const std::optional<WebCore::CharacterRange>&, const String&);
+    void removeInitialTextAnimationForActiveWritingToolsSession();
+    void addInitialTextAnimationForActiveWritingToolsSession();
+    void addSourceTextAnimationForActiveWritingToolsSession(const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
+    void addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<WebCore::CharacterRange>&, const String&);
 
-    void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&);
+    void clearAnimationsForActiveWritingToolsSession();
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool visible, CompletionHandler<void()>&&);
-
-    void showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID&);
 
     std::optional<WebCore::TextIndicatorData> createTextIndicatorForRange(const WebCore::SimpleRange&);
     void createTextIndicatorForTextAnimationID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
 
-    void enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID&);
-    void enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID&);
+    void enableSourceTextAnimationAfterElementWithID(const String& elementID);
+    void enableTextAnimationTypeForElementWithID(const String& elementID);
 
 private:
     std::optional<WebCore::SimpleRange> contextRangeForTextAnimationID(const WTF::UUID&) const;
-    std::optional<WebCore::SimpleRange> contextRangeForSessionWithID(const WebCore::WritingTools::SessionID&) const;
-    std::optional<WebCore::SimpleRange> unreplacedRangeForSessionWithID(const WebCore::WritingTools::SessionID&) const;
+    std::optional<WebCore::SimpleRange> contextRangeForActiveWritingToolsSession() const;
+    std::optional<WebCore::SimpleRange> unreplacedRangeForActiveWritingToolsSession() const;
 
     RefPtr<WebCore::Document> document() const;
     WeakPtr<WebPage> m_webPage;
 
-    HashMap<WebCore::WritingTools::SessionID, WTF::UUID> m_initialAnimations;
-    HashMap<WebCore::WritingTools::SessionID, Vector<TextAnimationRange>> m_textAnimationRanges;
-    HashMap<WebCore::WritingTools::SessionID, std::optional<ReplacedRangeAndString>> m_alreadyReplacedRanges;
-    HashMap<WebCore::WritingTools::SessionID, std::optional<TextAnimationUnstyledRangeData>> m_unstyledRanges;
-    HashMap<WebCore::WritingTools::SessionID, Ref<WebCore::Range>> m_manuallyEnabledAnimationRanges;
+    std::optional<WTF::UUID> m_initialAnimationID;
+    std::optional<TextAnimationUnstyledRangeData> m_unstyledRange;
+    std::optional<ReplacedRangeAndString> m_alreadyReplacedRange;
+    RefPtr<WebCore::Range> m_manuallyEnabledAnimationRange;
+    Vector<TextAnimationRange> m_textAnimationRanges;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -81,20 +81,19 @@ RefPtr<WebCore::Document> TextAnimationController::document() const
     return frame->document();
 }
 
-std::optional<WebCore::SimpleRange> TextAnimationController::unreplacedRangeForSessionWithID(const WebCore::WritingTools::Session::ID& sessionID) const
+std::optional<WebCore::SimpleRange> TextAnimationController::unreplacedRangeForActiveWritingToolsSession() const
 {
-    auto sessionRange = contextRangeForSessionWithID(sessionID);
+    auto sessionRange = contextRangeForActiveWritingToolsSession();
     if (!sessionRange) {
         ASSERT_NOT_REACHED();
         return std::nullopt;
     }
 
-    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionID);
-
+    auto previouslyReplacedRange = m_alreadyReplacedRange;
     if (!previouslyReplacedRange)
         return sessionRange;
 
-    auto replacedRange = WebCore::resolveCharacterRange(*sessionRange, (*previouslyReplacedRange)->range, defaultTextAnimationControllerTextIteratorBehaviors);
+    auto replacedRange = WebCore::resolveCharacterRange(*sessionRange, previouslyReplacedRange->range, defaultTextAnimationControllerTextIteratorBehaviors);
 
     auto remainingRange = *sessionRange;
     remainingRange.start = replacedRange.end;
@@ -103,7 +102,7 @@ std::optional<WebCore::SimpleRange> TextAnimationController::unreplacedRangeForS
 }
 
 // FIXME: This is a layering violation.
-std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForSessionWithID(const WebCore::WritingTools::Session::ID& sessionID) const
+std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForActiveWritingToolsSession() const
 {
     if (!m_webPage) {
         ASSERT_NOT_REACHED();
@@ -116,49 +115,44 @@ std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForSess
         return std::nullopt;
     }
 
-    return corePage->contextRangeForSessionWithID(sessionID);
+    return corePage->contextRangeForActiveWritingToolsSession();
 }
 
 std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForTextAnimationID(const WTF::UUID& animationUUID) const
 {
-    if (auto iterator = m_manuallyEnabledAnimationRanges.find(animationUUID); iterator != m_manuallyEnabledAnimationRanges.end())
-        return WebCore::makeSimpleRange(iterator->value.get());
+    if (RefPtr manuallyEnabledAnimationRange = m_manuallyEnabledAnimationRange; manuallyEnabledAnimationRange)
+        return WebCore::makeSimpleRange(*manuallyEnabledAnimationRange);
 
-    for (auto [sessionID, initialAnimationID] : m_initialAnimations) {
-        if (initialAnimationID == animationUUID)
-            return unreplacedRangeForSessionWithID(sessionID);
-    }
+    if (m_initialAnimationID == animationUUID)
+        return unreplacedRangeForActiveWritingToolsSession();
 
-    for (auto [sessionID, animationRanges] : m_textAnimationRanges) {
-        for (auto animationRange : animationRanges) {
-            if (animationRange.animationUUID == animationUUID) {
-                if (auto fullSessionRange = contextRangeForSessionWithID(sessionID))
-                    return WebCore::resolveCharacterRange(*fullSessionRange, animationRange.range, defaultTextAnimationControllerTextIteratorBehaviors);
-            }
+    for (auto animationRange : m_textAnimationRanges) {
+        if (animationRange.animationUUID == animationUUID) {
+            if (auto fullSessionRange = contextRangeForActiveWritingToolsSession())
+                return WebCore::resolveCharacterRange(*fullSessionRange, animationRange.range, defaultTextAnimationControllerTextIteratorBehaviors);
         }
     }
 
-    for (auto unstyledRangeData : m_unstyledRanges.values()) {
-        if (unstyledRangeData->animationUUID == animationUUID)
-            return unstyledRangeData->range;
-    }
+    if (m_unstyledRange && m_unstyledRange->animationUUID == animationUUID)
+        return m_unstyledRange->range;
 
     return std::nullopt;
 }
 
-void TextAnimationController::removeTransparentMarkersForSessionID(const WebCore::WritingTools::Session::ID& sessionID)
+void TextAnimationController::removeTransparentMarkersForActiveWritingToolsSession()
 {
-    if (auto iterator = m_initialAnimations.find(sessionID); iterator != m_initialAnimations.end())
-        removeTransparentMarkersForTextAnimationID(iterator->value);
+    if (auto initialAnimationID = m_initialAnimationID)
+        removeTransparentMarkersForTextAnimationID(*initialAnimationID);
 
-    auto animationStates = m_textAnimationRanges.take(sessionID);
-    if (animationStates.isEmpty())
+    auto textAnimationRanges = std::exchange(m_textAnimationRanges, { });
+
+    if (textAnimationRanges.isEmpty())
         return;
 
-    for (auto animationState : animationStates)
-        removeTransparentMarkersForTextAnimationID(animationState.animationUUID);
+    for (auto textAnimationRange : textAnimationRanges)
+        removeTransparentMarkersForTextAnimationID(textAnimationRange.animationUUID);
 
-    if (auto rangeData = m_unstyledRanges.get(sessionID))
+    if (auto rangeData = m_unstyledRange)
         removeTransparentMarkersForTextAnimationID(rangeData->animationUUID);
 }
 
@@ -175,10 +169,10 @@ void TextAnimationController::removeTransparentMarkersForTextAnimationID(const W
     });
 }
 
-void TextAnimationController::removeInitialTextAnimation(const WebCore::WritingTools::Session::ID& sessionID)
+void TextAnimationController::removeInitialTextAnimationForActiveWritingToolsSession()
 {
-    if (auto animationID = m_initialAnimations.take(sessionID))
-        m_webPage->removeTextAnimationForAnimationID(animationID);
+    if (auto initialAnimationID = std::exchange(m_initialAnimationID, std::nullopt))
+        m_webPage->removeTextAnimationForAnimationID(*initialAnimationID);
 }
 
 static WebCore::CharacterRange remainingCharacterRange(WebCore::CharacterRange totalRange, WebCore::CharacterRange previousRange)
@@ -192,10 +186,10 @@ static WebCore::CharacterRange remainingCharacterRange(WebCore::CharacterRange t
     return WebCore::CharacterRange { location, length };
 };
 
-void TextAnimationController::addInitialTextAnimation(const WebCore::WritingTools::Session::ID& sessionID)
+void TextAnimationController::addInitialTextAnimationForActiveWritingToolsSession()
 {
-    auto initialAnimationUUID = WTF::UUID::createVersion4();
-    auto animatingRange = unreplacedRangeForSessionWithID(sessionID);
+    auto initialAnimationID = WTF::UUID::createVersion4();
+    auto animatingRange = unreplacedRangeForActiveWritingToolsSession();
 
     if (!animatingRange || animatingRange->collapsed())
         return;
@@ -204,30 +198,31 @@ void TextAnimationController::addInitialTextAnimation(const WebCore::WritingTool
     if (!textIndicatorData)
         return;
 
-    m_webPage->addTextAnimationForAnimationID(initialAnimationUUID, { WebCore::TextAnimationType::Initial, WebCore::TextAnimationRunMode::RunAnimation, WTF::UUID(WTF::UUID::emptyValue) }, *textIndicatorData);
+    m_webPage->addTextAnimationForAnimationID(initialAnimationID, { WebCore::TextAnimationType::Initial, WebCore::TextAnimationRunMode::RunAnimation, WTF::UUID(WTF::UUID::emptyValue) }, *textIndicatorData);
 
-    m_initialAnimations.set(sessionID, initialAnimationUUID);
+    m_initialAnimationID = initialAnimationID;
 }
 
-void TextAnimationController::addSourceTextAnimation(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::CharacterRange& replacingRange, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+void TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession(const WebCore::CharacterRange& replacingRange, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
 #if PLATFORM(MAC)
-    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionID);
+    auto previouslyReplacedRange = m_alreadyReplacedRange;
     auto replaceCharacterRange = replacingRange;
 
     WebCore::TextAnimationRunMode runMode = WebCore::TextAnimationRunMode::RunAnimation;
     if (previouslyReplacedRange) {
         // If the text is the same as has been replaced before, this is the final replace, so we shouldn't
         // try and run the animation or recalculate the range for the animation.
-        if ((*previouslyReplacedRange)->range.location == replacingRange.location && (*previouslyReplacedRange)->string == string)
+        if (previouslyReplacedRange->range.location == replacingRange.location && previouslyReplacedRange->string == string)
             runMode = WebCore::TextAnimationRunMode::OnlyReplaceText;
         else
-            replaceCharacterRange = remainingCharacterRange(replacingRange, (*previouslyReplacedRange)->range);
+            replaceCharacterRange = remainingCharacterRange(replacingRange, previouslyReplacedRange->range);
     }
 
-    auto sessionRange = contextRangeForSessionWithID(sessionID);
+    auto sessionRange = contextRangeForActiveWritingToolsSession();
     if (!sessionRange) {
         ASSERT_NOT_REACHED();
+        completionHandler(WebCore::TextAnimationRunMode::RunAnimation);
         return;
     }
 
@@ -243,16 +238,11 @@ void TextAnimationController::addSourceTextAnimation(const WebCore::WritingTools
 
     m_webPage->addTextAnimationForAnimationID(sourceTextIndicatorUUID, { WebCore::TextAnimationType::Source, runMode, WTF::UUID(WTF::UUID::emptyValue) }, *textIndicatorData, WTFMove(completionHandler));
 
-    TextAnimationRange animationState = { sourceTextIndicatorUUID, replaceCharacterRange };
-    auto& animationRanges = m_textAnimationRanges.ensure(sessionID, [&] {
-        return Vector<TextAnimationRange> { };
-    }).iterator->value;
-
-    animationRanges.append(animationState);
+    m_textAnimationRanges.append({ sourceTextIndicatorUUID, replaceCharacterRange });
 #endif
 }
 
-void TextAnimationController::addDestinationTextAnimation(const WebCore::WritingTools::Session::ID& sessionID, const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
+void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
 {
     if (!characterRangeAfterReplace) {
         m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
@@ -260,7 +250,7 @@ void TextAnimationController::addDestinationTextAnimation(const WebCore::Writing
     }
 
     auto destinationTextIndicatorUUID = WTF::UUID::createVersion4();
-    auto sessionRange = contextRangeForSessionWithID(sessionID);
+    auto sessionRange = contextRangeForActiveWritingToolsSession();
     if (!sessionRange) {
         m_webPage->didEndPartialIntelligenceTextPonderingAnimation();
         ASSERT_NOT_REACHED();
@@ -274,11 +264,11 @@ void TextAnimationController::addDestinationTextAnimation(const WebCore::Writing
         return;
     }
 
-    auto previouslyReplacedRange = m_alreadyReplacedRanges.getOptional(sessionID);
+    auto previouslyReplacedRange = m_alreadyReplacedRange;
 
     auto replacedCharacterRange = *characterRangeAfterReplace;
     if (previouslyReplacedRange)
-        replacedCharacterRange = remainingCharacterRange(*characterRangeAfterReplace, (*previouslyReplacedRange)->range);
+        replacedCharacterRange = remainingCharacterRange(*characterRangeAfterReplace, previouslyReplacedRange->range);
 
     auto replacedRangeAfterReplace = WebCore::resolveCharacterRange(*sessionRange, replacedCharacterRange, defaultTextAnimationControllerTextIteratorBehaviors);
 
@@ -287,8 +277,7 @@ void TextAnimationController::addDestinationTextAnimation(const WebCore::Writing
     unstyledRange.start.offset = replacedRangeAfterReplace.endOffset();
 
     auto unstyledRangeUUID = WTF::UUID::createVersion4();
-    TextAnimationUnstyledRangeData unstyledRangeData = { unstyledRangeUUID, unstyledRange };
-    m_unstyledRanges.set(sessionID, unstyledRangeData);
+    m_unstyledRange = { unstyledRangeUUID, unstyledRange };
 
     auto textIndicatorData = createTextIndicatorForRange(replacedRangeAfterReplace);
     if (!textIndicatorData) {
@@ -296,48 +285,19 @@ void TextAnimationController::addDestinationTextAnimation(const WebCore::Writing
         return;
     }
 
-    m_webPage->addTextAnimationForAnimationID(destinationTextIndicatorUUID, { WebCore::TextAnimationType::Final, WebCore::TextAnimationRunMode::RunAnimation, unstyledRangeUUID }, *textIndicatorData, [weakWebPage = WeakPtr { *m_webPage }, sessionID](WebCore::TextAnimationRunMode runMode) mutable {
+    m_webPage->addTextAnimationForAnimationID(destinationTextIndicatorUUID, { WebCore::TextAnimationType::Final, WebCore::TextAnimationRunMode::RunAnimation, unstyledRangeUUID }, *textIndicatorData, [weakWebPage = WeakPtr { *m_webPage }](WebCore::TextAnimationRunMode runMode) mutable {
         if (runMode == WebCore::TextAnimationRunMode::DoNotRun)
             return;
 
         if (!weakWebPage)
             return;
 
-        weakWebPage->addInitialTextAnimation(sessionID);
+        weakWebPage->addInitialTextAnimationForActiveWritingToolsSession();
     });
 
-    TextAnimationRange animationState = { destinationTextIndicatorUUID, replacedCharacterRange };
-    auto& animationRanges = m_textAnimationRanges.ensure(sessionID, [&] {
-        return Vector<TextAnimationRange> { };
-    }).iterator->value;
+    m_textAnimationRanges.append({ destinationTextIndicatorUUID, replacedCharacterRange });
 
-    animationRanges.append(animationState);
-
-    ReplacedRangeAndString replacedRange = { *characterRangeAfterReplace, string };
-    m_alreadyReplacedRanges.set(sessionID, replacedRange);
-}
-
-void TextAnimationController::showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID& animationId)
-{
-    auto sessionIDForAnimationID = [&] -> std::optional<WebCore::WritingTools::Session::ID> {
-        for (auto& [sessionID, animationRanges] : m_textAnimationRanges) {
-            for (auto& animationRange : animationRanges) {
-                if (animationRange.animationUUID == animationId)
-                    return sessionID;
-            }
-        }
-
-        return std::nullopt;
-    }();
-
-    if (!sessionIDForAnimationID) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    RefPtr corePage = m_webPage->corePage();
-
-    corePage->showSelectionForWritingToolsSessionWithID(*sessionIDForAnimationID);
+    m_alreadyReplacedRange = { *characterRangeAfterReplace, string };
 }
 
 void TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
@@ -391,19 +351,18 @@ std::optional<WebCore::TextIndicatorData> TextAnimationController::createTextInd
     return textIndicatorData;
 }
 
-void TextAnimationController::clearAnimationsForSessionID(const WebCore::WritingTools::Session::ID& sessionID)
+void TextAnimationController::clearAnimationsForActiveWritingToolsSession()
 {
-    removeTransparentMarkersForSessionID(sessionID);
-    removeInitialTextAnimation(sessionID);
+    removeTransparentMarkersForActiveWritingToolsSession();
+    removeInitialTextAnimationForActiveWritingToolsSession();
 
-    auto animationRanges = m_textAnimationRanges.take(sessionID);
-    if (!animationRanges.isEmpty()) {
-        for (auto animationRange : animationRanges)
-            m_webPage->removeTextAnimationForAnimationID(animationRange.animationUUID);
-    }
+    auto textAnimationRanges = std::exchange(m_textAnimationRanges, { });
 
-    m_alreadyReplacedRanges.take(sessionID);
-    m_unstyledRanges.take(sessionID);
+    for (auto textAnimationRange : textAnimationRanges)
+        m_webPage->removeTextAnimationForAnimationID(textAnimationRange.animationUUID);
+
+    m_alreadyReplacedRange = std::nullopt;
+    m_unstyledRange = std::nullopt;
 }
 
 // FIXME: This shouldn't be called anymore, make sure that that is true, and remove.
@@ -419,7 +378,7 @@ void TextAnimationController::createTextIndicatorForTextAnimationID(const WTF::U
     completionHandler(createTextIndicatorForRange(*sessionRange));
 }
 
-void TextAnimationController::enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID& uuid)
+void TextAnimationController::enableSourceTextAnimationAfterElementWithID(const String& elementID)
 {
     RefPtr document = this->document();
     if (!document) {
@@ -446,10 +405,10 @@ void TextAnimationController::enableSourceTextAnimationAfterElementWithID(const 
             simpleRange->start = elementRange.end;
     }
 
-    m_manuallyEnabledAnimationRanges.add(uuid, createLiveRange(*simpleRange));
+    m_manuallyEnabledAnimationRange = createLiveRange(*simpleRange);
 }
 
-void TextAnimationController::enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID& uuid)
+void TextAnimationController::enableTextAnimationTypeForElementWithID(const String& elementID)
 {
     RefPtr document = this->document();
     if (!document) {
@@ -469,7 +428,7 @@ void TextAnimationController::enableTextAnimationTypeForElementWithID(const Stri
         return;
     }
 
-    m_manuallyEnabledAnimationRanges.add(uuid, createLiveRange(elementRange));
+    m_manuallyEnabledAnimationRange = createLiveRange(elementRange);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -326,34 +326,34 @@ void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
     send(Messages::WebPageProxy::RemoveTextAnimationForAnimationID(uuid));
 }
 
-void WebPage::removeTransparentMarkersForSessionID(const WTF::UUID& uuid)
+void WebPage::removeTransparentMarkersForActiveWritingToolsSession()
 {
-    m_textAnimationController->removeTransparentMarkersForSessionID(uuid);
+    m_textAnimationController->removeTransparentMarkersForActiveWritingToolsSession();
 }
 
-void WebPage::removeInitialTextAnimation(const WTF::UUID& uuid)
+void WebPage::removeInitialTextAnimationForActiveWritingToolsSession()
 {
-    m_textAnimationController->removeInitialTextAnimation(uuid);
+    m_textAnimationController->removeInitialTextAnimationForActiveWritingToolsSession();
 }
 
-void WebPage::addInitialTextAnimation(const WTF::UUID& uuid)
+void WebPage::addInitialTextAnimationForActiveWritingToolsSession()
 {
-    m_textAnimationController->addInitialTextAnimation(uuid);
+    m_textAnimationController->addInitialTextAnimationForActiveWritingToolsSession();
 }
 
-void WebPage::addSourceTextAnimation(const WTF::UUID& uuid, const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
+void WebPage::addSourceTextAnimationForActiveWritingToolsSession(const CharacterRange& range, const String& string, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
-    m_textAnimationController->addSourceTextAnimation(uuid, range, string, WTFMove(completionHandler));
+    m_textAnimationController->addSourceTextAnimationForActiveWritingToolsSession(range, string, WTFMove(completionHandler));
 }
 
-void WebPage::addDestinationTextAnimation(const WTF::UUID& uuid, const std::optional<CharacterRange>& range, const String& string)
+void WebPage::addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<CharacterRange>& range, const String& string)
 {
-    m_textAnimationController->addDestinationTextAnimation(uuid, range, string);
+    m_textAnimationController->addDestinationTextAnimationForActiveWritingToolsSession(range, string);
 }
 
-void WebPage::clearAnimationsForSessionID(const WTF::UUID& uuid)
+void WebPage::clearAnimationsForActiveWritingToolsSession()
 {
-    m_textAnimationController->clearAnimationsForSessionID(uuid);
+    m_textAnimationController->clearAnimationsForActiveWritingToolsSession();
 }
 
 void WebPage::createTextIndicatorForTextAnimationID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
@@ -366,24 +366,19 @@ void WebPage::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& 
     m_textAnimationController->updateUnderlyingTextVisibilityForTextAnimationID(uuid, visible, WTFMove(completionHandler));
 }
 
-void WebPage::enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID& uuid)
+void WebPage::enableSourceTextAnimationAfterElementWithID(const String& elementID)
 {
-    m_textAnimationController->enableSourceTextAnimationAfterElementWithID(elementID, uuid);
+    m_textAnimationController->enableSourceTextAnimationAfterElementWithID(elementID);
 }
 
-void WebPage::enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID& uuid)
+void WebPage::enableTextAnimationTypeForElementWithID(const String& elementID)
 {
-    m_textAnimationController->enableTextAnimationTypeForElementWithID(elementID, uuid);
+    m_textAnimationController->enableTextAnimationTypeForElementWithID(elementID);
 }
 
-void WebPage::showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID& animationID)
+void WebPage::showSelectionForActiveWritingToolsSession()
 {
-    m_textAnimationController->showSelectionForWritingToolsSessionAssociatedWithAnimationID(animationID);
-}
-
-void WebPage::showSelectionForWritingToolsSessionWithID(const WritingTools::Session::ID& sessionID)
-{
-    corePage()->showSelectionForWritingToolsSessionWithID(sessionID);
+    corePage()->showSelectionForActiveWritingToolsSession();
 }
 
 void WebPage::didEndPartialIntelligenceTextPonderingAnimation()
@@ -1037,14 +1032,14 @@ void WebPage::writingToolsSessionDidReceiveAction(const WritingTools::Session& s
     corePage()->writingToolsSessionDidReceiveAction(session, action);
 }
 
-void WebPage::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect rect)
+void WebPage::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect rect)
 {
-    send(Messages::WebPageProxy::ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, rect));
+    send(Messages::WebPageProxy::ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(replacementID, rect));
 }
 
-void WebPage::proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void WebPage::proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    send(Messages::WebPageProxy::ProofreadingSessionUpdateStateForSuggestionWithID(sessionID, state, replacementID));
+    send(Messages::WebPageProxy::ProofreadingSessionUpdateStateForSuggestionWithID(state, replacementID));
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1769,25 +1769,25 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect);
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect);
 
-    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
+    void proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
-    void enableSourceTextAnimationAfterElementWithID(const String&, const WTF::UUID&);
-    void enableTextAnimationTypeForElementWithID(const String&, const WTF::UUID&);
+    void enableSourceTextAnimationAfterElementWithID(const String&);
+    void enableTextAnimationTypeForElementWithID(const String&);
 
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&, const WebCore::TextIndicatorData&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& = nil);
 
     void removeTextAnimationForAnimationID(const WTF::UUID&);
-    void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&);
+    void removeTransparentMarkersForActiveWritingToolsSession();
 
-    void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&);
-    void addInitialTextAnimation(const WebCore::WritingTools::SessionID&);
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const std::optional<WebCore::CharacterRange>&, const String&);
-    void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&);
+    void removeInitialTextAnimationForActiveWritingToolsSession();
+    void addInitialTextAnimationForActiveWritingToolsSession();
+    void addSourceTextAnimationForActiveWritingToolsSession(const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
+    void addDestinationTextAnimationForActiveWritingToolsSession(const std::optional<WebCore::CharacterRange>&, const String&);
+    void clearAnimationsForActiveWritingToolsSession();
 
     std::optional<WebCore::TextIndicatorData> createTextIndicatorForRange(const WebCore::SimpleRange&);
     void createTextIndicatorForTextAnimationID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
@@ -2316,8 +2316,7 @@ private:
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
 
-    void showSelectionForWritingToolsSessionAssociatedWithAnimationID(const WTF::UUID&);
-    void showSelectionForWritingToolsSessionWithID(const WebCore::WritingTools::SessionID&);
+    void showSelectionForActiveWritingToolsSession();
 #endif
 
     void remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -382,11 +382,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     CreateTextIndicatorForTextAnimationID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
     UpdateUnderlyingTextVisibilityForTextAnimationID(WTF::UUID uuid, bool visible) -> ()
 
-    EnableSourceTextAnimationAfterElementWithID(String elementID, WTF::UUID uuid);
-    EnableTextAnimationTypeForElementWithID(String elementID, WTF::UUID uuid);
+    EnableSourceTextAnimationAfterElementWithID(String elementID);
+    EnableTextAnimationTypeForElementWithID(String elementID);
 
-    ShowSelectionForWritingToolsSessionAssociatedWithAnimationID(WTF::UUID animationID);
-    ShowSelectionForWritingToolsSessionWithID(WebCore::WritingTools::Session::ID sessionID);
+    ShowSelectionForActiveWritingToolsSession();
 #endif
 
     # Popup menu.


### PR DESCRIPTION
#### 4ef46f4e4c9551d4f25abb4d564e16bb0c2fe9d9
<pre>
[Writing Tools] Remove unnecessary infrastructure to support concurrent Writing Tools sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=277998">https://bugs.webkit.org/show_bug.cgi?id=277998</a>
<a href="https://rdar.apple.com/133726884">rdar://133726884</a>

Reviewed by Aditya Keerthi.

There&apos;s no need to support multiple sessions, and doing so significantly increases the complexity of the code.

* Source/WebCore/dom/DocumentMarker.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebCore::ChromeClient::proofreadingSessionUpdateStateForSuggestionWithID):
(WebCore::ChromeClient::removeTransparentMarkersForActiveWritingToolsSession):
(WebCore::ChromeClient::removeInitialTextAnimationForActiveWritingToolsSession):
(WebCore::ChromeClient::addInitialTextAnimationForActiveWritingToolsSession):
(WebCore::ChromeClient::addSourceTextAnimationForActiveWritingToolsSession):
(WebCore::ChromeClient::addDestinationTextAnimationForActiveWritingToolsSession):
(WebCore::ChromeClient::clearAnimationsForActiveWritingToolsSession):
(WebCore::ChromeClient::removeTransparentMarkersForSessionID): Deleted.
(WebCore::ChromeClient::removeInitialTextAnimation): Deleted.
(WebCore::ChromeClient::addInitialTextAnimation): Deleted.
(WebCore::ChromeClient::addSourceTextAnimation): Deleted.
(WebCore::ChromeClient::addDestinationTextAnimation): Deleted.
(WebCore::ChromeClient::clearAnimationsForSessionID): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::writingToolsSessionDidReceiveAction):
(WebCore::Page::contextRangeForActiveWritingToolsSession const):
(WebCore::Page::showSelectionForActiveWritingToolsSession const):
(WebCore::Page::contextRangeForSessionWithID const): Deleted.
(WebCore::Page::showSelectionForWritingToolsSessionWithID const): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion):
(WebCore::WritingToolsController::showSelection const):
(WebCore::WritingToolsController::compositionSessionDidFinishReplacement):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession):
(WebCore::WritingToolsController::updateStateForSelectedSuggestionIfNeeded):
(WebCore::WritingToolsController::respondToUnappliedEditing):
(WebCore::WritingToolsController::respondToReappliedEditing):
(WebCore::WritingToolsController::activeSessionRange const):
(WebCore::WritingToolsController::currentState):
(WebCore::WritingToolsController::showOriginalCompositionForSession):
(WebCore::WritingToolsController::showRewrittenCompositionForSession):
(WebCore::WritingToolsController::restartCompositionForSession):
(WebCore::WritingToolsController::showSelectionForWritingToolsSessionWithID const): Deleted.
(WebCore::WritingToolsController::contextRangeForSessionWithID const): Deleted.
(WebCore::WritingToolsController::stateForSession): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView _proofreadingSessionShowDetailsForSuggestionWithUUID:relativeToRect:]):
(-[WKWebView _proofreadingSessionUpdateState:forSuggestionWithUUID:]):
(-[WKWebView _enableSourceTextAnimationAfterElementWithID:]):
(-[WKWebView _enableFinalTextAnimationForElementWithID:]):
(-[WKWebView _proofreadingSessionWithUUID:showDetailsForSuggestionWithUUID:relativeToRect:]): Deleted.
(-[WKWebView _proofreadingSessionWithUUID:updateState:forSuggestionWithUUID:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::enableSourceTextAnimationAfterElementWithID):
(WebKit::WebPageProxy::enableTextAnimationTypeForElementWithID):
(WebKit::WebPageProxy::addTextAnimationForAnimationID):
(WebKit::WebPageProxy::showSelectionForActiveWritingToolsSession):
(WebKit::WebPageProxy::removeTextAnimationForAnimationID):
(WebKit::WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebPageProxy::showSelectionForWritingToolsSessionAssociatedWithAnimationID): Deleted.
(WebKit::WebPageProxy::showSelectionForWritingToolsSessionWithID): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebChromeClient::removeTransparentMarkersForActiveWritingToolsSession):
(WebKit::WebChromeClient::removeInitialTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::addInitialTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::addSourceTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession):
(WebKit::WebChromeClient::clearAnimationsForActiveWritingToolsSession):
(WebKit::WebChromeClient::removeTransparentMarkersForSessionID): Deleted.
(WebKit::WebChromeClient::removeInitialTextAnimation): Deleted.
(WebKit::WebChromeClient::addInitialTextAnimation): Deleted.
(WebKit::WebChromeClient::addSourceTextAnimation): Deleted.
(WebKit::WebChromeClient::addDestinationTextAnimation): Deleted.
(WebKit::WebChromeClient::clearAnimationsForSessionID): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::unreplacedRangeForActiveWritingToolsSession const):
(WebKit::TextAnimationController::contextRangeForActiveWritingToolsSession const):
(WebKit::TextAnimationController::contextRangeForTextAnimationID const):
(WebKit::TextAnimationController::removeTransparentMarkersForActiveWritingToolsSession):
(WebKit::TextAnimationController::removeInitialTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::addInitialTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::clearAnimationsForActiveWritingToolsSession):
(WebKit::TextAnimationController::enableSourceTextAnimationAfterElementWithID):
(WebKit::TextAnimationController::enableTextAnimationTypeForElementWithID):
(WebKit::TextAnimationController::unreplacedRangeForSessionWithID const): Deleted.
(WebKit::TextAnimationController::contextRangeForSessionWithID const): Deleted.
(WebKit::TextAnimationController::removeTransparentMarkersForSessionID): Deleted.
(WebKit::TextAnimationController::removeInitialTextAnimation): Deleted.
(WebKit::TextAnimationController::addInitialTextAnimation): Deleted.
(WebKit::TextAnimationController::addSourceTextAnimation): Deleted.
(WebKit::TextAnimationController::addDestinationTextAnimation): Deleted.
(WebKit::TextAnimationController::showSelectionForWritingToolsSessionAssociatedWithAnimationID): Deleted.
(WebKit::TextAnimationController::clearAnimationsForSessionID): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::removeTransparentMarkersForActiveWritingToolsSession):
(WebKit::WebPage::removeInitialTextAnimationForActiveWritingToolsSession):
(WebKit::WebPage::addInitialTextAnimationForActiveWritingToolsSession):
(WebKit::WebPage::addSourceTextAnimationForActiveWritingToolsSession):
(WebKit::WebPage::addDestinationTextAnimationForActiveWritingToolsSession):
(WebKit::WebPage::clearAnimationsForActiveWritingToolsSession):
(WebKit::WebPage::enableSourceTextAnimationAfterElementWithID):
(WebKit::WebPage::enableTextAnimationTypeForElementWithID):
(WebKit::WebPage::showSelectionForActiveWritingToolsSession):
(WebKit::WebPage::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebPage::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebPage::removeTransparentMarkersForSessionID): Deleted.
(WebKit::WebPage::removeInitialTextAnimation): Deleted.
(WebKit::WebPage::addInitialTextAnimation): Deleted.
(WebKit::WebPage::addSourceTextAnimation): Deleted.
(WebKit::WebPage::addDestinationTextAnimation): Deleted.
(WebKit::WebPage::clearAnimationsForSessionID): Deleted.
(WebKit::WebPage::showSelectionForWritingToolsSessionAssociatedWithAnimationID): Deleted.
(WebKit::WebPage::showSelectionForWritingToolsSessionWithID): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/282207@main">https://commits.webkit.org/282207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd011ad7feec8c4f453dcf88d76f18b421535c1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15040 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13333 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65514 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/38846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54094 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11407 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68158 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54118 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5316 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9397 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->