### PR TITLE
[css-anchor-position-1] Prevent animated elements from being anchor-positioned

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition of anchor() when changing target anchor element name assert_equals: expected 300 but got 225
+FAIL Transition of anchor() when changing target anchor element name assert_equals: expected 300 but got 0
 FAIL Transition of anchor-size() when changing target anchor element name assert_equals: expected 150 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 150 but got 188
+FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in three different tree scopes assert_equals: expected 300 but got 250
+FAIL Transition with anchor names defined in three different tree scopes assert_equals: expected 300 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Transition when the result of anchor() changes assert_equals: expected 110 but got 55
+FAIL Transition when the result of anchor() changes assert_equals: expected 110 but got 0
 FAIL Transition when the result of anchor-size() changes assert_equals: expected 50 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Transition to a flipped state assert_equals: expected 275 but got 225
-FAIL Transition to an unflipped state assert_equals: expected 250 but got 300
+FAIL Transition to a flipped state assert_equals: expected 275 but got 150
+FAIL Transition to an unflipped state assert_equals: expected 250 but got 150
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -350,6 +350,10 @@ Length AnchorPositionEvaluator::resolveAnchorValue(const BuilderState& builderSt
     if (builderState.style().pseudoElementType() != PseudoId::None)
         return Length(0, LengthType::Fixed);
 
+    // FIXME: Support animations and transitions.
+    if (builderState.style().hasAnimationsOrTransitions())
+        return Length(0, LengthType::Fixed);
+
     // In-flow elements cannot be anchor-positioned.
     // FIXME: Should attempt to resolve the fallback value.
     if (!builderState.style().hasOutOfFlowPosition())


### PR DESCRIPTION
#### f13277546b4122199f3986f0630612dc4ac85352
<pre>
[css-anchor-position-1] Prevent animated elements from being anchor-positioned
<a href="https://bugs.webkit.org/show_bug.cgi?id=278114">https://bugs.webkit.org/show_bug.cgi?id=278114</a>
<a href="https://rdar.apple.com/133852586">rdar://133852586</a>

Reviewed by Antti Koivisto.

We don&apos;t currently support animating / transitioning anchor-positioned
elements. This patch explicitly prevents elements with animations or
transitions from being anchor-positioned.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-transition-flip-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):

Canonical link: <a href="https://commits.webkit.org/282290@main">https://commits.webkit.org/282290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23aef480c5d0bed4e5ced44f0cd1b1ceb88324a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13133 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50422 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9055 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31164 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11537 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68296 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6527 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11540 "Found 1 new test failure: workers/worker-user-gesture.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57999 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5448 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37736 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->