### PR TITLE
Assert Lockdown Mode flag has been set before queried

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -88,48 +88,13 @@ void initializeAuxiliaryProcess(AuxiliaryProcessInitializationParameters&& param
 void setOSTransaction(OSObjectPtr<os_transaction_t>&&);
 #endif
 
+enum class EnableLockdownMode: bool { No, Yes };
+
+void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode);
+
 template<typename XPCServiceType, typename XPCServiceInitializerDelegateType>
 void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
 {
-    if (initializerMessage) {
-        bool optionsChanged = false;
-        if (xpc_dictionary_get_bool(initializerMessage, "configure-jsc-for-testing"))
-            JSC::Config::configureForTesting();
-        if (xpc_dictionary_get_bool(initializerMessage, "enable-captive-portal-mode")) {
-            JSC::Options::initialize();
-            JSC::Options::AllowUnfinalizedAccessScope scope;
-            JSC::ExecutableAllocator::disableJIT();
-            JSC::Options::useGenerationalGC() = false;
-            JSC::Options::useConcurrentGC() = false;
-            JSC::Options::useLLIntICs() = false;
-            JSC::Options::useWasm() = false;
-            JSC::Options::useZombieMode() = true;
-            JSC::Options::allowDoubleShape() = false;
-            JSC::Options::alwaysHaveABadTime() = true;
-            optionsChanged = true;
-        } else if (xpc_dictionary_get_bool(initializerMessage, "disable-jit")) {
-            JSC::Options::initialize();
-            JSC::Options::AllowUnfinalizedAccessScope scope;
-            JSC::ExecutableAllocator::disableJIT();
-            optionsChanged = true;
-        }
-        if (xpc_dictionary_get_bool(initializerMessage, "enable-shared-array-buffer")) {
-            JSC::Options::initialize();
-            JSC::Options::AllowUnfinalizedAccessScope scope;
-            JSC::Options::useSharedArrayBuffer() = true;
-            optionsChanged = true;
-        }
-        // FIXME (276012): Remove this XPC bootstrap message when it's no longer necessary. See rdar://130669638 for more context.
-        if (xpc_dictionary_get_bool(initializerMessage, "disable-jit-cage")) {
-            JSC::Options::initialize();
-            JSC::Options::AllowUnfinalizedAccessScope scope;
-            JSC::Options::useJITCage() = false;
-            optionsChanged = true;
-        }
-        if (optionsChanged)
-            JSC::Options::notifyOptionsChanged();
-    }
-
     XPCServiceInitializerDelegateType delegate(WTFMove(connection), initializerMessage);
 
     // We don't want XPC to be in charge of whether the process should be terminated or not,
@@ -177,6 +142,11 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
 #endif
 
     parameters.processType = XPCServiceType::processType;
+
+    if (initializerMessage) {
+        bool enableLockdownMode = parameters.extraInitializationData.get<HashTranslatorASCIILiteral>("enable-lockdown-mode"_s) == "1"_s;
+        setJSCOptions(initializerMessage, enableLockdownMode ? EnableLockdownMode::Yes : EnableLockdownMode::No);
+    }
 
     initializeAuxiliaryProcess<XPCServiceType>(WTFMove(parameters));
 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -130,6 +130,10 @@ bool XPCServiceInitializerDelegate::getExtraInitializationData(HashMap<String, S
     if (!isPrewarmedProcess.isEmpty())
         extraInitializationData.add("is-prewarmed"_s, isPrewarmedProcess);
 
+    auto isLockdownModeEnabled = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "enable-lockdown-mode"));
+    if (!isLockdownModeEnabled.isEmpty())
+        extraInitializationData.add("enable-lockdown-mode"_s, isLockdownModeEnabled);
+
     if (!isClientSandboxed()) {
         auto userDirectorySuffix = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "user-directory-suffix"));
         if (!userDirectorySuffix.isEmpty())
@@ -177,6 +181,46 @@ void setOSTransaction(OSObjectPtr<os_transaction_t>&& transaction)
     globalTransaction.get() = WTFMove(transaction);
 }
 #endif
+
+void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode enableLockdownMode)
+{
+    bool optionsChanged = false;
+    if (xpc_dictionary_get_bool(initializerMessage, "configure-jsc-for-testing"))
+        JSC::Config::configureForTesting();
+    if (enableLockdownMode == EnableLockdownMode::Yes) {
+        JSC::Options::initialize();
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::ExecutableAllocator::disableJIT();
+        JSC::Options::useGenerationalGC() = false;
+        JSC::Options::useConcurrentGC() = false;
+        JSC::Options::useLLIntICs() = false;
+        JSC::Options::useWasm() = false;
+        JSC::Options::useZombieMode() = true;
+        JSC::Options::allowDoubleShape() = false;
+        JSC::Options::alwaysHaveABadTime() = true;
+        optionsChanged = true;
+    } else if (xpc_dictionary_get_bool(initializerMessage, "disable-jit")) {
+        JSC::Options::initialize();
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::ExecutableAllocator::disableJIT();
+        optionsChanged = true;
+    }
+    if (xpc_dictionary_get_bool(initializerMessage, "enable-shared-array-buffer")) {
+        JSC::Options::initialize();
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::Options::useSharedArrayBuffer() = true;
+        optionsChanged = true;
+    }
+    // FIXME (276012): Remove this XPC bootstrap message when it's no longer necessary. See rdar://130669638 for more context.
+    if (xpc_dictionary_get_bool(initializerMessage, "disable-jit-cage")) {
+        JSC::Options::initialize();
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::Options::useJITCage() = false;
+        optionsChanged = true;
+    }
+    if (optionsChanged)
+        JSC::Options::notifyOptionsChanged();
+}
 
 void XPCServiceExit()
 {

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -125,7 +125,6 @@ struct WebProcessCreationParameters {
     bool attrStyleEnabled { false };
     bool shouldThrowExceptionForGlobalConstantRedeclaration { true };
     WebCore::CrossOriginMode crossOriginMode { WebCore::CrossOriginMode::Shared }; // Cross-origin isolation via COOP+COEP headers.
-    bool isLockdownModeEnabled { false };
 
 #if ENABLE(SERVICE_CONTROLS)
     bool hasImageServices { false };

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -74,7 +74,6 @@
     bool attrStyleEnabled;
     bool shouldThrowExceptionForGlobalConstantRedeclaration;
     WebCore::CrossOriginMode crossOriginMode;
-    bool isLockdownModeEnabled;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool hasImageServices;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -386,8 +386,6 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
             xpc_dictionary_set_bool(bootstrapMessage.get(), "disable-jit", true);
         if (m_client->shouldEnableSharedArrayBuffer())
             xpc_dictionary_set_bool(bootstrapMessage.get(), "enable-shared-array-buffer", true);
-        if (m_client->shouldEnableLockdownMode())
-            xpc_dictionary_set_bool(bootstrapMessage.get(), "enable-captive-portal-mode", true);
         if (m_client->shouldDisableJITCage())
             xpc_dictionary_set_bool(bootstrapMessage.get(), "disable-jit-cage", true);
     }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -954,7 +954,6 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
     parameters.attrStyleEnabled = m_configuration->attrStyleEnabled();
     parameters.shouldThrowExceptionForGlobalConstantRedeclaration = m_configuration->shouldThrowExceptionForGlobalConstantRedeclaration();
     parameters.crossOriginMode = process.crossOriginMode();
-    parameters.isLockdownModeEnabled = process.lockdownMode() == WebProcessProxy::LockdownMode::Enabled;
 
 #if ENABLE(SERVICE_CONTROLS)
     auto& serviceController = ServicesController::singleton();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -566,6 +566,9 @@ void WebProcessProxy::getLaunchOptions(ProcessLauncher::LaunchOptions& launchOpt
         launchOptions.extraInitializationData.add<HashTranslatorASCIILiteral>("service-worker-process"_s, "1"_s);
         launchOptions.extraInitializationData.add<HashTranslatorASCIILiteral>("registrable-domain"_s, m_registrableDomain->string());
     }
+
+    if (shouldEnableLockdownMode())
+        launchOptions.extraInitializationData.add<HashTranslatorASCIILiteral>("enable-lockdown-mode"_s, "1"_s);
 }
 
 #if !PLATFORM(GTK) && !PLATFORM(WPE)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -360,6 +360,8 @@ WebProcess::~WebProcess()
 
 void WebProcess::initializeProcess(const AuxiliaryProcessInitializationParameters& parameters)
 {
+    m_isLockdownModeEnabled = parameters.extraInitializationData.get<HashTranslatorASCIILiteral>("enable-lockdown-mode"_s) == "1"_s;
+
     WTF::setProcessPrivileges({ });
 
     {
@@ -603,8 +605,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
     commonVM().setGlobalConstRedeclarationShouldThrow(parameters.shouldThrowExceptionForGlobalConstantRedeclaration);
 
     ScriptExecutionContext::setCrossOriginMode(parameters.crossOriginMode);
-    m_isLockdownModeEnabled = parameters.isLockdownModeEnabled;
-    DeprecatedGlobalSettings::setArePDFImagesEnabled(!m_isLockdownModeEnabled);
+    DeprecatedGlobalSettings::setArePDFImagesEnabled(!isLockdownModeEnabled());
 
 #if ENABLE(SERVICE_CONTROLS)
     setEnabledServices(parameters.hasImageServices, parameters.hasSelectionServices, parameters.hasRichContentServices);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -408,7 +408,7 @@ public:
     SpeechRecognitionRealtimeMediaSourceManager& ensureSpeechRecognitionRealtimeMediaSourceManager();
 #endif
 
-    bool isLockdownModeEnabled() const { return m_isLockdownModeEnabled; }
+    bool isLockdownModeEnabled() const { return m_isLockdownModeEnabled.value(); }
     bool imageAnimationEnabled() const { return m_imageAnimationEnabled; }
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
     bool prefersNonBlinkingCursor() const { return m_prefersNonBlinkingCursor; }
@@ -778,7 +778,7 @@ private:
 
     bool m_hasSuspendedPageProxy { false };
     bool m_allowExitOnMemoryPressure { true };
-    bool m_isLockdownModeEnabled { false };
+    std::optional<bool> m_isLockdownModeEnabled;
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(SANDBOX_EXTENSIONS)
     HashMap<String, RefPtr<SandboxExtension>> m_mediaCaptureSandboxExtensions;


### PR DESCRIPTION
#### 28654e3c8848b9f0da4b47a5d7b6bd993aeddb7a
<pre>
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::setJSCOptions):
</pre>
----------------------------------------------------------------------
#### 636b7439525b734d003a09ae629297fd3cb94400
<pre>
Assert Lockdown Mode flag has been set before queried
<a href="https://bugs.webkit.org/show_bug.cgi?id=278128">https://bugs.webkit.org/show_bug.cgi?id=278128</a>
<a href="https://rdar.apple.com/133884110">rdar://133884110</a>

Reviewed by NOBODY (OOPS!).

Assert that Lockdown Mode flag has been set before queried in the WebContent process. This patch also
initializes the Lockdown Mode flag in WebProcess earlier by using the value from the XPC initialization
message, which is sent in the XPC extra initialization data. This patch also asserts that JSC options
are set before JSC::initialize() is called. Setting JSC options after this call can lead to crashes.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::getExtraInitializationData):
(WebKit::setJSCOptions):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::initializeNewWebProcess):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::getLaunchOptions):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeProcess):
(WebKit::WebProcess::initializeWebProcess):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::isLockdownModeEnabled const):
</pre>