### PR TITLE
[JSC] Remove already-shipped features' flags in ECMAScript

### DIFF
--- a/JSTests/microbenchmarks/emscripten-cube2hash-resizable.js
+++ b/JSTests/microbenchmarks/emscripten-cube2hash-resizable.js
@@ -1,5 +1,4 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Note: For maximum-speed code, see "Optimizing Code" on the Emscripten wiki, https://github.com/kripken/emscripten/wiki/Optimizing-Code
 // Note: Some Emscripten settings may limit the speed of the generated code.
 // The Module object: Our interface to the outside world. We import

--- a/JSTests/modules/import-attributes-empty.js
+++ b/JSTests/modules/import-attributes-empty.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useImportAttributes=1")
 import x from './resources/x.js' with {};
 import './resources/y.js' with {};
 export * from './resources/z.js' with {};

--- a/JSTests/modules/import-attributes-trailing.js
+++ b/JSTests/modules/import-attributes-trailing.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useImportAttributes=1")
-
 import { shouldBe } from "./resources/assert.js";
 import x from './resources/x.json' with { type: "json", };
 shouldBe(JSON.stringify(x), `["x"]`);

--- a/JSTests/modules/import-attributes-unsupported.js
+++ b/JSTests/modules/import-attributes-unsupported.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useImportAttributes=1")
 import { shouldBe } from "./resources/assert.js";
 
 {

--- a/JSTests/stress/array-buffer-resize.js
+++ b/JSTests/stress/array-buffer-resize.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/array-from-async-basic.js
+++ b/JSTests/stress/array-from-async-basic.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useArrayFromAsync=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/array-from-async-map-promise.js
+++ b/JSTests/stress/array-from-async-map-promise.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useArrayFromAsync=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/array-from-async-map-this.js
+++ b/JSTests/stress/array-from-async-map-this.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useArrayFromAsync=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/array-from-async-map.js
+++ b/JSTests/stress/array-from-async-map.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useArrayFromAsync=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/growable-typed-array.js
+++ b/JSTests/stress/growable-typed-array.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/intl-durationformat-basic.js
+++ b/JSTests/stress/intl-durationformat-basic.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIntlDurationFormat=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);

--- a/JSTests/stress/intl-durationformat-digital.js
+++ b/JSTests/stress/intl-durationformat-digital.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIntlDurationFormat=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/intl-durationformat-format-to-parts.js
+++ b/JSTests/stress/intl-durationformat-format-to-parts.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIntlDurationFormat=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);

--- a/JSTests/stress/intl-durationformat-fractionaldigits-undefined.js
+++ b/JSTests/stress/intl-durationformat-fractionaldigits-undefined.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIntlDurationFormat=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);

--- a/JSTests/stress/intl-durationformat-numeric-auto-and-zero.js
+++ b/JSTests/stress/intl-durationformat-numeric-auto-and-zero.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIntlDurationFormat=1")
-
 function assertSameValue(actual, expected) {
     if (actual !== expected)
         throw new Error(`Expected "${expected}" but got "${actual}"`)

--- a/JSTests/stress/intl-durationformat.js
+++ b/JSTests/stress/intl-durationformat.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useIntlDurationFormat=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);

--- a/JSTests/stress/map-groupBy.js
+++ b/JSTests/stress/map-groupBy.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useArrayGroupMethod=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/modules-syntax-import-assertion-error.js
+++ b/JSTests/stress/modules-syntax-import-assertion-error.js
@@ -1,5 +1,3 @@
-//@requireOptions("--useImportAttributes=true")
-
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;
     var error = null;

--- a/JSTests/stress/modules-syntax-import-assertion.js
+++ b/JSTests/stress/modules-syntax-import-assertion.js
@@ -1,5 +1,3 @@
-//@requireOptions("--useImportAttributes=true")
-
 var list = [
     String.raw`import v from "mod"`,
     String.raw`import * as ns from "mod"`,

--- a/JSTests/stress/object-groupBy.js
+++ b/JSTests/stress/object-groupBy.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useArrayGroupMethod=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/promise-withResolvers.js
+++ b/JSTests/stress/promise-withResolvers.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--usePromiseWithResolversMethod=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/resizable-bytelength.js
+++ b/JSTests/stress/resizable-bytelength.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/resizable-byteoffset.js
+++ b/JSTests/stress/resizable-byteoffset.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/resizable-length.js
+++ b/JSTests/stress/resizable-length.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/set-prototype-difference.js
+++ b/JSTests/stress/set-prototype-difference.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/set-prototype-intersection.js
+++ b/JSTests/stress/set-prototype-intersection.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/set-prototype-isDisjointfrom.js
+++ b/JSTests/stress/set-prototype-isDisjointfrom.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/set-prototype-isSubsetOf.js
+++ b/JSTests/stress/set-prototype-isSubsetOf.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/set-prototype-isSupersetOf.js
+++ b/JSTests/stress/set-prototype-isSupersetOf.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/set-prototype-symmetricDifference.js
+++ b/JSTests/stress/set-prototype-symmetricDifference.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/set-prototype-union.js
+++ b/JSTests/stress/set-prototype-union.js
@@ -1,5 +1,3 @@
-//@ runDefault("--useSetMethods=1")
-
 function assert(a, e, m) {
     if (a !== e)
         throw new Error(m);

--- a/JSTests/stress/string-well-formed.js
+++ b/JSTests/stress/string-well-formed.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useStringWellFormed=1")
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/v8-dataview-growablesharedarraybuffer.js
+++ b/JSTests/stress/v8-dataview-growablesharedarraybuffer.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-dataview-resizablearraybuffer.js
+++ b/JSTests/stress/v8-dataview-resizablearraybuffer.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-harmony-arraybuffer-transfer.js
+++ b/JSTests/stress/v8-harmony-arraybuffer-transfer.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1", "--useArrayBufferTransfer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-harmony-typed-array-to-reversed.js
+++ b/JSTests/stress/v8-harmony-typed-array-to-reversed.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-harmony-typed-array-to-sorted.js
+++ b/JSTests/stress/v8-harmony-typed-array-to-sorted.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-harmony-typed-array-with.js
+++ b/JSTests/stress/v8-harmony-typed-array-with.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-1358505.js
+++ b/JSTests/stress/v8-regress-1358505.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-1376784.js
+++ b/JSTests/stress/v8-regress-1376784.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-1380398.js
+++ b/JSTests/stress/v8-regress-1380398.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1347721.js
+++ b/JSTests/stress/v8-regress-crbug-1347721.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1359991.js
+++ b/JSTests/stress/v8-regress-crbug-1359991.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1362487.js
+++ b/JSTests/stress/v8-regress-crbug-1362487.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1377840.js
+++ b/JSTests/stress/v8-regress-crbug-1377840.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1381064.js
+++ b/JSTests/stress/v8-regress-crbug-1381064.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1384474-variant2.js
+++ b/JSTests/stress/v8-regress-crbug-1384474-variant2.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1384474-variant3.js
+++ b/JSTests/stress/v8-regress-crbug-1384474-variant3.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1384474.js
+++ b/JSTests/stress/v8-regress-crbug-1384474.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-regress-crbug-1392577.js
+++ b/JSTests/stress/v8-regress-crbug-1392577.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-resizablearraybuffer-growablesharedarraybuffer.js
+++ b/JSTests/stress/v8-resizablearraybuffer-growablesharedarraybuffer.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-growablesharedarraybuffer-array-methods.js
+++ b/JSTests/stress/v8-typedarray-growablesharedarraybuffer-array-methods.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-growablesharedarraybuffer-atomics.js
+++ b/JSTests/stress/v8-typedarray-growablesharedarraybuffer-atomics.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1", "--useAtomicsWaitAsync=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-growablesharedarraybuffer.js
+++ b/JSTests/stress/v8-typedarray-growablesharedarraybuffer.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-resizablearraybuffer-array-methods.js
+++ b/JSTests/stress/v8-typedarray-resizablearraybuffer-array-methods.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-resizablearraybuffer-atomics.js
+++ b/JSTests/stress/v8-typedarray-resizablearraybuffer-atomics.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-resizablearraybuffer-detach.js
+++ b/JSTests/stress/v8-typedarray-resizablearraybuffer-detach.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/stress/v8-typedarray-resizablearraybuffer.js
+++ b/JSTests/stress/v8-typedarray-resizablearraybuffer.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useResizableArrayBuffer=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -3,15 +3,8 @@
 flags:
   SharedArrayBuffer: useSharedArrayBuffer
   Atomics: useSharedArrayBuffer
-  Intl.DurationFormat: useIntlDurationFormat
   Temporal: useTemporal
-  array-grouping: useArrayGroupMethod
   ShadowRealm: useShadowRealm
-  resizable-arraybuffer: useResizableArrayBuffer
-  arraybuffer-transfer: useArrayBufferTransfer
-  import-assertions: useImportAttributes
-  json-modules: useImportAttributes
-  promise-with-resolvers: usePromiseWithResolversMethod
   promise-try: usePromiseTryMethod
   uint8array-base64: useUint8ArrayBase64Methods
   RegExp.escape: useRegExpEscape

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -3721,7 +3721,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseImportDeclara
         failIfFalse(moduleName, "Cannot parse the module name");
 
         typename TreeBuilder::ImportAttributesList attributesList = 0;
-        if (Options::useImportAttributes() && !m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
+        if (!m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
             next();
             attributesList = parseImportAttributes(context);
             failIfFalse(attributesList, "Unable to parse import attributes");
@@ -3781,7 +3781,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseImportDeclara
 
     // [no LineTerminator here] WithClause ;
     typename TreeBuilder::ImportAttributesList attributesList = 0;
-    if (Options::useImportAttributes() && !m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
+    if (!m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
         next();
         attributesList = parseImportAttributes(context);
         failIfFalse(attributesList, "Unable to parse import attributes");
@@ -3864,7 +3864,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
 
         // [no LineTerminator here] WithClause ;
         typename TreeBuilder::ImportAttributesList attributesList = 0;
-        if (Options::useImportAttributes() && !m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
+        if (!m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
             next();
             attributesList = parseImportAttributes(context);
             failIfFalse(attributesList, "Unable to parse import attributes");
@@ -4011,7 +4011,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
             failIfFalse(moduleName, "Cannot parse the 'from' clause");
 
             // [no LineTerminator here] WithClause ;
-            if (Options::useImportAttributes() && !m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
+            if (!m_lexer->hasLineTerminatorBeforeToken() && match(WITH)) {
                 next();
                 attributesList = parseImportAttributes(context);
                 failIfFalse(attributesList, "Unable to parse import attributes");

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -66,9 +66,7 @@ void ArrayConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject, Arra
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isArray, arrayConstructorIsArrayCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fromPrivateName(), arrayConstructorFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-
-    if (Options::useArrayFromAsync())
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fromAsyncPublicName(), arrayConstructorFromAsyncCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fromAsyncPublicName(), arrayConstructorFromAsyncCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 // ------------------------------ Functions ---------------------------

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -87,7 +87,7 @@ void AtomicsObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     FOR_EACH_ATOMICS_FUNC(PUT_DIRECT_NATIVE_FUNC)
 #undef PUT_DIRECT_NATIVE_FUNC
 
-    if (Options::useAtomicsWaitAsync() && vm.vmType == VM::Default)
+    if (vm.vmType == VM::Default)
         putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "waitAsync"_s), 4, atomicsFuncWaitAsync, ImplementationVisibility::Public, AtomicsWaitAsyncIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -255,8 +255,7 @@ void IntlObject::finishCreation(VM& vm, JSGlobalObject*)
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 #if HAVE(ICU_U_LIST_FORMATTER)
-    if (Options::useIntlDurationFormat())
-        putDirectWithoutTransition(vm, vm.propertyNames->DurationFormat, createDurationFormatConstructor(vm, this), static_cast<unsigned>(PropertyAttribute::DontEnum));
+    putDirectWithoutTransition(vm, vm.propertyNames->DurationFormat, createDurationFormatConstructor(vm, this), static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->ListFormat, createListFormatConstructor(vm, this), static_cast<unsigned>(PropertyAttribute::DontEnum));
 #else
     UNUSED_PARAM(&createDurationFormatConstructor);

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -85,16 +85,13 @@ EncodedJSValue JSGenericArrayBufferConstructor<sharingMode>::constructImpl(JSGlo
     if (hasArguments) {
         lengthDouble = callFrame->uncheckedArgument(0).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-
-        if (Options::useResizableArrayBuffer()) {
-            JSValue options = callFrame->argument(1);
-            if (options.isObject()) {
-                JSValue maxByteLengthValue = asObject(options)->get(globalObject, vm.propertyNames->maxByteLength);
+        JSValue options = callFrame->argument(1);
+        if (options.isObject()) {
+            JSValue maxByteLengthValue = asObject(options)->get(globalObject, vm.propertyNames->maxByteLength);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (!maxByteLengthValue.isUndefined()) {
+                maxByteLength = maxByteLengthValue.toTypedArrayIndex(globalObject, "maxByteLength"_s);
                 RETURN_IF_EXCEPTION(scope, { });
-                if (!maxByteLengthValue.isUndefined()) {
-                    maxByteLength = maxByteLengthValue.toTypedArrayIndex(globalObject, "maxByteLength"_s);
-                    RETURN_IF_EXCEPTION(scope, { });
-                }
             }
         }
     }

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -538,25 +538,18 @@ void JSArrayBufferPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject
     if (sharingMode == ArrayBufferSharingMode::Default) {
         JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->slice, arrayBufferProtoFuncSlice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
         JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->byteLength, arrayBufferProtoGetterFuncByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-        if (Options::useResizableArrayBuffer()) {
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->resize, arrayBufferProtoFuncResize, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-            if (Options::useArrayBufferTransfer()) {
-                JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->transfer, arrayBufferProtoFuncTransfer, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-                JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->transferToFixedLength, arrayBufferProtoFuncTransferToFixedLength, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-            }
-            JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->resizable, arrayBufferProtoGetterFuncResizable, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-            JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->maxByteLength, arrayBufferProtoGetterFuncMaxByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-            if (Options::useArrayBufferTransfer())
-                JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->detached, arrayBufferProtoGetterFuncDetached, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-        }
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->resize, arrayBufferProtoFuncResize, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->transfer, arrayBufferProtoFuncTransfer, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->transferToFixedLength, arrayBufferProtoFuncTransferToFixedLength, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->resizable, arrayBufferProtoGetterFuncResizable, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->maxByteLength, arrayBufferProtoGetterFuncMaxByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->detached, arrayBufferProtoGetterFuncDetached, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     } else {
         JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->slice, sharedArrayBufferProtoFuncSlice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
         JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->byteLength, sharedArrayBufferProtoGetterFuncByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-        if (Options::useResizableArrayBuffer()) {
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->grow, sharedArrayBufferProtoFuncGrow, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-            JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->growable, sharedArrayBufferProtoGetterFuncGrowable, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-            JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->maxByteLength, sharedArrayBufferProtoGetterFuncMaxByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-        }
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->grow, sharedArrayBufferProtoFuncGrow, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->growable, sharedArrayBufferProtoGetterFuncGrowable, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+        JSC_NATIVE_GETTER_WITHOUT_TRANSITION(vm.propertyNames->maxByteLength, sharedArrayBufferProtoGetterFuncMaxByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -85,9 +85,7 @@ void JSPromiseConstructor::finishCreation(VM& vm, JSPromisePrototype* promisePro
 
     GetterSetter* speciesGetterSetter = GetterSetter::create(vm, globalObject, JSFunction::create(vm, globalObject, 0, "get [Symbol.species]"_s, globalFuncSpeciesGetter, ImplementationVisibility::Public, SpeciesGetterIntrinsic), nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, speciesGetterSetter, PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
-
-    if (Options::usePromiseWithResolversMethod())
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().withResolversPublicName(), promiseConstructorWithResolversCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().withResolversPublicName(), promiseConstructorWithResolversCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     if (Options::usePromiseTryMethod())
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->tryKeyword, promiseConstructorTryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -47,9 +47,7 @@ void MapConstructor::finishCreation(VM& vm, MapPrototype* mapPrototype)
 
     GetterSetter* speciesGetterSetter = GetterSetter::create(vm, globalObject, JSFunction::create(vm, globalObject, 0, "get [Symbol.species]"_s, globalFuncSpeciesGetter, ImplementationVisibility::Public, SpeciesGetterIntrinsic), nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, speciesGetterSetter, PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
-
-    if (Options::useArrayGroupMethod())
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().groupByPublicName(), mapConstructorGroupByCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().groupByPublicName(), mapConstructorGroupByCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 static JSC_DECLARE_HOST_FUNCTION(callMap);

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -109,9 +109,7 @@ void ObjectConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject, Obj
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().valuesPrivateName(), objectConstructorValues, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->hasOwn, objectConstructorHasOwn, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().hasOwnPrivateName(), objectConstructorHasOwn, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-
-    if (Options::useArrayGroupMethod())
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().groupByPublicName(), objectConstructorGroupByCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().groupByPublicName(), objectConstructorGroupByCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 // ES 19.1.1.1 Object([value])

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -583,21 +583,11 @@ bool hasCapacityToUseLargeGigacage();
     \
     /* Feature Flags */\
     \
-    v(Bool, useArrayBufferTransfer, true, Normal, "Expose ArrayBuffer.transfer feature."_s) \
-    v(Bool, useArrayFromAsync, true, Normal, "Expose the Array.fromAsync."_s) \
-    v(Bool, useArrayGroupMethod, true, Normal, "Expose the Object.groupBy() and Map.groupBy() methods."_s) \
-    v(Bool, useAtomicsWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics."_s) \
     v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
-    v(Bool, useSetMethods, true, Normal, "Expose the various Set.prototype methods for handling combinations of sets"_s) \
-    v(Bool, useImportAttributes, true, Normal, "Enable import attributes."_s) \
-    v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat."_s) \
-    v(Bool, usePromiseWithResolversMethod, true, Normal, "Expose the Promise.withResolvers() method."_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \
-    v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature."_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
-    v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useUint8ArrayBase64Methods, true, Normal, "Expose methods for converting Uint8Array to/from base64 and hex."_s) \

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -89,15 +89,13 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, values, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
-    if (Options::useSetMethods()) {
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().unionPublicName(), setPrototypeUnionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().intersectionPublicName(), setPrototypeIntersectionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().differencePublicName(), setPrototypeDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSubsetOfPublicName(), setPrototypeIsSubsetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSupersetOfPublicName(), setPrototypeIsSupersetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isDisjointFromPublicName(), setPrototypeIsDisjointFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    }
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().unionPublicName(), setPrototypeUnionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().intersectionPublicName(), setPrototypeIntersectionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().differencePublicName(), setPrototypeDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSubsetOfPublicName(), setPrototypeIsSubsetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSupersetOfPublicName(), setPrototypeIsSupersetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isDisjointFromPublicName(), setPrototypeIsDisjointFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     globalObject->installSetPrototypeWatchpoint(this);
 }

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -167,11 +167,8 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().substrPrivateName(), stringProtoFuncSubstr, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().endsWithPrivateName(), stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-
-    if (Options::useStringWellFormed()) {
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isWellFormed, stringProtoFuncIsWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toWellFormed, stringProtoFuncToWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-    }
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isWellFormed, stringProtoFuncIsWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toWellFormed, stringProtoFuncToWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
 
     // The constructor will be added later, after StringConstructor has been built
 }

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -451,7 +451,7 @@ VM::~VM()
 {
     Locker destructionLocker { s_destructionLock.read() };
 
-    if (Options::useAtomicsWaitAsync() && vmType == Default)
+    if (vmType == Default)
         WaiterListManager::singleton().unregister(this);
 
     Gigacage::removePrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);


### PR DESCRIPTION
#### 39b7fd567abd1ae7fa55363412e5c999bb381862
<pre>
[JSC] Remove already-shipped features&apos; flags in ECMAScript
<a href="https://bugs.webkit.org/show_bug.cgi?id=278149">https://bugs.webkit.org/show_bug.cgi?id=278149</a>
<a href="https://rdar.apple.com/133912307">rdar://133912307</a>

Reviewed by Keith Miller.

As usual, we clean up already-shipped ECMAScript features&apos; flags. This makes JSC code simpler, more maintenable and less-branchy.

* JSTests/microbenchmarks/emscripten-cube2hash-resizable.js:
* JSTests/modules/import-attributes-empty.js:
* JSTests/modules/import-attributes-trailing.js:
* JSTests/modules/import-attributes-unsupported.js:
* JSTests/stress/array-buffer-resize.js:
* JSTests/stress/array-from-async-basic.js:
* JSTests/stress/array-from-async-map-promise.js:
* JSTests/stress/array-from-async-map-this.js:
* JSTests/stress/array-from-async-map.js:
* JSTests/stress/growable-typed-array.js:
* JSTests/stress/intl-durationformat-basic.js:
* JSTests/stress/intl-durationformat-digital.js:
* JSTests/stress/intl-durationformat-format-to-parts.js:
* JSTests/stress/intl-durationformat-fractionaldigits-undefined.js:
* JSTests/stress/intl-durationformat-numeric-auto-and-zero.js:
* JSTests/stress/intl-durationformat.js:
* JSTests/stress/map-groupBy.js:
* JSTests/stress/modules-syntax-import-assertion-error.js:
* JSTests/stress/modules-syntax-import-assertion.js:
* JSTests/stress/object-groupBy.js:
* JSTests/stress/promise-withResolvers.js:
* JSTests/stress/resizable-bytelength.js:
* JSTests/stress/resizable-byteoffset.js:
* JSTests/stress/resizable-length.js:
* JSTests/stress/set-prototype-difference.js:
* JSTests/stress/set-prototype-intersection.js:
* JSTests/stress/set-prototype-isDisjointfrom.js:
* JSTests/stress/set-prototype-isSubsetOf.js:
* JSTests/stress/set-prototype-isSupersetOf.js:
* JSTests/stress/set-prototype-symmetricDifference.js:
* JSTests/stress/set-prototype-union.js:
* JSTests/stress/string-well-formed.js:
* JSTests/stress/v8-dataview-growablesharedarraybuffer.js:
* JSTests/stress/v8-dataview-resizablearraybuffer.js:
* JSTests/stress/v8-harmony-arraybuffer-transfer.js:
* JSTests/stress/v8-harmony-typed-array-to-reversed.js:
* JSTests/stress/v8-harmony-typed-array-to-sorted.js:
* JSTests/stress/v8-harmony-typed-array-with.js:
* JSTests/stress/v8-regress-1358505.js:
* JSTests/stress/v8-regress-1376784.js:
* JSTests/stress/v8-regress-1380398.js:
* JSTests/stress/v8-regress-crbug-1347721.js:
* JSTests/stress/v8-regress-crbug-1359991.js:
* JSTests/stress/v8-regress-crbug-1362487.js:
* JSTests/stress/v8-regress-crbug-1377840.js:
* JSTests/stress/v8-regress-crbug-1381064.js:
* JSTests/stress/v8-regress-crbug-1384474-variant2.js:
* JSTests/stress/v8-regress-crbug-1384474-variant3.js:
* JSTests/stress/v8-regress-crbug-1384474.js:
* JSTests/stress/v8-regress-crbug-1392577.js:
* JSTests/stress/v8-resizablearraybuffer-growablesharedarraybuffer.js:
* JSTests/stress/v8-typedarray-growablesharedarraybuffer-array-methods.js:
* JSTests/stress/v8-typedarray-growablesharedarraybuffer-atomics.js:
* JSTests/stress/v8-typedarray-growablesharedarraybuffer.js:
* JSTests/stress/v8-typedarray-resizablearraybuffer-array-methods.js:
* JSTests/stress/v8-typedarray-resizablearraybuffer-atomics.js:
* JSTests/stress/v8-typedarray-resizablearraybuffer-detach.js:
* JSTests/stress/v8-typedarray-resizablearraybuffer.js:
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseImportDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseExportDeclaration):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::ArrayConstructor::finishCreation):
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::AtomicsObject::finishCreation):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::IntlObject::finishCreation):
* Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp:
(JSC::JSGenericArrayBufferConstructor&lt;sharingMode&gt;::constructImpl):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::JSArrayBufferPrototype::finishCreation):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::finishCreation):
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
(JSC::MapConstructor::finishCreation):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::ObjectConstructor::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::~VM):

Canonical link: <a href="https://commits.webkit.org/282285@main">https://commits.webkit.org/282285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/632e2191e6c3c580334812e6539d28b1278a9449

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13278 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50589 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12154 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55784 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68389 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61917 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58088 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5545 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83680 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37850 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14724 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38930 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->