### PR TITLE
[TZone] WebCore/bindings: Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -30,11 +30,12 @@
 #include "CachedScript.h"
 #include "CachedScriptFetcher.h"
 #include <JavaScriptCore/SourceProvider.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class CachedScriptSourceProvider : public JSC::SourceProvider, public CachedResourceClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CachedScriptSourceProvider);
 public:
     static Ref<CachedScriptSourceProvider> create(CachedScript* cachedScript, JSC::SourceProviderSourceType sourceType, Ref<CachedScriptFetcher>&& scriptFetcher) { return adoptRef(*new CachedScriptSourceProvider(cachedScript, sourceType, WTFMove(scriptFetcher))); }
 

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -34,10 +34,13 @@
 #include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/VM.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMGCOutputConstraint);
 
 DOMGCOutputConstraint::DOMGCOutputConstraint(VM& vm, JSHeapData& heapData)
     : MarkingConstraint("Domo", "DOM Output", ConstraintVolatility::SeldomGreyed, ConstraintConcurrency::Concurrent, ConstraintParallelism::Parallel)

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.h
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/MarkingConstraint.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class VM;
@@ -36,7 +37,7 @@ namespace WebCore {
 class JSHeapData;
 
 class DOMGCOutputConstraint : public JSC::MarkingConstraint {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DOMGCOutputConstraint);
 public:
     DOMGCOutputConstraint(JSC::VM&, JSHeapData&);
     ~DOMGCOutputConstraint();

--- a/Source/WebCore/bindings/js/DOMPromiseProxy.h
+++ b/Source/WebCore/bindings/js/DOMPromiseProxy.h
@@ -29,13 +29,14 @@
 #include "JSDOMGlobalObject.h"
 #include "JSDOMPromiseDeferred.h"
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 template<typename IDLType>
 class DOMPromiseProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMPromiseProxy);
 public:
     using Value = typename IDLType::StorageType;
 
@@ -61,7 +62,7 @@ private:
 
 template<>
 class DOMPromiseProxy<IDLUndefined> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMPromiseProxy);
 public:
     DOMPromiseProxy() = default;
     ~DOMPromiseProxy() = default;
@@ -86,7 +87,7 @@ private:
 // FontFace and FontFaceSet.
 template<typename IDLType>
 class DOMPromiseProxyWithResolveCallback {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMPromiseProxyWithResolveCallback);
 public:
     using ResolveCallback = Function<typename IDLType::ParameterType()>;
 

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -39,6 +39,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 using namespace JSC;
@@ -48,6 +49,8 @@ static void collect()
     JSLockHolder lock(commonVM());
     commonVM().heap.collectNow(Async, CollectionScope::Full);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GCController);
 
 GCController& GCController::singleton()
 {

--- a/Source/WebCore/bindings/js/GCController.h
+++ b/Source/WebCore/bindings/js/GCController.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/DeleteAllCodeEffort.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class VM;
@@ -37,7 +38,7 @@ class VM;
 namespace WebCore {
 
 class GCController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GCController);
     WTF_MAKE_NONCOPYABLE(GCController);
     friend class WTF::NeverDestroyed<GCController>;
 public:

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -34,10 +34,13 @@
 #include "JSExecState.h"
 #include "JSExecStateInstrumentation.h"
 #include <JavaScriptCore/Exception.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSCallbackData);
 
 // https://webidl.spec.whatwg.org/#call-a-user-objects-operation
 JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject* callback, JSValue thisValue, MarkedArgumentBuffer& args, CallbackType method, PropertyName functionName, NakedPtr<JSC::Exception>& returnedException)

--- a/Source/WebCore/bindings/js/JSCallbackData.h
+++ b/Source/WebCore/bindings/js/JSCallbackData.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
 namespace WebCore {
@@ -44,7 +45,7 @@ template<typename ImplementationClass> struct JSDOMCallbackConverterTraits;
 // (and synchronization would be slow).
 
 class JSCallbackData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(JSCallbackData, WEBCORE_EXPORT);
 public:
     enum class CallbackType { Function, Object, FunctionOrObject };
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -31,6 +31,7 @@
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/JSPromise.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -235,7 +236,7 @@ private:
 };
 
 class DOMPromiseDeferredBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DOMPromiseDeferredBase);
 public:
     DOMPromiseDeferredBase(Ref<DeferredPromise>&& genericPromise)
         : m_promise(WTFMove(genericPromise))

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -43,9 +43,12 @@
 #include "WorkerThread.h"
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/SourceProvider.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScheduledAction);
 
 std::unique_ptr<ScheduledAction> ScheduledAction::create(DOMWrapperWorld& isolatedWorld, Strong<JSObject>&& function)
 {

--- a/Source/WebCore/bindings/js/ScheduledAction.h
+++ b/Source/WebCore/bindings/js/ScheduledAction.h
@@ -22,6 +22,7 @@
 #include <JavaScriptCore/Strong.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
@@ -36,7 +37,7 @@ class ScriptExecutionContext;
 class WorkerGlobalScope;
 
 class ScheduledAction {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScheduledAction);
 public:
     static std::unique_ptr<ScheduledAction> create(DOMWrapperWorld&, JSC::Strong<JSC::JSObject>&&);
     static std::unique_ptr<ScheduledAction> create(DOMWrapperWorld&, String&&);

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -27,7 +27,7 @@
 
 #include "ScriptBuffer.h"
 #include <JavaScriptCore/SourceProvider.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class AbstractScriptBufferHolder;
@@ -49,7 +49,7 @@ public:
 };
 
 class ScriptBufferSourceProvider final : public JSC::SourceProvider, public AbstractScriptBufferHolder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ScriptBufferSourceProvider);
 public:
     static Ref<ScriptBufferSourceProvider> create(const ScriptBuffer& scriptBuffer, const JSC::SourceOrigin& sourceOrigin, String sourceURL, String preRedirectURL, const TextPosition& startPosition = TextPosition(), JSC::SourceProviderSourceType sourceType = JSC::SourceProviderSourceType::Program)
     {

--- a/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
+++ b/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
@@ -44,9 +44,12 @@
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScriptCachedFrameData);
 
 ScriptCachedFrameData::ScriptCachedFrameData(LocalFrame& frame)
 {

--- a/Source/WebCore/bindings/js/ScriptCachedFrameData.h
+++ b/Source/WebCore/bindings/js/ScriptCachedFrameData.h
@@ -33,6 +33,7 @@
 
 #include <JavaScriptCore/Strong.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -41,7 +42,8 @@ class JSDOMWindow;
 class LocalFrame;
 
 class ScriptCachedFrameData {
-    WTF_MAKE_NONCOPYABLE(ScriptCachedFrameData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScriptCachedFrameData);
+    WTF_MAKE_NONCOPYABLE(ScriptCachedFrameData);
 public:
     explicit ScriptCachedFrameData(LocalFrame&);
     ~ScriptCachedFrameData();

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -77,6 +77,7 @@
 #include <JavaScriptCore/WebAssemblyModuleRecord.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextPosition.h>
@@ -91,6 +92,8 @@ namespace WebCore {
 using namespace JSC;
 
 enum class WebCoreProfileTag { };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScriptController);
 
 void ScriptController::initializeMainThread()
 {

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/TextPosition.h>
 
@@ -79,7 +80,7 @@ enum class ReasonForCallingCanExecuteScripts : uint8_t {
 using ValueOrException = Expected<JSC::JSValue, ExceptionDetails>;
 
 class ScriptController final : public CanMakeWeakPtr<ScriptController>, public CanMakeCheckedPtr<ScriptController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScriptController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScriptController);
 
     using RootObjectMap = HashMap<void*, Ref<JSC::Bindings::RootObject>>;

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -61,9 +61,12 @@
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/Symbol.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScriptModuleLoader);
 
 ScriptModuleLoader::ScriptModuleLoader(ScriptExecutionContext* context, OwnerType ownerType)
     : m_context(context)

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -31,6 +31,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 
 namespace JSC {
@@ -50,7 +51,8 @@ class JSDOMGlobalObject;
 class ScriptExecutionContext;
 
 class ScriptModuleLoader final : private ModuleScriptLoaderClient {
-    WTF_MAKE_NONCOPYABLE(ScriptModuleLoader); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScriptModuleLoader);
+    WTF_MAKE_NONCOPYABLE(ScriptModuleLoader);
 public:
     enum class OwnerType : uint8_t { Document, WorkerOrWorklet };
     enum class ModuleType : uint8_t { Invalid, JavaScript, WebAssembly, JSON };

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -34,11 +34,12 @@
 #include "SharedBuffer.h"
 #include <JavaScriptCore/SourceProvider.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class WebAssemblyCachedScriptSourceProvider final : public JSC::BaseWebAssemblySourceProvider, public CachedResourceClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebAssemblyCachedScriptSourceProvider);
 public:
     static Ref<WebAssemblyCachedScriptSourceProvider> create(CachedScript* cachedScript, Ref<CachedScriptFetcher>&& scriptFetcher)
     {

--- a/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
@@ -29,11 +29,12 @@
 
 #include "ScriptBufferSourceProvider.h"
 #include <JavaScriptCore/SourceProvider.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class WebAssemblyScriptBufferSourceProvider final : public JSC::BaseWebAssemblySourceProvider, public AbstractScriptBufferHolder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebAssemblyScriptBufferSourceProvider);
 public:
     static Ref<WebAssemblyScriptBufferSourceProvider> create(const ScriptBuffer& scriptBuffer, URL&& sourceURL, Ref<JSC::ScriptFetcher>&& scriptFetcher)
     {

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -53,6 +54,8 @@ static void collectGarbageAfterWindowProxyDestruction()
     } else
         GCController::singleton().garbageCollectSoon();
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WindowProxy);
 
 WindowProxy::WindowProxy(Frame& frame)
     : m_frame(frame)

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -23,6 +23,7 @@
 #include <JavaScriptCore/Strong.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -39,7 +40,7 @@ class JSDOMGlobalObject;
 class JSWindowProxy;
 
 class WindowProxy : public RefCounted<WindowProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(WindowProxy, WEBCORE_EXPORT);
 public:
     using ProxyMap = HashMap<RefPtr<DOMWrapperWorld>, JSC::Strong<JSWindowProxy>>;
 


### PR DESCRIPTION
#### 85fc98ff8a75ce0946c3e243bb56e8f9d43c19ce
<pre>
[TZone] WebCore/bindings: Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278032">https://bugs.webkit.org/show_bug.cgi?id=278032</a>
<a href="https://rdar.apple.com/133775215">rdar://133775215</a>

Reviewed by Keith Miller.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
* Source/WebCore/bindings/js/DOMGCOutputConstraint.h:
* Source/WebCore/bindings/js/DOMPromiseProxy.h:
* Source/WebCore/bindings/js/GCController.cpp:
* Source/WebCore/bindings/js/GCController.h:
* Source/WebCore/bindings/js/JSCallbackData.cpp:
* Source/WebCore/bindings/js/JSCallbackData.h:
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
* Source/WebCore/bindings/js/ScheduledAction.cpp:
* Source/WebCore/bindings/js/ScheduledAction.h:
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Source/WebCore/bindings/js/ScriptCachedFrameData.cpp:
* Source/WebCore/bindings/js/ScriptCachedFrameData.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h:
* Source/WebCore/bindings/js/WindowProxy.cpp:
* Source/WebCore/bindings/js/WindowProxy.h:

Canonical link: <a href="https://commits.webkit.org/282434@main">https://commits.webkit.org/282434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21bbcbeeaf3f3b7caca032ab07d07892f006857

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50815 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11952 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68779 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58128 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58339 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5843 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38239 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39319 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->