### PR TITLE
Import WPT css/css-color/parsing as of d8271a5

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
@@ -1075,4 +1075,12 @@ PASS e.style['color'] = "LCH(from var(--accent) l c calc(h + 180))" should set t
 PASS e.style['color'] = "lch(from var(--mycolor) l 0 h)" should set the property value
 PASS e.style['color'] = "var(--mygray)" should set the property value
 PASS e.style['color'] = "lch(from var(--mygray) l 30 h)" should set the property value
+FAIL e.style['color'] = "color(from rebeccapurple srgb r g b)" should set the property value Colors do not match.
+Actual:   color(from rebeccapurple srgb r g b)
+Expected: color(srgb 0.4 0.2 0.6).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 0
+FAIL e.style['color'] = "rgb(from color(srgb 0.4 0.2 0.6) r g b)" should set the property value Colors do not match.
+Actual:   rgb(from color(srgb 0.4 0.2 0.6) r g b)
+Expected: color(srgb 0.4 0.2 0.6).
+Error: assert_equals: Color format is correct. expected "color(srgb   )" but got "rgb(from color(srgb   ) r g b)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html
@@ -755,6 +755,10 @@
     fuzzy_test_valid_color(`lch(from var(--mycolor) l 0 h)`);
     fuzzy_test_valid_color(`var(--mygray)`);
     fuzzy_test_valid_color(`lch(from var(--mygray) l 30 h)`);
+
+    // Ensure that converting between legacy and modern sRGB color spaces work as expected.
+    fuzzy_test_valid_color(`color(from rebeccapurple srgb r g b)`, `color(srgb 0.4 0.2 0.6)`, 0.01);
+    fuzzy_test_valid_color(`rgb(from color(srgb 0.4 0.2 0.6) r g b)`, `color(srgb 0.4 0.2 0.6)`, 0.01);
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/w3c-import.log
@@ -26,6 +26,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-rgb.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-invalid-color-function.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-invalid-color-layers-function.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-invalid-color-mix-function.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-invalid-hex-color.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-invalid-hsl.html
@@ -37,6 +38,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-color-function.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-color-layers-function.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-color-mix-function.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-hsl.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-hwb.html


### PR DESCRIPTION
#### 4cd4273632ecebd76524d75944b0ff403c2159f8
<pre>
Import WPT css/css-color/parsing as of d8271a5
<a href="https://bugs.webkit.org/show_bug.cgi?id=278076">https://bugs.webkit.org/show_bug.cgi?id=278076</a>
<a href="https://rdar.apple.com/problem/133812135">rdar://problem/133812135</a>

Reviewed by Tim Nguyen.

`import-w3c-tests -t web-platform-tests/css/css-color/parsing`
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d8271a53293d40c70cdabafe2b0acb69ea503895">https://github.com/web-platform-tests/wpt/commit/d8271a53293d40c70cdabafe2b0acb69ea503895</a>

The added tests in color-valid-relative-color.html were missed
in <a href="https://commits.webkit.org/281642@main">https://commits.webkit.org/281642@main</a>
These tests currently fail, the tests may actually be wrong,
to be investigated in follow-up <a href="https://bugs.webkit.org/show_bug.cgi?id=278077">https://bugs.webkit.org/show_bug.cgi?id=278077</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/282263@main">https://commits.webkit.org/282263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/614e5fc728caf7149f7d51eb50a6076f93b56ddb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13062 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50375 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8998 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11460 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68223 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6456 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11475 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57936 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5368 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37665 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->