### PR TITLE
Commit message reviewer list should use oxford comma as needed

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6467,7 +6467,8 @@ class AddReviewerMixin(object):
         if len(reviewers) == 1:
             return reviewers[0]
         if reviewers:
-            return f'{", ".join(reviewers[:-1])} and {reviewers[-1]}'
+            conjunction = f'{"," if len(reviewers) > 2 else ""} and '
+            return f'{", ".join(reviewers[:-1])}{conjunction}{reviewers[-1]}'
         return 'NOBODY (OOPS!)'
 
 
@@ -6530,7 +6531,7 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
     )
     RE_CHANGELOG = br'^(\+\+\+)\s+(.*/ChangeLog.*)'
     BY_RE = re.compile(r'.+\s+by\s+(.+)$')
-    SPLIT_RE = re.compile(r'(,\s*)|( and )')
+    SPLIT_RE = re.compile(r'\s+and\s+|,\s*and\s*|,\s*')
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, timeout=60, **kwargs)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
@@ -73,7 +73,8 @@ def join(list, conjunction='and'):
         return 'Nothing'
     if len(list) == 1:
         return list[0]
-    return '{} {} {}'.format(', '.join(list[:-1]), conjunction, list[-1])
+    conjunctionWithSerialCommaIfNeeded = f'{"," if len(list) > 2 else ""} {conjunction} '
+    return '{}{}{}'.format(', '.join(list[:-1]), conjunctionWithSerialCommaIfNeeded, list[-1])
 
 
 def split(string, conjunctions=None):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
@@ -61,7 +61,7 @@ class StringUtils(unittest.TestCase):
         self.assertEqual(string_utils.pluralize(2, 'mouse', 'mice'), '2 mice')
 
     def test_list(self):
-        self.assertEqual(string_utils.join(['integer', 'string', 'float']), 'integer, string and float')
+        self.assertEqual(string_utils.join(['integer', 'string', 'float']), 'integer, string, and float')
         self.assertEqual(string_utils.join(['integer', 'string']), 'integer and string')
         self.assertEqual(string_utils.join(['integer']), 'integer')
         self.assertEqual(string_utils.join([]), 'Nothing')
@@ -69,6 +69,7 @@ class StringUtils(unittest.TestCase):
 
     def test_split(self):
         self.assertEqual(string_utils.split('integer, string and float'), ['integer', 'string', 'float'])
+        self.assertEqual(string_utils.split('integer, string, and float'), ['integer', 'string', 'float'])
         self.assertEqual(string_utils.split('integer or string and float'), ['integer', 'string', 'float'])
         self.assertEqual(string_utils.split('integer and string'), ['integer', 'string'])
         self.assertEqual(string_utils.split('integer'), ['integer'])

--- a/Tools/Scripts/webkitpy/tool/commands/download_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/download_unittest.py
@@ -400,17 +400,17 @@ MOCK: user.open_url: file://...
 Was that diff correct?
 Building WebKit
 Committed r49824: <https://commits.webkit.org/r49824>
-MOCK reopen_bug 50000 with comment 'Reverted r852, r963 and r3001 for reason:
+MOCK reopen_bug 50000 with comment 'Reverted r852, r963, and r3001 for reason:
 
 Reason Description
 
 Committed r49824 (5@main): <https://commits.webkit.org/5@main>'
-MOCK reopen_bug 50005 with comment 'Reverted r852, r963 and r3001 for reason:
+MOCK reopen_bug 50005 with comment 'Reverted r852, r963, and r3001 for reason:
 
 Reason Description
 
 Committed r49824 (5@main): <https://commits.webkit.org/5@main>'
-MOCK reopen_bug 50004 with comment 'Reverted r852, r963 and r3001 for reason:
+MOCK reopen_bug 50004 with comment 'Reverted r852, r963, and r3001 for reason:
 
 Reason Description
 
@@ -428,12 +428,12 @@ MOCK: user.open_url: file://...
 Was that diff correct?
 Building WebKit
 Committed r49824: <https://commits.webkit.org/r49824>
-MOCK reopen_bug 50000 with comment 'Reverted r852, r963 and r999 for reason:
+MOCK reopen_bug 50000 with comment 'Reverted r852, r963, and r999 for reason:
 
 Reason Description
 
 Committed r49824 (5@main): <https://commits.webkit.org/5@main>'
-MOCK reopen_bug 50005 with comment 'Reverted r852, r963 and r999 for reason:
+MOCK reopen_bug 50005 with comment 'Reverted r852, r963, and r999 for reason:
 
 Reason Description
 

--- a/Tools/Scripts/webkitpy/tool/steps/preparechangelogforrevert_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/preparechangelogforrevert_unittest.py
@@ -62,7 +62,7 @@ class UpdateChangeLogsForRevertTest(unittest.TestCase):
 
     _multiple_revert_entry = '''2009-08-19  Eric Seidel  <eric@webkit.org>
 
-        Unreviewed, reverting r12345, r12346 and r12347.
+        Unreviewed, reverting r12345, r12346, and r12347.
 
         Reason
 
@@ -83,7 +83,7 @@ class UpdateChangeLogsForRevertTest(unittest.TestCase):
 
     _multiple_revert_entry_with_missing_bug_urls_and_descriptions = '''2009-08-19  Eric Seidel  <eric@webkit.org>
 
-        Unreviewed, reverting r12345, r12346 and r12347.
+        Unreviewed, reverting r12345, r12346, and r12347.
 
         Reason
 
@@ -98,7 +98,7 @@ class UpdateChangeLogsForRevertTest(unittest.TestCase):
 
     _multiple_revert_entry_with_a_missing_bug_url_and_description = '''2009-08-19  Eric Seidel  <eric@webkit.org>
 
-        Unreviewed, reverting r12345, r12346 and r12347.
+        Unreviewed, reverting r12345, r12346, and r12347.
 
         Reason
 
@@ -134,7 +134,7 @@ class UpdateChangeLogsForRevertTest(unittest.TestCase):
 
     _multiple_revert_entry_with_revert_bug_url = '''2009-08-19  Eric Seidel  <eric@webkit.org>
 
-        Unreviewed, reverting r12345, r12346 and r12347.
+        Unreviewed, reverting r12345, r12346, and r12347.
         http://revert.example.com/56789
 
         Reason


### PR DESCRIPTION
#### f1b791522de861c81203369526878b89c1057c4f
<pre>
Commit message reviewer list should use oxford comma as needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=278138">https://bugs.webkit.org/show_bug.cgi?id=278138</a>
<a href="https://rdar.apple.com/133897321">rdar://133897321</a>

Reviewed by Wenson Hsieh, Tim Horton and Richard Robinson.

Currently, if your patch has 3 reviewers (A, B, C), the reviewer list in
the patch (post landing) will read &quot;A, B and C&quot;. After this patch, it
will read &quot;A, B, and C&quot;, instead.

To achieve this, we imbibe the concept of a serial/oxford comma in both
tooling codepaths that require us to join items with conjunctions, namely
the AddReviewerMixin in CISupport.ews-build, and the string_utils.join()
method.

Furthermore, we update script test expectations to reflect this new
joining behavior.

* Tools/CISupport/ews-build/steps.py:
(AddReviewerMixin.reviewers):
(ValidateCommitMessage):
* Tools/CISupport/ews-build/steps_unittest.py:
(mock_load_contributors):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py:
(join):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py:
(StringUtils.test_list):
(StringUtils.test_split):
* Tools/Scripts/webkitpy/tool/commands/download_unittest.py:
* Tools/Scripts/webkitpy/tool/steps/preparechangelogforrevert_unittest.py:

Canonical link: <a href="https://commits.webkit.org/282350@main">https://commits.webkit.org/282350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73a53a6ef127acd3b40b9264d5bd5a7b23f71c8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13792 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9327 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65973 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31403 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/62415 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35967 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12384 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6850 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/62582 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54546 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5721 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38080 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->