### PR TITLE
[Writing Tools] iOS: Selection should be hidden when pondering effect begins, stay hidden until all animations complete

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -250,6 +250,9 @@ struct PerWebProcessState {
 #if ENABLE(WRITING_TOOLS)
     RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _writingToolsTextSuggestions;
     RetainPtr<WTSession> _activeWritingToolsSession;
+
+    NSUInteger _partialIntelligenceTextPonderingAnimationCount;
+    BOOL _writingToolsTextReplacementsFinished;
 #endif
 
 #if PLATFORM(MAC)
@@ -421,12 +424,18 @@ struct PerWebProcessState {
 - (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
 #endif
 
+- (void)_didEndPartialIntelligenceTextPonderingAnimation;
+- (BOOL)_intelligenceTextPonderingAnimationIsComplete;
+
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;
-- (void)_didEndPartialIntelligenceTextPonderingAnimation;
+
+- (NSUUID *)_enableSourceTextAnimationAfterElementWithID:(NSString *)elementID;
+- (NSUUID *)_enableFinalTextAnimationForElementWithID:(NSString *)elementID;
+- (void)_disableTextAnimationWithUUID:(NSUUID *)nsUUID;
 #endif
 
 - (void)_internalDoAfterNextPresentationUpdate:(void (^)(void))updateBlock withoutWaitingForPainting:(BOOL)withoutWaitingForPainting withoutWaitingForAnimatedResize:(BOOL)withoutWaitingForAnimatedResize;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -420,10 +420,6 @@ for this property.
 - (NSUUID *)_enableTextIndicatorStylingForElementWithID:(NSString *)elementID WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 - (void)_disableTextIndicatorStylingWithUUID:(NSUUID *)nsUUID WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
-- (NSUUID *)_enableSourceTextAnimationAfterElementWithID:(NSString *)elementID WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
-- (NSUUID *)_enableFinalTextAnimationForElementWithID:(NSString *)elementID WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
-- (void)_disableTextAnimationWithUUID:(NSUUID *)nsUUID WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
-
 // FIXME: Remove old `-[WKWebView _themeColor]` SPI <rdar://76662644>
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) UIColor *_themeColor WK_API_DEPRECATED_WITH_REPLACEMENT("themeColor", ios(15.0, 15.0));

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -102,7 +102,6 @@ public:
 #if ENABLE(WRITING_TOOLS_UI)
     void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) final;
     void removeTextAnimationForAnimationID(const WTF::UUID&) final;
-    void didEndPartialIntelligenceTextPonderingAnimation() final;
 #endif
 
     void microphoneCaptureWillChange() final;
@@ -126,6 +125,9 @@ public:
 
     void writingToolsActiveWillChange() final;
     void writingToolsActiveDidChange() final;
+
+    void didEndPartialIntelligenceTextPonderingAnimation() final;
+    bool intelligenceTextPonderingAnimationIsComplete() final;
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -157,23 +157,6 @@ void PageClientImplCocoa::storeAppHighlight(const WebCore::AppHighlight &highlig
 }
 #endif // ENABLE(APP_HIGHLIGHTS)
 
-#if ENABLE(WRITING_TOOLS_UI)
-void PageClientImplCocoa::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& data)
-{
-    [m_webView _addTextAnimationForAnimationID:uuid withData:data];
-}
-
-void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
-{
-    [m_webView _removeTextAnimationForAnimationID:uuid];
-}
-
-void PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation()
-{
-    [m_webView _didEndPartialIntelligenceTextPonderingAnimation];
-}
-#endif
-
 void PageClientImplCocoa::pageClosed()
 {
     m_alternativeTextUIController->clear();
@@ -313,6 +296,29 @@ void PageClientImplCocoa::writingToolsActiveWillChange()
 void PageClientImplCocoa::writingToolsActiveDidChange()
 {
     [m_webView didChangeValueForKey:writingToolsActiveKey];
+}
+
+void PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation()
+{
+    [m_webView _didEndPartialIntelligenceTextPonderingAnimation];
+}
+
+bool PageClientImplCocoa::intelligenceTextPonderingAnimationIsComplete()
+{
+    return [m_webView _intelligenceTextPonderingAnimationIsComplete];
+}
+
+#endif
+
+#if ENABLE(WRITING_TOOLS_UI)
+void PageClientImplCocoa::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& data)
+{
+    [m_webView _addTextAnimationForAnimationID:uuid withData:data];
+}
+
+void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
+{
+    [m_webView _removeTextAnimationForAnimationID:uuid];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1289,17 +1289,26 @@ void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::U
     legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::UpdateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::showSelectionForActiveWritingToolsSession()
+void WebPageProxy::didEndPartialIntelligenceTextPonderingAnimationImpl()
 {
-    if (!hasRunningProcess())
-        return;
-
-    legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForActiveWritingToolsSession(), webPageIDInMainFrameProcess());
+    protectedPageClient()->didEndPartialIntelligenceTextPonderingAnimation();
 }
 
 void WebPageProxy::didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&)
 {
-    protectedPageClient()->didEndPartialIntelligenceTextPonderingAnimation();
+    didEndPartialIntelligenceTextPonderingAnimationImpl();
+}
+
+void WebPageProxy::showSelectionForActiveWritingToolsSessionIfNeeded()
+{
+    if (!hasRunningProcess())
+        return;
+
+    if (protectedPageClient()->intelligenceTextPonderingAnimationIsComplete()) {
+        // If the entire replacement has already been completed, and this is the end of the last animation,
+        // then reveal the selection.
+        legacyMainFrameProcess().send(Messages::WebPage::ShowSelectionForActiveWritingToolsSession(), webPageIDInMainFrameProcess());
+    }
 }
 
 void WebPageProxy::removeTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -730,7 +730,6 @@ public:
 #if ENABLE(WRITING_TOOLS_UI)
     virtual void addTextAnimationForAnimationID(const WTF::UUID&, const WebCore::TextAnimationData&) = 0;
     virtual void removeTextAnimationForAnimationID(const WTF::UUID&) = 0;
-    virtual void didEndPartialIntelligenceTextPonderingAnimation() = 0;
 #endif
 
     virtual void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) { }
@@ -762,8 +761,10 @@ public:
     virtual void proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) = 0;
 
     virtual void writingToolsActiveWillChange() = 0;
-
     virtual void writingToolsActiveDidChange() = 0;
+
+    virtual void didEndPartialIntelligenceTextPonderingAnimation() = 0;
+    virtual bool intelligenceTextPonderingAnimationIsComplete() = 0;
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2440,8 +2440,9 @@ public:
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
 
-    void showSelectionForActiveWritingToolsSession();
+    void showSelectionForActiveWritingToolsSessionIfNeeded();
     void didEndPartialIntelligenceTextPonderingAnimation(IPC::Connection&);
+    void didEndPartialIntelligenceTextPonderingAnimationImpl();
 #endif
 
     void resetVisibilityAdjustmentsForTargetedElements(const Vector<Ref<API::TargetedElementInfo>>&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13359,6 +13359,12 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     _page->callCompletionHandlerForAnimationID(*animationUUID, WebCore::TextAnimationRunMode::RunAnimation);
 }
 
+- (void)replacementEffectDidComplete
+{
+    _page->didEndPartialIntelligenceTextPonderingAnimationImpl();
+    _page->showSelectionForActiveWritingToolsSessionIfNeeded();
+}
+
 #endif
 
 #pragma mark - BETextInteractionDelegate

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -123,13 +123,8 @@
             if (!strongWebView || !animationID)
                 return;
 
-            strongWebView->didEndPartialIntelligenceTextPonderingAnimation();
-
-            if (strongWebView->isIntelligenceTextPonderingAnimationFinished() && strongWebView->isWritingToolsTextReplacementsFinished()) {
-                // If the entire replacement has already been completed, and this is the end of the last animation,
-                // then reveal the selection.
-                strongWebView->page().showSelectionForActiveWritingToolsSession();
-            }
+            strongWebView->page().didEndPartialIntelligenceTextPonderingAnimationImpl();
+            strongWebView->page().showSelectionForActiveWritingToolsSessionIfNeeded();
 
             strongWebView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, true);
             strongWebView->page().callCompletionHandlerForAnimationID(*animationID, runMode);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -744,15 +744,6 @@ public:
 #if ENABLE(WRITING_TOOLS_UI)
     void addTextAnimationForAnimationID(WTF::UUID, const WebCore::TextAnimationData&);
     void removeTextAnimationForAnimationID(WTF::UUID);
-
-    void writingToolsCompositionSessionDidReceiveRestartAction();
-    void writingToolsCompositionSessionDidReceiveReplacements(const WTF::UUID&, bool finished);
-
-    bool isWritingToolsTextReplacementsFinished() const;
-    bool isIntelligenceTextPonderingAnimationFinished() const;
-
-    void willBeginPartialIntelligenceTextPonderingAnimation();
-    void didEndPartialIntelligenceTextPonderingAnimation();
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)
@@ -994,9 +985,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(WRITING_TOOLS_UI)
     RetainPtr<WKTextAnimationManager> m_textAnimationTypeManager;
-
-    unsigned m_partialIntelligenceTextPonderingAnimationCount { 0 };
-    bool m_writingToolsTextReplacementsFinished { false };
 #endif
 
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4664,43 +4664,6 @@ void WebViewImpl::removeTextAnimationForAnimationID(WTF::UUID uuid)
     [m_textAnimationTypeManager removeTextAnimationForAnimationID:uuid];
 }
 
-void WebViewImpl::writingToolsCompositionSessionDidReceiveRestartAction()
-{
-    m_writingToolsTextReplacementsFinished = false;
-    m_partialIntelligenceTextPonderingAnimationCount = 0;
-}
-
-void WebViewImpl::writingToolsCompositionSessionDidReceiveReplacements(const WTF::UUID& sessionID, bool finished)
-{
-    m_writingToolsTextReplacementsFinished = finished;
-
-    willBeginPartialIntelligenceTextPonderingAnimation();
-}
-
-bool WebViewImpl::isWritingToolsTextReplacementsFinished() const
-{
-    return m_writingToolsTextReplacementsFinished;
-}
-
-bool WebViewImpl::isIntelligenceTextPonderingAnimationFinished() const
-{
-    return !m_partialIntelligenceTextPonderingAnimationCount;
-}
-
-void WebViewImpl::willBeginPartialIntelligenceTextPonderingAnimation()
-{
-    m_partialIntelligenceTextPonderingAnimationCount += 1;
-}
-
-void WebViewImpl::didEndPartialIntelligenceTextPonderingAnimation()
-{
-    if (!m_partialIntelligenceTextPonderingAnimationCount) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    m_partialIntelligenceTextPonderingAnimationCount -= 1;
-}
 #endif
 
 ViewGestureController& WebViewImpl::ensureGestureController()

--- a/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
@@ -101,32 +101,36 @@ extension TextAnimationManager: UITextEffectView.ReplacementTextEffect.Delegate 
             Self.logger.debug("Can't get text preview. Incorrect UITextEffectTextChunk subclass")
             return nil
         }
+
         guard let delegate = self.delegate else {
             Self.logger.debug("Can't obtain Targeted Preview. Missing delegate." )
             return nil
         }
+
         guard let preview = await delegate.targetedPreview(for: uuidChunk.uuid) else {
             Self.logger.debug("Could not generate a UITargetedPreview")
             return nil
         }
+
         return preview
     }
     
     public func replacementEffectDidComplete(_ effect: UITextEffectView.ReplacementTextEffect) {
         self.effectView.removeEffect(effect.id)
 
-        guard let (animationID, _) = chunkToEffect.first(where: { (_, value) in value == effect.id }) else {
+        guard let (animationID, _) = self.chunkToEffect.first(where: { (_, value) in value == effect.id }) else {
             return
         }
 
-        chunkToEffect[animationID] = nil
+        self.chunkToEffect[animationID] = nil
 
         guard let delegate = self.delegate else {
-            Self.logger.debug("Can't obtain Targeted Preview. Missing delegate.")
+            Self.logger.debug("Missing delegate.")
             return
         }
 
         delegate.callCompletionHandler(forAnimationID: animationID)
+        delegate.replacementEffectDidComplete();
     }
 }
 

--- a/Source/WebKit/WebKitSwift/TextAnimation/WKSTextAnimationSourceDelegate.h
+++ b/Source/WebKit/WebKitSwift/TextAnimation/WKSTextAnimationSourceDelegate.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateUnderlyingTextVisibilityForTextAnimationID:(NSUUID *)uuid visible:(BOOL)visible completionHandler:(void (^)(void))completionHandler;
 - (UIView *)containingViewForTextAnimationType;
 - (void)callCompletionHandlerForAnimationID:(NSUUID *)uuid;
+- (void)replacementEffectDidComplete;
 
 @end
 


### PR DESCRIPTION
#### 8c521f3355c750400b7344a99e0e6221867ad0e2
<pre>
[Writing Tools] iOS: Selection should be hidden when pondering effect begins, stay hidden until all animations complete
<a href="https://bugs.webkit.org/show_bug.cgi?id=278144">https://bugs.webkit.org/show_bug.cgi?id=278144</a>
<a href="https://rdar.apple.com/133427551">rdar://133427551</a>

Reviewed by Aditya Keerthi.

Apply the same logic as was previously done on macOS to ensure the selection is cleared during the animation.

Also, refactor the previously-macOS specific logic from WebViewImpl into WKWebView.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
(-[WKWebView writingToolsSession:didReceiveAction:]):
(-[WKWebView _didEndPartialIntelligenceTextPonderingAnimation]):
(-[WKWebView _intelligenceTextPonderingAnimationIsComplete]):
(-[WKWebView _addTextAnimationForAnimationID:withData:]):
(-[WKWebView _removeTextAnimationForAnimationID:]):
(-[WKWebView _enableSourceTextAnimationAfterElementWithID:]):
(-[WKWebView _enableFinalTextAnimationForElementWithID:]):
(-[WKWebView _disableTextAnimationWithUUID:]):
(-[WKWebView _enableTextIndicatorStylingAfterElementWithID:]):
(-[WKWebView _enableTextIndicatorStylingForElementWithID:]):
(-[WKWebView _disableTextIndicatorStylingWithUUID:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didEndPartialIntelligenceTextPonderingAnimation):
(WebKit::PageClientImplCocoa::intelligenceTextPonderingAnimationIsComplete):
(WebKit::PageClientImplCocoa::addTextAnimationForAnimationID):
(WebKit::PageClientImplCocoa::removeTextAnimationForAnimationID):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didEndPartialIntelligenceTextPonderingAnimationImpl):
(WebKit::WebPageProxy::didEndPartialIntelligenceTextPonderingAnimation):
(WebKit::WebPageProxy::showSelectionForActiveWritingToolsSessionIfNeeded):
(WebKit::WebPageProxy::showSelectionForActiveWritingToolsSession): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView replacementEffectDidComplete]):
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::writingToolsCompositionSessionDidReceiveRestartAction): Deleted.
(WebKit::WebViewImpl::writingToolsCompositionSessionDidReceiveReplacements): Deleted.
(WebKit::WebViewImpl::isWritingToolsTextReplacementsFinished const): Deleted.
(WebKit::WebViewImpl::isIntelligenceTextPonderingAnimationFinished const): Deleted.
(WebKit::WebViewImpl::willBeginPartialIntelligenceTextPonderingAnimation): Deleted.
(WebKit::WebViewImpl::didEndPartialIntelligenceTextPonderingAnimation): Deleted.
* Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift:
(TextAnimationManager.performReplacementAndGeneratePreview(for:effect:animation:)):
(TextAnimationManager.replacementEffectDidComplete(_:)):
* Source/WebKit/WebKitSwift/TextAnimation/WKSTextAnimationSourceDelegate.h:

Canonical link: <a href="https://commits.webkit.org/282570@main">https://commits.webkit.org/282570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4216a58b1410d91460e1818361a19b8f456fdd46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51103 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9727 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36431 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12944 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69181 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58408 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55038 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58643 "2 api tests failed or timed out") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6184 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9606 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38641 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->