### PR TITLE
[visionOS] Environment docking may fail if a video's src changes while in element fullscreen

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -169,10 +169,10 @@ public:
 #endif
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const;
-    const Logger* loggerPtr() const;
+    WEBCORE_EXPORT const void* logIdentifier() const;
+    WEBCORE_EXPORT const Logger* loggerPtr() const;
     ASCIILiteral logClassName() const { return "VideoPresentationInterfaceIOS"_s; };
-    WTFLogChannel& logChannel() const;
+    WEBCORE_EXPORT WTFLogChannel& logChannel() const;
 #endif
 
 protected:

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -518,7 +518,7 @@ void VideoPresentationInterfaceIOS::cleanupFullscreen()
     m_shouldIgnoreAVKitCallbackAboutExitFullscreenReason = false;
 
     m_cleanupNeedsReturnVideoContentLayer = true;
-    auto model = videoPresentationModel();
+    RefPtr model = videoPresentationModel();
     if (m_hasVideoContentLayer && model) {
         model->returnVideoContentLayer();
         return;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -118,6 +118,7 @@ void VideoPresentationInterfaceLMK::setupPlayerViewController()
 
 void VideoPresentationInterfaceLMK::invalidatePlayerViewController()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_playerViewController = nil;
 }
 
@@ -209,6 +210,7 @@ void VideoPresentationInterfaceLMK::ensurePlayableViewController()
     if (m_playerViewController)
         return;
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_playerViewController = [linearMediaPlayer() makeViewController];
     [m_playerViewController view].alpha = 0;
 }

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -670,6 +670,7 @@ void VideoPresentationManagerProxy::removeClientForContext(PlaybackSessionContex
     int clientCount = m_clientCounts.get(contextId);
     ASSERT(clientCount > 0);
     clientCount--;
+    ALWAYS_LOG(LOGIDENTIFIER, clientCount);
 
     if (clientCount <= 0) {
         Ref interface = ensureInterface(contextId);
@@ -678,6 +679,10 @@ void VideoPresentationManagerProxy::removeClientForContext(PlaybackSessionContex
         m_playbackSessionManagerProxy->removeClientForContext(contextId);
         m_clientCounts.remove(contextId);
         m_contextMap.remove(contextId);
+
+        if (RefPtr page = m_page.get())
+            page->didCleanupFullscreen(contextId);
+
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7920,6 +7920,7 @@ void WebPageProxy::didExitFullscreen(PlaybackSessionContextIdentifier identifier
 
 void WebPageProxy::didCleanupFullscreen(PlaybackSessionContextIdentifier)
 {
+    WEBPAGEPROXY_RELEASE_LOG(Fullscreen, "didCleanupFullscreen");
     protectedPageClient()->didCleanupFullscreen();
 }
 


### PR DESCRIPTION
#### 8da9da634316e1ff561390301de8f03b4c25886a
<pre>
[visionOS] Environment docking may fail if a video&apos;s src changes while in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=278004">https://bugs.webkit.org/show_bug.cgi?id=278004</a>
<a href="https://rdar.apple.com/130920037">rdar://130920037</a>

Reviewed by Eric Carlson.

When a video&apos;s src (or srcObject) changes a new WebAVPlayerLayer will be created in the UI process,
removing the previous layer. VideoPresentationManagerProxy::removeClientForContext is called when
the old layer is removed, which invalidates and removes the video presentation model and interface
associated with the video element&apos;s context ID. When VideoPresentationInterfaceLMK is invalidated
it removes its LMPlayableViewController, even though an environment picker button owned by that
now-deallocated view controller may be presented in WKFullScreenViewController if the video is part
of an element fullscreen presentation. If the user were to tap that button and choose an
environment then docking would not occur since the LMPlayzableViewController and its associated
playable object no longer exist.

VideoPresentationInterfaceLMK attempted to account for this during invalidation by calling
VideoPresentationModel::didCleanupFullscreen(), which would ultimately call
-[WKFullScreenViewController configureEnvironmentPickerButtonView], re-creating a new video
presentation interface, LMPlayableViewController, playable object, and environment picker button if
the video was still in an element fullscreen presentation. While this re-creation did happen after
some forms of invalidation (e.g., when undocking and returning to element fullscreen) it did *not*
happen when a video layer changed because in VideoPresentationManagerProxy::removeClientForContext
the video presentation model had already been removed from the interface by the time
VideoPresentationInterface::invalidate was called.

To account ensure that a valid environment picker button is displayed in this case, this change
calls WebPageProxy::didCleanupFullscreen explicitly in VideoPresentationManagerProxy::removeClientForContext.
Also added additional logging to help diagnose bugs like this in the future.

* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::cleanupFullscreen):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::invalidatePlayerViewController):
(WebKit::VideoPresentationInterfaceLMK::ensurePlayableViewController):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::removeClientForContext):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCleanupFullscreen):

Canonical link: <a href="https://commits.webkit.org/282176@main">https://commits.webkit.org/282176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51224b07759864b0d3bcdb0a68e4d23e67e92c7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50205 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38703 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11794 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57793 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5181 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37472 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->