### PR TITLE
Fix incorrect parenthesization of OpcodeOrigin assertion

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
@@ -53,7 +53,7 @@ public:
     {
         ASSERT(static_cast<uint32_t>(offset) == offset);
         ASSERT(static_cast<OpType>(static_cast<uint8_t>(prefix)) == prefix);
-        ASSERT(((opcode & (1 << 24)) - 1) == opcode);
+        ASSERT((opcode & ((1 << 24) - 1)) == opcode);
         packedData = (static_cast<uint64_t>(opcode) << 40) | (static_cast<uint64_t>(prefix) << 32) | offset;
     }
     OpcodeOrigin(B3::Origin origin)


### PR DESCRIPTION
#### 56f5e3f163b718887889ad70381ddbad068bcaf7
<pre>
Fix incorrect parenthesization of OpcodeOrigin assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=278115">https://bugs.webkit.org/show_bug.cgi?id=278115</a>
<a href="https://rdar.apple.com/133845872">rdar://133845872</a>

Reviewed by Yusuke Suzuki, Keith Miller and Mark Lam.

The issue arises from 281900@main, which updated
```
(opcode &amp; (1 &lt;&lt; 24) - 1) == opcode
```
to
```
((opcode &amp; (1 &lt;&lt; 24)) - 1) == opcode
```

However, this changes the semantics, since `-` binds tighter
than `&amp;`, meaning that the new code would end up calculating
either `-1` or `(1 &lt;&lt; 24) - 1` for every case, regardless of
what the opcode is, and likely causing an error.

* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h:
(JSC::Wasm::OpcodeOrigin::OpcodeOrigin):

Canonical link: <a href="https://commits.webkit.org/282247@main">https://commits.webkit.org/282247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/363bb93f351f36f61ad77cd64f161b572265a36b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66567 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13135 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38976 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11539 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12063 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55680 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57284 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68298 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61826 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6529 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57994 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5450 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83589 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9417 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37738 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14679 "Found 2 new JSC stress test failures: stress/string-to-string-error.js.bytecode-cache, wasm.yaml/wasm/fuzz/memory.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->