### PR TITLE
[TZone] Change TZone manager to seed with bootsessionuuid

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -86,14 +86,13 @@ void TZoneHeapManager::init()
     // Use the boot UUID and the process' name to seed the key.
     static const size_t rawSeedLength = 128;
     char rawSeed[rawSeedLength] = { };
-    char bootDevUUID[NAME_MAX] = { };
-    size_t bootDevUUIDLen = sizeof(bootDevUUID);
+    char bootUUID[NAME_MAX] = { };
+    size_t bootUUIDLen = sizeof(bootUUID);
 
-    // try using "kern.bootuuid" sysctl to obtain boot volume UUID
-    RELEASE_BASSERT(!sysctlbyname("kern.bootuuid", bootDevUUID, &bootDevUUIDLen, nullptr, 0));
+    RELEASE_BASSERT(!sysctlbyname("kern.bootsessionuuid", bootUUID, &bootUUIDLen, nullptr, 0));
 
     if (verbose)
-        TZONE_LOG_DEBUG("kern.bootuuid: %s\n", bootDevUUID);
+        TZONE_LOG_DEBUG("kernel bootuuid: %s\n", bootUUID);
 
     const char* procName = processNameString();
 
@@ -103,8 +102,8 @@ void TZoneHeapManager::init()
     // Convert bootTime to hex values.
     unsigned byteIdx = 0;
 
-    for (unsigned i = 0; i < bootDevUUIDLen && byteIdx < rawSeedLength; byteIdx++, i++)
-        rawSeed[byteIdx] = bootDevUUID[i];
+    for (unsigned i = 0; i < bootUUIDLen && byteIdx < rawSeedLength; byteIdx++, i++)
+        rawSeed[byteIdx] = bootUUID[i];
 
     auto procNameLen = strlen(procName);
 


### PR DESCRIPTION
#### d17fa1c7ffb1dcb1d9c71ea6eca894996072185e
<pre>
[TZone] Change TZone manager to seed with bootsessionuuid
<a href="https://bugs.webkit.org/show_bug.cgi?id=278031">https://bugs.webkit.org/show_bug.cgi?id=278031</a>
<a href="https://rdar.apple.com/133774773">rdar://133774773</a>

Reviewed by NOBODY (OOPS!).

Changed to use kern.bootsessionuuid for seeding.  Updated related variable names to be more generic.

* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::init):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d17fa1c7ffb1dcb1d9c71ea6eca894996072185e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12937 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50290 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8933 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11866 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55483 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68099 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61629 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57662 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57865 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5274 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83392 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37541 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14638 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->