### PR TITLE
[GTK][WPE] Remove common code to get the a11y bus address from PlatformDisplay

### DIFF
--- a/Source/WTF/wtf/glib/Sandbox.cpp
+++ b/Source/WTF/wtf/glib/Sandbox.cpp
@@ -27,6 +27,9 @@
 #include <wtf/glib/Sandbox.h>
 
 #include <glib.h>
+#include <wtf/FileSystem.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/CString.h>
 
 namespace WTF {
 
@@ -85,15 +88,19 @@ bool shouldUsePortal()
     return returnValue;
 }
 
-String& sandboxedAccessibilityBusAddress()
+const CString& sandboxedUserRuntimeDirectory()
 {
-    static String accessibilityBusAddress;
-    return accessibilityBusAddress;
-}
-
-void setSandboxedAccessibilityBusAddress(String&& address)
-{
-    sandboxedAccessibilityBusAddress() = address;
+    static LazyNeverDestroyed<CString> userRuntimeDirectory;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+#if PLATFORM(GTK)
+        static constexpr ASCIILiteral baseDirectory = "webkitgtk"_s;
+#elif PLATFORM(WPE)
+        static constexpr ASCIILiteral baseDirectory = "wpe"_s;
+#endif
+        userRuntimeDirectory.construct(FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(g_get_user_runtime_dir()), baseDirectory).utf8());
+    });
+    return userRuntimeDirectory.get();
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/glib/Sandbox.h
+++ b/Source/WTF/wtf/glib/Sandbox.h
@@ -28,8 +28,7 @@ WTF_EXPORT_PRIVATE bool isInsideUnsupportedContainer();
 WTF_EXPORT_PRIVATE bool isInsideSnap();
 WTF_EXPORT_PRIVATE bool shouldUsePortal();
 
-WTF_EXPORT_PRIVATE String& sandboxedAccessibilityBusAddress();
-WTF_EXPORT_PRIVATE void setSandboxedAccessibilityBusAddress(String&&);
+WTF_EXPORT_PRIVATE const CString& sandboxedUserRuntimeDirectory();
 
 } // namespace WTF
 
@@ -38,5 +37,4 @@ using WTF::isInsideUnsupportedContainer;
 using WTF::isInsideSnap;
 using WTF::shouldUsePortal;
 
-using WTF::sandboxedAccessibilityBusAddress;
-using WTF::setSandboxedAccessibilityBusAddress;
+using WTF::sandboxedUserRuntimeDirectory;

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -189,11 +189,6 @@ PlatformDisplay::PlatformDisplay(GdkDisplay* display)
     , m_eglDisplay(EGL_NO_DISPLAY)
 {
     if (m_sharedDisplay) {
-#if USE(ATSPI) && USE(GTK4)
-        if (const char* atspiBusAddress = static_cast<const char*>(g_object_get_data(G_OBJECT(m_sharedDisplay.get()), "-gtk-atspi-bus-address")))
-            m_accessibilityBusAddress = String::fromUTF8(atspiBusAddress);
-#endif
-
         g_signal_connect(m_sharedDisplay.get(), "closed", G_CALLBACK(+[](GdkDisplay*, gboolean, gpointer userData) {
             auto& platformDisplay = *static_cast<PlatformDisplay*>(userData);
             platformDisplay.sharedDisplayDidClose();
@@ -450,46 +445,16 @@ const Vector<PlatformDisplay::DMABufFormat>& PlatformDisplay::dmabufFormats()
 #endif // USE(GBM)
 
 #if USE(ATSPI)
-const String& PlatformDisplay::accessibilityBusAddress() const
+String PlatformDisplay::accessibilityBusAddress() const
 {
-    if (m_accessibilityBusAddress)
-        return m_accessibilityBusAddress.value();
-
-    const char* address = g_getenv("AT_SPI_BUS_ADDRESS");
-    if (address && *address) {
-        m_accessibilityBusAddress = String::fromUTF8(address);
-        return m_accessibilityBusAddress.value();
+#if USE(GTK4)
+    if (m_sharedDisplay) {
+        if (const char* atspiBusAddress = static_cast<const char*>(g_object_get_data(G_OBJECT(m_sharedDisplay.get()), "-gtk-atspi-bus-address")))
+            return String::fromUTF8(atspiBusAddress);
     }
+#endif
 
-    auto platformAddress = platformAccessibilityBusAddress();
-    if (!platformAddress.isEmpty()) {
-        m_accessibilityBusAddress = platformAddress;
-        return m_accessibilityBusAddress.value();
-    }
-
-    GRefPtr<GDBusConnection> sessionBus = adoptGRef(g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr));
-    if (sessionBus.get()) {
-        GRefPtr<GDBusMessage> message = adoptGRef(g_dbus_message_new_method_call("org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus", "GetAddress"));
-        g_dbus_message_set_body(message.get(), g_variant_new("()"));
-        GRefPtr<GDBusMessage> reply = adoptGRef(g_dbus_connection_send_message_with_reply_sync(sessionBus.get(), message.get(),
-            G_DBUS_SEND_MESSAGE_FLAGS_NONE, 30000, nullptr, nullptr, nullptr));
-        if (reply) {
-            GUniqueOutPtr<GError> error;
-            if (g_dbus_message_to_gerror(reply.get(), &error.outPtr())) {
-                if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))
-                    WTFLogAlways("Can't find a11y bus: %s", error->message);
-            } else {
-                GUniqueOutPtr<char> a11yAddress;
-                g_variant_get(g_dbus_message_get_body(reply.get()), "(s)", &a11yAddress.outPtr());
-                m_accessibilityBusAddress = String::fromUTF8(a11yAddress.get());
-                return m_accessibilityBusAddress.value();
-            }
-        }
-    }
-
-    WTFLogAlways("Could not determine the accessibility bus address");
-    m_accessibilityBusAddress = String();
-    return m_accessibilityBusAddress.value();
+    return { };
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -138,7 +138,7 @@ public:
 #endif
 
 #if USE(ATSPI)
-    const String& accessibilityBusAddress() const;
+    virtual String accessibilityBusAddress() const;
 #endif
 
 protected:
@@ -162,12 +162,6 @@ protected:
 #if ENABLE(WEBGL) && !PLATFORM(WIN)
     std::optional<int> m_anglePlatform;
     void* m_angleNativeDisplay { nullptr };
-#endif
-
-#if USE(ATSPI)
-    virtual String platformAccessibilityBusAddress() const { return { }; }
-
-    mutable std::optional<String> m_accessibilityBusAddress;
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
@@ -145,8 +145,12 @@ void PlatformDisplayX11::initializeEGLDisplay()
 }
 
 #if USE(ATSPI)
-String PlatformDisplayX11::platformAccessibilityBusAddress() const
+String PlatformDisplayX11::accessibilityBusAddress() const
 {
+    auto address = PlatformDisplay::accessibilityBusAddress();
+    if (!address.isEmpty())
+        return address;
+
     Atom atspiBusAtom = XInternAtom(m_display, "AT_SPI_BUS", False);
     Atom type;
     int format;

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
@@ -61,7 +61,7 @@ private:
     void initializeEGLDisplay() override;
 
 #if USE(ATSPI)
-    String platformAccessibilityBusAddress() const override;
+    String accessibilityBusAddress() const override;
 #endif
 
     ::Display* m_display { nullptr };

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if ENABLE(BUBBLEWRAP_SANDBOX)
+#include "ProcessLauncher.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -43,16 +44,20 @@ public:
 
     enum class AllowPortals : bool { No, Yes };
     std::optional<CString> dbusSessionProxy(const char* baseDirectory, AllowPortals);
-    std::optional<CString> accessibilityProxy(const char* baseDirectory, const char* sandboxedAccessibilityBusPath);
+#if USE(ATSPI)
+    std::optional<CString> accessibilityProxy(const char* baseDirectory, const String& sandboxedAccessibilityBusPath);
+#endif
 
-    bool launch();
+    bool launch(const ProcessLauncher::LaunchOptions&);
 
 private:
     static CString makeProxy(const char* baseDirectory, const char* proxyTemplate);
 
     Vector<CString> m_args;
     CString m_dbusSessionProxyPath;
+#if USE(ATSPI)
     CString m_accessibilityProxyPath;
+#endif
     UnixFileDescriptor m_syncFD;
 };
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -510,6 +510,11 @@ public:
 
     void setUserMessageHandler(Function<void(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&)>&& handler) { m_userMessageHandler = WTFMove(handler); }
     const Function<void(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&)>& userMessageHandler() const { return m_userMessageHandler; }
+
+#if USE(ATSPI)
+    const String& accessibilityBusAddress() const;
+    const String& sandboxedAccessibilityBusAddress() const;
+#endif
 #endif
 
     WebProcessWithAudibleMediaToken webProcessWithAudibleMediaToken() const;
@@ -835,6 +840,11 @@ private:
     HashMap<CString, SandboxPermission> m_extraSandboxPaths;
 
     Function<void(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&)> m_userMessageHandler;
+
+#if USE(ATSPI)
+    mutable std::optional<String> m_accessibilityBusAddress;
+    String m_sandboxedAccessibilityBusAddress;
+#endif
 #endif
 
     WebProcessWithAudibleMediaCounter m_webProcessWithAudibleMediaCounter;

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -35,6 +35,7 @@
 #include "WebProcessCreationParameters.h"
 #include <WebCore/PlatformDisplay.h>
 #include <wtf/FileSystem.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/glib/Application.h>
 #include <wtf/glib/Sandbox.h>
 
@@ -154,18 +155,11 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if USE(ATSPI)
-    parameters.accessibilityBusAddress = [this] {
-        if (auto* address = getenv("WEBKIT_A11Y_BUS_ADDRESS"))
-            return String::fromUTF8(address);
-
-        if (m_sandboxEnabled) {
-            String& address = sandboxedAccessibilityBusAddress();
-            if (!address.isNull())
-                return address;
-        }
-
-        return WebCore::PlatformDisplay::sharedDisplay().accessibilityBusAddress();
-    }();
+    static const char* address = getenv("WEBKIT_A11Y_BUS_ADDRESS");
+    if (address)
+        parameters.accessibilityBusAddress = String::fromUTF8(address);
+    else
+        parameters.accessibilityBusAddress = m_sandboxEnabled ? sandboxedAccessibilityBusAddress() : accessibilityBusAddress();
 #endif
 
 #if PLATFORM(GTK)
@@ -200,6 +194,9 @@ void WebProcessPool::setSandboxEnabled(bool enabled)
         }
 #endif
         m_sandboxEnabled = false;
+#if USE(ATSPI)
+        m_sandboxedAccessibilityBusAddress = String();
+#endif
         return;
     }
 
@@ -214,6 +211,68 @@ void WebProcessPool::setSandboxEnabled(bool enabled)
     }
 
     m_sandboxEnabled = true;
+#if USE(ATSPI)
+    m_sandboxedAccessibilityBusAddress = makeString("unix:path="_s, FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(sandboxedUserRuntimeDirectory().data()), "at-spi-bus"_s));
+#endif
 }
+
+#if USE(ATSPI)
+static const String& queryAccessibilityBusAddress()
+{
+    static LazyNeverDestroyed<String> address;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+        GRefPtr<GDBusConnection> sessionBus = adoptGRef(g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr));
+        if (sessionBus.get()) {
+            GRefPtr<GDBusMessage> message = adoptGRef(g_dbus_message_new_method_call("org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus", "GetAddress"));
+            g_dbus_message_set_body(message.get(), g_variant_new("()"));
+            GRefPtr<GDBusMessage> reply = adoptGRef(g_dbus_connection_send_message_with_reply_sync(sessionBus.get(), message.get(),
+                G_DBUS_SEND_MESSAGE_FLAGS_NONE, 30000, nullptr, nullptr, nullptr));
+            if (reply) {
+                GUniqueOutPtr<GError> error;
+                if (g_dbus_message_to_gerror(reply.get(), &error.outPtr())) {
+                    if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))
+                        WTFLogAlways("Can't find a11y bus: %s", error->message);
+                } else {
+                    GUniqueOutPtr<char> a11yAddress;
+                    g_variant_get(g_dbus_message_get_body(reply.get()), "(s)", &a11yAddress.outPtr());
+                    address.construct(String::fromUTF8(a11yAddress.get()));
+                    return;
+                }
+            }
+        }
+        address.construct();
+    });
+    return address.get();
+}
+
+const String& WebProcessPool::accessibilityBusAddress() const
+{
+    if (m_accessibilityBusAddress.has_value())
+        return m_accessibilityBusAddress.value();
+
+    const char* addressEnv = getenv("AT_SPI_BUS_ADDRESS");
+    if (addressEnv && *addressEnv) {
+        m_accessibilityBusAddress = String::fromUTF8(addressEnv);
+        return m_accessibilityBusAddress.value();
+    }
+
+#if PLATFORM(GTK)
+    auto address = WebCore::PlatformDisplay::sharedDisplay().accessibilityBusAddress();
+    if (!address.isEmpty()) {
+        m_accessibilityBusAddress = WTFMove(address);
+        return m_accessibilityBusAddress.value();
+    }
+#endif
+
+    m_accessibilityBusAddress = queryAccessibilityBusAddress();
+    return m_accessibilityBusAddress.value();
+}
+
+const String& WebProcessPool::sandboxedAccessibilityBusAddress() const
+{
+    return m_sandboxedAccessibilityBusAddress;
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -41,6 +41,10 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
 {
     launchOptions.extraInitializationData.set("enable-sandbox"_s, m_processPool->sandboxEnabled() ? "true"_s : "false"_s);
 
+#if USE(ATSPI)
+    launchOptions.extraInitializationData.set("accessibilityBusAddress"_s, m_processPool->accessibilityBusAddress());
+#endif
+
     if (m_processPool->sandboxEnabled()) {
         // Prewarmed processes don't have a WebsiteDataStore yet, so use the primary WebsiteDataStore from the WebProcessPool.
         // The process won't be used if current WebsiteDataStore is different than the WebProcessPool primary one.
@@ -50,6 +54,9 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
         launchOptions.extraInitializationData.set("mediaKeysDirectory"_s, dataStore->resolvedDirectories().mediaKeysStorageDirectory);
 
         launchOptions.extraSandboxPaths = m_processPool->sandboxPaths();
+#if USE(ATSPI)
+        launchOptions.extraInitializationData.set("sandboxedAccessibilityBusAddress"_s, m_processPool->sandboxedAccessibilityBusAddress());
+#endif
     }
 }
 


### PR DESCRIPTION
#### e21334567540b56505d57741166cc20796dfdb08
<pre>
[GTK][WPE] Remove common code to get the a11y bus address from PlatformDisplay
<a href="https://bugs.webkit.org/show_bug.cgi?id=278164">https://bugs.webkit.org/show_bug.cgi?id=278164</a>

Reviewed by Adrian Perez de Castro.

Keeping only the GTK platform specific code that will be moved in a
follow up. The a11y bus address is now handled by WebProcessPool, that
passes both the host and the sandboxed dbus addresses to the launcher
as extra initialization data of the launch options.

* Source/WTF/wtf/glib/Sandbox.cpp:
(WTF::sandboxedUserRuntimeDirectory):
(WTF::sandboxedAccessibilityBusAddress): Deleted.
(WTF::setSandboxedAccessibilityBusAddress): Deleted.
* Source/WTF/wtf/glib/Sandbox.h:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::PlatformDisplay):
(WebCore::PlatformDisplay::accessibilityBusAddress const):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
(WebCore::PlatformDisplay::platformAccessibilityBusAddress const): Deleted.
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::accessibilityBusAddress const):
(WebCore::PlatformDisplayX11::platformAccessibilityBusAddress const): Deleted.
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h:
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindDBusSession):
(WebKit::bindA11y):
(WebKit::bubblewrapSpawn):
(WebKit::dbusProxyDirectory): Deleted.
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::accessibilityProxy):
(WebKit::XDGDBusProxy::launch):
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::setSandboxEnabled):
(WebKit::queryAccessibilityBusAddress):
(WebKit::WebProcessPool::accessibilityBusAddress const):
(WebKit::WebProcessPool::sandboxedAccessibilityBusAddress const):
* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformGetLaunchOptions):

Canonical link: <a href="https://commits.webkit.org/282339@main">https://commits.webkit.org/282339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85467a1f583f9d1b691fc1b5ff34dbeebdaffc44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50701 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11797 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12359 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55989 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68594 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62122 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5697 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83885 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9471 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38055 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14761 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40246 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->