### PR TITLE
Signposts for non-webkit browsers

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch
@@ -1,8 +1,27 @@
 diff --git a/resources/benchmark-runner.mjs b/resources/benchmark-runner.mjs
-index 06596a7..5db38cf 100644
+index 47084c8..4fd3dcd 100644
 --- a/resources/benchmark-runner.mjs
 +++ b/resources/benchmark-runner.mjs
-@@ -441,6 +441,8 @@ export class BenchmarkRunner {
+@@ -1,3 +1,18 @@
++const send_data = data => {
++    const req = new XMLHttpRequest();
++    req.open("POST", "/signpost", false); // synchronous fetch
++    req.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
++    req.send(JSON.stringify(data));
++};
++if (globalThis.__signpostStart === undefined && globalThis.__signpostStop === undefined) {
++    globalThis.__signpostStart = testname => {
++        send_data({type: "signpostStart", testname, timestamp: performance.now()});
++    };
++    globalThis.__signpostStop = testname => {
++        send_data({type: "signpostStop", testname, timestamp: performance.now()});
++    };
++};
++
+ import { Metric } from "./metric.mjs";
+ import { params } from "./params.mjs";
+ 
+@@ -462,6 +477,8 @@ export class BenchmarkRunner {
          const syncEndLabel = `${suite.name}.${test.name}-sync-end`;
          const asyncStartLabel = `${suite.name}.${test.name}-async-start`;
          const asyncEndLabel = `${suite.name}.${test.name}-async-end`;
@@ -11,7 +30,7 @@ index 06596a7..5db38cf 100644
  
          let syncTime;
          let asyncStartTime;
-@@ -455,21 +457,25 @@ export class BenchmarkRunner {
+@@ -476,21 +493,25 @@ export class BenchmarkRunner {
                  performance.mark("warmup-end");
              }
              performance.mark(startLabel);

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/signposts/setup.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/signposts/setup.py
@@ -1,0 +1,13 @@
+from distutils.core import setup, Extension
+
+module = Extension(
+    'signposts',
+    sources=['signposts.c'],
+)
+
+setup(
+    name='signposts',
+    version='1.0.0',
+    description='provides python api for emitting os_signposts while running a browser benchmark',
+    ext_modules=[module],
+)

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/signposts/signposts.c
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/signposts/signposts.c
@@ -1,0 +1,69 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <os/log.h>
+#include <os/signpost.h>
+#include <stdio.h>
+
+#define SIGNPOST_NAME "JSGlobalObject"
+
+static os_log_t handle;
+static os_signpost_id_t id;
+
+static PyObject *interval_begin(PyObject *self, PyObject *args) {
+    const char* s;
+    if (!PyArg_ParseTuple(args, "s", &s))
+        return NULL;
+
+    os_signpost_interval_begin(handle, id, SIGNPOST_NAME, "%s", s);
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject *interval_end(PyObject *self, PyObject *args) {
+    const char* s;
+    if (!PyArg_ParseTuple(args, "s", &s))
+        return NULL;
+
+    os_signpost_interval_end(handle, id, SIGNPOST_NAME, "%s", s);
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject *event_emit(PyObject *self, PyObject *args) {
+    const char* s;
+    if (!PyArg_ParseTuple(args, "s", &s))
+        return NULL;
+
+    os_signpost_event_emit(handle, id, SIGNPOST_NAME, "%s", s);
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyMethodDef module_methods[] = {
+    { "interval_begin", interval_begin, METH_VARARGS, "Emit interval begin signpost" },
+    { "interval_end", interval_end, METH_VARARGS, "Emit interval end signpost" },
+    { "event_emit", event_emit, METH_VARARGS, "Emit event signpost" },
+    { NULL, NULL, 0, NULL }
+};
+
+static PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "signposts",
+    NULL,
+    -1,
+    module_methods
+};
+
+PyMODINIT_FUNC
+PyInit_signposts(void) {
+    PyObject *obj = PyModule_Create(&module);
+
+    handle = os_log_create("UnknownBrowser", "Signposts");
+    id = os_signpost_id_generate(handle);
+
+    return obj;
+}


### PR DESCRIPTION
#### 30c8a4e236183b8bdbec55b20407f72243933ba7
<pre>
Signposts for non-webkit browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=278037">https://bugs.webkit.org/show_bug.cgi?id=278037</a>
<a href="https://rdar.apple.com/126143557">rdar://126143557</a>

Reviewed by NOBODY (OOPS!).

Test the js global object and monkey-patch signpost functions in existing SP3 signpost patch.
These signpost js functions perform synchronous fetch to new benchmark http server endpoint.
The endpoint calls into os-signpost mechanism so that we can filter traces to signpost intervals.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch:
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py:
(Handler.do_POST):
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/signposts/setup.py: Added.
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/signposts/signposts.c: Added.
(interval_begin):
(interval_end):
(event_emit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8beb70c1ccf861cfd96ebfe7444eb318c7c6909

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62431 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66415 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50314 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31065 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/61942 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11385 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68144 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6377 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11414 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57889 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5305 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37586 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->