### PR TITLE
idbobjectstore_createIndex.any.sharedworker.html is flakily failing on wpt

### DIFF
--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -571,13 +571,17 @@ void IDBConnectionProxy::forgetTransaction(IDBTransaction& transaction)
     m_abortingTransactions.remove(transaction.info().identifier());
 }
 
-template<typename KeyType, typename ValueType>
-void removeItemsMatchingCurrentThread(HashMap<KeyType, ValueType>& map)
+template<typename KeyType, typename ValueType, typename FunctionType>
+void removeItemsMatchingCurrentThread(HashMap<KeyType, ValueType>& map, FunctionType&& cleanupFunction)
 {
     // FIXME: Revisit when introducing WebThread aware thread comparison.
     // https://bugs.webkit.org/show_bug.cgi?id=204345
-    map.removeIf([currentThread = &Thread::current()](auto& entry) {
-        return &entry.value->originThread() == currentThread;
+    map.removeIf([currentThread = &Thread::current(), cleanupFunction = WTFMove(cleanupFunction)](auto& entry) {
+        if (&entry.value->originThread() == currentThread) {
+            cleanupFunction(entry.value);
+            return true;
+        }
+        return false;
     });
 }
 
@@ -600,29 +604,45 @@ void setMatchingItemsContextSuspended(ScriptExecutionContext& currentContext, Ha
     }
 }
 
-void IDBConnectionProxy::forgetActivityForCurrentThread()
+void IDBConnectionProxy::abortActivitiesForCurrentThread()
 {
     {
-        Locker locker { m_databaseConnectionMapLock };
-        removeItemsMatchingCurrentThread(m_databaseConnectionMap);
-    }
-    {
         Locker locker { m_openDBRequestMapLock };
-        removeItemsMatchingCurrentThread(m_openDBRequestMap);
+        removeItemsMatchingCurrentThread(m_openDBRequestMap, [](RefPtr<IDBOpenDBRequest>& request) {
+            if (request)
+                request->requestCompleted(IDBResultData::error(request->resourceIdentifier(), IDBError { ExceptionCode::InvalidStateError, "Request is removed"_s }));
+        });
     }
     {
         Locker locker { m_transactionMapLock };
-        removeItemsMatchingCurrentThread(m_pendingTransactions);
-        removeItemsMatchingCurrentThread(m_committingTransactions);
-        removeItemsMatchingCurrentThread(m_abortingTransactions);
+        removeItemsMatchingCurrentThread(m_pendingTransactions, [](auto& transaction) {
+            if (transaction)
+                transaction->didStart(IDBError { ExceptionCode::InvalidStateError, "Transaction is removed"_s });
+        });
+        removeItemsMatchingCurrentThread(m_committingTransactions, [](auto& transaction) {
+            if (transaction)
+                transaction->didCommit(IDBError { ExceptionCode::InvalidStateError, "Transaction is removed"_s });
+        });
+        removeItemsMatchingCurrentThread(m_abortingTransactions, [](auto& transaction) {
+            if (transaction)
+                transaction->didAbort(IDBError { ExceptionCode::InvalidStateError, "Transaction is removed"_s });
+        });
     }
     {
         Locker locker { m_transactionOperationLock };
-        removeItemsMatchingCurrentThread(m_activeOperations);
+        removeItemsMatchingCurrentThread(m_activeOperations, [](auto& operation) {
+            if (!operation)
+                return;
+
+            auto result = IDBResultData::error(operation->identifier(), IDBError { ExceptionCode::InvalidStateError, "Operation is removed"_s });
+            operation->transitionToComplete(result, Ref { *operation });
+        });
     }
     {
         Locker locker { m_databaseInfoMapLock };
-        removeItemsMatchingCurrentThread(m_databaseInfoCallbacks);
+        removeItemsMatchingCurrentThread(m_databaseInfoCallbacks, [](auto& request) {
+            request->complete(std::nullopt);
+        });
     }
 }
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -124,7 +124,7 @@ public:
 
     void forgetActiveOperations(const Vector<RefPtr<TransactionOperation>>&);
     void forgetTransaction(IDBTransaction&);
-    void forgetActivityForCurrentThread();
+    void abortActivitiesForCurrentThread();
     void setContextSuspended(ScriptExecutionContext& currentContext, bool isContextSuspended);
 
 private:

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -167,7 +167,8 @@ void WorkerGlobalScope::prepareForDestruction()
     if (settingsValues().serviceWorkersEnabled)
         swClientConnection().unregisterServiceWorkerClient(identifier());
 
-    stopIndexedDatabase();
+    if (m_connectionProxy)
+        m_connectionProxy->abortActivitiesForCurrentThread();
 
     if (m_storageConnection)
         m_storageConnection->scopeClosed();
@@ -237,12 +238,6 @@ IDBClient::IDBConnectionProxy* WorkerGlobalScope::idbConnectionProxy()
 GraphicsClient* WorkerGlobalScope::graphicsClient()
 {
     return workerClient();
-}
-
-void WorkerGlobalScope::stopIndexedDatabase()
-{
-    if (m_connectionProxy)
-        m_connectionProxy->forgetActivityForCurrentThread();
 }
 
 void WorkerGlobalScope::suspend()

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -209,8 +209,6 @@ private:
     std::optional<Vector<uint8_t>> wrapCryptoKey(const Vector<uint8_t>& key) final;
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>& wrappedKey) final;
 
-    void stopIndexedDatabase();
-
     // ReportingClient.
     void notifyReportObservers(Ref<Report>&&) final;
     String endpointURIForToken(const String&) const final;


### PR DESCRIPTION
#### 95ab9cb633317673f487aee8b67261228623451c
<pre>
idbobjectstore_createIndex.any.sharedworker.html is flakily failing on wpt
<a href="https://bugs.webkit.org/show_bug.cgi?id=278065">https://bugs.webkit.org/show_bug.cgi?id=278065</a>
<a href="https://rdar.apple.com/133796804">rdar://133796804</a>

Reviewed by Brady Eidson.

IDBTransaction and IDBDatabase can hold strong reference to each other when a transaction is in progress. This is fine
as a transaction should always be committed or aborted based on current design. When transaction is finished, database
will remove its reference and break the reference cycle. However, in the case of scope being closed, we just remove
existing transactions from IDBConnectionProxy without aborting it. This makes the transactions stop receiving update
from server side and thus not make progress or finish properly. Because of the reference cycle, IDBDatabase can be
kept alive and it will block the subsequent database open requests, leading to test timeout.

To fix this, this patch makes sure to error out pending operations and transactions when scope is closed.

* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::removeItemsMatchingCurrentThread):
(WebCore::IDBClient::IDBConnectionProxy::abortActivitiesForCurrentThread):
(WebCore::IDBClient::IDBConnectionProxy::forgetActivityForCurrentThread): Deleted.
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::prepareForDestruction):
(WebCore::WorkerGlobalScope::stopIndexedDatabase): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/282256@main">https://commits.webkit.org/282256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/649d259b659a9be24756e0e02f057af6bb59eef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50345 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11957 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6423 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11444 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57717 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13897 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5340 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37632 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->