### PR TITLE
[serializing] touch-action "pan-y pan-x" should be reordered as "pan-x pan-y" when serializing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/parsing/touch-action-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/parsing/touch-action-valid-expected.txt
@@ -4,5 +4,5 @@ PASS e.style['touch-action'] = "none" should set the property value
 PASS e.style['touch-action'] = "manipulation" should set the property value
 PASS e.style['touch-action'] = "pan-x" should set the property value
 PASS e.style['touch-action'] = "pan-y" should set the property value
-FAIL e.style['touch-action'] = "pan-y pan-x" should set the property value assert_equals: serialization should be canonical expected "pan-x pan-y" but got "pan-y pan-x"
+PASS e.style['touch-action'] = "pan-y pan-x" should set the property value
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1448,20 +1448,45 @@ RefPtr<CSSValue> consumeTouchAction(CSSParserTokenRange& range)
     if (auto ident = consumeIdent<CSSValueNone, CSSValueAuto, CSSValueManipulation>(range))
         return ident;
 
-    Vector<CSSValueID, 3> list;
+    bool hasPanX = false;
+    bool hasPanY = false;
+    bool hasPinchZoom = false;
     while (true) {
         auto ident = consumeIdentRaw<CSSValuePanX, CSSValuePanY, CSSValuePinchZoom>(range);
         if (!ident)
             break;
-        if (list.contains(*ident))
+        switch (*ident) {
+        case CSSValuePanX:
+            if (hasPanX)
+                return nullptr;
+            hasPanX = true;
+            break;
+        case CSSValuePanY:
+            if (hasPanY)
+                return nullptr;
+            hasPanY = true;
+            break;
+        case CSSValuePinchZoom:
+            if (hasPinchZoom)
+                return nullptr;
+            hasPinchZoom = true;
+            break;
+        default:
             return nullptr;
-        list.append(*ident);
+        }
     }
-    if (list.isEmpty())
+
+    if (!hasPanX && !hasPanY && !hasPinchZoom)
         return nullptr;
+
     CSSValueListBuilder builder;
-    for (auto ident : list)
-        builder.append(CSSPrimitiveValue::create(ident));
+    if (hasPanX)
+        builder.append(CSSPrimitiveValue::create(CSSValuePanX));
+    if (hasPanY)
+        builder.append(CSSPrimitiveValue::create(CSSValuePanY));
+    if (hasPinchZoom)
+        builder.append(CSSPrimitiveValue::create(CSSValuePinchZoom));
+
     return CSSValueList::createSpaceSeparated(WTFMove(builder));
 }
 


### PR DESCRIPTION
#### 9fd0377d3643d4e122c9bc46ac6cc9e438d13dee
<pre>
[serializing] touch-action &quot;pan-y pan-x&quot; should be reordered as &quot;pan-x pan-y&quot; when serializing
<a href="https://bugs.webkit.org/show_bug.cgi?id=271641">https://bugs.webkit.org/show_bug.cgi?id=271641</a>
&lt;<a href="https://rdar.apple.com/125349558">rdar://125349558</a>&gt;

Reviewed by Vitor Roriz.

Properly serialize touch-action according to spec.
This also makes us pass the `pointerevents/parsing/touch-action-valid.html` WPT.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/parsing/touch-action-valid-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTouchAction):

Canonical link: <a href="https://commits.webkit.org/282249@main">https://commits.webkit.org/282249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf3384ef398a95e0da3747d0f5eea8293af53b1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50394 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9017 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12021 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6487 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57767 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57957 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13895 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5401 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37696 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->