### PR TITLE
Change TZoneHeapManager::init() to not use kern.bootuuid.

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -215,6 +215,7 @@
         "hw.target"
         "hw.vectorunit"
         "kern.bootargs"
+        "kern.boottime"
         "kern.hostname"
         "kern.hv_vmm_present"
         "kern.iossupportversion"

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2013-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -297,6 +297,7 @@
         "hw.cputype"
         "hw.memsize"
         "hw.ncpu"
+        "kern.boottime"
         "kern.maxfilesperproc"
         "kern.osproductversion" ;; Needed by CFNetwork (HSTS store and others)
         "kern.osrelease"

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -271,7 +271,9 @@
     )
 
     (allow sysctl-read
-        (sysctl-name #"kern.bootsessionuuid"))
+        (sysctl-name
+            "kern.bootsessionuuid"
+            "kern.boottime"))
 
     (allow mach-lookup
        ;; <rdar://problem/47268166>

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -555,6 +555,7 @@
         "hw.ncpu"
         "hw.pagesize_compat"
         "kern.bootargs"
+        "kern.boottime"
         "kern.hostname"
         "kern.maxfilesperproc"
         "kern.osproductversion"

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -192,7 +192,9 @@
     )
 
     (allow sysctl-read
-           (sysctl-name #"kern.bootsessionuuid"))
+        (sysctl-name
+            "kern.bootsessionuuid"
+            "kern.boottime"))
 
     (mobile-preferences-read
         "com.apple.Metal" ;; <rdar://problem/25535471>

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2021-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -98,6 +98,7 @@
         "hw.ncpu"
         "hw.pagesize_compat"
         "kern.bootargs"
+        "kern.boottime"
         "kern.hostname"
         "kern.maxfilesperproc"
         "kern.osproductversion"

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2021-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -64,6 +64,7 @@
         "hw.ncpu"
         "hw.pagesize_compat"
         "kern.bootargs"
+        "kern.boottime"
         "kern.hostname"
         "kern.maxfilesperproc"
         "kern.osproductversion"

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -437,6 +437,7 @@
         "hw.tbfrequency_compat"
         "hw.vectorunit"
         "kern.bootargs" ;; <rdar://problem/47738015>
+        "kern.boottime"
         "kern.hostname"
         "kern.hv_vmm_present"
         "kern.maxfilesperproc"

--- a/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
+++ b/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2022 Apple Inc. All rights reserved.
+; Copyright (C) 2022-2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -132,6 +132,7 @@
         "hw.tbfrequency_compat"
         "hw.vectorunit"
         "kern.bootargs" ;; <rdar://problem/47738015>
+        "kern.boottime"
         "kern.hostname"
         "kern.hv_vmm_present"
         "kern.maxfilesperproc"

--- a/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in
+++ b/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2022 Apple Inc. All rights reserved.
+; Copyright (C) 2024 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -132,6 +132,7 @@
         "hw.tbfrequency_compat"
         "hw.vectorunit"
         "kern.bootargs" ;; <rdar://problem/47738015>
+        "kern.boottime"
         "kern.hostname"
         "kern.hv_vmm_present"
         "kern.maxfilesperproc"

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -79,32 +79,41 @@ void TZoneHeapManager::init()
 {
     RELEASE_BASSERT(m_state == TZoneHeapManager::Uninitialized);
 
-    if (verbose)
+    if constexpr (verbose)
         TZONE_LOG_DEBUG("TZoneHeapManager initialization ");
 
 #if BOS(DARWIN)
     // Use the boot UUID and the process' name to seed the key.
     static const size_t rawSeedLength = 128;
     char rawSeed[rawSeedLength] = { };
-    char bootDevUUID[NAME_MAX] = { };
-    size_t bootDevUUIDLen = sizeof(bootDevUUID);
 
-    // try using "kern.bootuuid" sysctl to obtain boot volume UUID
-    RELEASE_BASSERT(!sysctlbyname("kern.bootuuid", bootDevUUID, &bootDevUUIDLen, nullptr, 0));
+    uint64_t primordialSeed;
+    struct timeval timeValue;
+    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
+    size_t size = sizeof(timeValue);
 
-    if (verbose)
-        TZONE_LOG_DEBUG("kern.bootuuid: %s\n", bootDevUUID);
+    auto sysctlResult = sysctl(mib, 2, &timeValue, &size, nullptr, 0);
+    if (sysctlResult) {
+        TZONE_LOG_DEBUG("kern.boottime is required for TZoneHeap initialization: %d\n", sysctlResult);
+        RELEASE_BASSERT(!sysctlResult);
+    }
+    primordialSeed = timeValue.tv_sec * 1000 * 1000 + timeValue.tv_usec;
+
+    if constexpr (verbose)
+        TZONE_LOG_DEBUG("primordialSeed: 0x%llx\n", primordialSeed);
 
     const char* procName = processNameString();
 
-    if (verbose)
+    if constexpr (verbose)
         TZONE_LOG_DEBUG("Process Name: \"%s\"\n", procName);
 
-    // Convert bootTime to hex values.
     unsigned byteIdx = 0;
 
-    for (unsigned i = 0; i < bootDevUUIDLen && byteIdx < rawSeedLength; byteIdx++, i++)
-        rawSeed[byteIdx] = bootDevUUID[i];
+    while (primordialSeed && byteIdx < rawSeedLength) {
+        int digit = primordialSeed & 0xf;
+        rawSeed[byteIdx++] = 'Z' - digit;
+        primordialSeed >>= 4;
+    }
 
     auto procNameLen = strlen(procName);
 
@@ -112,18 +121,18 @@ void TZoneHeapManager::init()
         rawSeed[byteIdx] = procName[i];
 
     for (; byteIdx < rawSeedLength; byteIdx++)
-        rawSeed[byteIdx] = 0;
+        rawSeed[byteIdx] = 'Q' - (byteIdx & 0xf);
 
     (void)CC_SHA256(&rawSeed, rawSeedLength, (unsigned char*)&m_tzoneKey.seed);
 #else // OS(DARWIN) => !OS(DARWIN)
-    if (verbose)
+    if constexpr (verbose)
         TZONE_LOG_DEBUG("using static seed\n");
 
     const unsigned char defaultSeed[CC_SHA1_DIGEST_LENGTH] = { "DefaultSeed\x12\x34\x56\x78\x9a\xbc\xde\xf0" };
     memcpy(m_tzoneKey.seed, defaultSeed, CC_SHA1_DIGEST_LENGTH);
 #endif // OS(DARWIN) => !OS(DARWIN)
 
-    if (verbose) {
+    if constexpr (verbose) {
         TZONE_LOG_DEBUG("    Computed key {");
         for (unsigned i = 0; i < CC_SHA1_DIGEST_LENGTH; ++i)
             TZONE_LOG_DEBUG(" %02x",  m_tzoneKey.seed[i]);

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -50,7 +50,7 @@ class TZoneHeapManager {
         TypesRegistered
     };
 
-    static const bool verbose = false;
+    static constexpr bool verbose = false;
     static const unsigned typeNameLen = 12;
 
     typedef uint64_t SHA256ResultAsUnsigned[CC_SHA256_DIGEST_LENGTH / sizeof(uint64_t)];


### PR DESCRIPTION
#### 2737b157251428966201cfa5b69890f0e75a95a5
<pre>
Change TZoneHeapManager::init() to not use kern.bootuuid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278039">https://bugs.webkit.org/show_bug.cgi?id=278039</a>
<a href="https://rdar.apple.com/133782769">rdar://133782769</a>

Reviewed by Michael Saboff.

Also changed TZoneHeapManager::init() to fill the remainder of the rawSeed buffer with
non-zero characters.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in:
* Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in:
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::init):
* Source/bmalloc/bmalloc/TZoneHeapManager.h:

Canonical link: <a href="https://commits.webkit.org/282251@main">https://commits.webkit.org/282251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db79449c7ed3c545604a26f0e5156068f78578bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66503 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50369 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9001 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11999 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55616 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68232 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61762 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6465 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11485 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57747 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57941 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5377 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83525 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9421 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37674 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14670 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->