### PR TITLE
[WebAuthn] Implement batching for checking allowCredentials

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https-expected.txt
@@ -5,4 +5,5 @@ PASS PublicKeyCredential's [[get]] with authenticator downgrade failed in a mock
 PASS PublicKeyCredential's [[get]] with authenticator downgrade failed in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[get]] with authenticator downgrade succeeded and then U2F failed in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with getNextAssertion failed in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with many allowedCredentials necessitating batching without a match.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
@@ -83,4 +83,25 @@
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testAssertionMessageLongBase64, testCtapErrNotAllowedResponseBase64] } });
         return promiseRejects(t, "UnknownError", navigator.credentials.get(options), "Unknown internal error. Error code: 48");
     }, "PublicKeyCredential's [[get]] with getNextAssertion failed in a mock hid authenticator.");
+
+    promise_test(function(t) {
+        const config = { hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrInvalidCredentialResponseBase64] } };
+        const options = {
+            publicKey: {
+                challenge: asciiToUint8Array("123456"),
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 5;
+
+        for (let i = 0; i < numCredentials; i++) {
+            config.hid.payloadBase64.unshift("Lg==");
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return promiseRejects(t, "UnknownError", navigator.credentials.get(options), "Unknown internal error. Error code: 34");
+    }, "PublicKeyCredential's [[get]] with many allowedCredentials necessitating batching without a match.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
@@ -7,4 +7,6 @@ PASS PublicKeyCredential's [[get]] with mixed options in a mock hid authenticato
 PASS PublicKeyCredential's [[get]] with two consecutive requests.
 PASS PublicKeyCredential's [[get]] with multiple accounts in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with PIN supported in the authenticator but userVerification = 'discouraged' in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator. 2
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -132,4 +132,52 @@
             return checkCtapGetAssertionResult(credential);
         });
     }, "PublicKeyCredential's [[get]] with PIN supported in the authenticator but userVerification = 'discouraged' in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = { hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testAssertionMessageBase64] } };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 100,
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++) {
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+            config.hid.payloadBase64.unshift("Lg==");
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            return checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = { hid: { maxCredentialCountInList: 5, stage: "request", subStage: "msg", error: "success", payloadBase64: [testAssertionMessageBase64] } };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 100,
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++)
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+        for (let i = 0; i < Math.ceil(numCredentials/config.hid.maxCredentialCountInList); i++)
+            config.hid.payloadBase64.unshift("Lg==");
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator. 2");
 </script>

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
@@ -51,12 +51,12 @@ struct PinParameters {
 // Serializes MakeCredential request parameter into CBOR encoded map with
 // integer keys and CBOR encoded values as defined by the CTAP spec.
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorMakeCredential
-WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialCreationOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, AuthenticatorSupportedOptions::ResidentKeyAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt);
+WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialCreationOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, AuthenticatorSupportedOptions::ResidentKeyAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt, std::optional<Vector<WebCore::PublicKeyCredentialDescriptor>>&& = std::nullopt);
 
 // Serializes GetAssertion request parameter into CBOR encoded map with
 // integer keys and CBOR encoded values as defined by the CTAP spec.
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorGetAssertion
-WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt);
+WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt, std::optional<Vector<WebCore::PublicKeyCredentialDescriptor>>&& = std::nullopt);
 
 WEBCORE_EXPORT Vector<uint8_t> encodeSilentGetAssertion(const String& rpId, const Vector<uint8_t>& hash, const Vector<WebCore::PublicKeyCredentialDescriptor>& credentials, std::optional<PinParameters> = std::nullopt);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -129,31 +129,39 @@ void CtapAuthenticator::makeCredential()
             ASSERT(RunLoop::isMain());
             if (!weakThis)
                 return;
-            weakThis->continueCheckExcludedCredentialsAfterResponseRecieved(WTFMove(data));
+            weakThis->continueSilentlyCheckCredentials(WTFMove(data), [weakThis = WTFMove(weakThis)] (bool foundMatch) mutable {
+                if (!weakThis)
+                    return;
+                weakThis->continueMakeCredentialAfterCheckExcludedCredentials(foundMatch);
+            });
         });
     } else
         continueMakeCredentialAfterCheckExcludedCredentials();
 }
 
-void CtapAuthenticator::continueCheckExcludedCredentialsAfterResponseRecieved(Vector<uint8_t>&& data)
+void CtapAuthenticator::continueSilentlyCheckCredentials(Vector<uint8_t>&& data, CompletionHandler<void(bool)>&& completionHandler)
 {
     auto error = getResponseCode(data);
     if (error == CtapDeviceResponseCode::kSuccess)
-        return continueMakeCredentialAfterCheckExcludedCredentials(true);
+        return completionHandler(true);
     if (error == CtapDeviceResponseCode::kCtap2ErrNoCredentials) {
+        if (m_currentBatch + 1 >= m_batches.size())
+            return completionHandler(false);
         m_currentBatch += 1;
-        if (m_currentBatch >= m_batches.size())
-            return continueMakeCredentialAfterCheckExcludedCredentials();
     }
-    auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
+    Vector<uint8_t> cborCmd;
+    WTF::switchOn(requestData().options, [&](const PublicKeyCredentialCreationOptions& options) {
+        cborCmd = encodeSilentGetAssertion(*options.rp.id, requestData().hash, m_batches[m_currentBatch], std::nullopt);
+    }, [&](const PublicKeyCredentialRequestOptions& options) {
+        cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, m_batches[m_currentBatch], std::nullopt);
+    });
 
     auto response = readCTAPGetAssertionResponse(data, AuthenticatorAttachment::CrossPlatform);
-    Vector<uint8_t> cborCmd = encodeSilentGetAssertion(*options.rp.id, requestData().hash, m_batches[m_currentBatch], std::nullopt);
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](Vector<uint8_t>&& data) mutable {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
-            return;
-        weakThis->continueCheckExcludedCredentialsAfterResponseRecieved(WTFMove(data));
+            return completionHandler(false);
+        weakThis->continueSilentlyCheckCredentials(WTFMove(data), WTFMove(completionHandler));
     });
 }
 
@@ -161,6 +169,11 @@ void CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials(bool
 {
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
+    Vector<PublicKeyCredentialDescriptor> overrideExcludeCredentials;
+    if (includeCurrentBatch) {
+        ASSERT(m_currentBatch < m_batches.size());
+        overrideExcludeCredentials = m_batches[m_currentBatch];
+    }
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     auto residentKeyAvailability = m_info.options().residentKeyAvailability();
     Vector<String> authenticatorSupportedExtensions;
@@ -174,11 +187,11 @@ void CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials(bool
 
     // If UV is required, then either built-in uv or a pin will work.
     if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
-        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions);
+        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideExcludeCredentials));
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet)
-        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
+        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth }, WTFMove(overrideExcludeCredentials));
     else
-        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions);
+        cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideExcludeCredentials));
     CTAP_RELEASE_LOG("makeCredential: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
@@ -240,18 +253,51 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
 
 void CtapAuthenticator::getAssertion()
 {
+    CTAP_RELEASE_LOG("getAssertion");
+
+    auto& options = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
+    if (options.allowCredentials.size() > 1) {
+        uint32_t maxBatchSize = 1;
+        if (m_info.maxCredentialIDLength() && m_info.maxCredentialCountInList())
+            maxBatchSize = *m_info.maxCredentialCountInList();
+        m_batches = batchesForCredentials(options.allowCredentials, maxBatchSize, m_info.maxCredentialIDLength());
+        ASSERT(m_batches.size());
+        if (!m_batches.size())
+            return continueGetAssertionAfterCheckAllowCredentials();
+        m_currentBatch = 0;
+        Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, m_batches[m_currentBatch], std::nullopt);
+        driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+            ASSERT(RunLoop::isMain());
+            if (!weakThis)
+                return;
+            weakThis->continueSilentlyCheckCredentials(WTFMove(data), [weakThis = WTFMove(weakThis)] (bool) mutable {
+                if (!weakThis)
+                    return;
+                weakThis->continueGetAssertionAfterCheckAllowCredentials();
+            });
+        });
+    } else
+        continueGetAssertionAfterCheckAllowCredentials();
+}
+
+void CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials()
+{
     ASSERT(!m_isDowngraded);
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
+    std::optional<Vector<PublicKeyCredentialDescriptor>> overrideAllowCredentials;
+    if (m_currentBatch < m_batches.size())
+        overrideAllowCredentials = m_batches[m_currentBatch];
+
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     Vector<String> authenticatorSupportedExtensions;
     // If UV is required, then either built-in uv or a pin will work.
     if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideAllowCredentials));
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification != UserVerificationRequirement::Discouraged)
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth }, WTFMove(overrideAllowCredentials));
     else
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideAllowCredentials));
     CTAP_RELEASE_LOG("getAssertion: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -58,8 +58,9 @@ private:
     void makeCredential() final;
     void continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&&);
     void getAssertion() final;
-    void continueCheckExcludedCredentialsAfterResponseRecieved(Vector<uint8_t>&& data);
+    void continueSilentlyCheckCredentials(Vector<uint8_t>&&, CompletionHandler<void(bool)>&&);
     void continueMakeCredentialAfterCheckExcludedCredentials(bool includeCurrentBatch = false);
+    void continueGetAssertionAfterCheckAllowCredentials();
     void continueGetAssertionAfterResponseReceived(Vector<uint8_t>&&);
     void continueGetNextAssertionAfterResponseReceived(Vector<uint8_t>&&);
 


### PR DESCRIPTION
#### 52a47cbac08b216dcff99d9743a3d10b1c7c5991
<pre>
[WebAuthn] Implement batching for checking allowCredentials
<a href="https://rdar.apple.com/133711978">rdar://133711978</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277979">https://bugs.webkit.org/show_bug.cgi?id=277979</a>

Reviewed by Brent Fulgham.

This change implements checking the allowCredentials in batches as supported by
the authenticator during getAssertion. This is accomplished with smaller up=0,
get requests to determine if credentials are present on the authenticator.

Then if a credential is detected as present, it is included in the allowCredentials list
in the real request. If no credentials matched, then we already know the call will not
be able to succeed, so we just include the last batch.

Added layout tests for the new behaviors.

* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueSlientlyCheckCredentials):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials):
(WebKit::CtapAuthenticator::continueCheckExcludedCredentialsAfterResponseRecieved): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/282246@main">https://commits.webkit.org/282246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03653134d90fab82efba876d66e4821378dd7b9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50329 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8961 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68161 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6394 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11424 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57713 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54114 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57901 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5319 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37603 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38688 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->