### PR TITLE
Rename singleton accessor methods to singleton() to match WebKit convention.

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.h
+++ b/Source/JavaScriptCore/assembler/JITOperationList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ struct JITOperationAnnotation;
 
 class JITOperationList {
 public:
-    static JITOperationList& instance();
+    static JITOperationList& singleton();
     static void initialize();
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
@@ -76,7 +76,7 @@ public:
     {
         UNUSED_PARAM(function);
 #if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
-        RELEASE_ASSERT(!Options::useJIT() || JITOperationList::instance().map(function));
+        RELEASE_ASSERT(!Options::useJIT() || JITOperationList::singleton().map(function));
 #endif
     }
 
@@ -84,7 +84,7 @@ public:
     {
         UNUSED_PARAM(function);
 #if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
-        RELEASE_ASSERT(!Options::useJIT() || JITOperationList::instance().inverseMap(function));
+        RELEASE_ASSERT(!Options::useJIT() || JITOperationList::singleton().inverseMap(function));
 #endif
     }
 
@@ -113,7 +113,7 @@ private:
 
 JS_EXPORT_PRIVATE extern LazyNeverDestroyed<JITOperationList> jitOperationList;
 
-inline JITOperationList& JITOperationList::instance()
+inline JITOperationList& JITOperationList::singleton()
 {
     return jitOperationList.get();
 }

--- a/Source/JavaScriptCore/jit/ICStats.cpp
+++ b/Source/JavaScriptCore/jit/ICStats.cpp
@@ -60,7 +60,7 @@ void ICEvent::dump(PrintStream& out) const
 
 void ICEvent::log() const
 {
-    ICStats::instance().add(*this);
+    ICStats::singleton().add(*this);
 }
 
 Atomic<ICStats*> ICStats::s_instance;
@@ -104,7 +104,7 @@ void ICStats::add(const ICEvent& event)
     m_spectrum.add(event);
 }
 
-ICStats& ICStats::instance()
+ICStats& ICStats::singleton()
 {
     for (;;) {
         ICStats* result = s_instance.load();

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -202,7 +202,7 @@ public:
     
     void add(const ICEvent& event);
     
-    static ICStats& instance();
+    static ICStats& singleton();
     
 private:
 

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.h
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,7 +133,7 @@ ALWAYS_INLINE static PtrType tagJSCCodePtrImpl(PtrType ptr)
         JITOperationList::assertIsJITOperation(ptr);
 #if ENABLE(JIT_CAGE)
         if (Options::useJITCage())
-            return bitwise_cast<PtrType>(JITOperationList::instance().map(ptr));
+            return bitwise_cast<PtrType>(JITOperationList::singleton().map(ptr));
     } else {
         if (Options::useJITCage())
             return bitwise_cast<PtrType>(jitCagePtr(bitwise_cast<void*>(ptr), tag));
@@ -175,7 +175,7 @@ ALWAYS_INLINE static bool isTaggedJSCCodePtrImpl(PtrType ptr)
 #if ENABLE(JIT_CAGE)
         if (Options::useJITCage()) {
 #if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
-            return JITOperationList::instance().inverseMap(ptr);
+            return JITOperationList::singleton().inverseMap(ptr);
 #else
             // Not supported. We currently don't use this, and don't have an
             // efficient way to implement this. So, just assert that it's not used.

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -240,7 +240,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     if (UNLIKELY(vmCreationShouldCrash || g_jscConfig.vmCreationDisallowed))
         CRASH_WITH_EXTRA_SECURITY_IMPLICATION_AND_INFO(VMCreationDisallowed, "VM creation disallowed"_s, 0x4242424220202020, 0xbadbeef0badbeef, 0x1234123412341234, 0x1337133713371337);
 
-    VMInspector::instance().add(this);
+    VMInspector::singleton().add(this);
 
     // Set up lazy initializers.
     {
@@ -496,7 +496,7 @@ VM::~VM()
 
     JSRunLoopTimer::Manager::shared().unregisterVM(*this);
 
-    VMInspector::instance().remove(this);
+    VMInspector::singleton().remove(this);
 
     delete emptyList;
 

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -439,7 +439,7 @@ void HeapVerifier::checkIfRecorded(uintptr_t candidateCell)
 {
     HeapCell* candidateHeapCell = reinterpret_cast<HeapCell*>(candidateCell);
     
-    auto& inspector = VMInspector::instance();
+    auto& inspector = VMInspector::singleton();
     if (!inspector.getLock().tryLockWithTimeout(2_s)) {
         dataLog("ERROR: Timed out while waiting to iterate VMs.");
         return;

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(VMInspector);
 
 VM* VMInspector::m_recentVM { nullptr };
 
-VMInspector& VMInspector::instance()
+VMInspector& VMInspector::singleton()
 {
     static VMInspector* manager;
     static std::once_flag once;
@@ -109,7 +109,7 @@ void VMInspector::dumpVMs()
 
 void VMInspector::forEachVM(Function<IterationStatus(VM&)>&& func)
 {
-    VMInspector& inspector = instance();
+    VMInspector& inspector = singleton();
     Locker lock { inspector.getLock() };
     inspector.iterate(func);
 }
@@ -117,7 +117,7 @@ void VMInspector::forEachVM(Function<IterationStatus(VM&)>&& func)
 // Returns null if the callFrame doesn't actually correspond to any active VM.
 VM* VMInspector::vmForCallFrame(CallFrame* callFrame)
 {
-    VMInspector& inspector = instance();
+    VMInspector& inspector = singleton();
     Locker lock { inspector.getLock() };
 
     auto isOnVMStack = [] (VM& vm, CallFrame* callFrame) -> bool {

--- a/Source/JavaScriptCore/tools/VMInspector.h
+++ b/Source/JavaScriptCore/tools/VMInspector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ public:
         TimedOut
     };
 
-    static VMInspector& instance();
+    static VMInspector& singleton();
 
     void add(VM*);
     void remove(VM*);

--- a/Source/bmalloc/bmalloc/ProcessCheck.mm
+++ b/Source/bmalloc/bmalloc/ProcessCheck.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,17 +37,17 @@ class ProcessNames {
 public:
     static NSString* getAppName()
     {
-        return getInstance().appName();
+        return singleton().appName();
     }
 
     static NSString* getProcessName()
     {
-        return getInstance().processName();
+        return singleton().processName();
     }
 
     static const char* getCString()
     {
-        return getInstance().asCString();
+        return singleton().asCString();
     }
 
 private:
@@ -55,7 +55,7 @@ private:
     {
     }
 
-    static void ensureInstance()
+    static void ensureSingleton()
     {
         static std::once_flag onceFlag;
         std::call_once(
@@ -66,10 +66,10 @@ private:
         );
     }
 
-    static ProcessNames& getInstance()
+    static ProcessNames& singleton()
     {
         if (!theProcessNames)
-            ensureInstance();
+            ensureSingleton();
         BASSERT(theProcessNames);
         return *theProcessNames;
     }

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -84,7 +84,7 @@ struct TZoneHeapBase {
         static pas_heap_ref* heap = nullptr;
 
         if (!heap)
-            heap = TZoneHeapManager::getInstance().heapRefForTZoneType(&type);
+            heap = TZoneHeapManager::singleton().heapRefForTZoneType(&type);
 
         return *heap;
     }
@@ -96,7 +96,7 @@ struct TZoneHeapBase {
         TZONE_LOG_DEBUG("Unannotated TZone type %s:%d:%s\n", __FILE__, __LINE__, __PRETTY_FUNCTION__);
 
         //  &&&& Should we figure out a way to cache this different sized heap?
-        return *TZoneHeapManager::getInstance().heapRefForTZoneType(&type);
+        return *TZoneHeapManager::singleton().heapRefForTZoneType(&type);
     }
 };
 

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -72,7 +72,7 @@ static TypeNameTemplate typeNameTemplate;
 
 static void dumpRegisterdTypesAtExit(void)
 {
-    TZoneHeapManager::getInstance().dumpRegisterdTypes();
+    TZoneHeapManager::singleton().dumpRegisterdTypes();
 }
 
 void TZoneHeapManager::init()
@@ -248,7 +248,7 @@ void TZoneHeapManager::dumpRegisterdTypes()
     }
 }
 
-void TZoneHeapManager::ensureInstance()
+void TZoneHeapManager::ensureSingleton()
 {
     static std::once_flag onceFlag;
     std::call_once(

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -144,10 +144,10 @@ public:
 
     BEXPORT bool isReady();
 
-    BINLINE static TZoneHeapManager& getInstance()
+    BINLINE static TZoneHeapManager& singleton()
     {
         if (!theTZoneHeapManager)
-            ensureInstance();
+            ensureSingleton();
         BASSERT(theTZoneHeapManager);
         return *theTZoneHeapManager;
     }
@@ -156,7 +156,7 @@ public:
     BEXPORT void dumpRegisterdTypes();
 
 private:
-    BEXPORT static void ensureInstance();
+    BEXPORT static void ensureSingleton();
 
     BEXPORT void init();
 

--- a/Source/bmalloc/bmalloc/TZoneLog.cpp
+++ b/Source/bmalloc/bmalloc/TZoneLog.cpp
@@ -53,10 +53,10 @@ void TZoneLog::init()
     }
 }
 
-extern TZoneLog& TZoneLog::getInstance()
+extern TZoneLog& TZoneLog::singleton()
 {
     if (!theTZoneLog)
-        ensureInstance();
+        ensureSingleton();
     BASSERT(theTZoneLog);
     return *theTZoneLog;
 }
@@ -103,7 +103,7 @@ void TZoneLog::osLogWithLineBuffer(const char* format, va_list list)
 }
 #endif
 
-void TZoneLog::ensureInstance()
+void TZoneLog::ensureSingleton()
 {
     static std::once_flag onceFlag;
     std::call_once(

--- a/Source/bmalloc/bmalloc/TZoneLog.h
+++ b/Source/bmalloc/bmalloc/TZoneLog.h
@@ -55,11 +55,11 @@ public:
     TZoneLog(TZoneLog &other) = delete;
     void operator=(const TZoneLog &) = delete;
 
-    BEXPORT static TZoneLog& getInstance();
+    BEXPORT static TZoneLog& singleton();
     BEXPORT void log(const char* format, ...) BATTRIBUTE_PRINTF(2, 3);
 
 private:
-    static void ensureInstance();
+    static void ensureSingleton();
     void init();
     static TZoneLog* theTZoneLog;
 
@@ -82,7 +82,7 @@ private:
 
 } } // namespace bmalloc::api
 
-#define TZONE_LOG_DEBUG(...) TZoneLog::getInstance().log(__VA_ARGS__)
+#define TZONE_LOG_DEBUG(...) TZoneLog::singleton().log(__VA_ARGS__)
 
 #else // not BUSE(TZONE)
 #define TZONE_LOG_DEBUG(...)


### PR DESCRIPTION
#### e60e4ad864876164321293a426e6cc34531881f9
<pre>
Rename singleton accessor methods to singleton() to match WebKit convention.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278117">https://bugs.webkit.org/show_bug.cgi?id=278117</a>
<a href="https://rdar.apple.com/133864545">rdar://133864545</a>

Reviewed by Yijia Huang.

WebKit convention states:

&quot;Singleton pattern
Use a static member function named “singleton()” to access the instance of the singleton.&quot;

This patch renames relevant methods to conform to this WebKit style convention.

* Source/JavaScriptCore/assembler/JITOperationList.h:
(JSC::JITOperationList::assertIsJITOperation):
(JSC::JITOperationList::assertIsJITOperationWithValidation):
(JSC::JITOperationList::singleton):
(JSC::JITOperationList::instance): Deleted.
* Source/JavaScriptCore/jit/ICStats.cpp:
(JSC::ICEvent::log const):
(JSC::ICStats::singleton):
(JSC::ICStats::instance): Deleted.
* Source/JavaScriptCore/jit/ICStats.h:
* Source/JavaScriptCore/runtime/JSCPtrTag.h:
(JSC::tagJSCCodePtrImpl):
(JSC::isTaggedJSCCodePtrImpl):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::~VM):
* Source/JavaScriptCore/tools/HeapVerifier.cpp:
(JSC::HeapVerifier::checkIfRecorded):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::singleton):
(JSC::VMInspector::forEachVM):
(JSC::VMInspector::vmForCallFrame):
(JSC::VMInspector::instance): Deleted.
* Source/JavaScriptCore/tools/VMInspector.h:
* Source/bmalloc/bmalloc/ProcessCheck.mm:
(bmalloc::ProcessNames::getAppName):
(bmalloc::ProcessNames::getProcessName):
(bmalloc::ProcessNames::getCString):
(bmalloc::ProcessNames::ensureSingleton):
(bmalloc::ProcessNames::singleton):
(bmalloc::ProcessNames::ensureInstance): Deleted.
(bmalloc::ProcessNames::getInstance): Deleted.
* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::TZoneHeapBase::provideHeap):
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::dumpRegisterdTypesAtExit):
(bmalloc::api::TZoneHeapManager::ensureSingleton):
(bmalloc::api::TZoneHeapManager::ensureInstance): Deleted.
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
(bmalloc::api::TZoneHeapManager::singleton):
(bmalloc::api::TZoneHeapManager::getInstance): Deleted.
* Source/bmalloc/bmalloc/TZoneLog.cpp:
(bmalloc::api::TZoneLog::singleton):
(bmalloc::api::TZoneLog::ensureSingleton):
(bmalloc::api::TZoneLog::getInstance): Deleted.
(bmalloc::api::TZoneLog::ensureInstance): Deleted.
* Source/bmalloc/bmalloc/TZoneLog.h:

Canonical link: <a href="https://commits.webkit.org/282274@main">https://commits.webkit.org/282274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e0bde0c2ed330569689aa733d29c396f2ede984

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50439 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9079 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11553 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12082 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55699 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68317 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61845 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58014 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5467 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83608 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37757 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->