### PR TITLE
text-spacing: text-autospace: handle element boundary spacing on IFC (layout part)

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
@@ -29,12 +29,14 @@
 #include "InlineDisplayContent.h"
 #include "InlineItem.h"
 #include "LineLayoutResult.h"
+#include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Layout {
 
+using InlineBoxBoundaryTextSpacings = WTF::HashMap<unsigned, float>;
 // InlineContentCache is used to cache content for subsequent layouts.
 class InlineContentCache {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_INLINE(InlineContentCache);
@@ -79,8 +81,12 @@ public:
     std::optional<InlineLayoutUnit> maximumContentSize() const { return m_maximumContentSize; }
     void resetMinimumMaximumContentSizes();
 
+    const InlineBoxBoundaryTextSpacings& inlineBoxBoundaryTextSpacings() const { return m_inlineBoxBoundaryTextSpacings; }
+    void setInlineBoxBoundaryTextSpacings(InlineBoxBoundaryTextSpacings&& spacings) { m_inlineBoxBoundaryTextSpacings = WTFMove(spacings); }
+
 private:
     InlineItems m_inlineItems;
+    InlineBoxBoundaryTextSpacings m_inlineBoxBoundaryTextSpacings;
     std::optional<LineLayoutResult> m_maximumIntrinsicWidthLineContent { };
     std::optional<InlineLayoutUnit> m_minimumContentSize { };
     std::optional<InlineLayoutUnit> m_maximumContentSize { };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -98,6 +98,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
         // FIXME: Add support for partial, yet paragraph level bidi content handling.
         breakAndComputeBidiLevels(inlineItemList);
     }
+    computeInlineBoxBoundaryTextSpacingsIfNeeded();
     computeInlineTextItemWidths(inlineItemList);
 
     auto adjustInlineContentCacheWithNewInlineItems = [&] {
@@ -132,6 +133,60 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
     }
     ASSERT(inlineBoxStart == inlineBoxEnd);
 #endif
+}
+
+void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded()
+{
+    if (!m_hasTextAutospace)
+        return;
+
+    char32_t lastCharacterFromPreviousRun = 0;
+    size_t lastCharacterDepth = 0;
+    size_t currentCharacterDepth = 0;
+    InlineBoxBoundaryTextSpacings spacings;
+    Vector<unsigned> inlineBoxStartIndexesOnInlineItemsList;
+    bool processInlineBoxBoundary = false;
+    auto& inlineItemList = inlineContentCache().inlineItems().content();
+    for (unsigned inlineItemIndex = 0; inlineItemIndex < inlineItemList.size(); ++inlineItemIndex) {
+        auto& inlineItem = inlineItemList[inlineItemIndex];
+        if (inlineItem.isInlineBoxStart()) {
+            inlineBoxStartIndexesOnInlineItemsList.append(inlineItemIndex);
+            ++currentCharacterDepth;
+            continue;
+        }
+        if (inlineItem.isInlineBoxEnd()) {
+            --currentCharacterDepth;
+            processInlineBoxBoundary = true;
+            continue;
+        }
+        auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem);
+        if (!inlineTextItem)
+            continue;
+
+        auto start = inlineTextItem->start();
+        auto length = inlineTextItem->length();
+        auto& inlineTextBox = inlineTextItem->inlineTextBox();
+        if (!processInlineBoxBoundary || !lastCharacterFromPreviousRun) {
+            lastCharacterFromPreviousRun = inlineTextBox.content().characterAt(start + length - 1);
+            lastCharacterDepth = currentCharacterDepth;
+            processInlineBoxBoundary = false;
+            continue;
+        }
+
+        size_t boundaryDepth = std::min(currentCharacterDepth, lastCharacterDepth);
+        ASSERT((inlineBoxStartIndexesOnInlineItemsList.size() - 1 - (currentCharacterDepth - boundaryDepth)) >= 0);
+        size_t boundaryIndex = inlineBoxStartIndexesOnInlineItemsList.size() - 1 - (currentCharacterDepth - boundaryDepth);
+        const RenderStyle& boundaryOwnerStyle = inlineItemList[boundaryIndex].layoutBox().parent().style();
+        const TextAutospace& boundaryTextAutospace = boundaryOwnerStyle.textAutospace();
+        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox.content().characterAt(start), lastCharacterFromPreviousRun))
+            spacings.add(inlineBoxStartIndexesOnInlineItemsList[boundaryIndex], TextAutospace::textAutospaceSize(boundaryOwnerStyle.fontCascade().primaryFont()));
+
+        lastCharacterFromPreviousRun = inlineTextBox.content().characterAt(start + length - 1);
+        lastCharacterDepth = currentCharacterDepth;
+        processInlineBoxBoundary = false;
+    }
+    if (!spacings.isEmpty())
+        inlineContentCache().setInlineBoxBoundaryTextSpacings(WTFMove(spacings));
 }
 
 static inline bool isTextOrLineBreak(const Box& layoutBox)
@@ -255,6 +310,7 @@ void InlineItemsBuilder::collectInlineItems(InlineItemList& inlineItemList, Inli
     while (!layoutQueue.isEmpty()) {
         while (true) {
             auto layoutBox = layoutQueue.last();
+            m_hasTextAutospace |= !layoutBox->style().textAutospace().isNoAutospace();
             auto isInlineBoxWithInlineContent = layoutBox->isInlineBox() && !layoutBox->isInlineTextBox() && !layoutBox->isLineBreakBox() && !layoutBox->isOutOfFlowPositioned();
             if (!isInlineBoxWithInlineContent)
                 break;
@@ -681,10 +737,15 @@ static inline bool canCacheMeasuredWidthOnInlineTextItem(const InlineTextBox& in
 void InlineItemsBuilder::computeInlineTextItemWidths(InlineItemList& inlineItemList)
 {
     TextSpacing::SpacingState spacingState;
-    for (auto& inlineItem : inlineItemList) {
+    auto& inlineBoxBoundaryTextSpacings = inlineContentCache().inlineBoxBoundaryTextSpacings();
+    for (size_t inlineItemIndex = 0; inlineItemIndex < inlineItemList.size(); ++inlineItemIndex) {
+        auto extraInlineTextSpacing= 0.f;
+        auto& inlineItem = inlineItemList[inlineItemIndex];
         auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem);
-        if (!inlineTextItem)
+        if (!inlineTextItem) {
+            spacingState.lastCharacterClassFromPreviousRun = TextSpacing::CharacterClass::Undefined;
             continue;
+        }
 
         auto& inlineTextBox = inlineTextItem->inlineTextBox();
         auto start = inlineTextItem->start();
@@ -692,7 +753,10 @@ void InlineItemsBuilder::computeInlineTextItemWidths(InlineItemList& inlineItemL
         auto needsMeasuring = length && !inlineTextItem->isZeroWidthSpaceSeparator();
         if (!needsMeasuring || !canCacheMeasuredWidthOnInlineTextItem(inlineTextBox, inlineTextItem->isWhitespace()))
             continue;
-        inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + length, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState));
+        if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(inlineItemIndex); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
+            extraInlineTextSpacing = inlineBoxBoundaryTextSpacing->value;
+
+        inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + length, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState) + extraInlineTextSpacing);
         spacingState.lastCharacterClassFromPreviousRun = inlineItem.style().textAutospace().isNoAutospace() ? TextSpacing::CharacterClass::Undefined : TextSpacing::characterClass(inlineTextBox.content().characterAt(start + length - 1));
     }
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
@@ -61,6 +61,8 @@ private:
     
     bool contentRequiresVisualReordering() const { return m_contentRequiresVisualReordering; }
 
+    void computeInlineBoxBoundaryTextSpacingsIfNeeded();
+
     const ElementBox& root() const { return m_root; }
     InlineContentCache& inlineContentCache() { return m_inlineContentCache; }
 
@@ -72,6 +74,7 @@ private:
     bool m_contentRequiresVisualReordering { false };
     bool m_isTextAndForcedLineBreakOnlyContent { true };
     size_t m_inlineBoxCount { 0 };
+    bool m_hasTextAutospace { !root().style().textAutospace().isNoAutospace() };
 };
 
 }

--- a/Source/WebCore/platform/text/TextSpacing.cpp
+++ b/Source/WebCore/platform/text/TextSpacing.cpp
@@ -40,6 +40,11 @@ bool TextAutospace::shouldApplySpacing(CharacterClass firstCharacterClass, Chara
     return false;
 }
 
+bool TextAutospace::shouldApplySpacing(char32_t firstCharacter, char32_t secondCharacter) const
+{
+    return shouldApplySpacing(TextSpacing::characterClass(firstCharacter), TextSpacing::characterClass(secondCharacter));
+}
+
 float TextAutospace::textAutospaceSize(const Font& font)
 {
     // https://www.w3.org/TR/css-text-4/#text-autospace-property

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -107,6 +107,7 @@ public:
     Options options() { return m_options; }
     friend bool operator==(const TextAutospace&, const TextAutospace&) = default;
     bool shouldApplySpacing(TextSpacing::CharacterClass firstCharacterClass, TextSpacing::CharacterClass secondCharacterClass) const;
+    bool shouldApplySpacing(char32_t firstCharacter, char32_t secondCharacter) const;
     static float textAutospaceSize(const Font&);
 
 private:


### PR DESCRIPTION
#### 857fd6ae4fe6ff242b4375eb3538dc2995e93434
<pre>
text-spacing: text-autospace: handle element boundary spacing on IFC (layout part)
<a href="https://bugs.webkit.org/show_bug.cgi?id=278531">https://bugs.webkit.org/show_bug.cgi?id=278531</a>
<a href="https://rdar.apple.com/133319434">rdar://133319434</a>

Reviewed by Alan Baradlay.

This patch is a step on handling the addition of extra spacing between relevant
characters as required by the text-autospace property [1].
The work will be divided into 2 parts: lauout and display. This patch is
responsible for display.

Up to know we are able to handle spacing between characters within an element.
We also want to handle the case of two adjacent characters that belong to different
elements.

For characters within an element we add spacing by manipulating the
correspondent&apos;s character&apos;s glyphs and advances. We always add spacing as
leading spacing. So if character &quot;A&quot; and &quot;B&quot; need spacing in between them,
this is added as a leading spacing of &quot;B&quot; by expanding its advance.width and
moving its origin.x by the required spacing size.

However, for element boundaries, specification [1] says:

&quot;At element boundaries, the amount of extra spacing introduced between
characters is determined by and rendered within the innermost element that
contains the boundary.&quot;

This means that for such a case, spacing has to be added between the elements.

We compute the necessary spacing to be &quot;placed&quot; in between element boundaries at
InlineItemsBuilder::build with computeInlineBoxBoundaryTextSpacingsIfNeeded.
At InlineItemsBuilder::computeInlineTextItemWidths we use such spacing to
contribute to the related InlineTextItem&apos;s width.

Important thing to notice:
Given the example:
&lt;span&gt;agua&lt;/span&gt;&lt;span&gt;水&lt;span&gt;
This would be represented by:
 InlineStartBox | InlineTextItem | InlineEndBox | InlineStartBox | InlineTextItem | InlineEndBox
 Being &quot;agua&quot; the content of the first InlineTextItem and &quot;水&quot; the content of the second InlineTextItem.

 Visually, the spacing necessary between &quot;agua&quot; and &quot;水&quot; has to appear between the first InlineEndBox
 and the second InlineStartBox. This means that such spacing should not visually contribute for
 the width of InlineTextItem. It might seem that we are doing this at this patch, however,
 this part is just addressing layout, and this information is sufficient for InlineContentBreaker to
 take such spacing in consideration. Later, on a future patch which will address &quot;display&quot;, we will
 then need to place this spacing in its correct visual order: it should me moved in front of the InlineStartBox
 and its value should be removed from the InlineTextItem&apos;s width, such that it doesn&apos;t get accounted for twice.

[1] <a href="https://www.w3.org/TR/css-text-4/#text-autospace-property">https://www.w3.org/TR/css-text-4/#text-autospace-property</a>

* Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h:
(WebCore::Layout::InlineContentCache::inlineBoxBoundaryTextSpacings const):
(WebCore::Layout::InlineContentCache::setInlineBoxBoundaryTextSpacings):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
(WebCore::Layout::InlineFormattingContext::inlineContentCache const):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::build):
(WebCore::Layout::InlineItemsBuilder::adjustInlineBoxBoundaryTextSpacingsIfNeeded):
(WebCore::Layout::InlineItemsBuilder::collectInlineItems):
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidths):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h:
* Source/WebCore/platform/text/TextSpacing.cpp:
(WebCore::TextAutospace::shouldApplySpacing const):
* Source/WebCore/platform/text/TextSpacing.h:

Canonical link: <a href="https://commits.webkit.org/282917@main">https://commits.webkit.org/282917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe3e2fc7ca39a82785fbbabd502eb8da1ed19983

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15521 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13141 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56017 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/765 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39813 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->