### PR TITLE
[JSC] Simplify useInterpretedJSEntryWrappers condition

### DIFF
--- a/JSTests/microbenchmarks/wasm-cc-int-to-int.js
+++ b/JSTests/microbenchmarks/wasm-cc-int-to-int.js
@@ -1,5 +1,5 @@
 //@ skip unless $isWasmPlatform
-//@ runDefaultWasm("--useWasm=1", "--useInterpretedJSEntryWrappers=1")
+//@ runDefaultWasm("--useWasm=1", "--useWasmJITLessJSEntrypoint=1")
 
 var wasm_code;
 try {

--- a/JSTests/wasm/stress/cc-double-to-double.js
+++ b/JSTests/wasm/stress/cc-double-to-double.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-f32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-f32-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-float-to-float.js
+++ b/JSTests/wasm/stress/cc-float-to-float.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-funcref.js
+++ b/JSTests/wasm/stress/cc-funcref.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i32-kitchen-sink-neg.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink-neg.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i64-kitchen-sink-neg.js
+++ b/JSTests/wasm/stress/cc-i64-kitchen-sink-neg.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-i64-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i64-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-infinite-int-glitch.js
+++ b/JSTests/wasm/stress/cc-infinite-int-glitch.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,5 +1,5 @@
 //@ skip unless $isWasmPlatform
-//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
+//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useWasmJITLessJSEntrypoint=1")
 
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-memory.js
+++ b/JSTests/wasm/stress/cc-int-to-int-memory.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-no-jit.js
+++ b/JSTests/wasm/stress/cc-int-to-int-no-jit.js
@@ -1,4 +1,4 @@
-//@ runDefaultWasm("-m", "--useJIT=0", "--useWasm=1", "--useInterpretedJSEntryWrappers=1")
+//@ runDefaultWasm("-m", "--useJIT=0", "--useWasm=1", "--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-to-js.js
+++ b/JSTests/wasm/stress/cc-int-to-int-to-js.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int.js
+++ b/JSTests/wasm/stress/cc-int-to-int.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-lotsofints-to-int.js
+++ b/JSTests/wasm/stress/cc-lotsofints-to-int.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-lotsofints-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-lotsofints-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-so-i-heard-you-like-parameters.js
+++ b/JSTests/wasm/stress/cc-so-i-heard-you-like-parameters.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useInterpretedJSEntryWrappers=1")
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useWasmJITLessJSEntrypoint=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useWasmJITLessJSEntrypoint=1 --dumpDisassembly=0
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -649,7 +649,7 @@ if ASSERT_ENABLED
 end
 
     macro saveJSEntrypointInterpreterRegisters()
-        subp constexpr Wasm::JSEntrypointInterpreterCallee::SpillStackSpaceAligned, sp
+        subp constexpr Wasm::JITLessJSEntrypointCallee::SpillStackSpaceAligned, sp
         if ARM64 or ARM64E
             storepairq memoryBase, boundsCheckingSize, -2 * SlotSize[cfr]
             storep wasmInstance, -3 * SlotSize[cfr]
@@ -674,7 +674,7 @@ end
         else
             loadi -1 * SlotSize[cfr], wasmInstance
         end
-        addp constexpr Wasm::JSEntrypointInterpreterCallee::SpillStackSpaceAligned, sp
+        addp constexpr Wasm::JITLessJSEntrypointCallee::SpillStackSpaceAligned, sp
     end
 
     tagReturnAddress sp
@@ -684,11 +684,11 @@ end
     # Load data from the entry callee
     # This was written by doVMEntry
     loadp Callee[cfr], ws0 # WebAssemblyFunction*
-    loadp WebAssemblyFunction::m_jsToWasmInterpreterCallee[ws0], ws0 # JSEntrypointInterpreterCallee*
+    loadp WebAssemblyFunction::m_jsToWasmCallee[ws0], ws0 # JITLessJSEntrypointCallee*
 
 if ASSERT_ENABLED
     # Check to confirm we have the right kind of callee
-    loadi Wasm::JSEntrypointInterpreterCallee::ident[ws0], ws1
+    loadi Wasm::JITLessJSEntrypointCallee::ident[ws0], ws1
     move 0xBF, wa0
     bpeq wa0, ws1, .ident_ok
     break
@@ -696,12 +696,12 @@ if ASSERT_ENABLED
 end
 
     # Allocate stack space (no stack check)
-    loadi Wasm::JSEntrypointInterpreterCallee::frameSize[ws0], ws1
+    loadi Wasm::JITLessJSEntrypointCallee::frameSize[ws0], ws1
     subp ws1, sp
 
 if ASSERT_ENABLED
     repeat(macro (i)
-        storep ws0, -i * SlotSize + constexpr Wasm::JSEntrypointInterpreterCallee::RegisterStackSpaceAligned[sp]
+        storep ws0, -i * SlotSize + constexpr Wasm::JITLessJSEntrypointCallee::RegisterStackSpaceAligned[sp]
     end)
 end
 
@@ -751,7 +751,7 @@ else
 end
 
     # Pop argument space values
-    addp constexpr Wasm::JSEntrypointInterpreterCallee::RegisterStackSpaceAligned, sp
+    addp constexpr Wasm::JITLessJSEntrypointCallee::RegisterStackSpaceAligned, sp
 
 if ASSERT_ENABLED
     repeat(macro (i)
@@ -759,7 +759,7 @@ if ASSERT_ENABLED
     end)
 end
 
-    loadp Callee[cfr], ws0 # CalleeBits(JSEntrypointInterpreterCallee*)
+    loadp Callee[cfr], ws0 # CalleeBits(JITLessJSEntrypointCallee*)
 if JSVALUE64
     andp ~(constexpr JSValue::NativeCalleeTag), ws0
 end
@@ -769,36 +769,36 @@ end
 
     # Store Callee's wasm callee
 if JSVALUE64
-    loadp Wasm::JSEntrypointInterpreterCallee::wasmCallee[ws0], ws1
+    loadp Wasm::JITLessJSEntrypointCallee::wasmCallee[ws0], ws1
     storep ws1, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8[sp]
 else
-    loadp Wasm::JSEntrypointInterpreterCallee::wasmCallee + PayloadOffset[ws0], ws1
+    loadp Wasm::JITLessJSEntrypointCallee::wasmCallee + PayloadOffset[ws0], ws1
     storep ws1, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8 + PayloadOffset[sp]
-    loadp Wasm::JSEntrypointInterpreterCallee::wasmCallee + TagOffset[ws0], ws1
+    loadp Wasm::JITLessJSEntrypointCallee::wasmCallee + TagOffset[ws0], ws1
     storep ws1, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8 + TagOffset[sp]
 end
 
-    loadp Wasm::JSEntrypointInterpreterCallee::wasmFunctionPrologue[ws0], ws0
+    loadp Wasm::JITLessJSEntrypointCallee::wasmFunctionPrologue[ws0], ws0
     call ws0, WasmEntryPtrTag
 
     clobberVolatileRegisters()
 
     # Restore SP
-    loadp Callee[cfr], ws0 # CalleeBits(JSEntrypointInterpreterCallee*)
+    loadp Callee[cfr], ws0 # CalleeBits(JITLessJSEntrypointCallee*)
 if JSVALUE64
     andp ~(constexpr JSValue::NativeCalleeTag), ws0
 end
     leap WTFConfig + constexpr WTF::offsetOfWTFConfigLowestAccessibleAddress, ws1
     loadp [ws1], ws1
     addp ws1, ws0
-    loadi Wasm::JSEntrypointInterpreterCallee::frameSize[ws0], ws1
+    loadi Wasm::JITLessJSEntrypointCallee::frameSize[ws0], ws1
     subp cfr, ws1, ws1
     move ws1, sp
-    subp constexpr Wasm::JSEntrypointInterpreterCallee::SpillStackSpaceAligned, sp
+    subp constexpr Wasm::JITLessJSEntrypointCallee::SpillStackSpaceAligned, sp
 
 if ASSERT_ENABLED
     repeat(macro (i)
-        storep ws0, -i * SlotSize + constexpr Wasm::JSEntrypointInterpreterCallee::RegisterStackSpaceAligned[sp]
+        storep ws0, -i * SlotSize + constexpr Wasm::JITLessJSEntrypointCallee::RegisterStackSpaceAligned[sp]
     end)
 end
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -659,7 +659,7 @@ static inline void disableAllJITOptions()
     Options::useJITCage() = false;
     Options::useConcurrentJIT() = false;
 
-    if (!Options::useInterpretedJSEntryWrappers() && Options::useWasm())
+    if (!Options::useWasmJITLessJSEntrypoint() && Options::useWasm())
         disableAllWasmOptions();
 
     Options::useWasmSIMD() = false;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -578,7 +578,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
     v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
     v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
-    v(Bool, useInterpretedJSEntryWrappers, true, Normal, "Allow JS->wasm wrappers to be replaced by jit-less versions."_s) \
+    v(Bool, useWasmJITLessJSEntrypoint, true, Normal, "Allow JS->wasm wrappers to be replaced by jit-less versions."_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     \
     /* Feature Flags */\

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1049,7 +1049,7 @@ static String tierName(SamplingProfiler::StackFrame& frame)
             case Wasm::CompilationMode::IPIntMode:
                 return Tiers::ipint;
             case Wasm::CompilationMode::JSEntrypointJITMode:
-            case Wasm::CompilationMode::JSEntrypointInterpreterMode:
+            case Wasm::CompilationMode::JITLessJSEntrypointMode:
             case Wasm::CompilationMode::JSToWasmICMode:
             case Wasm::CompilationMode::WasmToJSMode:
                 // Just say "Wasm" for now.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -218,7 +218,7 @@ void BBQPlan::work(CompilationEffort effort)
     // Replace the LLInt interpreted entry callee. Note that we can do this after we publish our
     // callee because calling into the LLInt should still work.
     auto* jsEntrypointCallee = m_calleeGroup->m_jsEntrypointCallees.get(m_functionIndex);
-    if (jsEntrypointCallee && jsEntrypointCallee->compilationMode() == CompilationMode::JSEntrypointInterpreterMode && !static_cast<JSEntrypointInterpreterCallee*>(jsEntrypointCallee)->hasReplacement()) {
+    if (jsEntrypointCallee && jsEntrypointCallee->compilationMode() == CompilationMode::JITLessJSEntrypointMode && !static_cast<JITLessJSEntrypointCallee*>(jsEntrypointCallee)->hasReplacement()) {
         Locker locker { m_lock };
         TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
         const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
@@ -248,7 +248,7 @@ void BBQPlan::work(CompilationEffort effort)
             Locker locker { m_calleeGroup->m_lock };
             // Note that we can compile the same function with multiple memory modes, which can cause this
             // race. That's fine, both stubs should do the same thing.
-            static_cast<JSEntrypointInterpreterCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
+            static_cast<JITLessJSEntrypointCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
 
             auto result = m_jsToWasmInternalFunctions.add(m_functionIndex, std::tuple { WTFMove(callee), WTFMove(linkBuffer), WTFMove(jsToWasmInternalFunction) });
             ASSERT_UNUSED(result, result.isNewEntry);

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -44,7 +44,7 @@ namespace JSC::Wasm {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Callee);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITCallee);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JSEntrypointCallee);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(JSEntrypointInterpreterCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITLessJSEntrypointCallee);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JSEntrypointJITCallee);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WasmToJSCallee);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JSToWasmICCallee);
@@ -80,8 +80,8 @@ inline void Callee::runWithDowncast(const Func& func)
     case CompilationMode::LLIntMode:
         func(static_cast<LLIntCallee*>(this));
         break;
-    case CompilationMode::JSEntrypointInterpreterMode:
-        func(static_cast<JSEntrypointInterpreterCallee*>(this));
+    case CompilationMode::JITLessJSEntrypointMode:
+        func(static_cast<JITLessJSEntrypointCallee*>(this));
         break;
 #if ENABLE(WEBASSEMBLY_BBQJIT)
     case CompilationMode::BBQMode:
@@ -416,8 +416,8 @@ const StackMap& OptimizingJITCallee::stackmap(CallSiteIndex callSiteIndex) const
 }
 #endif
 
-JSEntrypointInterpreterCallee::JSEntrypointInterpreterCallee(unsigned frameSize, TypeIndex typeIndex, bool usesSIMD)
-    : JSEntrypointCallee(Wasm::CompilationMode::JSEntrypointInterpreterMode)
+JITLessJSEntrypointCallee::JITLessJSEntrypointCallee(unsigned frameSize, TypeIndex typeIndex, bool usesSIMD)
+    : JSEntrypointCallee(Wasm::CompilationMode::JITLessJSEntrypointMode)
     , frameSize(frameSize)
     , typeIndex(typeIndex)
 {
@@ -438,7 +438,7 @@ JSEntrypointInterpreterCallee::JSEntrypointInterpreterCallee(unsigned frameSize,
     }
 }
 
-CodePtr<WasmEntryPtrTag> JSEntrypointInterpreterCallee::entrypointImpl() const
+CodePtr<WasmEntryPtrTag> JITLessJSEntrypointCallee::entrypointImpl() const
 {
     const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
     if (m_replacementCallee)
@@ -458,7 +458,7 @@ CodePtr<WasmEntryPtrTag> JSEntrypointInterpreterCallee::entrypointImpl() const
     return LLInt::getCodeFunctionPtr<CFunctionPtrTag>(js_to_wasm_wrapper_entry);
 }
 
-RegisterAtOffsetList* JSEntrypointInterpreterCallee::calleeSaveRegistersImpl()
+RegisterAtOffsetList* JITLessJSEntrypointCallee::calleeSaveRegistersImpl()
 {
     // This must be the same to JSToWasm's callee save registers.
     // The reason is that we may use m_replacementCallee which can be set at any time.

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -176,12 +176,12 @@ private:
 #endif
 };
 
-class JSEntrypointInterpreterCallee final : public JSEntrypointCallee {
-    WTF_MAKE_TZONE_ALLOCATED(JSEntrypointInterpreterCallee);
+class JITLessJSEntrypointCallee final : public JSEntrypointCallee {
+    WTF_MAKE_TZONE_ALLOCATED(JITLessJSEntrypointCallee);
 public:
-    static inline Ref<JSEntrypointInterpreterCallee> create(unsigned frameSize, TypeIndex typeIndex, bool usesSIMD)
+    static inline Ref<JITLessJSEntrypointCallee> create(unsigned frameSize, TypeIndex typeIndex, bool usesSIMD)
     {
-        return adoptRef(*new JSEntrypointInterpreterCallee(frameSize, typeIndex, usesSIMD));
+        return adoptRef(*new JITLessJSEntrypointCallee(frameSize, typeIndex, usesSIMD));
     }
 
     inline bool hasReplacement() const { return !!m_replacementCallee; }
@@ -200,10 +200,10 @@ public:
     JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
 
-    static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JSEntrypointInterpreterCallee, ident); }
-    static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JSEntrypointInterpreterCallee, wasmCallee); }
-    static constexpr ptrdiff_t offsetOfWasmFunctionPrologue() { return OBJECT_OFFSETOF(JSEntrypointInterpreterCallee, wasmFunctionPrologue); }
-    static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JSEntrypointInterpreterCallee, frameSize); }
+    static constexpr ptrdiff_t offsetOfIdent() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, ident); }
+    static constexpr ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, wasmCallee); }
+    static constexpr ptrdiff_t offsetOfWasmFunctionPrologue() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, wasmFunctionPrologue); }
+    static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(JITLessJSEntrypointCallee, frameSize); }
 
     // Space for callee-saves; Not included in frameSize
     static constexpr unsigned SpillStackSpaceAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(3 * sizeof(UCPURegister));
@@ -221,7 +221,7 @@ public:
     CodePtr<WasmEntryPtrTag> wasmFunctionPrologue;
 
 private:
-    JSEntrypointInterpreterCallee(unsigned frameSize, TypeIndex, bool);
+    JITLessJSEntrypointCallee(unsigned frameSize, TypeIndex, bool);
 
     RefPtr<Wasm::Callee> m_replacementCallee { nullptr };
 };

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
@@ -48,7 +48,7 @@ ASCIILiteral makeString(CompilationMode mode)
         return "OMGForOSREntry"_s;
     case CompilationMode::JSEntrypointJITMode:
         return "JSEntrypoint"_s;
-    case CompilationMode::JSEntrypointInterpreterMode:
+    case CompilationMode::JITLessJSEntrypointMode:
         return "JSEntrypointInterpreter"_s;
     case CompilationMode::JSToWasmICMode:
         return "JSToWasmIC"_s;

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -37,7 +37,7 @@ enum class CompilationMode : uint8_t {
     OMGMode,
     OMGForOSREntryMode,
     JSEntrypointJITMode,
-    JSEntrypointInterpreterMode,
+    JITLessJSEntrypointMode,
     JSToWasmICMode,
     WasmToJSMode,
 };
@@ -52,7 +52,7 @@ constexpr inline bool isOSREntry(CompilationMode compilationMode)
     case CompilationMode::BBQMode:
     case CompilationMode::OMGMode:
     case CompilationMode::JSEntrypointJITMode:
-    case CompilationMode::JSEntrypointInterpreterMode:
+    case CompilationMode::JITLessJSEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -74,7 +74,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::IPIntMode:
     case CompilationMode::OMGMode:
     case CompilationMode::JSEntrypointJITMode:
-    case CompilationMode::JSEntrypointInterpreterMode:
+    case CompilationMode::JITLessJSEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -93,7 +93,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
     case CompilationMode::JSEntrypointJITMode:
-    case CompilationMode::JSEntrypointInterpreterMode:
+    case CompilationMode::JITLessJSEntrypointMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
@@ -89,8 +89,6 @@ private:
 
     bool ensureEntrypoint(LLIntCallee&, unsigned functionIndex);
 
-    RefPtr<JSEntrypointCallee> tryCreateInterpretedJSToWasmCallee(unsigned functionIndex);
-
     Vector<std::unique_ptr<FunctionCodeBlockGenerator>> m_wasmInternalFunctions;
     const Ref<LLIntCallee>* m_callees { nullptr };
     Vector<Ref<LLIntCallee>> m_calleesVector;

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -203,7 +203,7 @@ void OMGPlan::work(CompilationEffort)
     // Replace the LLInt interpreted entry callee. Note that we can do this after we publish our
     // callee because calling into the LLInt should still work.
     auto* jsEntrypointCallee = m_calleeGroup->m_jsEntrypointCallees.get(m_functionIndex);
-    if (jsEntrypointCallee && jsEntrypointCallee->compilationMode() == CompilationMode::JSEntrypointInterpreterMode && !static_cast<JSEntrypointInterpreterCallee*>(jsEntrypointCallee)->hasReplacement()) {
+    if (jsEntrypointCallee && jsEntrypointCallee->compilationMode() == CompilationMode::JITLessJSEntrypointMode && !static_cast<JITLessJSEntrypointCallee*>(jsEntrypointCallee)->hasReplacement()) {
         ASSERT(!m_entrypoint);
         Locker locker { m_lock };
         TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
@@ -233,7 +233,7 @@ void OMGPlan::work(CompilationEffort)
             callee->setEntrypoint(WTFMove(jsToWasmInternalFunction->entrypoint));
             // Note that we can compile the same function with multiple memory modes, which can cause this
             // race. That's fine, both stubs should do the same thing.
-            static_cast<JSEntrypointInterpreterCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
+            static_cast<JITLessJSEntrypointCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
             m_entrypoint = WTFMove(callee);
         }
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -480,7 +480,7 @@ WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, J
     : Base { vm, executable, globalObject, structure, instance, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation, &m_boxedWasmCallee, rtt.get() } }
     , m_jsEntrypoint { jsEntrypoint }
     , m_boxedWasmCallee(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCalleeIfExists(wasmCallee)))
-    , m_jsToWasmInterpreterCallee(jsEntrypoint.compilationMode() == Wasm::CompilationMode::JSEntrypointInterpreterMode ? static_cast<Wasm::JSEntrypointInterpreterCallee*>(&jsEntrypoint) : nullptr)
+    , m_jsToWasmCallee(jsEntrypoint.compilationMode() == Wasm::CompilationMode::JITLessJSEntrypointMode ? static_cast<Wasm::JITLessJSEntrypointCallee*>(&jsEntrypoint) : nullptr)
 { }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -76,7 +76,7 @@ public:
 #endif
     }
 
-    static constexpr ptrdiff_t offsetOfInterpreterCallee() { return OBJECT_OFFSETOF(WebAssemblyFunction, m_jsToWasmInterpreterCallee); }
+    static constexpr ptrdiff_t offsetOfJSToWasmCallee() { return OBJECT_OFFSETOF(WebAssemblyFunction, m_jsToWasmCallee); }
 
 private:
     DECLARE_VISIT_CHILDREN;
@@ -97,7 +97,7 @@ private:
     // This is the callee needed by LLInt/IPInt
     uintptr_t m_boxedWasmCallee;
     // This let's the JS->Wasm interpreter find its metadata
-    RefPtr<Wasm::JSEntrypointInterpreterCallee> m_jsToWasmInterpreterCallee;
+    RefPtr<Wasm::JITLessJSEntrypointCallee> m_jsToWasmCallee;
 #if ENABLE(JIT)
     RefPtr<Wasm::JSToWasmICCallee> m_jsToWasmICCallee;
 #endif


### PR DESCRIPTION
#### ec42d329299fa971b4c1e2c1637289175ffcce74
<pre>
[JSC] Simplify useInterpretedJSEntryWrappers condition
<a href="https://bugs.webkit.org/show_bug.cgi?id=278145">https://bugs.webkit.org/show_bug.cgi?id=278145</a>
<a href="https://rdar.apple.com/133909794">rdar://133909794</a>

Reviewed by Keith Miller.

1. memoryCount is not related to whether we can use JIT-less entrypoint. We removed, and simplified the code.
2. It is not longer having arguments interpreter. So we rename useInterpretedJSEntryWrappers to useWasmJITLessJSEntrypoint.
3. Rename JSEntrypointInterpreterCallee to JITLessJSEntrypointCallee.

* JSTests/microbenchmarks/wasm-cc-int-to-int.js:
* JSTests/wasm/stress/cc-double-to-double.js:
* JSTests/wasm/stress/cc-f32-kitchen-sink.js:
* JSTests/wasm/stress/cc-float-to-float.js:
* JSTests/wasm/stress/cc-funcref.js:
* JSTests/wasm/stress/cc-i32-kitchen-sink-neg.js:
* JSTests/wasm/stress/cc-i32-kitchen-sink.js:
* JSTests/wasm/stress/cc-i64-kitchen-sink-neg.js:
* JSTests/wasm/stress/cc-i64-kitchen-sink.js:
* JSTests/wasm/stress/cc-infinite-int-glitch.js:
* JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js:
* JSTests/wasm/stress/cc-int-to-int-cross-module.js:
* JSTests/wasm/stress/cc-int-to-int-memory.js:
* JSTests/wasm/stress/cc-int-to-int-no-jit.js:
* JSTests/wasm/stress/cc-int-to-int-to-js.js:
* JSTests/wasm/stress/cc-int-to-int.js:
* JSTests/wasm/stress/cc-lotsofints-to-int.js:
* JSTests/wasm/stress/cc-so-i-heard-you-like-parameters.js:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::disableAllJITOptions):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::ensureEntrypoint):
(JSC::Wasm::LLIntPlan::tryCreateInterpretedJSToWasmCallee): Deleted.
* Source/JavaScriptCore/wasm/WasmLLIntPlan.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/282291@main">https://commits.webkit.org/282291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35803f5316474763676eae9c91ac59c553ee3da6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50581 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11623 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12150 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55780 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61913 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58083 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5542 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83676 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9444 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37846 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->