### PR TITLE
[JSC] incorrectly reports SyntaxError when destructuring `let`

### DIFF
--- a/LayoutTests/js/let-syntax-expected.txt
+++ b/LayoutTests/js/let-syntax-expected.txt
@@ -82,8 +82,8 @@ PASS Has syntax error: 'const let;'
 SyntaxError: Cannot use 'let' as a lexical variable name in strict mode.
 SyntaxError: Cannot use 'let' as a lexical variable name in strict mode.
 PASS Has syntax error: ''use strict'; const let;'
-SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration.
-SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration.
+SyntaxError: Cannot use the keyword 'let' as a lexical variable name.
+SyntaxError: Cannot use the keyword 'let' as a lexical variable name.
 PASS Has syntax error: 'let {let};'
 SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'let'.
 SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'let'.
@@ -94,8 +94,8 @@ PASS Has syntax error: 'let {l: let};'
 SyntaxError: Cannot use 'let' as a lexical variable name in strict mode.
 SyntaxError: Cannot use 'let' as a lexical variable name in strict mode.
 PASS Has syntax error: ''use strict'; let {l: let};'
-SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration.
-SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration.
+SyntaxError: Cannot use the keyword 'let' as a lexical variable name.
+SyntaxError: Cannot use the keyword 'let' as a lexical variable name.
 PASS Has syntax error: 'let {l: {let}};'
 SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'let'.
 SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'let'.
@@ -445,6 +445,8 @@ PASS Does not have syntax error: 'let x; if (true) let: x = 3;'
 SyntaxError: Cannot use 'let' as a label in strict mode.
 SyntaxError: Cannot use 'let' as a label in strict mode.
 PASS Has syntax error: ''use strict'; let x; if (true) let: x = 3;'
+PASS Does not have syntax error: 'let {let: a} = {let: 1}'
+PASS Does not have syntax error: ''use strict'; let {let: a} = {let: 1}'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/js/script-tests/let-syntax.js
+++ b/LayoutTests/js/script-tests/let-syntax.js
@@ -169,3 +169,5 @@ shouldHaveSyntaxErrorStrictOnly("let: for (v in {}) break;");
 shouldHaveSyntaxErrorStrictOnly("let: for (var v = 0; false; ) {};");
 shouldHaveSyntaxErrorStrictOnly("try { } catch(let) {}");
 shouldHaveSyntaxErrorStrictOnly("let x; if (true) let: x = 3;");
+
+shouldNotHaveSyntaxError("let {let: a} = {let: 1}")

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -1293,13 +1293,14 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
             JSTokenLocation location = m_token.m_location;
             bool escapedKeyword = match(ESCAPED_KEYWORD);
             if (escapedKeyword || matchSpecIdentifier()) {
-                failIfTrue(match(LET) && (kind == DestructuringKind::DestructureToLet || kind == DestructuringKind::DestructureToConst), "Cannot use 'let' as an identifier name for a LexicalDeclaration");
+                bool letMatched = match(LET);
                 propertyName = m_token.m_data.ident;
                 JSToken identifierToken = m_token;
                 next();
                 if (consume(COLON))
                     innerPattern = parseBindingOrAssignmentElement(context, kind, exportType, duplicateIdentifier, hasDestructuringPattern, bindingContext, depth + 1);
                 else {
+                    semanticFailIfTrue(letMatched && (kind == DestructuringKind::DestructureToLet || kind == DestructuringKind::DestructureToConst), "Cannot use the keyword 'let' as a lexical variable name");
                     semanticFailIfTrue(escapedKeyword, "Cannot use abbreviated destructuring syntax for keyword '", propertyName->impl(), "'");
                     semanticFailIfTrue(isDisallowedIdentifierAwait(identifierToken), "Cannot use 'await' as a ", destructuringKindToVariableKindName(kind), " ", disallowedIdentifierAwaitReason());
                     if (kind == DestructuringKind::DestructureToExpressions) {


### PR DESCRIPTION
#### dbcb33d932fcf807466b7307cba24012ab4cc7f5
<pre>
[JSC] incorrectly reports SyntaxError when destructuring `let`
<a href="https://bugs.webkit.org/show_bug.cgi?id=157974">https://bugs.webkit.org/show_bug.cgi?id=157974</a>

Reviewed by Darin Adler.

Raise lexical error later to allow destructuring let

* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):

Canonical link: <a href="https://commits.webkit.org/283217@main">https://commits.webkit.org/283217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e989645a9ae58eb0db8a2b3fad52eaeff3fff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51078 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9697 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12903 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56535 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69140 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62668 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58380 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6147 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84429 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38600 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14873 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->