### PR TITLE
Make all elements in MathML namespace to be `display: block` and few other updates

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt
@@ -3,6 +3,7 @@
 
 
 
+
 PASS MathML annotation-xml with encoding=text/html should be an HTML integration point
 PASS MathML annotation-xml with encoding=application/xhtml+xml should be an HTML integration point
 PASS SVG foreignObject should be an HTML integration point

--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -44,6 +44,8 @@
 /* Universal rules */
 * {
     writing-mode: horizontal-tb !important;
+    /* FIXME: It should be 'display: block math'. (webkit.org/b/278533) */
+    display: block;
 }
 
 /* The <math> element */
@@ -139,16 +141,16 @@ math {
 }
 
 math[display="block" i] {
+    /* FIXME: It should be 'display: block math'. (webkit.org/b/278533) */
     display: block;
     page-break-inside: avoid;
     math-style: normal;
 }
-math[display="inline" i] {
-  math-style: compact;
-}
 
-ms, mspace, mtext, mi, mn, mo, mrow, mfenced, mfrac, msub, msup, msubsup, mmultiscripts, mprescripts, none, munder, mover, munderover, msqrt, mroot, merror, mphantom, mstyle, menclose, semantics, mpadded, maction {
-    display: block;
+math[display="inline" i] {
+    /* FIXME: It should be 'display: inline math'. (webkit.org/b/278533) */
+    display: inline;
+    math-style: compact;
 }
 
 ms, mtext, mi, mn, mo, annotation, mtd {


### PR DESCRIPTION
#### 5445c276ffb77eb1fbb54804de6753c1da4da9ff
<pre>
Make all elements in MathML namespace to be `display: block` and few other updates

<a href="https://bugs.webkit.org/show_bug.cgi?id=278163">https://bugs.webkit.org/show_bug.cgi?id=278163</a>
<a href="https://rdar.apple.com/problem/134494509">rdar://problem/134494509</a>

Reviewed by Frédéric Wang.

This patch partially aligns WebKit with web specification [1], although
bug 278533 (to implement &apos;display: math&apos;) is blocker, it enables by
making all elements under MathML namespace to have `display: block`.
As well, for`math` element with display `inline` attribute to have `display: inline`.

Additionally, as drive-by fix, It fixes &apos;indentation&apos; issue (2 spaces) and
adds FIXME for future work.

[1] <a href="https://w3c.github.io/mathml-core/#user-agent-stylesheet">https://w3c.github.io/mathml-core/#user-agent-stylesheet</a>

* Source/WebCore/css/mathml.css:
(*):
(math[display=&quot;inline&quot; i]):
(ms, mspace, mtext, mi, mn, mo, mrow, mfenced, mfrac, msub, msup, msubsup, mmultiscripts, mprescripts, none, munder, mover, munderover, msqrt, mroot, merror, mphantom, mstyle, menclose, semantics, mpadded, maction): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html-integration-point-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/283168@main">https://commits.webkit.org/283168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6ff0b3dabc9ede137b4ea0ff2643e33e6ee3d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16322 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11120 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68500 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56637 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/33171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38070 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/14012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14918 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71164 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56698 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/60148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7761 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->