### PR TITLE
[GTK][WPE] Own well-known bus name on a11y bus

### DIFF
--- a/Source/WTF/wtf/glib/Sandbox.h
+++ b/Source/WTF/wtf/glib/Sandbox.h
@@ -28,6 +28,7 @@ WTF_EXPORT_PRIVATE bool isInsideUnsupportedContainer();
 WTF_EXPORT_PRIVATE bool isInsideSnap();
 WTF_EXPORT_PRIVATE bool shouldUseBubblewrap();
 WTF_EXPORT_PRIVATE bool shouldUsePortal();
+WTF_EXPORT_PRIVATE bool checkFlatpakPortalVersion(int);
 
 WTF_EXPORT_PRIVATE const CString& sandboxedUserRuntimeDirectory();
 
@@ -38,5 +39,6 @@ using WTF::isInsideUnsupportedContainer;
 using WTF::isInsideSnap;
 using WTF::shouldUseBubblewrap;
 using WTF::shouldUsePortal;
+using WTF::checkFlatpakPortalVersion;
 
 using WTF::sandboxedUserRuntimeDirectory;

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -48,7 +48,7 @@ class AccessibilityAtspi {
 public:
     WEBCORE_EXPORT static AccessibilityAtspi& singleton();
 
-    void connect(const String&);
+    void connect(const String&, const String&);
 
     const char* uniqueName() const;
     GVariant* nullReference() const;
@@ -101,6 +101,7 @@ private:
     };
 
     void didConnect(GRefPtr<GDBusConnection>&&);
+    void didOwnName();
     void initializeRegistry();
     void addEventListener(const char* dbusName, const char* eventName);
     void removeEventListener(const char* dbusName, const char* eventName);
@@ -128,6 +129,7 @@ private:
 
     static GDBusInterfaceVTable s_cacheFunctions;
 
+    String m_busName;
     bool m_isConnecting { false };
     GRefPtr<GDBusConnection> m_connection;
     GRefPtr<GDBusProxy> m_registry;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -267,6 +267,7 @@ struct WebProcessCreationParameters {
 
 #if USE(ATSPI)
     String accessibilityBusAddress;
+    String accessibilityBusName;
 #endif
 
     String timeZoneOverride;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -217,6 +217,7 @@
 
 #if USE(ATSPI)
     String accessibilityBusAddress;
+    String accessibilityBusName;
 #endif
 
     String timeZoneOverride;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3463,7 +3463,13 @@ void webkitWebViewBaseSetPlugID(WebKitWebViewBase* webViewBase, const String& pl
     RELEASE_ASSERT(tokens.size() == 2);
 
     GUniqueOutPtr<GError> error;
-    GUniquePtr<char> busName(g_strdup_printf(":%s", tokens[0].utf8().data()));
+
+    auto plugBusName = tokens[0].utf8();
+    RELEASE_ASSERT(g_dbus_is_name(plugBusName.data()));
+
+    auto* busNamePrefix = !g_dbus_is_unique_name(plugBusName.data()) ? "" : ":";
+
+    GUniquePtr<char> busName(g_strdup_printf("%s%s", busNamePrefix, plugBusName.data()));
 
     priv->socketAccessible = adoptGRef(gtk_at_spi_socket_new(busName.get(), tokens[1].utf8().data(), &error.outPtr()));
 

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -354,9 +354,9 @@ static void bindGtkData(Vector<CString>& args)
 #endif
 
 #if USE(ATSPI)
-static void bindA11y(Vector<CString>& args, XDGDBusProxy& dbusProxy, const String& accessibilityBusAddress, const String& sandboxedAccessibilityBusAddress)
+static void bindA11y(Vector<CString>& args, XDGDBusProxy& dbusProxy, const String& accessibilityBusAddress, const String& accessibilityBusName, const String& sandboxedAccessibilityBusAddress)
 {
-    auto accessibilityProxyPath = dbusProxy.accessibilityProxy(BASE_DIRECTORY, accessibilityBusAddress);
+    auto accessibilityProxyPath = dbusProxy.accessibilityProxy(BASE_DIRECTORY, accessibilityBusAddress, accessibilityBusName);
     if (!accessibilityProxyPath)
         return;
 
@@ -727,7 +727,7 @@ static void addExtraPaths(const HashMap<CString, SandboxPermission>& paths, Vect
     }
 }
 
-GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const ProcessLauncher::LaunchOptions& launchOptions, char** argv, GError **error)
+GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const ProcessLauncher::LaunchOptions& launchOptions, XDGDBusProxy& dbusProxy, char** argv, GError **error)
 {
     ASSERT(launcher);
 
@@ -885,9 +885,7 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
                 sandboxArgs.appendVector(Vector<CString>({ "--bind-try", extraPath.utf8(), extraPath.utf8() }));
         }
 
-        static std::unique_ptr<XDGDBusProxy> dbusProxy = makeUnique<XDGDBusProxy>();
-        if (dbusProxy)
-            bindDBusSession(sandboxArgs, *dbusProxy, flatpakInfoFd != -1);
+        bindDBusSession(sandboxArgs, dbusProxy, flatpakInfoFd != -1);
         // FIXME: We should move to Pipewire as soon as viable, Pulse doesn't restrict clients atm.
         bindPulse(sandboxArgs);
         bindSndio(sandboxArgs);
@@ -897,18 +895,17 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
         // FIXME: This is also fixed by Pipewire once in use.
         bindV4l(sandboxArgs);
 #if USE(ATSPI)
-        if (dbusProxy) {
-            auto accessibilityBusAddress = launchOptions.extraInitializationData.get("accessibilityBusAddress"_s);
-            auto sandboxedAccessibilityBusAddress = launchOptions.extraInitializationData.get("sandboxedAccessibilityBusAddress"_s);
-            if (!accessibilityBusAddress.isEmpty() && !sandboxedAccessibilityBusAddress.isEmpty())
-                bindA11y(sandboxArgs, *dbusProxy, accessibilityBusAddress, sandboxedAccessibilityBusAddress);
+        auto accessibilityBusAddress = launchOptions.extraInitializationData.get("accessibilityBusAddress"_s);
+        auto sandboxedAccessibilityBusAddress = launchOptions.extraInitializationData.get("sandboxedAccessibilityBusAddress"_s);
+        if (!accessibilityBusAddress.isEmpty() && !sandboxedAccessibilityBusAddress.isEmpty()) {
+            auto a11yBusName = launchOptions.extraInitializationData.get<HashTranslatorASCIILiteral>("accessibilityBusName"_s);
+            bindA11y(sandboxArgs, dbusProxy, accessibilityBusAddress, a11yBusName, sandboxedAccessibilityBusAddress);
         }
 #endif
 #if PLATFORM(GTK)
         bindGtkData(sandboxArgs);
 #endif
-        if (dbusProxy && !dbusProxy->launch(launchOptions))
-            dbusProxy = nullptr;
+        dbusProxy.launch(launchOptions);
     } else {
         // Only X11 users need this for XShm which is only the Web process.
         sandboxArgs.append("--unshare-ipc");

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.h
@@ -36,7 +36,7 @@ typedef struct _GSubprocessLauncher GSubprocessLauncher;
 
 namespace WebKit {
 
-GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher*, const ProcessLauncher::LaunchOptions&, char** argv, GError**);
+GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher*, const ProcessLauncher::LaunchOptions&, XDGDBusProxy&, char** argv, GError**);
 int argumentsToFileDescriptor(const Vector<CString>&, const char*);
 
 };

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -235,7 +235,7 @@ void ProcessLauncher::launchProcess()
     // You cannot use bubblewrap within Flatpak or some containers so lets ensure it never happens.
     // Snap can allow it but has its own limitations that require workarounds.
     else if (sandboxEnabled && shouldUseBubblewrap())
-        process = bubblewrapSpawn(launcher.get(), m_launchOptions, argv, &error.outPtr());
+        process = bubblewrapSpawn(launcher.get(), m_launchOptions, m_dbusProxy, argv, &error.outPtr());
 #endif // ENABLE(BUBBLEWRAP_SANDBOX)
     else
 #endif // OS(LINUX)

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #if ENABLE(BUBBLEWRAP_SANDBOX)
-#include "ProcessLauncher.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -34,6 +33,8 @@
 #include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebKit {
+
+struct ProcessLaunchOptions;
 
 class XDGDBusProxy {
     WTF_MAKE_TZONE_ALLOCATED(XDGDBusProxy);
@@ -45,10 +46,10 @@ public:
     enum class AllowPortals : bool { No, Yes };
     std::optional<CString> dbusSessionProxy(const char* baseDirectory, AllowPortals);
 #if USE(ATSPI)
-    std::optional<CString> accessibilityProxy(const char* baseDirectory, const String& sandboxedAccessibilityBusPath);
+    std::optional<CString> accessibilityProxy(const char* baseDirectory, const String& sandboxedAccessibilityBusPath, const String& accessibilityBusName);
 #endif
 
-    bool launch(const ProcessLauncher::LaunchOptions&);
+    void launch(const ProcessLaunchOptions&);
 
 private:
     static CString makeProxy(const char* baseDirectory, const char* proxyTemplate);

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -522,7 +522,10 @@ public:
 
 #if USE(ATSPI)
     const String& accessibilityBusAddress() const;
+    const String& accessibilityBusName() const;
     const String& sandboxedAccessibilityBusAddress() const;
+
+    const String& generateNextAccessibilityBusName();
 #endif
 #endif
 
@@ -873,6 +876,7 @@ private:
 
 #if USE(ATSPI)
     mutable std::optional<String> m_accessibilityBusAddress;
+    mutable std::optional<String> m_accessibilityBusName;
     String m_sandboxedAccessibilityBusAddress;
 #endif
 #endif

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -44,6 +44,7 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
 
 #if USE(ATSPI)
     launchOptions.extraInitializationData.set("accessibilityBusAddress"_s, m_processPool->accessibilityBusAddress());
+    launchOptions.extraInitializationData.set("accessibilityBusName"_s, m_processPool->generateNextAccessibilityBusName());
 #endif
 
     if (m_processPool->sandboxEnabled()) {

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -56,8 +56,7 @@ GtkWidget* WebPageProxy::viewWidget()
 void WebPageProxy::bindAccessibilityTree(const String& plugID)
 {
 #if USE(GTK4)
-    // FIXME(273245): Make a11y work under Flatpak.
-    if (!isInsideFlatpak())
+    if (!isInsideFlatpak() || checkFlatpakPortalVersion(7))
         webkitWebViewBaseSetPlugID(WEBKIT_WEB_VIEW_BASE(viewWidget()), plugID);
 #else
     auto* accessible = gtk_widget_get_accessible(viewWidget());

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -225,7 +225,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #endif
 
 #if USE(ATSPI)
-    AccessibilityAtspi::singleton().connect(parameters.accessibilityBusAddress);
+    AccessibilityAtspi::singleton().connect(parameters.accessibilityBusAddress, parameters.accessibilityBusName);
 #endif
 
     if (parameters.disableFontHintingForTesting)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2557,7 +2557,7 @@ def check_namespace_indentation(clean_lines, line_number, file_extension, file_s
 _ALLOW_ALL_UPPERCASE_ENUM = ['JSTokenType']
 
 # Enum value allowlist
-_ALLOW_ABBREVIATION_ENUM_VALUES = ['AM', 'CF', 'PM', 'URL', 'XHR']
+_ALLOW_ABBREVIATION_ENUM_VALUES = ['AM', 'CF', 'GPU', 'PM', 'URL', 'XHR']
 
 def check_enum_casing(clean_lines, line_number, enum_state, error):
     """Looks for incorrectly named enum values.


### PR DESCRIPTION
#### 3672c423722b5f0b07fcb7962ee268f278c908ff
<pre>
[GTK][WPE] Own well-known bus name on a11y bus
<a href="https://bugs.webkit.org/show_bug.cgi?id=273245">https://bugs.webkit.org/show_bug.cgi?id=273245</a>

Reviewed by Michael Catanzaro.

Currently WebKit on Linux is not accesible when running under Flatpak,
because the Web process and the UI process cannot communicate across
sandbox boundaries and connect their a11y trees.

Fundamentally, the problem is that Flatpak creates a separate sandbox
for the Web process, but doesn&apos;t let the UI process sandbox talk to it.
It cannot, after all - Flatpak cannot know ahead of time which D-Bus
name the Web process sandboxes will end up having!

One way to circumvent this in a well tested manner, is to use well-known
names to identify the Web process in the a11y bus. The idea is that the
UI process will talk to a bus name that Flatpak can verify at runtime,
e.g. org.gnome.Epiphany.Sandboxed.WebProcess-UUID, instead of an opaque
unique name (e.g. :1.321).

This is possible on Flatpak as per portal version 7, which introduces
the necessary plumbing for the a11y bus ownership to pass through.

The Bubblewrap code path does the same, it lets the Web process own
the specific a11y bus name assigned from the UI process. To do that,
change XDGDBusProxy to spawn once for each Web process, instead of
once for all Web processes.

See <a href="https://github.com/flatpak/flatpak/pull/5898">https://github.com/flatpak/flatpak/pull/5898</a>
See <a href="https://github.com/flatpak/flatpak-xdg-utils/pull/67">https://github.com/flatpak/flatpak-xdg-utils/pull/67</a>

* Source/WTF/wtf/glib/Sandbox.cpp:
(WTF::checkFlatpakPortalVersion):
(WTF::sandboxedAccessibilityBusName):
(WTF::setSandboxedAccessibilityBusName):
* Source/WTF/wtf/glib/Sandbox.h:
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
(WebCore::AccessibilityAtspi::connect):
(WebCore::AccessibilityAtspi::didConnect):
(WebCore::AccessibilityAtspi::didOwnName):
(WebCore::AccessibilityAtspi::registerRoot):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.h:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseSetPlugID):
* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp:
(WebKit::flatpakSpawn):
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::accessibilityProxy):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::bindAccessibilityTree):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/284894@main">https://commits.webkit.org/284894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d477821efd4a7bbed27b42a5a5634962987e029

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21865 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/56064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36518 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/70353 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18511 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20386 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/63966 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/70093 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18072 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63751 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5478 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91874 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46055 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/826 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/20023 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47127 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->