### PR TITLE
[GTK][WPE] Remove PlatformDisplay methods to get DRM device and render node

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -35,9 +35,6 @@ typedef void *EGLContext;
 typedef void *EGLDisplay;
 typedef void *EGLImage;
 typedef unsigned EGLenum;
-#if USE(LIBDRM)
-typedef void *EGLDeviceEXT;
-#endif
 
 #if PLATFORM(GTK)
 #include <wtf/glib/GRefPtr.h>
@@ -111,10 +108,6 @@ public:
 
     EGLImage createEGLImage(EGLContext, EGLenum target, EGLClientBuffer, const Vector<EGLAttrib>&) const;
     bool destroyEGLImage(EGLImage) const;
-#if USE(LIBDRM)
-    const String& drmDeviceFile();
-    const String& drmRenderNodeFile();
-#endif
 #if USE(GBM)
     struct DMABufFormat {
         uint32_t fourcc { 0 };
@@ -166,11 +159,6 @@ protected:
     bool m_eglDisplayOwned { true };
     std::unique_ptr<GLContext> m_sharingGLContext;
 
-#if USE(LIBDRM)
-    std::optional<String> m_drmDeviceFile;
-    std::optional<String> m_drmRenderNodeFile;
-#endif
-
 #if ENABLE(WEBGL) && !PLATFORM(WIN)
     std::optional<int> m_anglePlatform;
     void* m_angleNativeDisplay { nullptr };
@@ -194,9 +182,6 @@ private:
 #endif
 
     void terminateEGLDisplay();
-#if USE(LIBDRM)
-    EGLDeviceEXT eglDevice();
-#endif
 
     bool m_eglDisplayInitialized { false };
     int m_eglMajorVersion { 0 };

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -253,6 +253,7 @@ UIProcess/WebsiteData/soup/WebsiteDataStoreSoup.cpp
 
 UIProcess/cairo/BackingStoreCairo.cpp
 
+UIProcess/glib/DRMDevice.cpp @no-unify
 UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -223,6 +223,7 @@ UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
 
 UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 
+UIProcess/glib/DRMDevice.cpp @no-unify
 UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -70,8 +70,8 @@
 #include <wtf/BlockPtr.h>
 #endif
 
-#if USE(GBM)
-#include <WebCore/PlatformDisplay.h>
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#include "DRMDevice.h"
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
@@ -202,7 +202,7 @@ GPUProcessProxy::GPUProcessProxy()
 #endif
 
 #if USE(GBM)
-    parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
+    parameters.renderDeviceFile = drmRenderNodeDevice();
 #endif
 
     platformInitializeGPUProcessParameters(parameters);

--- a/Source/WebKit/UIProcess/glib/DRMDevice.cpp
+++ b/Source/WebKit/UIProcess/glib/DRMDevice.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DRMDevice.h"
+
+#include <WebCore/GLContext.h>
+#include <WebCore/PlatformDisplay.h>
+#include <epoxy/egl.h>
+#include <mutex>
+#include <wtf/Function.h>
+#include <wtf/NeverDestroyed.h>
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include <wpe/wpe-platform.h>
+#endif
+
+#if USE(LIBDRM)
+#include <xf86drm.h>
+#endif
+
+#ifndef EGL_DRM_RENDER_NODE_FILE_EXT
+#define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
+#endif
+
+namespace WebKit {
+
+static EGLDeviceEXT eglDisplayDevice(EGLDisplay eglDisplay)
+{
+    if (!WebCore::GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query"))
+        return nullptr;
+
+    EGLDeviceEXT eglDevice;
+    if (eglQueryDisplayAttribEXT(eglDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+        return eglDevice;
+
+    return nullptr;
+}
+
+#if USE(LIBDRM)
+static void drmForeachDevice(Function<bool(drmDevice*)>&& functor)
+{
+    drmDevicePtr devices[64];
+    memset(devices, 0, sizeof(devices));
+
+    int numDevices = drmGetDevices2(0, devices, std::size(devices));
+    if (numDevices <= 0)
+        return;
+
+    for (int i = 0; i < numDevices; ++i) {
+        if (!functor(devices[i]))
+            break;
+    }
+    drmFreeDevices(devices, numDevices);
+}
+
+static String drmFirstRenderNode()
+{
+    String renderNodeDeviceFile;
+    drmForeachDevice([&](drmDevice* device) {
+        if (!(device->available_nodes & (1 << DRM_NODE_RENDER)))
+            return true;
+
+        renderNodeDeviceFile = String::fromUTF8(device->nodes[DRM_NODE_RENDER]);
+        return false;
+    });
+    return renderNodeDeviceFile;
+}
+
+static String drmRenderNodeFromPrimaryDeviceFile(const String& primaryDeviceFile)
+{
+    if (primaryDeviceFile.isEmpty())
+        return drmFirstRenderNode();
+
+    String renderNodeDeviceFile;
+    drmForeachDevice([&](drmDevice* device) {
+        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY | 1 << DRM_NODE_RENDER)))
+            return true;
+
+        if (String::fromUTF8(device->nodes[DRM_NODE_PRIMARY]) == primaryDeviceFile) {
+            renderNodeDeviceFile = String::fromUTF8(device->nodes[DRM_NODE_RENDER]);
+            return false;
+        }
+
+        return true;
+    });
+    // If we fail to find a render node for the device file, just use the device file as render node.
+    return !renderNodeDeviceFile.isEmpty() ? renderNodeDeviceFile : primaryDeviceFile;
+}
+#endif
+
+static String drmRenderNodeForEGLDisplay(EGLDisplay eglDisplay)
+{
+    if (EGLDeviceEXT device = eglDisplayDevice(eglDisplay)) {
+        if (WebCore::GLContext::isExtensionSupported(eglQueryDeviceStringEXT(device, EGL_EXTENSIONS), "EGL_EXT_device_drm_render_node"))
+            return String::fromUTF8(eglQueryDeviceStringEXT(device, EGL_DRM_RENDER_NODE_FILE_EXT));
+
+#if USE(LIBDRM)
+        // If EGL_EXT_device_drm_render_node is not present, try to get the render node using DRM API.
+        return drmRenderNodeFromPrimaryDeviceFile(drmPrimaryDevice());
+#endif
+    }
+
+#if USE(LIBDRM)
+    // If EGLDevice is not available, just get the first render node returned by DRM.
+    return drmFirstRenderNode();
+#else
+    return { };
+#endif
+}
+
+static String drmPrimaryDeviceForEGLDisplay(EGLDisplay eglDisplay)
+{
+    EGLDeviceEXT device = eglDisplayDevice(eglDisplay);
+    if (!device)
+        return { };
+
+    if (!WebCore::GLContext::isExtensionSupported(eglQueryDeviceStringEXT(device, EGL_EXTENSIONS), "EGL_EXT_device_drm"))
+        return { };
+
+    return String::fromUTF8(eglQueryDeviceStringEXT(device, EGL_DRM_DEVICE_FILE_EXT));
+}
+
+const String& drmPrimaryDevice()
+{
+    static LazyNeverDestroyed<String> primaryDevice;
+    static std::once_flag once;
+    std::call_once(once, [] {
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+        if (g_type_class_peek(WPE_TYPE_DISPLAY)) {
+            primaryDevice.construct(String::fromUTF8(wpe_display_get_drm_device(wpe_display_get_primary())));
+            return;
+        }
+#endif
+
+        auto eglDisplay = WebCore::PlatformDisplay::sharedDisplay().eglDisplay();
+        if (eglDisplay != EGL_NO_DISPLAY) {
+            primaryDevice.construct(drmPrimaryDeviceForEGLDisplay(eglDisplay));
+            return;
+        }
+
+        primaryDevice.construct();
+    });
+    return primaryDevice.get();
+}
+
+const String& drmRenderNodeDevice()
+{
+    static LazyNeverDestroyed<String> renderNodeDevice;
+    static std::once_flag once;
+    std::call_once(once, [] {
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+        if (g_type_class_peek(WPE_TYPE_DISPLAY)) {
+            renderNodeDevice.construct(String::fromUTF8(wpe_display_get_drm_render_node(wpe_display_get_primary())));
+            return;
+        }
+#endif
+
+        const char* envDeviceFile = getenv("WEBKIT_WEB_RENDER_DEVICE_FILE");
+        if (envDeviceFile && *envDeviceFile) {
+            renderNodeDevice.construct(String::fromUTF8(envDeviceFile));
+            return;
+        }
+
+        auto eglDisplay = WebCore::PlatformDisplay::sharedDisplay().eglDisplay();
+        if (eglDisplay != EGL_NO_DISPLAY) {
+            renderNodeDevice.construct(drmRenderNodeForEGLDisplay(eglDisplay));
+            return;
+        }
+
+        renderNodeDevice.construct();
+    });
+    return renderNodeDevice.get();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/glib/DRMDevice.h
+++ b/Source/WebKit/UIProcess/glib/DRMDevice.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+const String& drmPrimaryDevice();
+const String& drmRenderNodeDevice();
+
+} // namespace WebKit
+
+#endif // PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "WebProcessPool.h"
 
+#include "DRMDevice.h"
 #include "LegacyGlobalSettings.h"
 #include "MemoryPressureMonitor.h"
 #include "WebMemoryPressureHandler.h"
@@ -62,10 +63,6 @@
 #include <wpe/wpe-platform.h>
 #endif
 
-#if USE(GBM)
-#include <WebCore/DRMDeviceManager.h>
-#endif
-
 namespace WebKit {
 
 void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
@@ -88,17 +85,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if USE(GBM)
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-    if (usingWPEPlatformAPI)
-        parameters.renderDeviceFile = String::fromUTF8(wpe_display_get_drm_render_node(wpe_display_get_primary()));
-    else
-        parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
-#else
-    parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
-#endif
-    auto& manager = WebCore::DRMDeviceManager::singleton();
-    if (!manager.isInitialized())
-        manager.initializeMainDevice(parameters.renderDeviceFile);
+    parameters.renderDeviceFile = drmRenderNodeDevice();
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -29,6 +29,7 @@
 #include "AcceleratedBackingStoreDMABufMessages.h"
 #include "AcceleratedSurfaceDMABufMessages.h"
 #include "DMABufRendererBufferMode.h"
+#include "DRMDevice.h"
 #include "LayerTreeContext.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
@@ -104,7 +105,7 @@ Vector<DMABufRendererBufferFormat> AcceleratedBackingStoreDMABuf::preferredBuffe
         if (!tokens.isEmpty() && tokens[0].length() >= 2 && tokens[0].length() <= 4) {
             DMABufRendererBufferFormat format;
             format.usage = display.gtkEGLDisplay() ? DMABufRendererBufferFormat::Usage::Rendering : DMABufRendererBufferFormat::Usage::Mapping;
-            format.drmDevice = display.drmRenderNodeFile().utf8();
+            format.drmDevice = drmRenderNodeDevice().utf8();
             uint32_t fourcc = fourcc_code(tokens[0][0], tokens[0][1], tokens[0].length() > 2 ? tokens[0][2] : ' ', tokens[0].length() > 3 ? tokens[0][3] : ' ');
             char* endptr = nullptr;
             uint64_t modifier = tokens.size() > 1 ? g_ascii_strtoull(tokens[1].ascii().data(), &endptr, 16) : DRM_FORMAT_MOD_INVALID;
@@ -120,7 +121,7 @@ Vector<DMABufRendererBufferFormat> AcceleratedBackingStoreDMABuf::preferredBuffe
     if (!display.gtkEGLDisplay()) {
         DMABufRendererBufferFormat format;
         format.usage = DMABufRendererBufferFormat::Usage::Mapping;
-        format.drmDevice = display.drmRenderNodeFile().utf8();
+        format.drmDevice = drmRenderNodeDevice().utf8();
         format.formats.append({ DRM_FORMAT_XRGB8888, { DRM_FORMAT_MOD_LINEAR } });
         format.formats.append({ DRM_FORMAT_ARGB8888, { DRM_FORMAT_MOD_LINEAR } });
         return { WTFMove(format) };
@@ -128,7 +129,7 @@ Vector<DMABufRendererBufferFormat> AcceleratedBackingStoreDMABuf::preferredBuffe
 
     DMABufRendererBufferFormat format;
     format.usage = DMABufRendererBufferFormat::Usage::Rendering;
-    format.drmDevice = display.drmRenderNodeFile().utf8();
+    format.drmDevice = drmRenderNodeDevice().utf8();
     format.formats = display.dmabufFormats().map([](const auto& format) -> DMABufRendererBufferFormat::Format {
         return { format.fourcc, format.modifiers };
     });
@@ -422,7 +423,10 @@ void AcceleratedBackingStoreDMABuf::BufferEGLImage::release()
 #if USE(GBM)
 RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferGBM::create(WebPageProxy& webPage, uint64_t id, uint64_t surfaceID, const WebCore::IntSize& size, DMABufRendererBufferFormat::Usage usage, uint32_t format, UnixFileDescriptor&& fd, uint32_t stride)
 {
-    auto* device = WebCore::DRMDeviceManager::singleton().mainGBMDeviceNode(WebCore::DRMDeviceManager::NodeType::Render);
+    auto& manager = WebCore::DRMDeviceManager::singleton();
+    if (!manager.isInitialized())
+        manager.initializeMainDevice(drmRenderNodeDevice());
+    auto* device = manager.mainGBMDeviceNode(WebCore::DRMDeviceManager::NodeType::Render);
     if (!device) {
         WTFLogAlways("Failed to get GBM device");
         return nullptr;


### PR DESCRIPTION
#### 3dcbd5449947b81372052a2d2d6b77195a10821d
<pre>
[GTK][WPE] Remove PlatformDisplay methods to get DRM device and render node
<a href="https://bugs.webkit.org/show_bug.cgi?id=278098">https://bugs.webkit.org/show_bug.cgi?id=278098</a>

Reviewed by Adrian Perez de Castro.

Those are only used by the UI process, so we can add global functions to get them instead.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::eglDevice): Deleted.
(WebCore::PlatformDisplay::drmDeviceFile): Deleted.
(WebCore::drmForeachDevice): Deleted.
(WebCore::drmFirstRenderNode): Deleted.
(WebCore::drmRenderNodeFromPrimaryDeviceFile): Deleted.
(WebCore::PlatformDisplay::drmRenderNodeFile): Deleted.
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/glib/DRMDevice.cpp: Added.
(WebKit::eglDisplayDevice):
(WebKit::drmForeachDevice):
(WebKit::drmFirstRenderNode):
(WebKit::drmRenderNodeFromPrimaryDeviceFile):
(WebKit::drmRenderNodeForEGLDisplay):
(WebKit::drmPrimaryDeviceForEGLDisplay):
(WebKit::drmPrimaryDevice):
(WebKit::drmRenderNodeDevice):
* Source/WebKit/UIProcess/glib/DRMDevice.h: Added.
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::preferredBufferFormats):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::create):

Canonical link: <a href="https://commits.webkit.org/282277@main">https://commits.webkit.org/282277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad0139919a772ed7b634aa1c9ccd188ebee17062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50406 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9035 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35667 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11514 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/stretchy-mover-1b.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12037 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6503 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11515 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57780 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57973 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5422 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9436 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37712 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->