### PR TITLE
[JSC] Add Load/StorePair pattern matching to B3LowerToAir

### DIFF
--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -4163,6 +4163,60 @@ void testSub32ArgImm()
 }
 
 #if CPU(ARM64)
+void testLoadStorePair32Int()
+{
+    struct Pair {
+        uint32_t value1;
+        uint32_t value2;
+    };
+
+    Pair pair1 = { 1, 2 };
+    Pair pair2 = { 0, 0 };
+
+    auto testLoadStorePair = compile([] (CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg pair1 = GPRInfo::argumentGPR0;
+        constexpr GPRReg pair2 = GPRInfo::argumentGPR1;
+        jit.loadPair32(CCallHelpers::Address(pair1, 0), GPRInfo::regT2, GPRInfo::regT3);
+        jit.storePair32(GPRInfo::regT2, GPRInfo::regT3, CCallHelpers::Address(pair2, 0));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    invoke<void>(testLoadStorePair, &pair1, &pair2);
+    CHECK_EQ(pair1.value1, pair2.value1);
+    CHECK_EQ(pair1.value2, pair2.value2);
+}
+
+void testLoadStorePair64Int()
+{
+    struct Pair {
+        uint64_t value1;
+        uint64_t value2;
+    };
+
+    Pair pair1 = { 1, 2 };
+    Pair pair2 = { 0, 0 };
+
+    auto testLoadStorePair = compile([] (CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg pair1 = GPRInfo::argumentGPR0;
+        constexpr GPRReg pair2 = GPRInfo::argumentGPR1;
+        jit.loadPair64(CCallHelpers::Address(pair1, 0), GPRInfo::regT2, GPRInfo::regT3);
+        jit.storePair64(GPRInfo::regT2, GPRInfo::regT3, CCallHelpers::Address(pair2, 0));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    invoke<void>(testLoadStorePair, &pair1, &pair2);
+    CHECK_EQ(pair1.value1, pair2.value1);
+    CHECK_EQ(pair1.value2, pair2.value2);
+}
+
 void testLoadStorePair64Int64()
 {
     constexpr uint64_t initialValue = 0x5555aaaabbbb8800ull;
@@ -6087,6 +6141,8 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 #endif
 
 #if CPU(ARM64)
+    RUN(testLoadStorePair32Int());
+    RUN(testLoadStorePair64Int());
     RUN(testLoadStorePair64Int64());
     RUN(testLoadStorePair64Double());
     RUN(testMultiplySignExtend32());

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1195,6 +1195,12 @@ void testNegDouble(double);
 void testNegFloat(float);
 void testNegFloatWithUselessDoubleConversion(float);
 
+void testLoadStorePair1();
+void testLoadStorePair2();
+void testLoadStorePair3();
+void testLoadStorePair4();
+void testLoadStorePair5();
+
 void addArgTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 void addBitTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 void addCallTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -468,6 +468,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxB3TailDupBlockSuccessors, 3, Normal, nullptr) \
     v(Bool, useB3HoistLoopInvariantValues, true, Normal, nullptr) \
     v(Bool, useB3CanonicalizePrePostIncrements, false, Normal, nullptr) \
+    v(Bool, useB3CanonicalizeLoadStorePair, false, Normal, nullptr) \
     v(Bool, useAirOptimizePairedLoadStore, true, Normal, nullptr) \
     \
     v(Bool, useDollarVM, false, Restricted, "installs the $vm debugging tool in global objects"_s) \


### PR DESCRIPTION
#### 594be26e345ae25300c9687cbb3cf37e8bde38ec
<pre>
[JSC] Add Load/StorePair pattern matching to B3LowerToAir
<a href="https://bugs.webkit.org/show_bug.cgi?id=278035">https://bugs.webkit.org/show_bug.cgi?id=278035</a>
<a href="https://rdar.apple.com/133778522">rdar://133778522</a>

Reviewed by NOBODY (OOPS!).

This patch adds basic pattern matching for Load/StorePair in B3LowerToAir.

            Turn Canonical Form                                  Into This
--------------------------------------------------------------------------------------------
memory1 = Load(base, offset)                  |
memory2 = Load(base, offset + bytes)          | LoadPair (%base, offset), %memory1, %memory2
--------------------------------------------------------------------------------------------
memory1 = Store(value1, base, offset)         |
memory2 = Store(value2, base, offset + bytes) | StorePair %value1, %value2, (%base, offset)

A canonicalizeLoadStorePair phase will be added to B3CanonicalizePrePostIncrements
in the future if profitable.

* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testLoadStorePair32Int):
(JSC::testLoadStorePair64Int):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_4.cpp:
(testLoadStorePair1):
(testLoadStorePair2):
(testLoadStorePair3):
(testLoadStorePair4):
(testLoadStorePair5):
(addSExtTests):
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594be26e345ae25300c9687cbb3cf37e8bde38ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15000 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/49447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13290 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65474 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/49447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/49447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/55502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/49447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/61648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/6351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/6380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83411 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/14644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->