### PR TITLE
Merge full-width/full-height Overlay Regions when they intersect

### DIFF
--- a/LayoutTests/overlay-region/full-page-dynamic-expected.txt
+++ b/LayoutTests/overlay-region/full-page-dynamic-expected.txt
@@ -5,8 +5,7 @@
   (subviews
     (view [class: WKScrollView]
       (scrolling behavior 2)
-      (overlay region [x: 0 y: 0 width: 800 height: 50])
-      (overlay region [x: 0 y: 50 width: 800 height: 50])
+      (overlay region [x: 0 y: 0 width: 800 height: 100])
       (overlay region [x: 0 y: 550 width: 800 height: 50])
       (layer bounds [x: 0 y: 0 width: 800 height: 600])
       (layer position [x: 400 y: 400])

--- a/LayoutTests/overlay-region/full-page-expected.txt
+++ b/LayoutTests/overlay-region/full-page-expected.txt
@@ -5,8 +5,7 @@
   (subviews
     (view [class: WKScrollView]
       (scrolling behavior 2)
-      (overlay region [x: 0 y: 0 width: 800 height: 50])
-      (overlay region [x: 0 y: 50 width: 800 height: 50])
+      (overlay region [x: 0 y: 0 width: 800 height: 100])
       (overlay region [x: 0 y: 550 width: 800 height: 50])
       (layer bounds [x: 0 y: 0 width: 800 height: 600])
       (layer position [x: 400 y: 400])

--- a/LayoutTests/overlay-region/full-page-overflow-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-expected.txt
@@ -44,8 +44,7 @@
                                       (subviews
                                         (view [class: <class not in allowed list of classes>]
                                           (scrolling behavior 2)
-                                          (overlay region [x: 0 y: 0 width: 800 height: 50])
-                                          (overlay region [x: 0 y: 50 width: 800 height: 50])
+                                          (overlay region [x: 0 y: 0 width: 800 height: 100])
                                           (overlay region [x: 0 y: 550 width: 800 height: 50])
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400])

--- a/LayoutTests/overlay-region/full-page-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-scrolling-expected.txt
@@ -5,8 +5,7 @@
   (subviews
     (view [class: WKScrollView]
       (scrolling behavior 2)
-      (overlay region [x: 0 y: 0 width: 800 height: 50])
-      (overlay region [x: 0 y: 50 width: 800 height: 50])
+      (overlay region [x: 0 y: 0 width: 800 height: 100])
       (overlay region [x: 0 y: 550 width: 800 height: 50])
       (layer bounds [x: 0 y: 2000 width: 800 height: 600])
       (layer position [x: 400 y: 400])

--- a/LayoutTests/overlay-region/merging-expected.txt
+++ b/LayoutTests/overlay-region/merging-expected.txt
@@ -39,32 +39,34 @@
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer bounds [x: 0 y: 0 width: 640 height: 480])
                                       (layer position [x: 400 y: 400])
                                       (subviews
                                         (view [class: <class not in allowed list of classes>]
-                                          (scrolling behavior 2)
-                                          (overlay region [x: 0 y: 0 width: 800 height: 100])
-                                          (overlay region [x: 0 y: 550 width: 800 height: 50])
-                                          (layer bounds [x: 0 y: 4100 width: 800 height: 600])
-                                          (layer position [x: 400 y: 400])
+                                          (scrolling behavior 3)
+                                          (overlay region [x: 0 y: 0 width: 640 height: 48])
+                                          (overlay region [x: 0 y: 0 width: 72 height: 480])
+                                          (overlay region [x: 0 y: 408 width: 640 height: 72])
+                                          (overlay region [x: 604 y: 0 width: 36 height: 480])
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 480])
+                                          (layer position [x: 320 y: 320])
                                           (subviews
                                             (view [class: WKCompositingView]
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 7100])
+                                              (layer bounds [x: 0 y: 0 width: 4000 height: 4000])
                                               (layer anchorPoint [x: 0 y: 0])
                                               (subviews
                                                 (view [class: WKCompositingView]
                                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
                                             (view [class: <class not in allowed list of classes>]
-                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
-                                              (layer position [x: 791 y: 791])
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 480])
+                                              (layer position [x: 631 y: 631])
                                               (layer zPosition 1000)
                                               (subviews
                                                 (view [class: UIView]
                                                   (layer bounds [x: 0 y: 0 width: 32 height: 116])
                                                   (layer position [x: 6 y: 6]))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 480])
                                                   (layer position [x: 6 y: 6])
                                                   (subviews
                                                     (view [class: <class not in allowed list of classes>]
@@ -78,68 +80,137 @@
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
                                                           (layer position [x: 6 y: 6]))))))))
                                             (view [class: <class not in allowed list of classes>]
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
-                                              (layer position [x: 400 y: 400])
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                              (layer position [x: 320 y: 320])
                                               (layer zPosition 1000)
                                               (subviews
                                                 (view [class: UIView]
                                                   (layer bounds [x: 0 y: 0 width: 116 height: 32])
-                                                  (layer position [x: 400 y: 400]))
+                                                  (layer position [x: 320 y: 320]))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
-                                                  (layer position [x: 400 y: 400])
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                  (layer position [x: 320 y: 320])
                                                   (subviews
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                                                      (layer position [x: 400 y: 400])
+                                                      (layer position [x: 320 y: 320])
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
-                                                          (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
-                                    (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
-                                      (subviews
-                                        (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
-                                          (subviews
-                                            (view [class: WKTransformView]
-                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                              (layer position [x: 0 y: 0])
-                                              (subviews
-                                                (view [class: WKCompositingView]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                                  (layer position [x: 400 y: 400]))))))))
-                                    (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
-                                      (subviews
-                                        (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
-                                          (subviews
-                                            (view [class: WKTransformView]
-                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                              (layer position [x: 0 y: 0])
-                                              (subviews
-                                                (view [class: WKCompositingView]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                                  (layer position [x: 400 y: 400]))))))))
+                                                          (layer bounds [x: 0 y: 0 width: 28 height: 6])
+                                                          (layer position [x: 17 y: 17]))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                          (layer position [x: 400 y: 400]))))
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                      (layer position [x: 0 y: 0])
+                                      (layer position [x: 80 y: 80])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                          (layer position [x: 400 y: 400]))))))))))))))))
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 104 y: 104])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 128 y: 128])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 696 y: 696])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 684 y: 684])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
             (view [class: UIView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))

--- a/LayoutTests/overlay-region/merging.html
+++ b/LayoutTests/overlay-region/merging.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 10%;
+            left: 10%;
+            right: 10%;
+            bottom: 10%;
+            overflow: scroll;
+
+            --dimension: 24px;
+        }
+
+        .big {
+            position: relative;
+            width: 4000px;
+            height: 4000px;
+            background: #355C7D;
+        }
+        .big::before {
+            content: "↘";
+            color: white;
+            font-size: 8em;
+            text-align: center;
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+
+        .fixed {
+            position: fixed;
+            background: rgba(100, 200, 200, 0.5);
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="big"></div>
+    <div class="fixed" style="top: 10%; left: 10%; right: 10%; height: var(--dimension);"></div>
+    <div class="fixed" style="top: calc(10% + var(--dimension)); left: 10%; right: 10%; height: var(--dimension)"></div>
+
+    <div class="fixed" style="top: 10%; left: 10%; bottom: 10%; width: var(--dimension)"></div>
+    <div class="fixed" style="top: 10%; left: calc(10% + var(--dimension)); bottom: 10%; width: var(--dimension)"></div>
+    <div class="fixed" style="top: 10%; left: calc(10% + calc(var(--dimension) * 2)); bottom: 10%; width: var(--dimension)"></div>
+
+    <div class="fixed" style="top: 10%; right: 10%; bottom: 10%; width: var(--dimension)"></div>
+    <div class="fixed" style="top: 10%; right: calc(10% + calc(var(--dimension) / 2)); bottom: 10%; width: var(--dimension)"></div>
+
+    <div class="fixed" style="bottom: 10%; left: 10%; right: 10%; height: var(--dimension);"></div>
+    <div class="fixed" style="bottom: calc(10% + var(--dimension)); left: 10%; right: 10%; height: var(--dimension)"></div>
+    <div class="fixed" style="bottom: calc(10% + var(--dimension) * 2); left: 10%; right: 10%; height: var(--dimension)"></div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/no-merging-expected.txt
+++ b/LayoutTests/overlay-region/no-merging-expected.txt
@@ -39,32 +39,39 @@
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer bounds [x: 0 y: 0 width: 640 height: 480])
                                       (layer position [x: 400 y: 400])
                                       (subviews
                                         (view [class: <class not in allowed list of classes>]
-                                          (scrolling behavior 2)
-                                          (overlay region [x: 0 y: 0 width: 800 height: 100])
-                                          (overlay region [x: 0 y: 550 width: 800 height: 50])
-                                          (layer bounds [x: 0 y: 4100 width: 800 height: 600])
-                                          (layer position [x: 400 y: 400])
+                                          (scrolling behavior 3)
+                                          (overlay region [x: 0 y: 0 width: 24 height: 480])
+                                          (overlay region [x: 0 y: 0 width: 320 height: 24])
+                                          (overlay region [x: 0 y: 24 width: 640 height: 24])
+                                          (overlay region [x: 0 y: 408 width: 640 height: 24])
+                                          (overlay region [x: 0 y: 456 width: 640 height: 24])
+                                          (overlay region [x: 160 y: 432 width: 320 height: 24])
+                                          (overlay region [x: 44 y: 0 width: 24 height: 480])
+                                          (overlay region [x: 592 y: 0 width: 24 height: 240])
+                                          (overlay region [x: 616 y: 0 width: 24 height: 480])
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 480])
+                                          (layer position [x: 320 y: 320])
                                           (subviews
                                             (view [class: WKCompositingView]
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 7100])
+                                              (layer bounds [x: 0 y: 0 width: 4000 height: 4000])
                                               (layer anchorPoint [x: 0 y: 0])
                                               (subviews
                                                 (view [class: WKCompositingView]
                                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
                                             (view [class: <class not in allowed list of classes>]
-                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
-                                              (layer position [x: 791 y: 791])
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 480])
+                                              (layer position [x: 631 y: 631])
                                               (layer zPosition 1000)
                                               (subviews
                                                 (view [class: UIView]
                                                   (layer bounds [x: 0 y: 0 width: 32 height: 116])
                                                   (layer position [x: 6 y: 6]))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 480])
                                                   (layer position [x: 6 y: 6])
                                                   (subviews
                                                     (view [class: <class not in allowed list of classes>]
@@ -78,68 +85,126 @@
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
                                                           (layer position [x: 6 y: 6]))))))))
                                             (view [class: <class not in allowed list of classes>]
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
-                                              (layer position [x: 400 y: 400])
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                              (layer position [x: 320 y: 320])
                                               (layer zPosition 1000)
                                               (subviews
                                                 (view [class: UIView]
                                                   (layer bounds [x: 0 y: 0 width: 116 height: 32])
-                                                  (layer position [x: 400 y: 400]))
+                                                  (layer position [x: 320 y: 320]))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
-                                                  (layer position [x: 400 y: 400])
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                  (layer position [x: 320 y: 320])
                                                   (subviews
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                                                      (layer position [x: 400 y: 400])
+                                                      (layer position [x: 320 y: 320])
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
-                                                          (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
-                                    (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
-                                      (subviews
-                                        (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
-                                          (subviews
-                                            (view [class: WKTransformView]
-                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                              (layer position [x: 0 y: 0])
-                                              (subviews
-                                                (view [class: WKCompositingView]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                                  (layer position [x: 400 y: 400]))))))))
-                                    (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
-                                      (subviews
-                                        (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
-                                          (subviews
-                                            (view [class: WKTransformView]
-                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                              (layer position [x: 0 y: 0])
-                                              (subviews
-                                                (view [class: WKCompositingView]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                                  (layer position [x: 400 y: 400]))))))))
+                                                          (layer bounds [x: 0 y: 0 width: 28 height: 6])
+                                                          (layer position [x: 17 y: 17]))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                          (layer position [x: 400 y: 400]))))
+                                          (layer bounds [x: 0 y: 0 width: 320 height: 24])
+                                          (layer position [x: 160 y: 160])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 320 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                      (layer position [x: 0 y: 0])
+                                      (layer position [x: 80 y: 80])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                          (layer position [x: 400 y: 400]))))))))))))))))
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 124 y: 124])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 696 y: 696])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 480])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 672 y: 672])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 24 height: 240])
+                                          (layer position [x: 12 y: 12])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 24 height: 240])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 240 y: 240])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 320 height: 24])
+                                          (layer position [x: 160 y: 160])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 320 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 24])
+                                              (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
             (view [class: UIView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))

--- a/LayoutTests/overlay-region/no-merging.html
+++ b/LayoutTests/overlay-region/no-merging.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 10%;
+            left: 10%;
+            right: 10%;
+            bottom: 10%;
+            overflow: scroll;
+
+            --dimension: 24px;
+        }
+
+        .big {
+            position: relative;
+            width: 4000px;
+            height: 4000px;
+            background: #355C7D;
+        }
+        .big::before {
+            content: "↘";
+            color: white;
+            font-size: 8em;
+            text-align: center;
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+
+        .fixed {
+            position: fixed;
+            background: rgba(100, 200, 200, 0.5);
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="big"></div>
+    <div class="fixed" style="top: 10%; left: 10%; right: 50%; height: var(--dimension);"></div>
+    <div class="fixed" style="top: calc(10% + var(--dimension)); left: 10%; right: 10%; height: var(--dimension)"></div>
+
+    <div class="fixed" style="top: 10%; left: 10%; bottom: 10%; width: var(--dimension)"></div>
+    <div class="fixed" style="top: 10%; left: calc(10% + var(--dimension) + 20px); bottom: 10%; width: var(--dimension)"></div>
+
+    <div class="fixed" style="top: 10%; right: 10%; bottom: 10%; width: var(--dimension)"></div>
+    <div class="fixed" style="top: 10%; right: calc(10% + var(--dimension)); bottom: 50%; width: var(--dimension)"></div>
+
+    <div class="fixed" style="bottom: 10%; left: 10%; right: 10%; height: var(--dimension);"></div>
+    <div class="fixed" style="bottom: calc(10% + var(--dimension)); left: 30%; right: 30%; height: var(--dimension)"></div>
+    <div class="fixed" style="bottom: calc(10% + var(--dimension) * 2); left: 10%; right: 10%; height: var(--dimension)"></div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### dc2829c6d51b5fbad8876d98764cda8b9068dcae
<pre>
Merge full-width/full-height Overlay Regions when they intersect
<a href="https://bugs.webkit.org/show_bug.cgi?id=278121">https://bugs.webkit.org/show_bug.cgi?id=278121</a>
&lt;<a href="https://rdar.apple.com/132904789">rdar://132904789</a>&gt;

Reviewed by Mike Wyrzykowski.

When configuring a ScrollView with Overlay regions, keep full-width/
full-height rects in separate vectors so we can easily merge them before
adding them to the final set.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(configureScrollViewWithOverlayRegionsIDs):
For each axis, sort the rects then simply check for overlap with y/maxY
x/maxX since we know the rects have the same width/height.

* LayoutTests/overlay-region/merging-expected.txt:
* LayoutTests/overlay-region/merging.html: Added.
* LayoutTests/overlay-region/no-merging-expected.txt:
* LayoutTests/overlay-region/no-merging.html: Added.
Add new tests for different cases where we merge or skip merging.

* LayoutTests/overlay-region/full-page-dynamic-expected.txt:
* LayoutTests/overlay-region/full-page-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt:
* LayoutTests/overlay-region/full-page-scrolling-expected.txt:
Update test expectations with merges.

Canonical link: <a href="https://commits.webkit.org/282278@main">https://commits.webkit.org/282278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a030d63b06d274b8a654b31b31c583d71eeb802f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50541 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68322 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57817 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54272 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58020 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5466 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37762 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->