### PR TITLE
(RE-BASELINE) REGRESSION (282253@main): [ iOS macOS ] 5x imported/w3c/web-platform-t ests/navigation-api/* are constantly failing.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN navigate event should fire when traversing to a bfcache hit Should be BFCached but actually wasn't
+NOTRUN navigate event should fire when traversing to a bfcache hit Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-after-bfcache-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-after-bfcache-cross-origin-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN navigation.activation must be updated when restored from bfcache Should be BFCached but actually wasn't
+NOTRUN navigation.activation must be updated when restored from bfcache Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-after-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-after-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN navigation.activation must be updated when restored from bfcache Should be BFCached but actually wasn't
+NOTRUN navigation.activation must be updated when restored from bfcache Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Should be BFCached but actually wasn't
+NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN entries() in an iframe must be updated after navigating back to a bfcached page Should be BFCached but actually wasn't
+NOTRUN entries() in an iframe must be updated after navigating back to a bfcached page Could have been BFCached but actually wasn't
 


### PR DESCRIPTION
#### 98394ed76969d1f782a10b98e74910bdd4da7e6f
<pre>
(RE-BASELINE) REGRESSION (282253@main): [ iOS macOS ] 5x imported/w3c/web-platform-t ests/navigation-api/* are constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278134">https://bugs.webkit.org/show_bug.cgi?id=278134</a>
<a href="https://rdar.apple.com/133891302">rdar://133891302</a>

Unreviewed re-baseline

Re-baselining tests with new results.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-after-bfcache-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-after-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt:

Canonical link: <a href="https://commits.webkit.org/282267@main">https://commits.webkit.org/282267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57455c0822495a68c605768014ca72f92f7f7fd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66669 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13537 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65718 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12129 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/11933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6595 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6625 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/5522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9430 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->