### PR TITLE
Fix crash in WebPushDaemon::connectionRemoved

### DIFF
--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -244,7 +244,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
 
         RefPtr pushConnection = PushClientConnection::create(xpcConnection.get(), *decoder);
         if (!pushConnection) {
-            RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - Could not initialize PushClientConnection");
+            RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - Could not initialize PushClientConnection from xpc connection %p", xpcConnection.get());
             tryCloseRequestConnection(request);
             return;
         }
@@ -288,7 +288,13 @@ void WebPushDaemon::connectionRemoved(xpc_connection_t connection)
         return;
     }
 
-    auto clientConnection = m_connectionMap.take(connection);
+    auto it = m_connectionMap.find(connection);
+    if (it == m_connectionMap.end()) {
+        RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionRemoved: couldn't find XPC connection %p in pending connection set or connection map", connection);
+        return;
+    }
+
+    auto clientConnection = m_connectionMap.take(it);
     clientConnection->connectionClosed();
 }
 


### PR DESCRIPTION
#### 84d583b6a22beacdf79831377549aeadaf510f3a
<pre>
Fix crash in WebPushDaemon::connectionRemoved
<a href="https://bugs.webkit.org/show_bug.cgi?id=278109">https://bugs.webkit.org/show_bug.cgi?id=278109</a>
<a href="https://rdar.apple.com/133806943">rdar://133806943</a>

Reviewed by Brady Eidson.

In 282035@main I changed how PushClientConnection creation occurs by introducing a pending
connection set. This can cause a crash in WebPushDaemon::connectionRemoved when an invalid
connection is detected. In that case, we remove the connection from pendingConnectionSet in
connectionEventHandler, which then eventually triggers the connectionRemoved callback to run. When
the connectionRemoved callback runs, it cannot find the XPC connection in either the pending
connection set or the connection map, leading to a crash.

Fix this by allowing connectionRemoved to ignore the case where the passed in connection is in
neither the pending connection set nor the connection map.

* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::connectionRemoved):

Canonical link: <a href="https://commits.webkit.org/282244@main">https://commits.webkit.org/282244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6df36134ccc721e9a27d7a449a942dbec4503e20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15174 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13131 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13467 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9053 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54200 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35692 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57278 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57992 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5446 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37734 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38819 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->