### PR TITLE
[JSC] Use for-of instead of for-in in stress tests for Temporal.Duration

### DIFF
--- a/JSTests/stress/temporal-duration.js
+++ b/JSTests/stress/temporal-duration.js
@@ -79,7 +79,7 @@ shouldThrow(() => Temporal.Duration.from({}), TypeError);
         'PT1.1111111111H', 'PT1.1111111111M', 'PT1.1111111111S',
         `P${Array(309).fill(9).join('')}Y`
     ];
-    for (const badString in badStrings)
+    for (const badString of badStrings)
         shouldThrow(() => Temporal.Duration.from(badString), RangeError);
     
     const fromString = Temporal.Duration.from('P1Y2M3W4DT5H6M7.008009010S');


### PR DESCRIPTION
#### c5784413c9600f6135b620857ae987b1d7b8cf87
<pre>
[JSC] Use for-of instead of for-in in stress tests for Temporal.Duration
<a href="https://bugs.webkit.org/show_bug.cgi?id=278070">https://bugs.webkit.org/show_bug.cgi?id=278070</a>

Reviewed by Yusuke Suzuki.

In `stress/temporal-duration.js`, a `for-in` loop is used as follows:

    const badStrings = [
        &apos;&apos;, &apos;+&apos;, &apos;+P&apos;, &apos;-P&apos;, &apos;+-P&apos;,
        &apos;P&apos;, &apos;P1&apos;, &apos;PT&apos;, &apos;P1YT&apos;, &apos;PT1&apos;,
        &apos;PT20.S&apos;, &apos;PT.20S&apos;,
        &apos;P1W1Y&apos;,  &apos;PT1S1M&apos;,
        &apos;P1.1Y&apos;, &apos;PT1.1H1M&apos;, &apos;PT1.1M1S&apos;,
        &apos;PT1.1111111111H&apos;, &apos;PT1.1111111111M&apos;, &apos;PT1.1111111111S&apos;,
        `P${Array(309).fill(9).join(&apos;&apos;)}Y`
    ];
    for (const badString in badStrings)
        shouldThrow(() =&gt; Temporal.Duration.from(badString), RangeError);

Since `badString` becomes the index of the array, this test will pass regardless of the values.

This patch changes the loop to use `for-of` instead of `for-in`.

* JSTests/stress/temporal-duration.js:
(shouldThrow.Temporal.Duration.from):

Canonical link: <a href="https://commits.webkit.org/282271@main">https://commits.webkit.org/282271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/613ea4d202d9c08463f8e2eee2d91fd25d064dd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13041 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50349 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8986 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35579 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11969 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55586 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68202 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61732 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57919 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5346 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83495 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9432 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37644 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14718 "Found 1 new JSC stress test failure: stress/proxy-set.js.dfg-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38729 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->