### PR TITLE
Move the page/text Zoom Factors to Page

### DIFF
--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -207,9 +207,9 @@ public:
     void setDocument(RefPtr<Document>&&);
 
     WEBCORE_EXPORT void setPageZoomFactor(float);
-    float pageZoomFactor() const { return m_pageZoomFactor; }
+    WEBCORE_EXPORT float pageZoomFactor() const;
     WEBCORE_EXPORT void setTextZoomFactor(float);
-    float textZoomFactor() const { return m_textZoomFactor; }
+    WEBCORE_EXPORT float textZoomFactor() const;
     WEBCORE_EXPORT void setPageAndTextZoomFactors(float pageZoomFactor, float textZoomFactor);
 
     // Scale factor of this frame with respect to the container.
@@ -370,9 +370,6 @@ private:
     VisibleSelection m_rangedSelectionBase;
     VisibleSelection m_rangedSelectionInitialExtent;
 #endif
-
-    float m_pageZoomFactor;
-    float m_textZoomFactor;
 
     int m_activeDOMObjectsAndAnimationsSuspendedCount { 0 };
     bool m_documentIsBeingReplaced { false };

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -551,6 +551,11 @@ public:
     WEBCORE_EXPORT void setZoomedOutPageScaleFactor(float);
     float zoomedOutPageScaleFactor() const { return m_zoomedOutPageScaleFactor; }
 
+    void setPageZoomFactor(float pageZoomFactor) { m_pageZoomFactor = pageZoomFactor; }
+    float pageZoomFactor() const { return m_pageZoomFactor; }
+    void setTextZoomFactor(float textZoomFactor) { m_textZoomFactor = textZoomFactor; }
+    float textZoomFactor() const { return m_textZoomFactor; }
+
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
     WEBCORE_EXPORT void setDeviceScaleFactor(float);
 
@@ -1331,6 +1336,8 @@ private:
     float m_zoomedOutPageScaleFactor { 0 };
     float m_deviceScaleFactor { 1 };
     float m_viewScaleFactor { 1 };
+    float m_pageZoomFactor { 1 };
+    float m_textZoomFactor { 1 };
 
     float m_topContentInset { 0 };
     FloatBoxExtent m_obscuredInsets;


### PR DESCRIPTION
#### e8a0211078956cda773c87d4b04111588fbd0dbf
<pre>
Move the page/text Zoom Factors to Page
<a href="https://bugs.webkit.org/show_bug.cgi?id=278112">https://bugs.webkit.org/show_bug.cgi?id=278112</a>
<a href="https://rdar.apple.com/132440413">rdar://132440413</a>

Reviewed by NOBODY (OOPS!).

The storage is moved to Page.h. This needed for modifying the Internals.idl
zoom APIs and making them async similar to setPageScaleFactor that was
recently moved in 282710@main.

No behavior change so no new tests have been added.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::pageZoomFactor const):
(WebCore::LocalFrame::textZoomFactor const):
(WebCore::LocalFrame::setPageZoomFactor):
(WebCore::LocalFrame::setTextZoomFactor):
(WebCore::LocalFrame::setPageAndTextZoomFactors):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.h:
(WebCore::Page::setPageZoomFactor):
(WebCore::Page::pageZoomFactor const):
(WebCore::Page::setTextZoomFactor):
(WebCore::Page::textZoomFactor const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8a0211078956cda773c87d4b04111588fbd0dbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13699 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50665 "Found 43 new test failures: fast/backgrounds/size/contain-and-cover-zoomed.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/dom/Document/CaretRangeFromPoint/hittest-relative-to-viewport.html fast/events/clientXY-in-zoom-and-scroll.html fast/images/animated-gif-zooming.html fast/images/imagemap-focus-ring-zoom.html fast/loader/policy-delegate-action-hit-test-zoomed.html fast/scrolling/page-y-offset-should-not-be-changed-after-zoom.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9263 "Found 8 new test failures: fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/dom/Document/CaretRangeFromPoint/hittest-relative-to-viewport.html fast/events/zoom-dblclick.html fast/visual-viewport/client-rects-relative-to-layout-viewport-zoomed.html fast/visual-viewport/viewport-dimensions-exclude-custom-scrollbars.html fast/visual-viewport/viewport-dimensions-exclude-scrollbars.html fast/visual-viewport/viewport-dimensions-under-page-zoom.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65880 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39206 "Found 13 new test failures: fast/css/preserve-user-specified-zoom-level-on-reload.html fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/images/animated-gif-zooming.html fast/media/mq-width-pagezoom.html fast/scrolling/page-y-offset-should-not-be-changed-after-zoom.html fast/text/line-height-minimumFontSize-text-zoom.html fast/visual-viewport/viewport-dimensions-exclude-custom-scrollbars.html fast/visual-viewport/viewport-dimensions-exclude-scrollbars.html fast/visual-viewport/viewport-dimensions-under-page-zoom.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54409 "Found 4 new API test failures: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZoom, TestWebKitAPI.WKWebView.PageZoom, TestWebKitAPI.ProcessSwap.PageZoomLevelAfterSwap, TestWebKitAPI.WebKit.TextSize (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31344 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35910 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair.html imported/w3c/web-platform-tests/websockets/basic-auth.any.sharedworker.html?wss (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11741 "Found 60 new test failures: fast/backgrounds/size/contain-and-cover-zoomed.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/dom/Document/CaretRangeFromPoint/hittest-relative-to-viewport.html fast/dom/horizontal-scrollbar-in-rtl.html fast/dom/move-embedded-during-update.html fast/dom/vertical-scrollbar-in-rtl.html fast/events/clientXY-in-zoom-and-scroll.html fast/events/zoom-dblclick.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12291 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57456 "Found 2 new API test failures: TestWebKitAPI.WKWebView.PageZoom, TestWebKitAPI.WebKit.TextSize (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12072 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html editing/input/scroll-viewport-page-up-down.html fast/backgrounds/size/contain-and-cover-zoomed.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/dom/Document/CaretRangeFromPoint/hittest-relative-to-viewport.html fast/events/clientXY-in-zoom-and-scroll.html fast/events/zoom-dblclick.html fast/images/animated-gif-zooming.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68526 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6757 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11717 "Found 60 new test failures: fast/backgrounds/size/contain-and-cover-zoomed.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/dom/Document/CaretRangeFromPoint/hittest-relative-to-viewport.html fast/dom/Element/id-in-getelement01.html fast/events/clientXY-in-zoom-and-scroll.html fast/events/zoom-dblclick.html fast/forms/form-submission-crash-4.html fast/images/animated-gif-zooming.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57979 "Found 43 new test failures: fast/backgrounds/size/contain-and-cover-zoomed.html fast/css/preserve-user-specified-zoom-level-on-reload.html fast/css/view-transitions-zoom.html fast/css/zoom-body-scroll.html fast/dom/Document/CaretRangeFromPoint/hittest-relative-to-viewport.html fast/events/clientXY-in-zoom-and-scroll.html fast/events/zoom-dblclick.html fast/images/imagemap-focus-ring-zoom.html fast/loader/policy-delegate-action-hit-test-zoomed.html fast/media/mq-width-pagezoom.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58171 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5648 "Found 1 new test failure: interaction-region/full-page-overlay-page-zoom.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37987 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->