### PR TITLE
[appearance: base] Add style switching mechanism for UA stylesheets

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -891,6 +891,7 @@ css/CSSImageSetOptionValue.cpp
 css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp
 css/CSSImportRule.cpp
+css/CSSInternalBaseAppearanceRule.cpp
 css/CSSKeyframeRule.cpp
 css/CSSKeyframesRule.cpp
 css/CSSLayerBlockRule.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -127,6 +127,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSStartingStyleRule>(globalObject, WTFMove(rule));
     case StyleRuleType::ViewTransition:
         return createWrapper<CSSViewTransitionRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::InternalBaseAppearance:
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSInternalBaseAppearanceRule.h"
+
+#include "StyleRule.h"
+
+namespace WebCore {
+
+CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
+    : CSSGroupingRule(rule, parent)
+{
+}
+
+String CSSInternalBaseAppearanceRule::cssText() const
+{
+    StringBuilder builder;
+    builder.append("@-internal-base-appearance"_s);
+    appendCSSTextForItems(builder);
+    return builder.toString();
+}
+
+}

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGroupingRule.h"
+
+namespace WebCore {
+
+class StyleRuleInternalBaseAppearance;
+
+class CSSInternalBaseAppearanceRule final : public CSSGroupingRule {
+public:
+    static Ref<CSSInternalBaseAppearanceRule> create(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
+    {
+        return adoptRef(*new CSSInternalBaseAppearanceRule(rule, parent));
+    }
+
+    String cssText() const final;
+
+private:
+    CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance&, CSSStyleSheet*);
+
+    StyleRuleType styleRuleType() const final { return StyleRuleType::InternalBaseAppearance; }
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSInternalBaseAppearanceRule, StyleRuleType::InternalBaseAppearance)
+

--- a/Source/WebCore/css/CSSTimingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSTimingFunctionValue.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSTimingFunctionValue.h"
 
+#include "CSSPrimitiveValue.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -903,7 +903,7 @@ anywhere
 
 // -webkit-appearance
 // The order here must match the order in the StyleAppearance enum in StyleAppearance.h.
-// All appearance values that should be accepted by the parser should be listed between 'base' and 'textarea':
+// All appearance values that should be accepted by the parser should be listed between 'base' and 'textfield':
 base
 checkbox
 radio

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -29,6 +29,7 @@
 #include "CSSFontPaletteValuesRule.h"
 #include "CSSGroupingRule.h"
 #include "CSSImportRule.h"
+#include "CSSInternalBaseAppearanceRule.h"
 #include "CSSKeyframeRule.h"
 #include "CSSKeyframesRule.h"
 #include "CSSLayerBlockRule.h"
@@ -130,6 +131,8 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleStartingStyle>(*this));
     case StyleRuleType::ViewTransition:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleViewTransition>(*this));
+    case StyleRuleType::InternalBaseAppearance:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleInternalBaseAppearance>(*this));
     case StyleRuleType::Margin:
         break;
     case StyleRuleType::Unknown:
@@ -228,6 +231,9 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         },
         [&](StyleRuleViewTransition& rule) -> Ref<CSSRule> {
             return CSSViewTransitionRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleInternalBaseAppearance& rule) -> Ref<CSSRule> {
+            return CSSInternalBaseAppearanceRule::create(rule, parentSheet);
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();
@@ -489,6 +495,16 @@ StyleRuleFontPaletteValues::StyleRuleFontPaletteValues(const AtomString& name, V
     , m_name(name)
     , m_fontFamilies(WTFMove(fontFamilies))
     , m_fontPaletteValues(basePalette, WTFMove(overrideColors))
+{
+}
+
+Ref<StyleRuleInternalBaseAppearance> StyleRuleInternalBaseAppearance::create(Vector<Ref<StyleRuleBase>>&& rules)
+{
+    return adoptRef(*new StyleRuleInternalBaseAppearance(WTFMove(rules)));
+}
+
+StyleRuleInternalBaseAppearance::StyleRuleInternalBaseAppearance(Vector<Ref<StyleRuleBase>>&& rules)
+    : StyleRuleGroup(StyleRuleType::InternalBaseAppearance, WTFMove(rules))
 {
 }
 

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -63,6 +63,7 @@ public:
     bool isFontPaletteValuesRule() const { return type() == StyleRuleType::FontPaletteValues; }
     bool isFontFeatureValuesRule() const { return type() == StyleRuleType::FontFeatureValues; }
     bool isFontFeatureValuesBlockRule() const { return type() == StyleRuleType::FontFeatureValuesBlock; }
+    bool isInternalBaseAppearanceRule() const { return type() == StyleRuleType::InternalBaseAppearance; }
     bool isKeyframesRule() const { return type() == StyleRuleType::Keyframes; }
     bool isKeyframeRule() const { return type() == StyleRuleType::Keyframe; }
     bool isNamespaceRule() const { return type() == StyleRuleType::Namespace; }
@@ -71,7 +72,7 @@ public:
     bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
     bool isNestedDeclarationsRule() const { return type() == StyleRuleType::NestedDeclarations; }
-    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle; }
+    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle || type() == StyleRuleType::InternalBaseAppearance; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }
@@ -446,6 +447,16 @@ private:
     StyleRuleStartingStyle(const StyleRuleStartingStyle&) = default;
 };
 
+class StyleRuleInternalBaseAppearance final : public StyleRuleGroup {
+public:
+    static Ref<StyleRuleInternalBaseAppearance> create(Vector<Ref<StyleRuleBase>>&&);
+    Ref<StyleRuleInternalBaseAppearance> copy() const { return adoptRef(*new StyleRuleInternalBaseAppearance(*this)); }
+
+private:
+    StyleRuleInternalBaseAppearance(Vector<Ref<StyleRuleBase>>&&);
+    StyleRuleInternalBaseAppearance(const StyleRuleInternalBaseAppearance&) = default;
+};
+
 // This is only used by the CSS parser.
 class StyleRuleCharset final : public StyleRuleBase {
 public:
@@ -595,4 +606,8 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleStartingStyle)
     static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStartingStyleRule(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleInternalBaseAppearance)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isInternalBaseAppearanceRule(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -55,7 +55,8 @@ enum class StyleRuleType : uint8_t {
     StyleWithNesting,
     Scope,
     StartingStyle,
-    NestedDeclarations
+    NestedDeclarations,
+    InternalBaseAppearance, // For UA stylesheets only.
 };
 
 static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::ViewTransition;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -584,6 +584,7 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
         case StyleRuleType::Scope:
         case StyleRuleType::StartingStyle:
         case StyleRuleType::ViewTransition:
+        case StyleRuleType::InternalBaseAppearance:
             return false;
         };
         ASSERT_NOT_REACHED();
@@ -659,6 +660,7 @@ bool StyleSheetContents::mayDependOnBaseURL() const
         case StyleRuleType::Scope:
         case StyleRuleType::StartingStyle:
         case StyleRuleType::ViewTransition:
+        case StyleRuleType::InternalBaseAppearance:
             return false;
         };
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1492,3 +1492,51 @@ ins, del {
 :root:lang(zh), [lang|=zh] {
     text-underline-position: left;
 }
+
+/* Form control base appearance (TBD) */
+
+@-internal-base-appearance {
+    input,
+    textarea {
+      appearance: none;
+      border: 1px solid currentColor;
+      background-color: transparent;
+      color: inherit;
+      font: inherit;
+      padding: 0.25em;
+    }
+  
+    ::placeholder {
+      color: color-mix(in lab, currentColor 50%, transparent);
+    }
+  
+    input[type=button],
+    input[type=submit],
+    input[type=reset],
+    button {
+      border: 1px solid currentColor;
+      background-color: color-mix(in lab, currentColor 10%, transparent);
+      color: inherit;
+      font: inherit;
+      padding: 0.25em .5em;
+      text-box: trim-both;
+    }
+  
+    :is(
+      input[type=button],
+      input[type=submit],
+      input[type=reset],
+      button
+    ):enabled:hover  {
+      background-color: color-mix(in lab, currentColor 20%, transparent);
+    }
+  
+    :is(
+      input[type=button],
+      input[type=submit],
+      input[type=reset],
+      button
+    ):enabled:hover:active  {
+      background-color: color-mix(in lab, currentColor 30%, transparent);
+    }
+}

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -37,6 +37,7 @@ namespace WebCore {
 CSSAtRuleID cssAtRuleID(StringView name)
 {
     static constexpr std::pair<ComparableLettersLiteral, CSSAtRuleID> mappings[] = {
+        { "-internal-base-appearance", CSSAtRuleInternalBaseAppearance },
         { "-webkit-keyframes",     CSSAtRuleWebkitKeyframes },
         { "annotation",            CSSAtRuleAnnotation },
         { "character-variant",     CSSAtRuleCharacterVariant },

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -46,6 +46,7 @@ enum CSSAtRuleID {
     CSSAtRuleSupports,
     CSSAtRuleViewTransition,
 
+    CSSAtRuleInternalBaseAppearance,
     CSSAtRuleWebkitKeyframes,
     CSSAtRuleCounterStyle,
     CSSAtRuleLayer,

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -484,6 +484,8 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeAtRule(CSSParserTokenRange& range, A
         return consumeStartingStyleRule(prelude, block);
     case CSSAtRuleViewTransition:
         return consumeViewTransitionRule(prelude, block);
+    case CSSAtRuleInternalBaseAppearance:
+        return consumeInternalBaseAppearanceRule(prelude, block);
     default:
         return nullptr; // Parse error, unrecognised at-rule with block
     }
@@ -1171,6 +1173,28 @@ RefPtr<StyleRuleStartingStyle> CSSParserImpl::consumeStartingStyleRule(CSSParser
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
 
     return StyleRuleStartingStyle::create(WTFMove(rules));
+}
+
+RefPtr<StyleRuleInternalBaseAppearance> CSSParserImpl::consumeInternalBaseAppearanceRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
+{
+    if (m_context.mode != UASheetMode)
+        return nullptr;
+
+    if (!prelude.atEnd())
+        return nullptr;
+
+    if (m_observerWrapper) {
+        m_observerWrapper->observer().startRuleHeader(StyleRuleType::InternalBaseAppearance, m_observerWrapper->startOffset(prelude));
+        m_observerWrapper->observer().endRuleHeader(m_observerWrapper->endOffset(prelude));
+        m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
+    }
+
+    auto rules = consumeNestedGroupRules(block);
+
+    if (m_observerWrapper)
+        m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
+
+    return StyleRuleInternalBaseAppearance::create(WTFMove(rules));
 }
 
 RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -64,6 +64,7 @@ class StyleRulePage;
 class StyleRuleSupports;
 class StyleRuleViewport;
 class StyleRuleViewTransition;
+class StyleRuleInternalBaseAppearance;
 class StyleSheetContents;
 class ImmutableStyleProperties;
 class Element;
@@ -165,6 +166,7 @@ private:
     RefPtr<StyleRuleScope> consumeScopeRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleStartingStyle> consumeStartingStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleViewTransition> consumeViewTransitionRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleInternalBaseAppearance> consumeInternalBaseAppearanceRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -242,6 +242,9 @@ bool CSSPropertyParser::parseValue(CSSPropertyID propertyID, bool important, con
     case StyleRuleType::ViewTransition:
         parseSuccess = parser.parseViewTransitionDescriptor(propertyID);
         break;
+    case StyleRuleType::InternalBaseAppearance:
+        parseSuccess = parser.parseInternalBaseAppearanceDescriptor(propertyID, important);
+        break;
     default:
         parseSuccess = parser.parseValueStart(propertyID, important);
         break;
@@ -669,6 +672,16 @@ bool CSSPropertyParser::parsePageDescriptor(CSSPropertyID property, bool importa
 
     addProperty(property, CSSPropertyInvalid, WTFMove(parsedValue), false);
     return true;
+}
+
+bool CSSPropertyParser::parseInternalBaseAppearanceDescriptor(CSSPropertyID property, bool important)
+{
+    ASSERT(m_context.mode == UASheetMode);
+
+    if (property == CSSPropertyAppearance)
+        return false;
+
+    return parseValueStart(property, important);
 }
 
 bool CSSPropertyParser::consumeFont(bool important)

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -92,6 +92,9 @@ private:
     // @view-transition descriptors.
     bool parseViewTransitionDescriptor(CSSPropertyID);
 
+    // @-internal-base-appearance descriptors.
+    bool parseInternalBaseAppearanceDescriptor(CSSPropertyID, bool important);
+
     void addProperty(CSSPropertyID longhand, CSSPropertyID shorthand, RefPtr<CSSValue>&&, bool important, bool implicit = false);
     void addExpandedProperty(CSSPropertyID shorthand, RefPtr<CSSValue>&&, bool important, bool implicit = false);
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -94,6 +94,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::LayerBlock:
     case StyleRuleType::Container:
     case StyleRuleType::StartingStyle:
+    case StyleRuleType::InternalBaseAppearance:
         // These rules MUST be handled by the static `isValidRuleHeaderText`, `protocolGroupingTypeForStyleRuleType`,
         // and `asCSSRuleList` in order to provide functionality in Web Inspector. Additionally, they MUST have a CSSOM
         // representation created in `StyleRuleBase::createCSSOMWrapper`, otherwise we will end up with a mismatched

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -276,7 +276,7 @@ void ElementRuleCollector::transferMatchedRules(DeclarationOrigin declarationOri
             matchedRule.styleScopeOrdinal,
             FromStyleAttribute::No,
             matchedRule.cascadeLayerPriority,
-            matchedRule.ruleData->isStartingStyle()
+            matchedRule.ruleData->atRuleTypes(),
         }, declarationOrigin);
     }
 }
@@ -881,8 +881,11 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
         // It might also be beneficial to overwrite the previous declaration (insteading of appending) if it affects the same exact properties.
         return;
     }
-    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes)
-        m_result->hasStartingStyle = true;
+    if (matchedProperties.atRuleTypes.contains(AtRuleType::StartingStyle))
+        m_result->atRuleTypes.add(AtRuleType::StartingStyle);
+
+    if (matchedProperties.atRuleTypes.contains(AtRuleType::BaseAppearance))
+        m_result->atRuleTypes.add(AtRuleType::BaseAppearance);
 
     if (matchedProperties.isCacheable == IsCacheable::Partially && !m_result->isCompletelyNonCacheable) {
         for (auto property : matchedProperties.properties.get())

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -43,7 +43,7 @@ struct MatchedProperties {
     ScopeOrdinal styleScopeOrdinal { ScopeOrdinal::Element };
     FromStyleAttribute fromStyleAttribute { FromStyleAttribute::No };
     CascadeLayerPriority cascadeLayerPriority { RuleSet::cascadeLayerPriorityForUnlayered };
-    IsStartingStyle isStartingStyle { IsStartingStyle::No };
+    OptionSet<AtRuleType> atRuleTypes { };
     IsCacheable isCacheable { IsCacheable::Yes };
 };
 
@@ -55,7 +55,7 @@ struct MatchResult {
 
     bool isForLink { false };
     bool isCompletelyNonCacheable { false };
-    bool hasStartingStyle { false };
+    OptionSet<AtRuleType> atRuleTypes { };
     Vector<MatchedProperties> userAgentDeclarations;
     Vector<MatchedProperties> userDeclarations;
     Vector<MatchedProperties> authorDeclarations;
@@ -75,13 +75,13 @@ inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
         && a.styleScopeOrdinal == b.styleScopeOrdinal
         && a.fromStyleAttribute == b.fromStyleAttribute
         && a.cascadeLayerPriority == b.cascadeLayerPriority
-        && a.isStartingStyle == b.isStartingStyle
+        && a.atRuleTypes == b.atRuleTypes
         && a.isCacheable == b.isCacheable;
 }
 
 inline bool MatchResult::cacheablePropertiesEqual(const MatchResult& other) const
 {
-    if (isForLink != other.isForLink || hasStartingStyle != other.hasStartingStyle)
+    if (isForLink != other.isForLink || atRuleTypes != other.atRuleTypes)
         return false;
 
     // Only author style can be non-cacheable.
@@ -123,7 +123,7 @@ inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
         matchedProperties.styleScopeOrdinal,
         matchedProperties.fromStyleAttribute,
         matchedProperties.cascadeLayerPriority,
-        matchedProperties.isStartingStyle
+        matchedProperties.atRuleTypes
     );
 }
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -196,7 +196,10 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
     if (m_maximumCascadeLayerPriorityForRollback && !includePropertiesForRollback())
         return false;
 
-    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes && !m_includedProperties.contains(PropertyType::StartingStyle))
+    if ((matchedProperties.atRuleTypes & AtRuleType::StartingStyle) && !m_includedProperties.contains(PropertyType::StartingStyle))
+        return false;
+
+    if ((matchedProperties.atRuleTypes & AtRuleType::BaseAppearance) && !m_includedProperties.contains(PropertyType::BaseAppearanceStyle))
         return false;
 
     auto propertyAllowlist = matchedProperties.allowlistType;
@@ -400,6 +403,12 @@ const HashSet<AnimatableCSSProperty> PropertyCascade::overriddenAnimatedProperti
     if (m_animationLayer)
         return m_animationLayer->overriddenProperties;
     return { };
+}
+
+void PropertyCascade::addBaseAppearanceStyles()
+{
+    const_cast<OptionSet<PropertyType>&>(m_includedProperties).add(PropertyCascade::PropertyType::BaseAppearanceStyle);
+    buildCascade();
 }
 
 }

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -49,7 +49,8 @@ public:
         AfterAnimation = 1 << 3,
         AfterTransition = 1 << 4,
         StartingStyle = 1 << 5,
-        NonCacheable = 1 << 6,
+        BaseAppearanceStyle = 1 << 6,
+        NonCacheable = 1 << 7,
     };
     static constexpr OptionSet<PropertyType> normalProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
     static constexpr OptionSet<PropertyType> startingStyleProperties() { return normalProperties() | PropertyType::StartingStyle; }
@@ -87,6 +88,8 @@ public:
 
     PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
+
+    void addBaseAppearanceStyles();
 
 private:
     void buildCascade();

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -56,6 +56,7 @@ struct SameSizeAsRuleData {
     unsigned b;
     unsigned c;
     unsigned d[4];
+    bool e;
 };
 
 static_assert(sizeof(RuleData) == sizeof(SameSizeAsRuleData), "RuleData should stay small");
@@ -166,7 +167,7 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
     return PropertyAllowlist::None;
 }
 
-RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle isStartingStyle)
+RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, OptionSet<AtRuleType> atRuleTypes)
     : m_styleRule(&styleRule)
     , m_selectorIndex(selectorIndex)
     , m_selectorListIndex(selectorListIndex)
@@ -176,7 +177,7 @@ RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned 
     , m_containsUncommonAttributeSelector(computeContainsUncommonAttributeSelector(*selector()))
     , m_linkMatchType(SelectorChecker::determineLinkMatchType(selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
-    , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
+    , m_atRuleTypes(atRuleTypes.toRaw())
     , m_isEnabled(true)
     , m_descendantSelectorIdentifierHashes(SelectorFilter::collectHashes(*selector()))
 {

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -24,6 +24,7 @@
 #include "PropertyAllowlist.h"
 #include "SelectorFilter.h"
 #include "StyleRule.h"
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 namespace Style {
@@ -36,13 +37,16 @@ enum class MatchBasedOnRuleHash : unsigned {
     ClassC
 };
 
-enum class IsStartingStyle : bool { No, Yes };
+enum class AtRuleType : uint8_t {
+    StartingStyle = 1 << 0,
+    BaseAppearance = 1 << 1
+};
 
 class RuleData {
 public:
     static const unsigned maximumSelectorComponentCount = 8192;
 
-    RuleData(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle);
+    RuleData(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, OptionSet<AtRuleType>);
 
     unsigned position() const { return m_position; }
 
@@ -65,7 +69,7 @@ public:
     bool containsUncommonAttributeSelector() const { return m_containsUncommonAttributeSelector; }
     unsigned linkMatchType() const { return m_linkMatchType; }
     PropertyAllowlist propertyAllowlist() const { return static_cast<PropertyAllowlist>(m_propertyAllowlist); }
-    IsStartingStyle isStartingStyle() const { return static_cast<IsStartingStyle>(m_isStartingStyle); }
+    OptionSet<AtRuleType> atRuleTypes() const { return OptionSet<AtRuleType>::fromRaw(m_atRuleTypes); }
     bool isEnabled() const { return m_isEnabled; }
     void setEnabled(bool value) { m_isEnabled = value; }
 
@@ -85,7 +89,7 @@ private:
     unsigned m_containsUncommonAttributeSelector : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
     unsigned m_propertyAllowlist : 2;
-    unsigned m_isStartingStyle : 1;
+    unsigned m_atRuleTypes : 2;
     unsigned m_isEnabled : 1;
     SelectorFilter::Hashes m_descendantSelectorIdentifierHashes;
 };
@@ -99,4 +103,3 @@ namespace WTF {
 template<> struct VectorTraits<WebCore::Style::RuleData> : SimpleClassVectorTraits { };
 
 } // namespace WTF
-

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -408,7 +408,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
         siblingRules.append({ ruleData });
     if (ruleData.containsUncommonAttributeSelector())
         uncommonAttributeRules.append({ ruleData });
-    if (ruleData.isStartingStyle() == IsStartingStyle::Yes)
+    if (ruleData.atRuleTypes().contains(AtRuleType::StartingStyle))
         hasStartingStyleRules = true;
 
     auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -133,7 +133,7 @@ static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelecto
 
 void RuleSet::addRule(const StyleRule& rule, unsigned selectorIndex, unsigned selectorListIndex)
 {
-    RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, IsStartingStyle::No);
+    RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, { });
     addRule(WTFMove(ruleData), 0, 0, 0);
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -202,7 +202,7 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
     }
 
     case StyleRuleType::StartingStyle: {
-        SetForScope startingStyleScope { m_isStartingStyle, IsStartingStyle::Yes };
+        SetForScope startingStyleScope { m_atRuleTypes, m_atRuleTypes | AtRuleType::StartingStyle };
         auto startingStyleRule = uncheckedDowncast<StyleRuleStartingStyle>(WTFMove(rule));
         addChildRules(startingStyleRule->childRules());
         return;
@@ -224,6 +224,13 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
         auto supportsRule = uncheckedDowncast<StyleRuleSupports>(WTFMove(rule));
         if (supportsRule->conditionIsSupported())
             addChildRules(supportsRule->childRules());
+        return;
+    }
+
+    case StyleRuleType::InternalBaseAppearance: {
+        SetForScope scope { m_atRuleTypes, m_atRuleTypes | AtRuleType::BaseAppearance };
+        auto internalBaseAppearanceRule = uncheckedDowncast<StyleRuleInternalBaseAppearance>(WTFMove(rule));
+        addChildRules(internalBaseAppearanceRule->childRules());
         return;
     }
 
@@ -290,7 +297,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     if (!selectorList.isEmpty()) {
         unsigned selectorListIndex = 0;
         for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
-            RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_isStartingStyle);
+            RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_atRuleTypes);
             m_mediaQueryCollector.addRuleIfNeeded(ruleData);
             m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
             ++selectorListIndex;

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -92,7 +92,7 @@ private:
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
     RuleSet::ScopeRuleIdentifier m_currentScopeIdentifier { 0 };
 
-    IsStartingStyle m_isStartingStyle { IsStartingStyle::No };
+    OptionSet<AtRuleType> m_atRuleTypes { };
 
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -87,10 +87,13 @@ inline bool isValidVisitedLinkProperty(CSSPropertyID id)
     return false;
 }
 
-Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, OptionSet<PropertyCascade::PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* animatedPropertes)
-    : m_cascade(matchResult, cascadeLevel, includedProperties, animatedPropertes)
+Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, OptionSet<PropertyCascade::PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties)
+    : m_cascade(matchResult, cascadeLevel, includedProperties, animatedProperties)
     , m_state(*this, style, WTFMove(context))
 {
+    applyProperty(CSSPropertyAppearance);
+    if (m_state.style().appearance() == StyleAppearance::Base)
+        m_cascade.addBaseAppearanceStyles();
 }
 
 Builder::~Builder() = default;

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -80,7 +80,7 @@ private:
     using RollbackCascadeKey = std::tuple<unsigned, unsigned, unsigned>;
     RollbackCascadeKey makeRollbackCascadeKey(CascadeLevel, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
 
-    const PropertyCascade m_cascade;
+    PropertyCascade m_cascade;
     // Rollback cascades are build on demand to resolve 'revert' and 'revert-layer' keywords.
     HashMap<RollbackCascadeKey, std::unique_ptr<const PropertyCascade>> m_rollbackCascades;
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -377,6 +377,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
         collector.matchUserRules();
     }
     collector.addAuthorKeyframeRules(keyframe);
+
     Builder builder(*state.style(), builderContext(state), collector.matchResult(), CascadeLevel::Author);
     builder.state().setIsBuildingKeyframeStyle();
     builder.applyAllProperties();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -775,7 +775,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
 std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext) const
 {
-    if (!resolvedStyle.matchResult || !resolvedStyle.matchResult->hasStartingStyle)
+    if (!resolvedStyle.matchResult || !resolvedStyle.matchResult->atRuleTypes.contains(AtRuleType::StartingStyle))
         return nullptr;
 
     // "Starting style inherits from the parent’s after-change style just like after-change style does."


### PR DESCRIPTION
#### 80e4e359050621254fcf171cb1ae9ac32c48f74d
<pre>
[appearance: base] Add style switching mechanism for UA stylesheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=278084">https://bugs.webkit.org/show_bug.cgi?id=278084</a>
<a href="https://rdar.apple.com/133818717">rdar://133818717</a>

Reviewed by Antti Koivisto.

This adds a `@-internal-base-appearance` at-rule that can only be used in UA stylesheets.

Rules contained inside that at-rule will only be applied when `appearance: base` is set (see `html.css`).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp: Added.
(WebCore::CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule):
(WebCore::CSSInternalBaseAppearanceRule::cssText const):
* Source/WebCore/css/CSSInternalBaseAppearanceRule.h: Added.
* Source/WebCore/css/CSSTimingFunctionValue.cpp:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleInternalBaseAppearance::create):
(WebCore::StyleRuleInternalBaseAppearance::StyleRuleInternalBaseAppearance):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isInternalBaseAppearanceRule const):
(WebCore::StyleRuleBase::isGroupRule const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
(WebCore::StyleSheetContents::mayDependOnBaseURL const):
* Source/WebCore/css/html.css:
(@-internal-base-appearance):
(::placeholder):
(input[type=button],):
(:is():
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumeInternalBaseAppearanceRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
(WebCore::CSSPropertyParser::parseInternalBaseAppearanceDescriptor):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::transferMatchedRules):
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::operator==):
(WebCore::Style::MatchResult::cacheablePropertiesEqual const):
(WebCore::Style::add):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::addBaseAppearanceStyles):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::atRuleTypes const):
(WebCore::Style::RuleData::isStartingStyle const): Deleted.
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveStartingStyle const):

Canonical link: <a href="https://commits.webkit.org/283852@main">https://commits.webkit.org/283852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baf43a8e2f78c6c63e48e5194844f14894cffc4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71513 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54071 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12456 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16960 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73212 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61516 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61577 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2956 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42649 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->