### PR TITLE
[Writing Tools] Hide blinking insertion cursor while text placeholders are present

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
@@ -30,19 +30,6 @@
 #import <AppKit/NSTextInputContext_Private.h>
 #import <AppKit/NSTextPlaceholder_Private.h>
 
-#if HAVE(NSTEXTPLACEHOLDER_RECTS)
-// Staging for rdar://126696059
-@interface NSTextPlaceholder (staging_126696059)
-@property (nonatomic, readonly) NSArray *rects;
-@end
-
-@protocol NSTextInputClient_Async_staging_126696059
-@optional
-- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler;
-- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
-@end
-#endif // HAVE(NSTEXTPLACEHOLDER_RECTS)
-
 #else // !USE(APPLE_INTERNAL_SDK)
 
 @interface NSTextSelectionRect : NSObject

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3670,6 +3670,8 @@ RefPtr<TextPlaceholderElement> Editor::insertTextPlaceholder(const IntSize& size
     if (!placeholder->parentNode())
         return nullptr;
 
+    document->selection().addCaretVisibilitySuppressionReason(CaretVisibilitySuppressionReason::TextPlaceholderIsShowing);
+
     document->selection().setSelection(VisibleSelection { positionInParentBeforeNode(placeholder.ptr()) }, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));
 
     return placeholder;
@@ -3691,6 +3693,8 @@ void Editor::removeTextPlaceholder(TextPlaceholderElement& placeholder)
     // To match the Legacy WebKit implementation, set the text insertion point to be before where the placeholder used to be.
     if (document->selection().isFocusedAndActive() && document->focusedElement() == savedRootEditableElement)
         document->selection().setSelection(VisibleSelection { savedPositionBeforePlaceholder }, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));
+
+    document->selection().removeCaretVisibilitySuppressionReason(CaretVisibilitySuppressionReason::TextPlaceholderIsShowing);
 }
 
 static inline void collapseCaretWidth(IntRect& rect)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1921,7 +1921,16 @@ ExceptionOr<Ref<DOMRect>> Internals::absoluteCaretBounds()
 
     return DOMRect::create(document->frame()->selection().absoluteCaretBounds());
 }
-    
+
+ExceptionOr<bool> Internals::isCaretVisible()
+{
+    RefPtr document = contextDocument();
+    if (!document || !document->frame())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    return document->frame()->selection().isCaretVisible();
+}
+
 ExceptionOr<bool> Internals::isCaretBlinkingSuspended()
 {
     auto* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -331,6 +331,7 @@ public:
     ExceptionOr<Ref<DOMRect>> absoluteLineRectFromPoint(int x, int y);
 
     ExceptionOr<Ref<DOMRect>> absoluteCaretBounds();
+    ExceptionOr<bool> isCaretVisible();
     ExceptionOr<bool> isCaretBlinkingSuspended();
     ExceptionOr<bool> isCaretBlinkingSuspended(Document&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -551,6 +551,7 @@ enum RenderingMode {
     DOMRect absoluteLineRectFromPoint(long x, long y);
 
     DOMRect absoluteCaretBounds();
+    boolean isCaretVisible();
 
     // isCaretBlinkingSuspended() returns whether the frame selection of the context document
     // is suspended, while the parameterized method returns the state for a particular document

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if PLATFORM(COCOA)
+#if PLATFORM(IOS_FAMILY) || HAVE(NSTEXTPLACEHOLDER_RECTS)
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>
@@ -38,18 +38,11 @@ class SelectionGeometry;
 #if PLATFORM(IOS_FAMILY)
 @interface WKTextSelectionRect : UITextSelectionRect
 #else
-@interface WKTextSelectionRect : NSObject // FIXME: Change to NSTextSelectionRect after rdar://126379463 lands
+@interface WKTextSelectionRect : NSTextSelectionRect
 #endif
 
 - (instancetype)initWithCGRect:(CGRect)rect;
 - (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry scaleFactor:(CGFloat)scaleFactor;
-
-#if PLATFORM(MAC)
-@property (nonatomic, readonly) NSRect rect;
-@property (nonatomic, readonly) NSWritingDirection writingDirection;
-@property (nonatomic, readonly) BOOL isVertical;
-@property (nonatomic, readonly) NSAffineTransform *transform;
-#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
@@ -76,6 +76,8 @@
 
 #endif // HAVE(UI_TEXT_SELECTION_RECT_CUSTOM_HANDLE_INFO)
 
+#if PLATFORM(IOS_FAMILY) || HAVE(NSTEXTPLACEHOLDER_RECTS)
+
 @implementation WKTextSelectionRect {
     WebCore::SelectionGeometry _selectionGeometry;
     CGFloat _scaleFactor;
@@ -173,3 +175,5 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 @end
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -40,12 +40,16 @@
 
 #else
 
+@class NSTextPlaceholder;
+
 @protocol NSTextInputClient_Async
 - (void)selectedRangeWithCompletionHandler:(void(^)(NSRange selectedRange))completionHandler;
 - (void)markedRangeWithCompletionHandler:(void(^)(NSRange markedRange))completionHandler;
 - (void)hasMarkedTextWithCompletionHandler:(void(^)(BOOL hasMarkedText))completionHandler;
 - (void)attributedSubstringForProposedRange:(NSRange)range completionHandler:(void(^)(NSAttributedString *, NSRange actualRange))completionHandler;
 - (void)firstRectForCharacterRange:(NSRange)range completionHandler:(void(^)(NSRect firstRect, NSRange actualRange))completionHandler;
+- (void)insertTextPlaceholderWithSize:(CGSize)size completionHandler:(void (^)(NSTextPlaceholder *))completionHandler;
+- (void)removeTextPlaceholder:(NSTextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
 @end
 
 @protocol NSInspectorBarClient <NSObject>


### PR DESCRIPTION
#### 77eec0a20396c7532b1f63a835b078e57747504c
<pre>
[Writing Tools] Hide blinking insertion cursor while text placeholders are present
<a href="https://bugs.webkit.org/show_bug.cgi?id=278067">https://bugs.webkit.org/show_bug.cgi?id=278067</a>
<a href="https://rdar.apple.com/132432864">rdar://132432864</a>

Reviewed by Aditya Keerthi.

Hide the caret when inserting the placeholder, and unhide it when removing the placeholder.

Also remove some staging declarations.

* Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::insertTextPlaceholder):
(WebCore::Editor::removeTextPlaceholder):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::FrameSelection):
(WebCore::FrameSelection::focusedOrActiveStateChanged):
(WebCore::FrameSelection::addCaretVisibilitySuppressionReason):
(WebCore::FrameSelection::removeCaretVisibilitySuppressionReason):
(WebCore::FrameSelection::updateCaretVisibility):
(WebCore::FrameSelection::setCaretVisibility): Deleted.
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isCaretVisible):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h:
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm:
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextPlaceholderTests.mm:
(createWebViewForNSTextPlaceholder):
(TEST(NSTextPlaceholder, InsertTextPlaceholder)):
(TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithoutIncomingText)):
(TEST(NSTextPlaceholder, InsertAndRemoveTextPlaceholderWithIncomingText)):

Canonical link: <a href="https://commits.webkit.org/282500@main">https://commits.webkit.org/282500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98552fd514dec9ef9e5c20cd7f0a6184b95d7bea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67297 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50970 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9582 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31653 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36266 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12142 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/stretch-along-block-axis-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58282 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58506 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6015 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9566 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38453 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->