### PR TITLE
Implement Observable#forEach

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.any-expected.txt
@@ -1,21 +1,8 @@
 
-FAIL forEach(): Visitor callback called synchronously for each value promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach((value) => {
-    results.push(value);
-  })', 'source.forEach' is undefined)"
-FAIL Errors thrown by Observable reject the returned promise assert_equals: expected object "Error: error" but got object "TypeError: source.forEach is not a function. (In 'source.forEach(() => {
-      assert_unreached("Visitor callback is not invoked when Observable errors");
-    })', 'source.forEach' is undefined)"
-FAIL Errors pushed by Observable reject the returned promise assert_equals: expected object "Error: error" but got object "TypeError: source.forEach is not a function. (In 'source.forEach(() => {
-      assert_unreached("Visitor callback is not invoked when Observable errors");
-    })', 'source.forEach' is undefined)"
-FAIL Errors thrown in the visitor callback reject the promise and unsubscribe from the source promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach((value) => {
-    results.push(value);
-    if (value === 2) {
-      throw error;
-    }
-  })', 'source.forEach' is undefined)"
-FAIL forEach visitor callback rejection microtask ordering promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach(() => {}, {signal: controller.signal})', 'source.forEach' is undefined)"
-FAIL forEach() promise resolves with undefined promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach((value) => {
-    results.push(value);
-  })', 'source.forEach' is undefined)"
+PASS forEach(): Visitor callback called synchronously for each value
+PASS Errors thrown by Observable reject the returned promise
+PASS Errors pushed by Observable reject the returned promise
+PASS Errors thrown in the visitor callback reject the promise and unsubscribe from the source
+PASS forEach visitor callback rejection microtask ordering
+PASS forEach() promise resolves with undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.any.worker-expected.txt
@@ -1,21 +1,8 @@
 
-FAIL forEach(): Visitor callback called synchronously for each value promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach((value) => {
-    results.push(value);
-  })', 'source.forEach' is undefined)"
-FAIL Errors thrown by Observable reject the returned promise assert_equals: expected object "Error: error" but got object "TypeError: source.forEach is not a function. (In 'source.forEach(() => {
-      assert_unreached("Visitor callback is not invoked when Observable errors");
-    })', 'source.forEach' is undefined)"
-FAIL Errors pushed by Observable reject the returned promise assert_equals: expected object "Error: error" but got object "TypeError: source.forEach is not a function. (In 'source.forEach(() => {
-      assert_unreached("Visitor callback is not invoked when Observable errors");
-    })', 'source.forEach' is undefined)"
-FAIL Errors thrown in the visitor callback reject the promise and unsubscribe from the source promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach((value) => {
-    results.push(value);
-    if (value === 2) {
-      throw error;
-    }
-  })', 'source.forEach' is undefined)"
-FAIL forEach visitor callback rejection microtask ordering promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach(() => {}, {signal: controller.signal})', 'source.forEach' is undefined)"
-FAIL forEach() promise resolves with undefined promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach((value) => {
-    results.push(value);
-  })', 'source.forEach' is undefined)"
+PASS forEach(): Visitor callback called synchronously for each value
+PASS Errors thrown by Observable reject the returned promise
+PASS Errors pushed by Observable reject the returned promise
+PASS Errors thrown in the visitor callback reject the promise and unsubscribe from the source
+PASS forEach visitor callback rejection microtask ordering
+PASS forEach() promise resolves with undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.window-expected.txt
@@ -1,9 +1,4 @@
 
-FAIL forEach()'s internal observer's next steps do not crash in a detached document promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach(value => {
-      parentResults.push(value);
-    })', 'source.forEach' is undefined)"
-FAIL forEach()'s internal observer's next steps do not crash when visitor callback detaches the document promise_test: Unhandled rejection with value: object "TypeError: source.forEach is not a function. (In 'source.forEach(value => {
-      window.frameElement.remove();
-      parentResults.push(value);
-    })', 'source.forEach' is undefined)"
+PASS forEach()'s internal observer's next steps do not crash in a detached document
+PASS forEach()'s internal observer's next steps do not crash when visitor callback detaches the document
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1209,6 +1209,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ViewTransitionTypeSet.idl
     dom/ViewTransitionUpdateCallback.idl
     dom/VisibilityState.idl
+    dom/VisitorCallback.idl
     dom/WheelEvent.idl
     dom/WindowOrWorkerGlobalScope+TrustedTypes.idl
     dom/XMLDocument.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1549,6 +1549,7 @@ $(PROJECT_DIR)/dom/ViewTransition.idl
 $(PROJECT_DIR)/dom/ViewTransitionTypeSet.idl
 $(PROJECT_DIR)/dom/ViewTransitionUpdateCallback.idl
 $(PROJECT_DIR)/dom/VisibilityState.idl
+$(PROJECT_DIR)/dom/VisitorCallback.idl
 $(PROJECT_DIR)/dom/WheelEvent.idl
 $(PROJECT_DIR)/dom/WindowOrWorkerGlobalScope+TrustedTypes.idl
 $(PROJECT_DIR)/dom/XMLDocument.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3111,6 +3111,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionUpdateCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTransitionUpdateCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisibilityState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisibilityState.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisitorCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisitorCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisualViewport.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisualViewport.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVoidCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1235,6 +1235,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/ViewTransition+Types.idl \
     $(WebCore)/dom/ViewTransitionUpdateCallback.idl \
     $(WebCore)/dom/VisibilityState.idl \
+    $(WebCore)/dom/VisitorCallback.idl \
     $(WebCore)/dom/WheelEvent.idl \
     $(WebCore)/dom/WindowOrWorkerGlobalScope+TrustedTypes.idl \
     $(WebCore)/dom/XMLDocument.idl \
@@ -2670,4 +2671,3 @@ vpath %.js $(sort $(foreach f,$(WebCore_BUILTINS_SOURCES),$(realpath $(dir $(f))
 all : $(notdir $(WebCore_BUILTINS_SOURCES:%.js=%Builtins.h)) $(WebCore_BUILTINS_WRAPPERS)
 
 # ------------------------
-

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1229,6 +1229,7 @@ dom/InternalObserver.cpp
 dom/InternalObserverDrop.cpp
 dom/InternalObserverFilter.cpp
 dom/InternalObserverFirst.cpp
+dom/InternalObserverForEach.cpp
 dom/InternalObserverFromScript.cpp
 dom/InternalObserverLast.cpp
 dom/InternalObserverMap.cpp
@@ -4654,6 +4655,7 @@ JSViewTransition.cpp
 JSViewTransitionTypeSet.cpp
 JSViewTransitionUpdateCallback.cpp
 JSVisibilityState.cpp
+JSVisitorCallback.cpp
 JSVisualViewport.cpp
 JSVoidCallback.cpp
 JSWakeLock.cpp

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -1,0 +1,140 @@
+/*
+* Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "InternalObserverForEach.h"
+
+#include "AbortSignal.h"
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include "VisitorCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverForEach final : public InternalObserver {
+public:
+    static Ref<InternalObserverForEach> create(ScriptExecutionContext& context, Ref<VisitorCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverForEach(context, WTFMove(callback), WTFMove(signal), WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        ASSERT(globalObject);
+
+        Ref vm = globalObject->vm();
+
+        {
+            JSC::JSLockHolder lock(vm);
+
+            // The exception is not reported, instead it is forwarded to the
+            // abort signal and promise rejection.
+            // As such, VisitorCallback `[RethrowsException]` and here a
+            // catch scope is declared so the error can be passed to any promise
+            // rejection handlers and abort handlers.
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+
+            protectedCallback()->handleEvent(value, m_idx++);
+
+            JSC::Exception* exception = scope.exception();
+            if (UNLIKELY(exception)) {
+                scope.clearException();
+                auto value = exception->value();
+                protectedPromise()->reject<IDLAny>(value);
+                Ref { m_signal }->signalAbort(value);
+            }
+        }
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        protectedPromise()->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        protectedPromise()->resolve();
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        protectedCallback()->visitJSFunction(visitor);
+    }
+
+    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<VisitorCallback> protectedCallback() const { return m_callback; }
+
+    InternalObserverForEach(ScriptExecutionContext& context, Ref<VisitorCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_callback(WTFMove(callback))
+        , m_signal(WTFMove(signal))
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    uint64_t m_idx { 0 };
+    Ref<VisitorCallback> m_callback;
+    Ref<AbortSignal> m_signal;
+    Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorForEach(ScriptExecutionContext& context, Observable& observable, Ref<VisitorCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    Ref signal = AbortSignal::create(&context);
+
+    Vector<Ref<AbortSignal>> dependentSignals = { signal };
+    if (options.signal)
+        dependentSignals.append(Ref { *options.signal });
+    Ref dependentSignal = AbortSignal::any(context, dependentSignals);
+
+    if (dependentSignal->aborted())
+        return promise->reject<IDLAny>(dependentSignal->reason().getValue());
+
+    dependentSignal->addAlgorithm([promise](JSC::JSValue reason) {
+        promise->reject<IDLAny>(reason);
+    });
+
+    Ref observer = InternalObserverForEach::create(context, WTFMove(callback), WTFMove(signal), WTFMove(promise));
+
+    observable.subscribeInternal(context, WTFMove(observer), SubscribeOptions { .signal = WTFMove(dependentSignal) });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverForEach.h
+++ b/Source/WebCore/dom/InternalObserverForEach.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+class VisitorCallback;
+struct SubscribeOptions;
+
+void createInternalObserverOperatorForEach(ScriptExecutionContext&, Observable&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -33,10 +33,12 @@
 #include "InternalObserverDrop.h"
 #include "InternalObserverFilter.h"
 #include "InternalObserverFirst.h"
+#include "InternalObserverForEach.h"
 #include "InternalObserverFromScript.h"
 #include "InternalObserverLast.h"
 #include "InternalObserverMap.h"
 #include "InternalObserverTake.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSSubscriptionObserverCallback.h"
 #include "MapperCallback.h"
 #include "PredicateCallback.h"
@@ -44,6 +46,7 @@
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
 #include "SubscriptionObserver.h"
+#include "VisitorCallback.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -121,6 +124,11 @@ Ref<Observable> Observable::drop(ScriptExecutionContext& context, uint64_t amoun
 void Observable::first(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
 {
     return createInternalObserverOperatorFirst(context, *this, options, WTFMove(promise));
+}
+
+void Observable::forEach(ScriptExecutionContext& context, Ref<VisitorCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorForEach(context, *this, WTFMove(callback), options, WTFMove(promise));
 }
 
 void Observable::last(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -33,13 +33,15 @@
 
 namespace WebCore {
 
+class DeferredPromise;
 class InternalObserver;
-class ScriptExecutionContext;
 class JSSubscriptionObserverCallback;
-class PredicateCallback;
 class MapperCallback;
-struct SubscriptionObserver;
+class PredicateCallback;
+class ScriptExecutionContext;
+class VisitorCallback;
 struct SubscribeOptions;
+struct SubscriptionObserver;
 
 class Observable final : public ScriptWrappable, public RefCounted<Observable> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Observable);
@@ -65,6 +67,7 @@ public:
     // Promise-returning operators.
 
     void first(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 private:

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -45,5 +45,6 @@ interface Observable {
   // Promise-returning operators.
 
   [CallWith=CurrentScriptExecutionContext] Promise<any> first(optional SubscribeOptions options = {});
+  [CallWith=CurrentScriptExecutionContext] Promise<undefined> forEach(VisitorCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});
 };

--- a/Source/WebCore/dom/VisitorCallback.h
+++ b/Source/WebCore/dom/VisitorCallback.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class VisitorCallback : public RefCounted<VisitorCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<void> handleEvent(JSC::JSValue, uint64_t) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/VisitorCallback.idl
+++ b/Source/WebCore/dom/VisitorCallback.idl
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[ RethrowException ] callback VisitorCallback = undefined (any value, unsigned long long index);


### PR DESCRIPTION
#### 7b5785e176c2c2c256da316e0ad378e927a404b9
<pre>
Implement Observable#forEach
<a href="https://bugs.webkit.org/show_bug.cgi?id=277510">https://bugs.webkit.org/show_bug.cgi?id=277510</a>

Reviewed by Chris Dumez.

This change introduces the `.forEach` promise-returning operator
for Observables, using the InternalObserver and subscribes immediately.
This is required by the specification <a href="https://wicg.github.io/observable/#dom-observable-foreach.">https://wicg.github.io/observable/#dom-observable-foreach.</a>

This change also includes a new VisitorCallback IDL which represents a callback
that receives each value of an Subscription, which unlike MapperCallback, does not return a value.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.any.worker-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-forEach.window-expected.txt: Rebaselined.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverForEach.cpp: Added.
(WebCore::createInternalObserverOperatorForEach):
* Source/WebCore/dom/InternalObserverForEach.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::forEach):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
  Exposes the `Promise&lt;undefiend&gt; forEach(callback, options)`.
* Source/WebCore/dom/VisitorCallback.h: Added.
* Source/WebCore/dom/VisitorCallback.idl: Added.

Canonical link: <a href="https://commits.webkit.org/285693@main">https://commits.webkit.org/285693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/693aa8ed9ee5a4b26fb4daee94abd7d5750bf21a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/73520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/26328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/75635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/76587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/44483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/66270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/79406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66166 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16176 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/7482 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/799 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/3542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->