### PR TITLE
[WebKitLegacy] Fix -Wenum-compare in WebDefaultPolicyDelegate.m

### DIFF
--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 		939810D00824BF01008DF038 /* WebPanelAuthenticationHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 93154EF203A41270008635CE /* WebPanelAuthenticationHandler.m */; };
 		939810DC0824BF01008DF038 /* WebPluginPackage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83E4AF4C036659440000E506 /* WebPluginPackage.mm */; };
 		939810E40824BF01008DF038 /* WebJavaScriptTextInputPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9345D4EB0365C5B2008635CE /* WebJavaScriptTextInputPanel.m */; };
-		939810F00824BF01008DF038 /* WebDefaultPolicyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5152FAE0033FC50400CA2ACD /* WebDefaultPolicyDelegate.m */; };
+		939810F00824BF01008DF038 /* WebDefaultPolicyDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5152FAE0033FC50400CA2ACD /* WebDefaultPolicyDelegate.mm */; };
 		939810F10824BF01008DF038 /* WebDynamicScrollBarsView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3944606C020F50ED0ECA1767 /* WebDynamicScrollBarsView.mm */; };
 		939810F30824BF01008DF038 /* WebHTMLRepresentation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35081D9302B6D4D80ACA2ACA /* WebHTMLRepresentation.mm */; };
 		939810F80824BF01008DF038 /* WebPreferences.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5AEBB3D024A527601C1A526 /* WebPreferences.mm */; };
@@ -808,7 +808,7 @@
 		5152FADD033FC50400CA2ACD /* WebDefaultContextMenuDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebDefaultContextMenuDelegate.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		5152FADE033FC50400CA2ACD /* WebDefaultContextMenuDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebDefaultContextMenuDelegate.mm; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		5152FADF033FC50400CA2ACD /* WebDefaultPolicyDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebDefaultPolicyDelegate.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
-		5152FAE0033FC50400CA2ACD /* WebDefaultPolicyDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = WebDefaultPolicyDelegate.m; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
+		5152FAE0033FC50400CA2ACD /* WebDefaultPolicyDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebDefaultPolicyDelegate.mm; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		5152FAE5033FC52200CA2ACD /* WebFrameLoadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebFrameLoadDelegate.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		5158F6EE106D862A00AF457C /* WebHistoryDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebHistoryDelegate.h; sourceTree = "<group>"; };
 		515E27CC0458C86500CA2D3A /* WebUIDelegate.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebUIDelegate.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
@@ -1810,7 +1810,7 @@
 				BE95BEE605FD0805006E1513 /* WebDefaultEditingDelegate.h */,
 				BE95BEE505FD0805006E1513 /* WebDefaultEditingDelegate.m */,
 				5152FADF033FC50400CA2ACD /* WebDefaultPolicyDelegate.h */,
-				5152FAE0033FC50400CA2ACD /* WebDefaultPolicyDelegate.m */,
+				5152FAE0033FC50400CA2ACD /* WebDefaultPolicyDelegate.mm */,
 				515E27CF0458CA4B00CA2D3A /* WebDefaultUIDelegate.h */,
 				515E27D00458CA4B00CA2D3A /* WebDefaultUIDelegate.mm */,
 			);
@@ -3434,7 +3434,7 @@
 				9398111B0824BF01008DF038 /* WebDefaultEditingDelegate.m in Sources */,
 				A10C1D1918202F9C0036883A /* WebDefaultFormDelegate.m in Sources */,
 				A10C1D1B18202F9C0036883A /* WebDefaultFrameLoadDelegate.m in Sources */,
-				939810F00824BF01008DF038 /* WebDefaultPolicyDelegate.m in Sources */,
+				939810F00824BF01008DF038 /* WebDefaultPolicyDelegate.mm in Sources */,
 				A10C1D1D18202F9C0036883A /* WebDefaultResourceLoadDelegate.m in Sources */,
 				9398110A0824BF01008DF038 /* WebDefaultUIDelegate.mm in Sources */,
 				A10C1D1F18202F9C0036883A /* WebDefaultUIKitDelegate.m in Sources */,

--- a/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultPolicyDelegate.mm
+++ b/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultPolicyDelegate.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #import <Foundation/NSURLRequest.h>
 #import <Foundation/NSURLResponse.h>
 #import <wtf/Assertions.h>
+#import <wtf/EnumTraits.h>
 
 @implementation WebDefaultPolicyDelegate
 
@@ -85,7 +86,7 @@ static WebDefaultPolicyDelegate *sharedDelegate = nil;
 
     if ([WebView _canHandleRequest:request forMainFrame:frame == [wv mainFrame]]) {
         [listener use];
-    } else if (navType == WebNavigationTypePlugInRequest) {
+    } else if (enumToUnderlyingType(navType) == enumToUnderlyingType(WebNavigationTypePlugInRequest)) {
         [listener use];
     } else {
         // A file URL shouldn't fall through to here, but if it did,

--- a/Tools/DumpRenderTree/DefaultPolicyDelegate.mm
+++ b/Tools/DumpRenderTree/DefaultPolicyDelegate.mm
@@ -13,6 +13,7 @@
 #import "TestRunner.h"
 #import <WebKit/WebPolicyDelegatePrivate.h>
 #import <WebKit/WebViewPrivate.h>
+#import <wtf/EnumTraits.h>
 
 @implementation DefaultPolicyDelegate
 
@@ -26,7 +27,7 @@
     }
 
     WebNavigationType navType = (WebNavigationType)[[actionInformation objectForKey:WebActionNavigationTypeKey] intValue];
-    if (static_cast<unsigned>(navType) == static_cast<unsigned>(WebNavigationTypePlugInRequest)) {
+    if (enumToUnderlyingType(navType) == enumToUnderlyingType(WebNavigationTypePlugInRequest)) {
         if (![frame frameElement])
             gTestRunner->willNavigate();
         [listener use];


### PR DESCRIPTION
#### a27fb4bae52ef8b9ab9339790660631f387df44f
<pre>
[WebKitLegacy] Fix -Wenum-compare in WebDefaultPolicyDelegate.m
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278073">https://bugs.webkit.org/show_bug.cgi?id=278073</a>&gt;
&lt;<a href="https://rdar.apple.com/133809285">rdar://133809285</a>&gt;

Reviewed by Alex Christensen.

Use WTF::enumToUnderlyingType() to compare
WebNavigationTypePlugInRequest to a WebNavigationType enum.

Also convert WebDefaultPolicyDelegate.m to Obj-C++ source file so that
WTF::enumToUnderlyingType() can be used.

* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj:
- Rename WebDefaultPolicyDelegate.m to WebDefaultPolicyDelegate.mm.
* Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultPolicyDelegate.mm: Rename from Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultPolicyDelegate.m.
(-[WebDefaultPolicyDelegate webView:decidePolicyForNavigationAction:request:frame:decisionListener:]):
- Use WTF::enumToUnderlyingType() to fix the warning.
* Tools/DumpRenderTree/DefaultPolicyDelegate.mm:
(-[DefaultPolicyDelegate webView:decidePolicyForNavigationAction:request:frame:decisionListener:]):
- Use WTF::enumToUnderlyingType() instead of static_cast&lt;unsigned&gt;()
  to match code in WebDefaultPolicyDelegate.mm.

Canonical link: <a href="https://commits.webkit.org/282241@main">https://commits.webkit.org/282241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b77b4d0a03eb4132926f18233a52f2b3e08f1321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62500 "20 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50360 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8991 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6446 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11469 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57733 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57930 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5361 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9415 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37655 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38740 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->