### PR TITLE
[JSC] Rename smallOffset to truncatedOffset in B3LowerToAir and B3LowerToAir

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -2950,18 +2950,18 @@ private:
                 if (base1 != base2 || !address->child(1)->hasIntPtr())
                     return false;
                 intptr_t offset = address->child(1)->asIntPtr();
-                Value::OffsetType smallOffset = static_cast<Value::OffsetType>(offset);
-                if (smallOffset != offset || !Arg::isValidIncrementIndexForm(smallOffset))
+                Value::OffsetType truncatedOffset = static_cast<Value::OffsetType>(offset);
+                if (truncatedOffset != offset || !Arg::isValidIncrementIndexForm(truncatedOffset))
                     return false;
                 if (m_locked.contains(address) || m_locked.contains(base1))
                     return false;
 
                 Arg incrementArg = Arg();
                 if (memory->offset()) {
-                    if (smallOffset == memory->offset())
-                        incrementArg = Arg::preIndex(tmp(address), smallOffset);
+                    if (truncatedOffset == memory->offset())
+                        incrementArg = Arg::preIndex(tmp(address), truncatedOffset);
                 } else
-                    incrementArg = Arg::postIndex(tmp(address), smallOffset);
+                    incrementArg = Arg::postIndex(tmp(address), truncatedOffset);
 
                 if (incrementArg) {
                     append(relaxedMoveForType(address->type()), tmp(address->child(0)), tmp(address));
@@ -3881,18 +3881,18 @@ private:
                 if (base1 != base2 || !address->child(1)->hasIntPtr())
                     return false;
                 intptr_t offset = address->child(1)->asIntPtr();
-                Value::OffsetType smallOffset = static_cast<Value::OffsetType>(offset);
-                if (smallOffset != offset || !Arg::isValidIncrementIndexForm(smallOffset))
+                Value::OffsetType truncatedOffset = static_cast<Value::OffsetType>(offset);
+                if (truncatedOffset != offset || !Arg::isValidIncrementIndexForm(truncatedOffset))
                     return false;
                 if (m_locked.contains(address) || m_locked.contains(base1) || m_locked.contains(value))
                     return false;
 
                 Arg incrementArg = Arg();
                 if (memory->offset()) {
-                    if (smallOffset == memory->offset())
-                        incrementArg = Arg::preIndex(tmp(address), smallOffset);
+                    if (truncatedOffset == memory->offset())
+                        incrementArg = Arg::preIndex(tmp(address), truncatedOffset);
                 } else
-                    incrementArg = Arg::postIndex(tmp(address), smallOffset);
+                    incrementArg = Arg::postIndex(tmp(address), truncatedOffset);
 
                 if (incrementArg) {
                     append(relaxedMoveForType(address->type()), tmp(base1), tmp(address));

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2155,11 +2155,11 @@ private:
                 intptr_t offset = address->child(1)->asIntPtr();
                 if (!sumOverflows<intptr_t>(offset, memory->offset())) {
                     offset += memory->offset();
-                    Value::OffsetType smallOffset = static_cast<Value::OffsetType>(offset);
-                    if (smallOffset == offset) {
+                    Value::OffsetType truncatedOffset = static_cast<Value::OffsetType>(offset);
+                    if (truncatedOffset == offset) {
                         address = address->child(0);
                         memory->lastChild() = address;
-                        memory->setOffset(smallOffset);
+                        memory->setOffset(truncatedOffset);
                         m_changed = true;
                     }
                 }


### PR DESCRIPTION
#### 1c18868dc7570ac6d3b1592d420528f13408c1a0
<pre>
[JSC] Rename smallOffset to truncatedOffset in B3LowerToAir and B3LowerToAir
<a href="https://bugs.webkit.org/show_bug.cgi?id=278009">https://bugs.webkit.org/show_bug.cgi?id=278009</a>
<a href="https://rdar.apple.com/133743080">rdar://133743080</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c18868dc7570ac6d3b1592d420528f13408c1a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12876 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50219 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11807 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55427 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68041 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61574 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6274 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11316 "Found 1 new test failure: workers/wasm-references.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57592 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57804 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5203 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83337 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37486 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14625 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->