### PR TITLE
[GTK][WPE] Remove PlatformDisplay::gbmDevice

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -510,15 +510,6 @@ const String& PlatformDisplay::drmRenderNodeFile()
 #endif // USE(LIBDRM)
 
 #if USE(GBM)
-struct gbm_device* PlatformDisplay::gbmDevice()
-{
-    auto& manager = DRMDeviceManager::singleton();
-    if (!manager.isInitialized())
-        manager.initializeMainDevice(drmRenderNodeFile());
-
-    return manager.mainGBMDeviceNode(DRMDeviceManager::NodeType::Render);
-}
-
 const Vector<PlatformDisplay::DMABufFormat>& PlatformDisplay::dmabufFormats()
 {
     static std::once_flag onceFlag;

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -38,9 +38,6 @@ typedef unsigned EGLenum;
 #if USE(LIBDRM)
 typedef void *EGLDeviceEXT;
 #endif
-#if USE(GBM)
-struct gbm_device;
-#endif
 
 #if PLATFORM(GTK)
 #include <wtf/glib/GRefPtr.h>
@@ -119,7 +116,6 @@ public:
     const String& drmRenderNodeFile();
 #endif
 #if USE(GBM)
-    struct gbm_device* gbmDevice();
     struct DMABufFormat {
         uint32_t fourcc { 0 };
         Vector<uint64_t, 1> modifiers;

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
@@ -28,6 +28,8 @@
 #if USE(GBM)
 #include "PlatformDisplay.h"
 
+struct gbm_device;
+
 namespace WebCore {
 
 class PlatformDisplayGBM final : public PlatformDisplay {

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -68,6 +68,7 @@
 #endif
 
 #if USE(GBM)
+#include <WebCore/DRMDeviceManager.h>
 #include <WebCore/PlatformDisplayGBM.h>
 #include <gbm.h>
 #endif
@@ -506,7 +507,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #if USE(GBM)
             const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
             if (!disableGBM || !strcmp(disableGBM, "0")) {
-                if (auto* device = PlatformDisplay::sharedDisplay().gbmDevice())
+                if (auto* device = DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render))
                     platformDisplay = PlatformDisplayGBM::create(device);
             }
 #endif
@@ -523,7 +524,8 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 
 #if USE(GBM)
                 if (platformDisplay->type() == PlatformDisplay::Type::GBM) {
-                    if (drmVersion* version = drmGetVersion(gbm_device_get_fd(PlatformDisplay::sharedDisplay().gbmDevice()))) {
+                    auto* device = DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render);
+                    if (drmVersion* version = drmGetVersion(gbm_device_get_fd(device))) {
                         addTableRow(hardwareAccelerationObject, "DRM version"_s, makeString(span(version->name), " ("_s, span(version->desc), ") "_s, version->version_major, '.', version->version_minor, '.', version->version_patchlevel, ". "_s, span(version->date)));
                         drmFreeVersion(version);
                     }

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -62,6 +62,10 @@
 #include <wpe/wpe-platform.h>
 #endif
 
+#if USE(GBM)
+#include <WebCore/DRMDeviceManager.h>
+#endif
+
 namespace WebKit {
 
 void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
@@ -92,6 +96,9 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #else
     parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
 #endif
+    auto& manager = WebCore::DRMDeviceManager::singleton();
+    if (!manager.isInitialized())
+        manager.initializeMainDevice(parameters.renderDeviceFile);
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -43,6 +43,7 @@
 #include <wtf/glib/WTFGType.h>
 
 #if USE(GBM)
+#include <WebCore/DRMDeviceManager.h>
 #include <drm_fourcc.h>
 #include <gbm.h>
 
@@ -421,7 +422,7 @@ void AcceleratedBackingStoreDMABuf::BufferEGLImage::release()
 #if USE(GBM)
 RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferGBM::create(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const WebCore::IntSize& size, DMABufRendererBufferFormat::Usage usage, uint32_t format, UnixFileDescriptor&& fd, uint32_t stride)
 {
-    auto* device = WebCore::PlatformDisplay::sharedDisplay().gbmDevice();
+    auto* device = WebCore::DRMDeviceManager::singleton().mainGBMDeviceNode(WebCore::DRMDeviceManager::NodeType::Render);
     if (!device) {
         WTFLogAlways("Failed to get GBM device");
         return nullptr;


### PR DESCRIPTION
#### 32eb0649ba22466de0d37cb4ebe2bc83e2cab6bb
<pre>
[GTK][WPE] Remove PlatformDisplay::gbmDevice
<a href="https://bugs.webkit.org/show_bug.cgi?id=278018">https://bugs.webkit.org/show_bug.cgi?id=278018</a>

Reviewed by Michael Catanzaro.

It&apos;s only used in the UI process where we could use DRMDeviceManager directly.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::gbmDevice): Deleted.
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::create):

Canonical link: <a href="https://commits.webkit.org/282224@main">https://commits.webkit.org/282224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eb6e7d830bf5a711699e395c64fffcc4ecec250

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15138 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13431 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65612 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/38930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12023 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6489 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6518 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/5404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9406 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->