### PR TITLE
Fix masonry-intrinsic-sizing-cols-002-expected.html fixed + auto + fr scenario

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-expected.html
@@ -283,7 +283,7 @@ grid {
 <!-- ditto with mixed sizing: fixed + auto + fr -->
 
 <section class="mix2">
-<grid>
+<grid style="grid-template-columns: 1.1ch 2ch 1.4ch 2ch;">
   <item style="width:2ch">1</item>
   <item>2</item>
   <item>3</item>
@@ -291,7 +291,7 @@ grid {
   <item>5</item>
 </grid>
 
-<grid>
+<grid style="grid-template-columns: 1.1ch 2ch 1.4ch 2ch;">
   <item>1</item>
   <item>2</item>
   <item>3</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-ref.html
@@ -283,7 +283,7 @@ grid {
 <!-- ditto with mixed sizing: fixed + auto + fr -->
 
 <section class="mix2">
-<grid>
+<grid style="grid-template-columns: 1.1ch 2ch 1.4ch 2ch;">
   <item style="width:2ch">1</item>
   <item>2</item>
   <item>3</item>
@@ -291,7 +291,7 @@ grid {
   <item>5</item>
 </grid>
 
-<grid>
+<grid style="grid-template-columns: 1.1ch 2ch 1.4ch 2ch;">
   <item>1</item>
   <item>2</item>
   <item>3</item>


### PR DESCRIPTION
#### c3b35fb1be6dbf9597c349e524558729054143fd
<pre>
Fix masonry-intrinsic-sizing-cols-002-expected.html fixed + auto + fr scenario
<a href="https://bugs.webkit.org/show_bug.cgi?id=278059">https://bugs.webkit.org/show_bug.cgi?id=278059</a>
<a href="https://rdar.apple.com/problem/133793978">rdar://problem/133793978</a>

Reviewed by Sammy Gill.

In masonry, the indefinite items will be placed in every column during intrinsic sizing.
This will cause &apos;auto&apos; and &apos;fr&apos; to be resolved to 2ch.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-002-ref.html:

Canonical link: <a href="https://commits.webkit.org/282216@main">https://commits.webkit.org/282216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/127846c92d8cebf14797314a1414b53a71b50473

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12999 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35550 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11408 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68160 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57896 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5317 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37602 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->