### PR TITLE
xywh() shape's dimensions should not accept negative values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/xywh-function-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/xywh-function-invalid-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL e.style['shape-outside'] = "xywh(0px 1px -2% 3em)" should not set the property value assert_equals: expected "" but got "xywh(0px 1px -2% 3em)"
-FAIL e.style['shape-outside'] = "xywh(0px 1px 2% -3em)" should not set the property value assert_equals: expected "" but got "xywh(0px 1px 2% -3em)"
+PASS e.style['shape-outside'] = "xywh(0px 1px -2% 3em)" should not set the property value
+PASS e.style['shape-outside'] = "xywh(0px 1px 2% -3em)" should not set the property value
 PASS e.style['shape-outside'] = "xywh(10px 20px)" should not set the property value
 PASS e.style['shape-outside'] = "xywh(10px 20px 30px)" should not set the property value
 PASS e.style['shape-outside'] = "xywh(10px 20px, 30px 25px)" should not set the property value

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -2941,7 +2941,7 @@ static RefPtr<CSSXywhValue> consumeBasicShapeXywh(CSSParserTokenRange& args, con
 
     std::array<RefPtr<CSSValue>, 2> dimensions;
     for (auto& dimension : dimensions) {
-        dimension = consumeLengthOrPercent(args, context.mode);
+        dimension = consumeLengthOrPercent(args, context.mode, ValueRange::NonNegative);
         if (!dimension)
             return nullptr;
     }


### PR DESCRIPTION
#### 935d438f1288b7c7dc73eb3432fe68ddbc430002
<pre>
xywh() shape&apos;s dimensions should not accept negative values
<a href="https://bugs.webkit.org/show_bug.cgi?id=278120">https://bugs.webkit.org/show_bug.cgi?id=278120</a>
<a href="https://rdar.apple.com/133870976">rdar://133870976</a>

Reviewed by Tim Nguyen.

Disallow negative values in the &quot;dimension&quot; arguments of the `xywh()` shape, per spec[1]

[1] <a href="https://www.w3.org/TR/css-shapes/#supported-basic-shapes">https://www.w3.org/TR/css-shapes/#supported-basic-shapes</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-functions/xywh-function-invalid-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeBasicShapeXywh):

Canonical link: <a href="https://commits.webkit.org/282264@main">https://commits.webkit.org/282264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d1e0f4ad90fdbf652946dd269dab1b5695f566b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50441 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9074 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12085 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6551 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5469 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37760 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39942 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->