### PR TITLE
Fix extents of background-images for table cell groups

### DIFF
--- a/LayoutTests/fast/table/row-background-image-extent-expected.html
+++ b/LayoutTests/fast/table/row-background-image-extent-expected.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<title>Row background image extent</title>
+<style>* { box-sizing: border-box }</style>
+</head>
+<body>
+    <p>A background applied to a table row (or row-group or column or column-group) should cover the whole area of contained cells, including borders. The two dashed squares should look identical.</p>
+
+    <div style="background: linear-gradient(to bottom right, royalblue 0, black 100%); width: 100px; height: 100px; margin-bottom: 1em">
+        <div style="border: 5px dashed aqua; width: 100px; height: 100px">
+        </div>
+    </div>
+
+    <div style="background: linear-gradient(to bottom right, royalblue 0, black 100%); width: 100px; height: 100px">
+        <div style="border: 5px dashed aqua; width: 100px; height: 100px">
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/table/row-background-image-extent.html
+++ b/LayoutTests/fast/table/row-background-image-extent.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<title>Row background image extent</title>
+<style>* { box-sizing: border-box }</style>
+</head>
+<body>
+    <p>A background applied to a table row (or row-group or column or column-group) should cover the whole area of contained cells, including borders. The two dashed squares should look identical.</p>
+
+    <table style="width: 100px; border-spacing: 0; margin-bottom: 1em">
+        <tr style="background-image: linear-gradient(to bottom right, royalblue 0, black 100%)">
+            <td style="width: 100px; height: 100px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <div style="background: linear-gradient(to bottom right, royalblue 0, black 100%); width: 100px; height: 100px">
+        <div style="border: 5px dashed aqua; width: 100px; height: 100px">
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -59,6 +59,8 @@ class BackgroundPainter {
 public:
     BackgroundPainter(RenderBoxModelObject&, const PaintInfo&);
 
+    void setOverrideClip(FillBox overrideClip) { m_overrideClip = overrideClip; }
+
     void paintBackground(const LayoutRect&, BackgroundBleedAvoidance) const;
 
     void paintFillLayers(const Color&, const FillLayer&, const LayoutRect&, BackgroundBleedAvoidance, CompositeOperator, RenderElement* backgroundObject = nullptr) const;
@@ -67,7 +69,7 @@ public:
     void paintBoxShadow(const LayoutRect&, const RenderStyle&, ShadowStyle, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true) const;
 
     static bool paintsOwnBackground(const RenderBoxModelObject&);
-    static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect);
+    static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin = std::nullopt);
     static void clipRoundedInnerRect(GraphicsContext&, const FloatRoundedRect& clipRect);
     static bool boxShadowShouldBeAppliedToBackground(const RenderBoxModelObject&, const LayoutPoint& paintOffset, BackgroundBleedAvoidance, const InlineIterator::InlineBoxIterator&);
 
@@ -81,6 +83,7 @@ private:
 
     RenderBoxModelObject& m_renderer;
     const PaintInfo& m_paintInfo;
+    std::optional<FillBox> m_overrideClip;
 };
 
 }


### PR DESCRIPTION
#### 47dcecbf0d79bf840895cd7a8b3254c34b675a73
<pre>
Fix extents of background-images for table cell groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=278038">https://bugs.webkit.org/show_bug.cgi?id=278038</a>

Reviewed by Simon Fraser.

RenderTableCell::paintBackgroundsBehindCell() uses BackgroundPainter, with primary
renderer set to the cell renderer. This improperly shrinks a row (or column) image
to fit inside the cell&apos;s border. The row (or column) image is actually sized to the
row (or column) box, which is the union of the relevant cells&apos; border-boxes.

It would not be correct, though, to construct the BackgroundPainter with primary
renderer set to the row or column. This is because the cell might have rounded
edges; and if it does, those rounded edges should clip the row or column
background image. (Space between cells is transparent.)

So give BackgroundPainter the ability to override a FillLayer&apos;s clip and origin.

* LayoutTests/fast/table/row-background-image-extent-expected.html: Added.
* LayoutTests/fast/table/row-background-image-extent.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
(WebCore::BackgroundPainter::calculateBackgroundImageGeometry):
* Source/WebCore/rendering/BackgroundPainter.h:
(WebCore::BackgroundPainter::setOverrideClip):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):

Canonical link: <a href="https://commits.webkit.org/282712@main">https://commits.webkit.org/282712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cefb30293279a9e23ae9aedf2045aa7315c4c305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51560 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10100 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69744 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59027 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14155 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6611 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39200 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->