### PR TITLE
Use smart pointer when accessing BackForwardController

### DIFF
--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -185,9 +185,9 @@ void CachedPage::restore(Page& page)
             frameView->updateContentsSize();
     }
 
-    if (auto& backForwardController = page.backForward(); page.settings().navigationAPIEnabled() && focusedDocument->domWindow() && backForwardController.currentItem()) {
-        Ref currentItem = *backForwardController.currentItem();
-        auto allItems = backForwardController.allItems();
+    if (CheckedRef backForwardController = page.backForward(); page.settings().navigationAPIEnabled() && focusedDocument->domWindow() && backForwardController->currentItem()) {
+        Ref currentItem = *backForwardController->currentItem();
+        auto allItems = backForwardController->allItems();
         focusedDocument->domWindow()->navigation().updateForReactivation(allItems, currentItem);
     }
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2847,7 +2847,7 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
         }
         if (shouldReset && item) {
             if (RefPtr page = m_frame->page())
-                page->backForward().setCurrentItem(*item);
+                page->checkedBackForward()->setCurrentItem(*item);
         }
 
         handleLoadFailureRecovery(*provisionalDocumentLoader, error, isHTTPSFirstApplicable);
@@ -3958,7 +3958,7 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
         if ((isTargetItem || frame->isMainFrame()) && isBackForwardLoadType(policyChecker().loadType())) {
             if (RefPtr page = frame->page()) {
                 if (RefPtr resetItem = frame->mainFrame().history().currentItem())
-                    page->backForward().setCurrentItem(*resetItem);
+                    page->checkedBackForward()->setCurrentItem(*resetItem);
             }
         }
         return;
@@ -4855,7 +4855,7 @@ void FrameLoader::updateNavigationAPIEntries(std::optional<NavigationNavigationT
     Vector<Ref<HistoryItem>> entriesForNavigationAPI;
     entriesForNavigationAPI.append(*currentItem);
 
-    auto rawEntries = page->backForward().allItems();
+    auto rawEntries = page->checkedBackForward()->allItems();
     auto startingIndex = rawEntries.find(*currentItem);
     if (startingIndex != notFound) {
         Ref startingOrigin = SecurityOrigin::create(rawEntries[startingIndex]->url());

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -335,8 +335,9 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, Sh
     // Set the BF cursor before commit, which lets the user quickly click back/forward again.
     // - plus, it only makes sense for the top level of the operation through the frame tree,
     // as opposed to happening for some/one of the page commits that might happen soon
-    RefPtr currentItem = page->backForward().currentItem();
-    page->backForward().setCurrentItem(targetItem);
+    CheckedRef backForward = page->backForward();
+    RefPtr currentItem = backForward->currentItem();
+    backForward->setCurrentItem(targetItem);
 
     // First set the provisional item of any frames that are not actually navigating.
     // This must be done before trying to navigate the desired frame, because some
@@ -877,7 +878,7 @@ void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
     Ref topItem = mainFrame->checkedHistory()->createItemTree(page->historyItemClient(), *frame, doClip);
     LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, topItem.ptr(), frame.get(), frame->isMainFrame(), frame->loader().documentLoader()->url().string().utf8().data());
 
-    page->backForward().addItem(frame->frameID(), WTFMove(topItem));
+    page->checkedBackForward()->addItem(frame->frameID(), WTFMove(topItem));
 }
 
 void HistoryController::updateCurrentItem()
@@ -941,7 +942,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
 
     LOG(History, "HistoryController %p pushState: Adding top item %p, setting url of current item %p to %s, scrollRestoration is %s", this, topItem.ptr(), m_currentItem.get(), urlString.ascii().data(), topItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
-    page->backForward().addItem(frame->frameID(), WTFMove(topItem));
+    page->checkedBackForward()->addItem(frame->frameID(), WTFMove(topItem));
 
     if (page->usesEphemeralSession())
         return;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -294,12 +294,12 @@ public:
     {
         // If the destination HistoryItem is no longer in the back/forward list, then we don't proceed.
         RefPtr page { frame.page() };
-        if (!page || !page->backForward().containsItem(m_historyItem))
+        if (!page || !page->checkedBackForward()->containsItem(m_historyItem))
             return;
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
-        if (page->backForward().currentItem() == m_historyItem.ptr()) {
+        if (page->checkedBackForward()->currentItem() == m_historyItem.ptr()) {
             // Special case for go(0) from a frame -> reload only the frame
             // To follow Firefox and IE's behavior, history reload can only navigate the self frame.
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
@@ -671,14 +671,14 @@ void NavigationScheduler::scheduleHistoryNavigation(int steps)
     // Invalid history navigations (such as history.forward() during a new load) have the side effect of cancelling any scheduled
     // redirects. We also avoid the possibility of cancelling the current load by avoiding the scheduled redirection altogether.
     RefPtr page = m_frame->page();
-    auto& backForward = page->backForward();
-    if ((steps > 0 && static_cast<unsigned>(steps) > backForward.forwardCount())
-        || (steps < 0 && static_cast<unsigned>(-steps) > backForward.backCount())) {
+    CheckedRef backForward = page->backForward();
+    if ((steps > 0 && static_cast<unsigned>(steps) > backForward->forwardCount())
+        || (steps < 0 && static_cast<unsigned>(-steps) > backForward->backCount())) {
         cancel();
         return;
     }
 
-    RefPtr historyItem = backForward.itemAtIndex(steps);
+    RefPtr historyItem = backForward->itemAtIndex(steps);
     if (!historyItem) {
         cancel();
         return;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1208,10 +1208,10 @@ void ContextMenuController::populate()
 #else
 
                 if (isMainFrame) {
-                    if (page && page->backForward().canGoBackOrForward(-1))
+                    if (page && page->checkedBackForward()->canGoBackOrForward(-1))
                         appendItem(BackItem, m_contextMenu.get());
 
-                    if (page && page->backForward().canGoBackOrForward(1))
+                    if (page && page->checkedBackForward()->canGoBackOrForward(1))
                         appendItem(ForwardItem, m_contextMenu.get());
 
                     // Here we use isLoadingInAPISense rather than isLoading because Stop/Reload are
@@ -1657,10 +1657,10 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
 #endif
 #if PLATFORM(GTK)
         case ContextMenuItemTagGoBack:
-            shouldEnable = frame->page() && frame->page()->backForward().canGoBackOrForward(-1);
+            shouldEnable = frame->page() && frame->page()->checkedBackForward()->canGoBackOrForward(-1);
             break;
         case ContextMenuItemTagGoForward:
-            shouldEnable = frame->page() && frame->page()->backForward().canGoBackOrForward(1);
+            shouldEnable = frame->page() && frame->page()->checkedBackForward()->canGoBackOrForward(1);
             break;
         case ContextMenuItemTagStop:
             shouldEnable = frame->loader().documentLoader()->isLoadingInAPISense();

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -112,7 +112,7 @@ void DOMWindow::close()
     if (!frame->isMainFrame())
         return;
 
-    if (!(page->openedByDOM() || page->backForward().count() <= 1)) {
+    if (!(page->openedByDOM() || page->checkedBackForward()->count() <= 1)) {
         checkedConsole()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
         return;
     }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4595,9 +4595,9 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
     bool handledEvent = false;
 
     if (event.shiftKey())
-        handledEvent = page->backForward().goForward();
+        handledEvent = page->checkedBackForward()->goForward();
     else
-        handledEvent = page->backForward().goBack();
+        handledEvent = page->checkedBackForward()->goBack();
 
     if (handledEvent)
         event.setDefaultHandled();

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -79,7 +79,7 @@ ExceptionOr<unsigned> History::length() const
     RefPtr page = frame->page();
     if (!page)
         return 0;
-    return page->backForward().count();
+    return page->checkedBackForward()->count();
 }
 
 ExceptionOr<History::ScrollRestoration> History::scrollRestoration() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -468,7 +468,7 @@ public:
     void progressEstimateChanged(LocalFrame&) const;
     void progressFinished(LocalFrame&) const;
     BackForwardController& backForward() { return m_backForwardController.get(); }
-    CheckedRef<BackForwardController> checkedBackForward();
+    WEBCORE_EXPORT CheckedRef<BackForwardController> checkedBackForward();
 
     Seconds domTimerAlignmentInterval() const { return m_domTimerAlignmentInterval; }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2515,14 +2515,14 @@ String WebPage::dumpHistoryForTesting(const String& directory)
     if (!m_page)
         return { };
 
-    auto& list = m_page->backForward();
+    CheckedRef list = m_page->backForward();
     
     StringBuilder builder;
-    int begin = -list.backCount();
-    if (list.itemAtIndex(begin)->url() == aboutBlankURL())
+    int begin = -list->backCount();
+    if (list->itemAtIndex(begin)->url() == aboutBlankURL())
         ++begin;
-    for (int i = begin; i <= static_cast<int>(list.forwardCount()); ++i)
-        dumpHistoryItem(*list.itemAtIndex(i), 8, !i, builder, directory);
+    for (int i = begin; i <= static_cast<int>(list->forwardCount()); ++i)
+        dumpHistoryItem(*list->itemAtIndex(i), 8, !i, builder, directory);
     return builder.toString();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -427,9 +427,9 @@ bool WebPage::performNonEditingBehaviorForSelector(const String& selector, Keybo
     }
 
     if (selector == "moveToLeftEndOfLine:"_s)
-        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? m_page->backForward().goBack() : m_page->backForward().goForward();
+        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? m_page->checkedBackForward()->goBack() : m_page->checkedBackForward()->goForward();
     else if (selector == "moveToRightEndOfLine:"_s)
-        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? m_page->backForward().goForward() : m_page->backForward().goBack();
+        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? m_page->checkedBackForward()->goForward() : m_page->checkedBackForward()->goBack();
 
     return didPerformAction;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2760,17 +2760,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // type.  (See behavior matrix at the top of WebFramePrivate.)  So we copy all the items
     // in the back forward list, and go to the current one.
 
-    auto& backForward = _private->page->backForward();
-    ASSERT(!backForward.currentItem()); // destination list should be empty
+    CheckedRef backForward = _private->page->backForward();
+    ASSERT(!backForward->currentItem()); // destination list should be empty
 
-    auto& otherBackForward = otherView->_private->page->backForward();
-    if (!otherBackForward.currentItem())
+    CheckedRef otherBackForward = otherView->_private->page->backForward();
+    if (!otherBackForward->currentItem())
         return; // empty back forward list, bail
 
     WebCore::HistoryItem* newItemToGoTo = nullptr;
 
-    int lastItemIndex = otherBackForward.forwardCount();
-    for (int i = -otherBackForward.backCount(); i <= lastItemIndex; ++i) {
+    int lastItemIndex = otherBackForward->forwardCount();
+    for (int i = -otherBackForward->backCount(); i <= lastItemIndex; ++i) {
         if (i == 0) {
             // If this item is showing , save away its current scroll and form state,
             // since that might have changed since loading and it is normally not saved
@@ -2778,10 +2778,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(otherView->_private->page->mainFrame()))
                 localMainFrame->history().saveDocumentAndScrollState();
         }
-        Ref<WebCore::HistoryItem> newItem = otherBackForward.itemAtIndex(i)->copy();
+        Ref newItem = otherBackForward->itemAtIndex(i)->copy();
         if (i == 0)
             newItemToGoTo = newItem.ptr();
-        backForward.client().addItem(_private->page->mainFrame().frameID(), WTFMove(newItem));
+        backForward->client().addItem(_private->page->mainFrame().frameID(), WTFMove(newItem));
     }
 
     ASSERT(newItemToGoTo);


### PR DESCRIPTION
#### 42aed7355cb1430dbe69c60fb5720f68a14e9f9b
<pre>
Use smart pointer when accessing BackForwardController
<a href="https://bugs.webkit.org/show_bug.cgi?id=278017">https://bugs.webkit.org/show_bug.cgi?id=278017</a>

Reviewed by Ryosuke Niwa.

Use smart pointer when accessing BackForwardController
based on [alpha.webkit.UncountedCallArgsChecker] warnings.

Note that most methods in BackForwardController are not trivial
since they delegate to the client, which likely ends up sending
IPC messages.

* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::updateNavigationAPIEntries):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::pushState):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleHistoryNavigation):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultBackspaceEventHandler):
* Source/WebCore/page/History.cpp:
(WebCore::History::length const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::dumpHistoryForTesting):
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performNonEditingBehaviorForSelector):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _loadBackForwardListFromOtherView:]):

Canonical link: <a href="https://commits.webkit.org/283019@main">https://commits.webkit.org/283019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac3159e9f6d03e1ecf428ef8cbc389a57df51546

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68967 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52174 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70672 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59710 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7336 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1009 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->