### PR TITLE
PointerEvent and PointerEventIOS should share tilt-to-spherical angle conversion code

### DIFF
--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -36,16 +36,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(PointerEvent);
 
-typedef struct PointerEventTilt {
-    long tiltX;
-    long tiltY;
-} PointerEventTilt;
-
-typedef struct PointerEventAngle {
-    double altitudeAngle;
-    double azimuthAngle;
-} PointerEventAngle;
-
 static AtomString pointerEventType(const AtomString& mouseEventType)
 {
     auto& names = eventNames();
@@ -97,7 +87,7 @@ PointerEvent::PointerEvent()
 }
 
 // Calculated in accordance with https://w3c.github.io/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle.
-static PointerEventAngle angleFromTilt(long tiltX, long tiltY)
+auto PointerEvent::angleFromTilt(long tiltX, long tiltY) -> PointerEventAngle
 {
     const double tiltXRadians = tiltX * radiansPerDegreeDouble;
     const double tiltYRadians = tiltY * radiansPerDegreeDouble;
@@ -129,7 +119,7 @@ static PointerEventAngle angleFromTilt(long tiltX, long tiltY)
 }
 
 // This algorithm is equivalent to the one provided in https://w3c.github.io/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle.
-static PointerEventTilt tiltFromAngle(double altitudeAngle, double azimuthAngle)
+auto PointerEvent::tiltFromAngle(double altitudeAngle, double azimuthAngle) -> PointerEventTilt
 {
     double tiltXRadians = WTF::areEssentiallyEqual(altitudeAngle, 0.0) ? cos(azimuthAngle) * piOverTwoDouble : atan(cos(azimuthAngle) / tan(altitudeAngle));
     double tiltYRadians = WTF::areEssentiallyEqual(altitudeAngle, 0.0) ? sin(azimuthAngle) * piOverTwoDouble : atan(sin(azimuthAngle) / tan(altitudeAngle));

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -151,6 +151,19 @@ private:
         return isInActiveButtonsState ? 0.5 : 0;
     }
 
+    struct PointerEventTilt {
+        long tiltX;
+        long tiltY;
+    };
+
+    struct PointerEventAngle {
+        double altitudeAngle;
+        double azimuthAngle;
+    };
+
+    static PointerEventAngle angleFromTilt(long tiltX, long tiltY);
+    static PointerEventTilt tiltFromAngle(double altitudeAngle, double azimuthAngle);
+
     PointerEvent();
     PointerEvent(const AtomString&, Init&&, IsTrusted);
     PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable);

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -84,8 +84,9 @@ PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& eve
 {
     m_azimuthAngle = event.azimuthAngleAtIndex(index);
     m_altitudeAngle = event.altitudeAngleAtIndex(index);
-    m_tiltX = round(cos(m_azimuthAngle) * cos(m_altitudeAngle) * 90);
-    m_tiltY = round(sin(m_azimuthAngle) * cos(m_altitudeAngle) * 90);
+    auto tilt = tiltFromAngle(m_altitudeAngle, m_azimuthAngle);
+    m_tiltX = tilt.tiltX;
+    m_tiltY = tilt.tiltY;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### d3d1407655456554f0f3421198bc0b67f90a02ad
<pre>
PointerEvent and PointerEventIOS should share tilt-to-spherical angle conversion code
<a href="https://bugs.webkit.org/show_bug.cgi?id=278095">https://bugs.webkit.org/show_bug.cgi?id=278095</a>
<a href="https://rdar.apple.com/133829451">rdar://133829451</a>

Reviewed by Tim Horton.

Following 282017@main, there were two code snippets that performed the
same spherical-to-tilt angle conversion, one in PointerEvent.cpp and
the other in PointerEventIOS.cpp. This patch fixes said duplication by
exposing tilt-to-spherical (and vice versa) conversion methods as
private static methods in the PointerEvent class.

* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::angleFromTilt):
(WebCore::PointerEvent::tiltFromAngle):
(WebCore::angleFromTilt): Deleted.
(WebCore::tiltFromAngle): Deleted.
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::m_predictedEvents):

Canonical link: <a href="https://commits.webkit.org/282255@main">https://commits.webkit.org/282255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a71cc125321aa43a12a1b7adc3492b41e280a69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66536 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50402 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9029 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35662 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11505 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68265 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6498 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11513 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13896 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5415 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37707 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38792 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->