### PR TITLE
[WPE][Skia] Address pending review comments of 282223@main

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -141,7 +141,7 @@ public:
 #if USE(SKIA)
     GLContext* skiaGLContext();
     GrDirectContext* skiaGrContext();
-    unsigned msaaSampleCount();
+    unsigned msaaSampleCount() const;
 #endif
 
 #if USE(ATSPI)


### PR DESCRIPTION
#### fc56b1c7abd33011e43565ab665053a52d8873f0
<pre>
[WPE][Skia] Address pending review comments of 282223@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=278094">https://bugs.webkit.org/show_bug.cgi?id=278094</a>

Reviewed by Carlos Garcia Campos and Nikolas Zimmermann.

Rename the env var with the MSAA samples, and don&apos;t try to create the test
SkSurface if the env var samples are 0 or 1, as that means disabling MSAA.
Move the call to initializeMSAASampleCount() to a place were we&apos;re sure that
there&apos;s a valid Skia context, and add make const the functions that return
the sample count.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::initializeMSAASampleCount):
(WebCore::SkiaGLContext::sampleCount const):
(WebCore::SkiaGLContext::SkiaGLContext):
(WebCore::PlatformDisplay::msaaSampleCount const):
(WebCore::SkiaGLContext::sampleCount): Deleted.
(WebCore::PlatformDisplay::msaaSampleCount): Deleted.

Canonical link: <a href="https://commits.webkit.org/282233@main">https://commits.webkit.org/282233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48a6d8a2234743319883ad93a98376b33af9bb7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13103 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50400 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9027 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11509 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68264 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57774 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57966 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5414 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9412 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->