### PR TITLE
WIP: Premultiply color conversion matrices

### DIFF
--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -32,28 +32,49 @@ namespace WebCore {
 
 template<typename, size_t> struct ColorComponents;
 
-template<size_t ColumnCount, size_t RowCount>
+template<size_t ColumnCount, size_t RowCount, typename MatrixValueType = float>
 class ColorMatrix {
 public:
-    template<typename ...Ts>
+    template<typename ...Ts, typename = std::enable_if_t<(std::is_convertible_v<Ts, MatrixValueType> && ...)>>
     explicit constexpr ColorMatrix(Ts ...input)
-        : m_matrix {{ static_cast<float>(input) ... }}
+        : m_matrix { { static_cast<MatrixValueType>(input) ... } }
     {
         static_assert(sizeof...(Ts) == RowCount * ColumnCount);
     }
 
-    template<size_t NumberOfComponents>
-    constexpr ColorComponents<float, NumberOfComponents> transformedColorComponents(const ColorComponents<float, NumberOfComponents>&) const;
+    template<typename ColorValueType, size_t NumberOfComponents>
+    constexpr ColorComponents<ColorValueType, NumberOfComponents> transformedColorComponents(const ColorComponents<ColorValueType, NumberOfComponents>&) const;
 
-    constexpr float at(size_t row, size_t column) const
+    constexpr MatrixValueType at(size_t row, size_t column) const
     {
         return m_matrix[(row * ColumnCount) + column];
     }
 
     friend bool operator==(const ColorMatrix&, const ColorMatrix&) = default;
 
+    template <typename TargetValueType>
+    constexpr ColorMatrix<ColumnCount, RowCount, TargetValueType> toValueType() const
+    {
+        if constexpr(std::is_same_v<TargetValueType, MatrixValueType>)
+            return *this;
+        else
+            return ColorMatrix<ColumnCount, RowCount, TargetValueType> { *this };
+    }
+
 private:
-    std::array<float, RowCount * ColumnCount> m_matrix;
+    template <size_t OtherColumnCount, size_t OtherRowCount, typename OtherMatrixValueType>
+    friend class ColorMatrix;
+
+    template <typename FromValueType>
+    constexpr ColorMatrix(const ColorMatrix<ColumnCount, RowCount, FromValueType>& input)
+    {
+        for (size_t row = 0; row < RowCount; ++row) {
+            for (size_t column = 0; column < ColumnCount; ++column)
+                m_matrix[(row * ColumnCount) + column] = input.at(row, column);
+        }
+    }
+
+    std::array<MatrixValueType, RowCount * ColumnCount> m_matrix;
 };
 
 constexpr ColorMatrix<3, 3> brightnessColorMatrix(float amount)
@@ -156,26 +177,27 @@ inline ColorMatrix<3, 3> hueRotateColorMatrix(float angleInDegrees)
     };
 }
 
-template<size_t ColumnCount, size_t RowCount>
-template<size_t NumberOfComponents>
-constexpr auto ColorMatrix<ColumnCount, RowCount>::transformedColorComponents(const ColorComponents<float, NumberOfComponents>& inputVector) const -> ColorComponents<float, NumberOfComponents>
+template<size_t ColumnCount, size_t RowCount, typename MatrixValueType>
+template<typename ColorValueType, size_t NumberOfComponents>
+constexpr auto ColorMatrix<ColumnCount, RowCount, MatrixValueType>::transformedColorComponents(const ColorComponents<ColorValueType, NumberOfComponents>& inputVector) const -> ColorComponents<ColorValueType, NumberOfComponents>
 {
-    static_assert(ColorComponents<float, NumberOfComponents>::Size >= RowCount);
+    using ValueType = std::conditional_t<sizeof(MatrixValueType) >= sizeof(ColorValueType), MatrixValueType, ColorValueType>;
+    static_assert(ColorComponents<ValueType, NumberOfComponents>::Size >= RowCount);
     
-    ColorComponents<float, NumberOfComponents> result;
+    ColorComponents<ValueType, NumberOfComponents> result;
     for (size_t row = 0; row < RowCount; ++row) {
-        if constexpr (ColumnCount <= ColorComponents<float, NumberOfComponents>::Size) {
+        if constexpr (ColumnCount <= ColorComponents<ColorValueType, NumberOfComponents>::Size) {
             for (size_t column = 0; column < ColumnCount; ++column)
                 result[row] += at(row, column) * inputVector[column];
-        } else if constexpr (ColumnCount > ColorComponents<float, NumberOfComponents>::Size) {
-            for (size_t column = 0; column < ColorComponents<float, NumberOfComponents>::Size; ++column)
+        } else if constexpr (ColumnCount > ColorComponents<ColorValueType, NumberOfComponents>::Size) {
+            for (size_t column = 0; column < ColorComponents<ColorValueType, NumberOfComponents>::Size; ++column)
                 result[row] += at(row, column) * inputVector[column];
-            for (size_t additionalColumn = ColorComponents<float, NumberOfComponents>::Size; additionalColumn < ColumnCount; ++additionalColumn)
+            for (size_t additionalColumn = ColorComponents<ColorValueType, NumberOfComponents>::Size; additionalColumn < ColumnCount; ++additionalColumn)
                 result[row] += at(row, additionalColumn);
         }
     }
-    if constexpr (ColorComponents<float, NumberOfComponents>::Size > RowCount) {
-        for (size_t additionalRow = RowCount; additionalRow < ColorComponents<float, NumberOfComponents>::Size; ++additionalRow)
+    if constexpr (ColorComponents<ColorValueType, NumberOfComponents>::Size > RowCount) {
+        for (size_t additionalRow = RowCount; additionalRow < ColorComponents<ColorValueType, NumberOfComponents>::Size; ++additionalRow)
             result[additionalRow] = inputVector[additionalRow];
     }
 
@@ -190,6 +212,27 @@ template<typename T, typename M> inline constexpr auto applyMatricesToColorCompo
 template<typename T, typename M, typename... Matrices> inline constexpr auto applyMatricesToColorComponents(const ColorComponents<T, 4>& components, M matrix, Matrices... matrices) -> ColorComponents<T, 4>
 {
     return applyMatricesToColorComponents(matrix.transformedColorComponents(components), matrices...);
+}
+
+template<size_t ColumnCount, size_t RowCount, typename MatrixValueType>
+consteval ColorMatrix<ColumnCount, RowCount, MatrixValueType> premultiply(const ColorMatrix<ColumnCount, RowCount, MatrixValueType>& m1, const ColorMatrix<ColumnCount, RowCount, MatrixValueType>& m2)
+{
+    static_assert(ColumnCount == 3);
+    static_assert(ColumnCount == 3);
+
+    float a = m1.at(0, 0), b = m1.at(0, 1), c = m1.at(0, 2);
+    float d = m1.at(1, 0), e = m1.at(1, 1), f = m1.at(1, 2);
+    float g = m1.at(2, 0), h = m1.at(2, 1), i = m1.at(2, 2);
+
+    float j = m2.at(0, 0), k = m2.at(0, 1), l = m2.at(0, 2);
+    float m = m2.at(1, 0), n = m2.at(1, 1), o = m2.at(1, 2);
+    float p = m2.at(2, 0), q = m2.at(2, 1), r = m2.at(2, 2);
+
+    return ColorMatrix<ColumnCount, RowCount, MatrixValueType> {
+        a*j + d*k + g*l, b*j + e*k + h*l, c*j + f*k + i*l,
+        a*m + d*n + g*o, b*m + e*n + h*o, c*m + f*n + i*o,
+        a*p + d*q + g*r, b*p + e*q + h*r, c*p + f*q + i*r
+    };
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### fb9c68512622c1af0a2636faf675adfc4d5d7db3
<pre>
WIP: Premultiply color conversion matrices
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/ColorConversion.h:
(WebCore::ColorConversion::handleMatrixConversion):
* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::premultiply):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb9c68512622c1af0a2636faf675adfc4d5d7db3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66510 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50386 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9010 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6472 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11493 "Found 1 new test failure: workers/wasm-references.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57768 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57958 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5388 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37681 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->