### PR TITLE
[css-anchor-position-1] Disregard transforms when calculating `anchor()` location

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-001-expected.txt
@@ -1,15 +1,7 @@
 spacer
 
-FAIL .target 1 assert_equals:
-<div class="target" style="left: anchor(--a1 left)" data-offset-x="110"></div>
-offsetLeft expected 110 but got 118
-FAIL .target 2 assert_equals:
-<div class="target" style="right: anchor(--a1 right)" data-offset-x="320"></div>
-offsetLeft expected 320 but got 328
-FAIL .target 3 assert_equals:
-<div class="target" style="top: anchor(--a1 top)" data-offset-y="10"></div>
-offsetTop expected 10 but got 18
-FAIL .target 4 assert_equals:
-<div class="target" style="bottom: anchor(--a1 bottom)" data-offset-y="110"></div>
-offsetTop expected 110 but got 118
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt
@@ -6,35 +6,27 @@ FAIL .target 1 assert_equals:
 width expected 160 but got 0
 FAIL .target 2 assert_equals:
 <div class="target target1-rb" data-offset-x="168" data-offset-y="155"></div>
-offsetLeft expected 168 but got 302
+offsetLeft expected 168 but got 278
 FAIL .target 3 assert_equals:
 <div class="target fixed target1" data-offset-x="26" data-offset-y="70" data-expected-width="160" data-expected-height="100"></div>
 width expected 160 but got 0
 FAIL .target 4 assert_equals:
 <div class="target fixed target1-rb" data-offset-x="176" data-offset-y="160"></div>
-offsetLeft expected 176 but got 310
+offsetLeft expected 176 but got 286
 FAIL .target 5 assert_equals:
 <div class="target target1" data-offset-x="144" data-offset-y="5" data-expected-width="160" data-expected-height="100"></div>
 width expected 160 but got 0
-FAIL .target 6 assert_equals:
-<div class="target target1-rb" data-offset-x="294" data-offset-y="95"></div>
-offsetLeft expected 294 but got 302
+PASS .target 6
 FAIL .target 7 assert_equals:
 <div class="target fixed target1" data-offset-x="152" data-offset-y="10" data-expected-width="160" data-expected-height="100"></div>
 width expected 160 but got 0
-FAIL .target 8 assert_equals:
-<div class="target fixed target1-rb" data-offset-x="302" data-offset-y="100"></div>
-offsetLeft expected 302 but got 310
+PASS .target 8
 FAIL .target 9 assert_equals:
 <div class="target target1" data-offset-x="144" data-offset-y="5" data-expected-width="160" data-expected-height="100"></div>
 width expected 160 but got 0
-FAIL .target 10 assert_equals:
-<div class="target target1-rb" data-offset-x="294" data-offset-y="95"></div>
-offsetLeft expected 294 but got 302
+PASS .target 10
 FAIL .target 11 assert_equals:
 <div class="target fixed target1" data-offset-x="152" data-offset-y="10" data-expected-width="160" data-expected-height="100"></div>
 width expected 160 but got 0
-FAIL .target 12 assert_equals:
-<div class="target fixed target1-rb" data-offset-x="302" data-offset-y="100"></div>
-offsetLeft expected 302 but got 310
+PASS .target 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt
@@ -6,11 +6,11 @@ FAIL .target 1 assert_equals:
 width expected 130 but got 0
 FAIL .target 2 assert_equals:
 <div class="target target1-rb" data-offset-x="138" data-offset-y="155"></div>
-offsetLeft expected 138 but got 492
+offsetLeft expected 138 but got 468
 FAIL .target 3 assert_equals:
 <div class="target target1" data-offset-x="34" data-offset-y="225" data-expected-width="130" data-expected-height="100"></div>
 width expected 130 but got 0
 FAIL .target 4 assert_equals:
 <div class="target target1-rb" data-offset-x="154" data-offset-y="315"></div>
-offsetLeft expected 154 but got 492
+offsetLeft expected 154 but got 484
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -186,9 +186,28 @@ static LayoutUnit removeBorderForInsetValue(LayoutUnit insetValue, BoxSide inset
     }
 }
 
+static LayoutSize offsetFromAncestorContainer(const RenderElement& descendantContainer, const RenderElement& ancestorContainer)
+{
+    LayoutSize offset;
+    LayoutPoint referencePoint;
+    CheckedPtr currentContainer = &descendantContainer;
+    do {
+        CheckedPtr nextContainer = currentContainer->container();
+        ASSERT(nextContainer); // This means we reached the top without finding container.
+        if (!nextContainer)
+            break;
+        LayoutSize currentOffset = currentContainer->offsetFromContainer(*nextContainer, referencePoint);
+        offset += currentOffset;
+        referencePoint.move(currentOffset);
+        currentContainer = WTFMove(nextContainer);
+    } while (currentContainer != &ancestorContainer);
+
+    return offset;
+}
+
 // This computes the top left location, physical width, and physical height of the specified
 // anchor element. The location is computed relative to the specified containing block.
-static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, CheckedRef<const RenderBlock> containingBlock)
+static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock)
 {
     // Fragmented flows are a little tricky to deal with. One example of a fragmented
     // flow is a block anchor element that is "fragmented" or split across multiple columns
@@ -197,9 +216,6 @@ static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const Re
     // We also need to adjust the anchor's top left location to match that of the bounding box
     // instead of the first fragment.
     if (CheckedPtr fragmentedFlow = anchorBox->enclosingFragmentedFlow()) {
-        // Compute the location of the fragmented flow relative to the containing block.
-        LayoutPoint fragmentedFlowLocation { fragmentedFlow->localToContainerPoint({ }, &containingBlock.get()) };
-
         // Compute the bounding box of the fragments.
         // Location is relative to the fragmented flow.
         CheckedPtr anchorRenderBox = dynamicDowncast<RenderBox>(&anchorBox.get());
@@ -210,23 +226,26 @@ static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const Re
         unfragmentedBorderBox.moveBy(offsetRelativeToFragmentedFlow);
         auto fragmentsBoundingBox = fragmentedFlow->fragmentsBoundingBox(unfragmentedBorderBox);
 
-        // Compute the final location.
+        // Change the location to be relative to the anchor's containing block.
+        if (fragmentedFlow->isDescendantOf(&containingBlock))
+            fragmentsBoundingBox.move(offsetFromAncestorContainer(*fragmentedFlow, containingBlock));
+        else
+            fragmentsBoundingBox.move(-offsetFromAncestorContainer(containingBlock, *fragmentedFlow));
+
         // FIXME: The final location of the fragments bounding box is not correctly
         // computed in flipped writing modes (i.e. vertical-rl and horizontal-bt).
-        fragmentsBoundingBox.moveBy(fragmentedFlowLocation);
         return fragmentsBoundingBox;
     }
 
-    FloatPoint localPoint;
     auto anchorWidth = anchorBox->offsetWidth();
     auto anchorHeight = anchorBox->offsetHeight();
+    auto anchorLocation = LayoutPoint { offsetFromAncestorContainer(anchorBox, containingBlock) };
     if (CheckedPtr anchorRenderInline = dynamicDowncast<RenderInline>(&anchorBox.get())) {
-        // RenderInline objects do not automatically account for their offset in RenderObject::localToContainerPoint,
-        // so we incorporate this offset via the localPoint.
-        localPoint = anchorRenderInline->linesBoundingBox().location();
+        // RenderInline objects do not automatically account for their offset in offsetFromAncestorContainer,
+        // so we incorporate this offset here.
+        anchorLocation.moveBy(anchorRenderInline->linesBoundingBox().location());
     }
 
-    LayoutPoint anchorLocation { anchorBox->localToContainerPoint(localPoint, &containingBlock.get()) };
     return LayoutRect(anchorLocation, LayoutSize(anchorWidth, anchorHeight));
 }
 


### PR DESCRIPTION
#### df419b7ac5fae718ea1dce64c347a87c9ca8e849
<pre>
[css-anchor-position-1] Disregard transforms when calculating `anchor()` location
<a href="https://bugs.webkit.org/show_bug.cgi?id=277935">https://bugs.webkit.org/show_bug.cgi?id=277935</a>
<a href="https://rdar.apple.com/133652587">rdar://133652587</a>

Reviewed by Alan Baradlay.

CSS transforms should not impact anchor positioning. We should not use
`localToContainerPoint()` to compute the location of an anchor.

This patch instead uses `offsetFromAncestorContainer()`, which ignores
transforms. Some test progressions occur as a result of subtle
differences between how the two functions handle multicol content.

This patch also addresses the fact that an anchor&apos;s enclosing fragmented
flow may actually be an ancestor of the anchor&apos;s containing block.
(Previously it was assumed that the anchor&apos;s enclosing fragmented flow
is always a descendant of the anchor&apos;s containing block.)

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::offsetFromAncestorContainer):
(WebCore::Style::computeAnchorRectRelativeToContainingBlock):

Canonical link: <a href="https://commits.webkit.org/282335@main">https://commits.webkit.org/282335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a35389f99772b49fe6139be4dbdda29703a4f7b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13386 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49825 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13670 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50641 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9240 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68497 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6728 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11697 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5619 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37958 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39038 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->