### PR TITLE
[JSC] Fix tryAppendIncrementAddress in B3LowerToAir

### DIFF
--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -142,7 +142,7 @@ void testLoadPreIndex32()
     fixSSA(proc);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "#4]!");
 
     auto expected = [&] () -> int32_t {
@@ -215,7 +215,7 @@ void testLoadPreIndex64()
     fixSSA(proc);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "#8]!");
 
     auto expected = [&] () -> int64_t {
@@ -288,7 +288,7 @@ void testLoadPostIndex32()
     fixSSA(proc);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "], #4");
 
     auto expected = [&] () -> int32_t {
@@ -361,7 +361,7 @@ void testLoadPostIndex64()
     fixSSA(proc);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "], #8");
 
     auto expected = [&] () -> int64_t {
@@ -472,7 +472,7 @@ void testStorePreIndex32()
     root->appendNewControlValue(proc, Return, Origin(), preIncrement);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "#4]!");
     intptr_t res = invoke<intptr_t>(*code, bitwise_cast<intptr_t>(ptr), 4);
     ptr = bitwise_cast<int32_t*>(res);
@@ -498,7 +498,7 @@ void testStorePreIndex64()
     root->appendNewControlValue(proc, Return, Origin(), preIncrement);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "#8]!");
     intptr_t res = invoke<intptr_t>(*code, bitwise_cast<intptr_t>(ptr), 4);
     ptr = bitwise_cast<int64_t*>(res);
@@ -526,7 +526,7 @@ void testStorePostIndex32()
     root->appendNewControlValue(proc, Return, Origin(), preIncrement);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "], #4");
     intptr_t res = invoke<intptr_t>(*code, bitwise_cast<intptr_t>(ptr), 4);
     ptr = bitwise_cast<int32_t*>(res);
@@ -553,7 +553,7 @@ void testStorePostIndex64()
     root->appendNewControlValue(proc, Return, Origin(), preIncrement);
 
     auto code = compileProc(proc);
-    if (isARM64())
+    if (isARM64() && Options::useB3CanonicalizePrePostIncrements())
         checkUsesInstruction(*code, "], #8");
     intptr_t res = invoke<intptr_t>(*code, bitwise_cast<intptr_t>(ptr), 4);
     ptr = bitwise_cast<int64_t*>(res);
@@ -4233,18 +4233,15 @@ void addShrTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
     RUN(testZShrArgImm32(0xffffffff, 63));
     RUN(testCSEStoreWithLoop());
 
-    if (Options::useB3CanonicalizePrePostIncrements()) {
-        RUN(testLoadPreIndex32());
-        RUN(testLoadPreIndex64());
-        RUN(testLoadPostIndex32());
-        RUN(testLoadPostIndex64());
-        RUN(testLoadPreIndex32WithStore());
-
-        RUN(testStorePreIndex32());
-        RUN(testStorePreIndex64());
-        RUN(testStorePostIndex32());
-        RUN(testStorePostIndex64());
-    }
+    RUN(testLoadPreIndex32());
+    RUN(testLoadPreIndex64());
+    RUN(testLoadPostIndex32());
+    RUN(testLoadPostIndex64());
+    RUN(testLoadPreIndex32WithStore());
+    RUN(testStorePreIndex32());
+    RUN(testStorePreIndex64());
+    RUN(testStorePostIndex32());
+    RUN(testStorePostIndex64());
 }
 
 #endif // ENABLE(B3_JIT)


### PR DESCRIPTION
#### a07f08e06e0312b120602a4776d1438db2b377b7
<pre>
[JSC] Fix tryAppendIncrementAddress in B3LowerToAir
<a href="https://bugs.webkit.org/show_bug.cgi?id=278008">https://bugs.webkit.org/show_bug.cgi?id=278008</a>
<a href="https://rdar.apple.com/133742537">rdar://133742537</a>

Reviewed by Yusuke Suzuki.

This patch fixes two things:
1. Shouldn&apos;t emit MoveWithIncrement when the Load node has fence.
2. We only care about the node would be committed internal in
   tryAppendIncrementAddress.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testLoadPreIndex32):
(testLoadPreIndex64):
(testLoadPostIndex32):
(testLoadPostIndex64):
(testStorePreIndex32):
(testStorePreIndex64):
(testStorePostIndex32):
(testStorePostIndex64):
(addShrTests):

Canonical link: <a href="https://commits.webkit.org/282173@main">https://commits.webkit.org/282173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd1194210c5fa81c2b6e345e69ecb5b44d97c968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50218 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11274 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11806 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55426 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68040 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61573 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6273 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11315 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57596 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57807 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5201 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83336 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37484 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14624 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->