### PR TITLE
AX: text-transform: full-size-kana must not affect AT/speech output

### DIFF
--- a/LayoutTests/accessibility/full-size-kana-untransformed-expected.txt
+++ b/LayoutTests/accessibility/full-size-kana-untransformed-expected.txt
@@ -1,0 +1,8 @@
+This tests that text with full-size-kana returns the untransformed text to Accessibility APIs.
+
+AX String: じゅう must read the same as じゅう not じゆう.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+じゆう must read the same as じゅう not じゆう.

--- a/LayoutTests/accessibility/full-size-kana-untransformed.html
+++ b/LayoutTests/accessibility/full-size-kana-untransformed.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<meta charset=utf-8>
+</head>
+<body>
+
+<div id="text">
+<strong style="text-transform: full-size-kana" id="full-size-kana-text">じゅう</strong> must read the same as じゅう not じゆう.
+</div>
+
+<script>
+var output = "This tests that text with full-size-kana returns the untransformed text to Accessibility APIs.\n\n";
+
+if (window.accessibilityController) {
+    var textElement = accessibilityController.accessibleElementById("text");
+    var textMarkerRange = textElement.textMarkerRangeForElement(textElement);
+
+    output += `AX String: ${textElement.stringForTextMarkerRange(textMarkerRange)}\n`;
+      
+    debug(output);
+    finishJSTest();
+}
+</script>
+
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -707,6 +707,9 @@ accessibility/cells-inside-contenteditable.html [ Skip ]
 
 http/wpt/service-workers/mac [ Skip ]
 
+# TextMarkerRangeForElement is only implemented on Cocoa platforms.
+accessibility/full-size-kana-untransformed.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Accessibility-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1707,7 +1707,7 @@ StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Pos
 
 String AccessibilityObject::stringForRange(const SimpleRange& range) const
 {
-    TextIterator it(range);
+    TextIterator it = textIteratorIgnoringFullSizeKana(range);
     if (it.atEnd())
         return String();
 
@@ -1738,7 +1738,8 @@ String AccessibilityObject::stringForVisiblePositionRange(const VisiblePositionR
         return { };
 
     StringBuilder builder;
-    for (TextIterator it(*range); !it.atEnd(); it.advance()) {
+    TextIterator it = textIteratorIgnoringFullSizeKana(*range);
+    for (; !it.atEnd(); it.advance()) {
         // non-zero length means textual node, zero length means replaced node (AKA "attachments" in AX)
         if (it.text().length()) {
             // Add a textual representation for list marker text.
@@ -3851,7 +3852,7 @@ bool AccessibilityObject::pressedIsPresent() const
 
 TextIteratorBehaviors AccessibilityObject::textIteratorBehaviorForTextRange() const
 {
-    TextIteratorBehaviors behaviors { TextIteratorBehavior::IgnoresStyleVisibility };
+    TextIteratorBehaviors behaviors { TextIteratorBehavior::IgnoresStyleVisibility, TextIteratorBehavior::IgnoresFullSizeKana };
 
 #if USE(ATSPI)
     // We need to emit replaced elements for ATSPI, and present
@@ -3861,7 +3862,12 @@ TextIteratorBehaviors AccessibilityObject::textIteratorBehaviorForTextRange() co
     
     return behaviors;
 }
-    
+
+TextIterator AccessibilityObject::textIteratorIgnoringFullSizeKana(const SimpleRange& range)
+{
+    return TextIterator(range, { TextIteratorBehavior::IgnoresFullSizeKana });
+}
+
 AccessibilityRole AccessibilityObject::buttonRoleType() const
 {
     // If aria-pressed is present, then it should be exposed as a toggle button.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -36,6 +36,7 @@
 #include "LayoutRect.h"
 #include "Path.h"
 #include "RuntimeApplicationChecks.h"
+#include "TextIterator.h"
 #include <iterator>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
@@ -449,6 +450,7 @@ public:
     bool supportsPath() const override { return false; }
 
     TextIteratorBehaviors textIteratorBehaviorForTextRange() const;
+    static TextIterator textIteratorIgnoringFullSizeKana(const SimpleRange&);
     CharacterRange selectedTextRange() const override { return { }; }
     int insertionPointLineNumber() const override { return -1; }
 

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -196,7 +196,8 @@ RetainPtr<NSArray> AccessibilityObject::contentForRange(const SimpleRange& range
     auto result = adoptNS([[NSMutableArray alloc] init]);
 
     // Iterate over the range to build the AX attributed strings.
-    for (TextIterator it(range); !it.atEnd(); it.advance()) {
+    TextIterator it = textIteratorIgnoringFullSizeKana(range);
+    for (; !it.atEnd(); it.advance()) {
         Node& node = it.range().start.container;
 
         // Non-zero length means textual node, zero length means replaced node (AKA "attachments" in AX).

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1157,8 +1157,10 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
     ASSERT(textEndOffset >= 0);
     ASSERT(textStartOffset <= textEndOffset);
 
+    bool shouldIgnoreFullSizeKana = m_behaviors.contains(TextIteratorBehavior::IgnoresFullSizeKana) && renderer.style().textTransform().contains(TextTransform::FullSizeKana);
+
     // FIXME: This probably yields the wrong offsets when text-transform: lowercase turns a single character into two characters.
-    String string = m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) ? renderer.originalText()
+    String string = m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || shouldIgnoreFullSizeKana ? renderer.originalText()
         : (m_behaviors.contains(TextIteratorBehavior::EmitsTextsWithoutTranscoding) ? renderer.textWithoutConvertingBackslashToYenSymbol() : renderer.text());
 
     ASSERT(m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || string.length() >= static_cast<unsigned>(textEndOffset));

--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -69,6 +69,9 @@ enum class TextIteratorBehavior : uint16_t {
 #if ENABLE(ATTACHMENT_ELEMENT)
     EmitsObjectReplacementCharactersForAttachments = 1 << 13,
 #endif
+
+    // Used by accessibility to expose untransformed kana text.
+    IgnoresFullSizeKana = 1 << 14
 };
 
 using TextIteratorBehaviors = OptionSet<TextIteratorBehavior>;


### PR DESCRIPTION
#### 00c8f47583643ff7824ed18bd0470c1b066ee74a
<pre>
AX: text-transform: full-size-kana must not affect AT/speech output
<a href="https://bugs.webkit.org/show_bug.cgi?id=261565">https://bugs.webkit.org/show_bug.cgi?id=261565</a>
<a href="https://rdar.apple.com/115504070">rdar://115504070</a>

Reviewed by Tyler Wilcock.

`full-size-kana` is used to improve legibility issues with small Kana text. Readers are the ones
who are supposed to make the distinction, but for ATs, we need to make sure we aren&apos;t using this
visually transformed text for speech output.

This patch adds a new IteratorBehavior, IgnoresFullSizeKana, to the text iterator for use by
Accessibility. This will return the original, untransformed text, to our string-creation
methods.

* LayoutTests/accessibility/full-size-kana-untransformed-expected.txt: Added.
* LayoutTests/accessibility/full-size-kana-untransformed.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::stringForRange const):
(WebCore::AccessibilityObject::stringForVisiblePositionRange):
(WebCore::AccessibilityObject::textIteratorBehaviorForTextRange const):
(WebCore::AccessibilityObject::textIteratorIgnoringFullSizeKana):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::AccessibilityObject::contentForRange const):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::emitText):
* Source/WebCore/editing/TextIteratorBehavior.h:

Canonical link: <a href="https://commits.webkit.org/282258@main">https://commits.webkit.org/282258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75417630cfbc494cfdccb4bfb4e29b3dae725c26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50418 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68288 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57797 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57991 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13899 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5438 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37728 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38813 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->