### PR TITLE
Use double-backticks in Web Extension Headers docs for symbols and methods.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
@@ -37,11 +37,11 @@
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract Indicates a @link WKWebExtension @/link error. */
+/*! @abstract Indicates a ``WKWebExtension`` error. */
 WK_EXTERN NSErrorDomain const WKWebExtensionErrorDomain NS_SWIFT_NAME(WKWebExtension.ErrorDomain) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by NSError to indicate errors in the @link WKWebExtension @/link domain.
+ @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtension`` domain.
  @constant WKWebExtensionErrorUnknown  Indicates that an unknown error occurred.
  @constant WKWebExtensionErrorResourceNotFound  Indicates that a specified resource was not found on disk.
  @constant WKWebExtensionErrorInvalidResourceCodeSignature  Indicates that a resource failed the bundle's code signature checks.
@@ -62,12 +62,12 @@ typedef NS_ERROR_ENUM(WKWebExtensionErrorDomain, WKWebExtensionError) {
     WKWebExtensionErrorInvalidBackgroundPersistence,
 } NS_SWIFT_NAME(WKWebExtension.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-/*! @abstract This notification is sent whenever a @link WKWebExtension @/link has new errors or errors were cleared. */
+/*! @abstract This notification is sent whenever a ``WKWebExtension`` has new errors or errors were cleared. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionErrorsWereUpdatedNotification NS_SWIFT_NAME(WKWebExtension.errorsWereUpdatedNotification);
 
 /*!
- @abstract A `WKWebExtension` object encapsulates a web extension’s resources that are defined by a `manifest.json` file.
+ @abstract A ``WKWebExtension`` object encapsulates a web extension’s resources that are defined by a `manifest.json`` file.
  @discussion This class handles the reading and parsing of the manifest file along with the supporting resources like icons and localizations.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
@@ -101,7 +101,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*!
  @abstract The parsed manifest version, or `0` if there is no version specified in the manifest.
- @note An `WKWebExtensionErrorUnsupportedManifestVersion` error will be reported if the manifest version isn't specified.
+ @note An ``WKWebExtensionErrorUnsupportedManifestVersion`` error will be reported if the manifest version isn't specified.
  */
 @property (nonatomic, readonly) double manifestVersion;
 
@@ -130,7 +130,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract The default localized extension action label. Returns `nil` if there was no default action label specified.
  @discussion This label serves as a default and should be used to represent the extension in contexts like action sheets or toolbars prior to
- the extension being loaded into an extension context. Once the extension is loaded, use the `actionForTab:` API to get the tab-specific label.
+ the extension being loaded into an extension context. Once the extension is loaded, use the ``actionForTab:`` API to get the tab-specific label.
  */
 @property (nonatomic, nullable, readonly, copy) NSString *displayActionLabel;
 
@@ -156,7 +156,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param size The size to use when looking up the action icon.
  @result The action icon, or `nil` if the icon was unable to be loaded.
  @discussion This icon serves as a default and should be used to represent the extension in contexts like action sheets or toolbars prior to
- the extension being loaded into an extension context. Once the extension is loaded, use the `actionForTab:` API to get the tab-specific icon.
+ the extension being loaded into an extension context. Once the extension is loaded, use the ``actionForTab:`` API to get the tab-specific icon.
  The returned image will be the best match for the specified size that is available in the extension's action icon set. If no matching icon is available,
  the method will fall back to the extension's icon.
  @seealso iconForSize:
@@ -190,7 +190,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*!
  @abstract A Boolean value indicating whether the extension has background content that stays in memory as long as the extension is loaded.
- @note Note that extensions are only allowed to have persistent background content on macOS. An `WKWebExtensionErrorInvalidBackgroundPersistence`
+ @note Note that extensions are only allowed to have persistent background content on macOS. An ``WKWebExtensionErrorInvalidBackgroundPersistence``
  error will be reported on iOS, iPadOS, and visionOS if an attempt is made to load a persistent extension.
  */
 @property (nonatomic, readonly) BOOL hasPersistentBackgroundContent;
@@ -198,28 +198,28 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract A Boolean value indicating whether the extension has script or stylesheet content that can be injected into webpages.
  @discussion If this property is `YES`, the extension has content that can be injected by matching against the extension's requested match patterns.
- @note Once the extension is loaded, use the `hasInjectedContent` property on the extension context, as the injectable content can change after the extension is loaded.
+ @note Once the extension is loaded, use the ``hasInjectedContent`` property on the extension context, as the injectable content can change after the extension is loaded.
  */
 @property (nonatomic, readonly) BOOL hasInjectedContent;
 
 /*!
  @abstract A Boolean value indicating whether the extension has an options page.
  @discussion If this property is `YES`, the extension includes a dedicated options page where users can customize settings.
- The app should provide access to this page through a user interface element, which can be accessed via `optionsPageURL` on an extension context.
+ The app should provide access to this page through a user interface element, which can be accessed via ``optionsPageURL`` on an extension context.
  */
 @property (nonatomic, readonly) BOOL hasOptionsPage;
 
 /*!
  @abstract A Boolean value indicating whether the extension provides an alternative to the default new tab page.
  @discussion If this property is `YES`, the extension can specify a custom page that can be displayed when a new tab is opened in the app, instead of the default new tab page.
- The app should prompt the user for permission to use the extension's new tab page as the default, which can be accessed via `overrideNewTabPageURL` on an extension context.
+ The app should prompt the user for permission to use the extension's new tab page as the default, which can be accessed via ``overrideNewTabPageURL`` on an extension context.
  */
 @property (nonatomic, readonly) BOOL hasOverrideNewTabPage;
 
 /*!
  @abstract A Boolean value indicating whether the extension includes commands that users can invoke.
  @discussion If this property is `YES`, the extension contains one or more commands that can be performed by the user. These commands should be accessible via keyboard shortcuts,
- menu items, or other user interface elements provided by the app. The list of commands can be accessed via `commands` on an extension context, and invoked via `performCommand:`.
+ menu items, or other user interface elements provided by the app. The list of commands can be accessed via ``commands`` on an extension context, and invoked via ``performCommand:``.
  */
 @property (nonatomic, readonly) BOOL hasCommands;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h
@@ -47,7 +47,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionActionPropertiesDidChangeNotification NS_SWIFT_NAME(WKWebExtensionAction.propertiesDidChangeNotification);
 
 /*!
- @abstract A `WKWebExtensionAction` object encapsulates the properties for an individual web extension action.
+ @abstract A ``WKWebExtensionAction`` object encapsulates the properties for an individual web extension action.
  @discussion Provides access to action properties such as popup, icon, and title, with tab-specific values.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -90,7 +90,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Action)
 
 /*!
  @abstract A Boolean value indicating whether the badge text is unread.
- @discussion This property is automatically set to `YES` when `badgeText` changes and is not empty. If `badgeText` becomes empty or the
+ @discussion This property is automatically set to `YES` when ``badgeText`` changes and is not empty. If ``badgeText`` becomes empty or the
  popup associated with the action is presented, this property is automatically set to `NO`. Additionally, it should be set to `NO` by the app when the badge
  has been presented to the user. This property is useful for higher-level notification badges when extensions might be hidden behind an action sheet.
  */
@@ -128,8 +128,8 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Action)
 /*!
  @abstract A view controller that presents a web view loaded with the popup page for this action, or `nil` if no popup is specified.
  @discussion The view controller adaptively adjusts its presentation style based on where it is presented from, preferring popover.
- It contains a web view preloaded with the popup page and automatically adjusts tis `preferredContentSize` to fit the web view's
- content size. The `presentsPopup` property should be checked to determine the availability of a popup before using this property.
+ It contains a web view preloaded with the popup page and automatically adjusts its ``preferredContentSize`` to fit the web view's
+ content size. The ``presentsPopup`` property should be checked to determine the availability of a popup before using this property.
  Dismissing the view controller will close the popup and unload the web view.
  @seealso presentsPopup
  */
@@ -140,7 +140,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Action)
 /*!
  @abstract A popover that presents a web view loaded with the popup page for this action, or `nil` if no popup is specified.
  @discussion This popover contains a view controller with a web view preloaded with the popup page. It automatically adjusts its size to fit
- the web view's content size. The `presentsPopup` property should be checked to determine the availability of a popup before using this
+ the web view's content size. The ``presentsPopup`` property should be checked to determine the availability of a popup before using this
  property.  Dismissing the popover will close the popup and unload the web view.
  @seealso presentsPopup
  */
@@ -149,7 +149,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Action)
 
 /*!
  @abstract A web view loaded with the popup page for this action, or `nil` if no popup is specified.
- @discussion The web view will be preloaded with the popup page upon first access or after it has been unloaded. Use the `presentsPopup`
+ @discussion The web view will be preloaded with the popup page upon first access or after it has been unloaded. Use the ``presentsPopup``
  property to determine whether a popup should be displayed before using this property.
  @seealso presentsPopup
  */
@@ -158,7 +158,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Action)
 /*!
  @abstract Triggers the dismissal process of the popup.
  @discussion Invoke this method to manage the popup's lifecycle, ensuring the web view is unloaded and resources are released once the
- popup closes. This method is automatically called upon the dismissal of the action's `UIViewController` or `NSPopover`.  For custom
+ popup closes. This method is automatically called upon the dismissal of the action's ``UIViewController`` or ``NSPopover``.  For custom
  scenarios where the popup's lifecycle is manually managed, it must be explicitly invoked to ensure proper closure.
  */
 - (void)closePopup;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.h
@@ -35,7 +35,7 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract A `WKWebExtensionCommand` object encapsulates the properties for an individual web extension command.
+ @abstract A ``WKWebExtensionCommand`` object encapsulates the properties for an individual web extension command.
  @discussion Provides access to command properties such as a unique identifier, a descriptive title, and shortcut keys. Commands
  can be used by a web extension to perform specific actions within a web extension context, such toggling features, or interacting with
  web content. These commands enhance the functionality of the extension by allowing users to invoke actions quickly.
@@ -93,9 +93,9 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Command)
 #if TARGET_OS_IPHONE
 /*!
  @abstract A key command representation of the web extension command for use in the responder chain.
- @discussion Provides a `UIKeyCommand` instance representing the web extension command, ready for integration in the app.
+ @discussion Provides a ``UIKeyCommand`` instance representing the web extension command, ready for integration in the app.
  The property is `nil` if no shortcut is defined. Otherwise, the key command is fully configured with the necessary input key and modifier flags
- to perform the associated command upon activation. It can be included in a view controller or other responder's `keyCommands` property, enabling
+ to perform the associated command upon activation. It can be included in a view controller or other responder's ``keyCommands`` property, enabling
  keyboard activation and discoverability of the web extension command.
  */
 @property (nonatomic, readonly, copy, nullable) UIKeyCommand *keyCommand;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandPrivate.h
@@ -29,8 +29,8 @@
 
 /*!
  @abstract Represents the shortcut for the web extension, formatted according to web extension specification.
- @discussion Provides a string representation of the shortcut, incorporating any customizations made to the `activationKey`
- and `modifierFlags` properties. It will be empty if no shortcut is defined for the command.
+ @discussion Provides a string representation of the shortcut, incorporating any customizations made to the ``activationKey``
+ and ``modifierFlags`` properties. It will be empty if no shortcut is defined for the command.
  */
 @property (nonatomic, readonly, copy) NSString *_shortcut;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
@@ -46,14 +46,14 @@
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract Indicates a @link WKWebExtensionContext @/link error. */
+/*! @abstract Indicates a ``WKWebExtensionContext`` error. */
 WK_EXTERN NSErrorDomain const WKWebExtensionContextErrorDomain NS_SWIFT_NAME(WKWebExtensionContext.ErrorDomain) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by NSError to indicate errors in the @link WKWebExtensionContext @/link domain.
+ @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionContext`` domain.
  @constant WKWebExtensionContextErrorUnknown  Indicates that an unknown error occurred.
- @constant WKWebExtensionContextErrorAlreadyLoaded  Indicates that the context is already loaded by a @link WKWebExtensionController @/link.
- @constant WKWebExtensionContextErrorNotLoaded  Indicates that the context is not loaded by a @link WKWebExtensionController @/link.
+ @constant WKWebExtensionContextErrorAlreadyLoaded  Indicates that the context is already loaded by a ``WKWebExtensionController``.
+ @constant WKWebExtensionContextErrorNotLoaded  Indicates that the context is not loaded by a ``WKWebExtensionController``.
  @constant WKWebExtensionContextErrorBaseURLAlreadyInUse  Indicates that another context is already using the specified base URL.
  @constant WKWebExtensionContextErrorNoBackgroundContent  Indicates that the extension does not have background content.
  @constant WKWebExtensionContextErrorBackgroundContentFailedToLoad  Indicates that an error occurred loading the background content.
@@ -68,7 +68,7 @@ typedef NS_ERROR_ENUM(WKWebExtensionContextErrorDomain, WKWebExtensionContextErr
 } NS_SWIFT_NAME(WKWebExtensionContext.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used to indicate permission status in @link WKWebExtensionContext @/link.
+ @abstract Constants used to indicate permission status in ``WKWebExtensionContext``.
  @constant WKWebExtensionContextPermissionStatusDeniedExplicitly  Indicates that the permission was explicitly denied.
  @constant WKWebExtensionContextPermissionStatusDeniedImplicitly  Indicates that the permission was implicitly denied because of another explicitly denied permission.
  @constant WKWebExtensionContextPermissionStatusRequestedImplicitly  Indicates that the permission was implicitly requested because of another explicitly requested permission.
@@ -87,52 +87,52 @@ typedef NS_ENUM(NSInteger, WKWebExtensionContextPermissionStatus) {
     WKWebExtensionContextPermissionStatusGrantedExplicitly   =  3,
 } NS_SWIFT_NAME(WKWebExtensionContext.PermissionState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly granted permissions. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionsWereGrantedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionsWereGrantedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly denied permissions. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly denied permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionsWereDeniedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionsWereDeniedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed granted permissions. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextGrantedPermissionsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.grantedPermissionsWereRemovedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed denied permissions. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed denied permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextDeniedPermissionsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.deniedPermissionsWereRemovedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly granted permission match patterns. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly granted permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionMatchPatternsWereGrantedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly denied permission match patterns. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly denied permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionMatchPatternsWereDeniedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed granted permission match patterns. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed granted permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.grantedPermissionMatchPatternsWereRemovedNotification);
 
-/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed denied permission match patterns. */
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed denied permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN NSNotificationName const WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.deniedPermissionMatchPatternsWereRemovedNotification);
 
-/*! @abstract Constants for specifying @link WKWebExtensionContext @/link information in notifications. */
+/*! @abstract Constants for specifying ``WKWebExtensionContext`` information in notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 typedef NSString * WKWebExtensionContextNotificationUserInfoKey NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(WKWebExtensionContext.NotificationUserInfoKey);
 
-/*! @abstract The corresponding value represents the affected permissions in @link WKWebExtensionContext @/link notifications. */
+/*! @abstract The corresponding value represents the affected permissions in ``WKWebExtensionContext`` notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN WKWebExtensionContextNotificationUserInfoKey const WKWebExtensionContextNotificationUserInfoKeyPermissions;
 
-/*! @abstract The corresponding value represents the affected permission match patterns in @link WKWebExtensionContext @/link notifications. */
+/*! @abstract The corresponding value represents the affected permission match patterns in ``WKWebExtensionContext`` notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN WKWebExtensionContextNotificationUserInfoKey const WKWebExtensionContextNotificationUserInfoKeyMatchPatterns;
 
 /*!
- @abstract A `WKWebExtensionContext` object represents the runtime environment for a web extension.
+ @abstract A ``WKWebExtensionContext`` object represents the runtime environment for a web extension.
  @discussion This class provides methods for managing the extension's permissions, allowing it to inject content, run
  background logic, show popovers, and display other web-based UI to the user.
  */
@@ -170,7 +170,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @abstract The base URL the context uses for loading extension resources or injecting content into webpages.
  @discussion The default value is a unique URL using the `webkit-extension` scheme.
  The base URL can be set to any URL, but only the scheme and host will be used. The scheme cannot be a scheme that is
- already supported by @link WKWebView @/link (e.g. http, https, etc.) Setting is only allowed when the context is not loaded.
+ already supported by ``WKWebView`` (e.g. http, https, etc.) Setting is only allowed when the context is not loaded.
  */
 @property (nonatomic, copy) NSURL *baseURL;
 
@@ -183,8 +183,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 @property (nonatomic, copy) NSString *uniqueIdentifier;
 
 /*!
- @abstract Determines whether Web Inspector can inspect the @link WKWebView @/link instances for this context.
- @discussion A context can control multiple `WKWebView` instances, from the background content, to the popover.
+ @abstract Determines whether Web Inspector can inspect the ``WKWebView`` instances for this context.
+ @discussion A context can control multiple ``WKWebView`` instances, from the background content, to the popover.
  You should set this to `YES` when needed for debugging purposes. The default value is `NO`.
 */
 @property (nonatomic, getter=isInspectable) BOOL inspectable;
@@ -293,8 +293,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion If this property is `YES`, the extension is granted permission to interact with private windows, tabs, and cookies. Access to private data
  should be explicitly allowed by the user before setting this property. This value should be saved and restored as needed by the app.
  @note To ensure proper isolation between private and non-private data, web views associated with private data must use a
- different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
- website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
+ different ``WKUserContentController``. Likewise, to be identified as a private web view and to ensure that cookies and other
+ website data is not shared, private web views must be configured to use a non-persistent ``WKWebsiteDataStore``.
  */
 @property (nonatomic) BOOL hasAccessToPrivateData;
 
@@ -360,7 +360,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*!
  @abstract A Boolean value indicating if the currently granted permission match patterns set contains the `<all_urls>` pattern.
- @discussion This does not check for any `*` host patterns. In most cases you should use the broader `hasAccessToAllHosts`.
+ @discussion This does not check for any `*` host patterns. In most cases you should use the broader ``hasAccessToAllHosts``.
  @seealso currentPermissionMatchPatterns
  @seealso hasAccessToAllHosts
  */
@@ -383,7 +383,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.
  @param url The webpage URL to check.
- @result Returns `YES` if the extension has content that can be injected by matching the `url` against the extension's requested match patterns.
+ @result Returns `YES` if the extension has content that can be injected by matching the URL against the extension's requested match patterns.
  @discussion The extension context will still need to be loaded and have granted website permissions for its content to actually be injected.
  */
 - (BOOL)hasInjectedContentForURL:(NSURL *)url NS_SWIFT_NAME(hasInjectedContent(for:));
@@ -417,8 +417,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @abstract Sets the status of a permission with a distant future expiration date.
  @param status The new permission status to set for the given permission.
  @param permission The permission for which to set the status.
- @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's status.
- Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`, and `WKWebExtensionContextPermissionStatusGrantedExplicitly`
+ @discussion This method will update ``grantedPermissions`` and ``deniedPermissions``. Use this method for changing a single permission's status.
+ Only ``WKWebExtensionContextPermissionStatusDeniedExplicitly``, ``WKWebExtensionContextPermissionStatusUnknown``, and ``WKWebExtensionContextPermissionStatusGrantedExplicitly``
  states are allowed to be set using this method.
  @seealso setPermissionStatus:forPermission:expirationDate:
  @seealso setPermissionStatus:forPermission:inTab:
@@ -430,9 +430,9 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param status The new permission status to set for the given permission.
  @param permission The permission for which to set the status.
  @param expirationDate The expiration date for the new permission status, or \c nil for distant future.
- @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's status.
- Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`,
- and `WKWebExtensionContextPermissionStatusGrantedExplicitly` states are allowed to be set using this method.
+ @discussion This method will update ``grantedPermissions`` and ``deniedPermissions``. Use this method for changing a single permission's status.
+ Passing a `nil` expiration date will be treated as a distant future date. Only ``WKWebExtensionContextPermissionStatusDeniedExplicitly``, ``WKWebExtensionContextPermissionStatusUnknown``,
+ and ``WKWebExtensionContextPermissionStatusGrantedExplicitly`` states are allowed to be set using this method.
  @seealso setPermissionStatus:forPermission:
  @seealso setPermissionStatus:forPermission:inTab:
 */
@@ -461,8 +461,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @abstract Sets the permission status of a URL with a distant future expiration date.
  @param status The new permission status to set for the given URL.
  @param url The URL for which to set the status.
- @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's status.
- Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`, and `WKWebExtensionContextPermissionStatusGrantedExplicitly`
+ @discussion The URL is converted into a match pattern and will update ``grantedPermissionMatchPatterns`` and ``deniedPermissionMatchPatterns``. Use this method for changing a single URL's status.
+ Only ``WKWebExtensionContextPermissionStatusDeniedExplicitly``, ``WKWebExtensionContextPermissionStatusUnknown``, and ``WKWebExtensionContextPermissionStatusGrantedExplicitly``
  states are allowed to be set using this method.
  @seealso setPermissionStatus:forURL:expirationDate:
  @seealso setPermissionStatus:forURL:inTab:
@@ -474,9 +474,9 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param status The new permission status to set for the given URL.
  @param url The URL for which to set the status.
  @param expirationDate The expiration date for the new permission status, or \c nil for distant future.
- @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's status.
- Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`,
- and `WKWebExtensionContextPermissionStatusGrantedExplicitly` states are allowed to be set using this method.
+ @discussion The URL is converted into a match pattern and will update ``grantedPermissionMatchPatterns`` and ``deniedPermissionMatchPatterns``. Use this method for changing a single URL's status.
+ Passing a `nil` expiration date will be treated as a distant future date. Only ``WKWebExtensionContextPermissionStatusDeniedExplicitly``, ``WKWebExtensionContextPermissionStatusUnknown``,
+ and ``WKWebExtensionContextPermissionStatusGrantedExplicitly`` states are allowed to be set using this method.
  @seealso setPermissionStatus:forURL:
  @seealso setPermissionStatus:forURL:inTab:
 */
@@ -505,8 +505,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @abstract Sets the status of a match pattern with a distant future expiration date.
  @param status The new permission status to set for the given match pattern.
  @param pattern The match pattern for which to set the status.
- @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's status.
- Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`, and `WKWebExtensionContextPermissionStatusGrantedExplicitly`
+ @discussion This method will update ``grantedPermissionMatchPatterns`` and ``deniedPermissionMatchPatterns``. Use this method for changing a single match pattern's status.
+ Only ``WKWebExtensionContextPermissionStatusDeniedExplicitly``, ``WKWebExtensionContextPermissionStatusUnknown``, and ``WKWebExtensionContextPermissionStatusGrantedExplicitly``
  states are allowed to be set using this method.
  @seealso setPermissionStatus:forMatchPattern:expirationDate:
  @seealso setPermissionStatus:forMatchPattern:inTab:
@@ -518,9 +518,9 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param status The new permission status to set for the given match pattern.
  @param pattern The match pattern for which to set the status.
  @param expirationDate The expiration date for the new permission status, or \c nil for distant future.
- @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's status.
- Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`,
- and `WKWebExtensionContextPermissionStatusGrantedExplicitly` states are allowed to be set using this method.
+ @discussion This method will update ``grantedPermissionMatchPatterns`` and ``deniedPermissionMatchPatterns``. Use this method for changing a single match pattern's status.
+ Passing a `nil` expiration date will be treated as a distant future date. Only ``WKWebExtensionContextPermissionStatusDeniedExplicitly``, ``WKWebExtensionContextPermissionStatusUnknown``,
+ and ``WKWebExtensionContextPermissionStatusGrantedExplicitly`` states are allowed to be set using this method.
  @seealso setPermissionStatus:forMatchPattern:
  @seealso setPermissionStatus:forMatchPattern:inTab:
 */
@@ -547,7 +547,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract Performs the extension action associated with the specified tab or performs the default action if `nil` is passed.
  @param tab The tab for which to perform the extension action, or `nil` to perform the default action.
- @discussion Performing the action will mark the tab, if specified, as having an active user gesture. When the `tab` parameter is `nil`,
+ @discussion Performing the action will mark the tab, if specified, as having an active user gesture. When the ``tab`` parameter is `nil`,
  the default action is performed. The action can either trigger an event or display a popup, depending on how the extension is configured.
  If the action is configured to display a popup, implementing the appropriate web extension controller delegate method is required; otherwise,
  no action is performed for popup actions.
@@ -570,10 +570,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 #if TARGET_OS_IPHONE
 /*!
- @abstract Performs the command associated with the given UIKeyCommand.
- @discussion This method checks for a command corresponding to the provided UIKeyCommand and performs it, if available. The app should use this method to perform
- any extension commands at an appropriate time in the app's responder object that handles the performWebExtensionCommandForKeyCommand: action.
- @param event The UIKeyCommand received by the first responder.
+ @abstract Performs the command associated with the given key command.
+ @discussion This method checks for a command corresponding to the provided ``UIKeyCommand`` and performs it, if available. The app should use this method to perform
+ any extension commands at an appropriate time in the app's responder object that handles the ``performWebExtensionCommandForKeyCommand:`` action.
+ @param keyCommand The key command received by the first responder.
  @result Returns `YES` if a command corresponding to the UIKeyCommand was found and performed, `NO` otherwise.
  */
 - (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand NS_SWIFT_NAME(performCommand(for:));
@@ -583,7 +583,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract Performs the command associated with the given event.
  @discussion This method checks for a command corresponding to the provided event and performs it, if available. The app should use this method to perform
- any extension commands at an appropriate time in the app's event handling, like in `sendEvent:` of `NSApplication` or `NSWindow` subclasses.
+ any extension commands at an appropriate time in the app's event handling, like in ``sendEvent:`` of ``NSApplication`` or ``NSWindow`` subclasses.
  @param event The event representing the user input.
  @result Returns `YES` if a command corresponding to the event was found and performed, `NO` otherwise.
  */
@@ -618,7 +618,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param tab The tab in which the user gesture was performed.
  @discussion When a user gesture is performed in a tab, this method should be called to update the extension context.
  This enables the extension to be aware of the user gesture, potentially granting it access to features that require user interaction,
- such as `activeTab`. Not required if using `performActionForTab:`.
+ such as `activeTab`. Not required if using ``performActionForTab:``.
  @seealso hasActiveUserGestureInTab:
  */
 - (void)userGesturePerformedInTab:(id <WKWebExtensionTab>)tab NS_SWIFT_NAME(userGesturePerformed(in:));
@@ -645,8 +645,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*!
  @abstract The open windows that are exposed to this extension.
- @discussion Provides the windows that are open and visible to the extension, as updated by the `didOpenWindow:` and `didCloseWindow:` methods.
- Initially populated by the windows returned by the extension controller delegate method `webExtensionController:openWindowsForExtensionContext:`.
+ @discussion Provides the windows that are open and visible to the extension, as updated by the ``didOpenWindow:`` and ``didCloseWindow:`` methods.
+ Initially populated by the windows returned by the extension controller delegate method ``webExtensionController:openWindowsForExtensionContext:``.
  @seealso didOpenWindow:
  @seealso didCloseWindow:
  */
@@ -654,17 +654,17 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*!
  @abstract The window that currently has focus for this extension.
- @discussion Provides the window that currently has focus, as set by the `didFocusWindow:` method.
- It will be \c nil if no window has focus or if a window has focus that is not visible to the extension. Initially populated by the window
- returned by the extension controller delegate method `webExtensionController:focusedWindowForExtensionContext:`.
+ @discussion Provides the window that currently has focus, as set by the ``didFocusWindow:`` method.
+ It will be `nil` if no window has focus or if a window has focus that is not visible to the extension. Initially populated by the window
+ returned by the extension controller delegate method ``webExtensionController:focusedWindowForExtensionContext:``.
  @seealso didFocusWindow:
  */
 @property (nonatomic, readonly, weak, nullable) id <WKWebExtensionWindow> focusedWindow;
 
 /*!
  @abstract A set of open tabs in all open windows that are exposed to this extension.
- @discussion Provides a set of tabs in all open windows that are visible to the extension, as updated by the `didOpenTab:` and `didCloseTab:` methods.
- Initially populated by the tabs in the windows returned by the extension controller delegate method `webExtensionController:openWindowsForExtensionContext:`.
+ @discussion Provides a set of tabs in all open windows that are visible to the extension, as updated by the ``didOpenTab:`` and ``didCloseTab:`` methods.
+ Initially populated by the tabs in the windows returned by the extension controller delegate method ``webExtensionController:openWindowsForExtensionContext:``.
  @seealso didOpenTab:
  @seealso didCloseTab:
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h
@@ -39,9 +39,9 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract A `WKWebExtensionController` object manages a set of loaded extension contexts.
+ @abstract A ``WKWebExtensionController`` object manages a set of loaded extension contexts.
  @discussion You can have one or more extension controller instances, allowing different parts of the app to use different sets of extensions.
- A controller is associated with @link WKWebView @/link via the `webExtensionController` property on @link WKWebViewConfiguration @/link.
+ A controller is associated with ``WKWebView`` via the ``webExtensionController`` property on ``WKWebViewConfiguration``.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
 @interface WKWebExtensionController : NSObject
@@ -49,7 +49,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract Returns a web extension controller initialized with the default configuration.
  @result An initialized web extension controller, or nil if the object could not be initialized.
- @discussion This is a designated initializer. You can use @link -initWithConfiguration: @/link to
+ @discussion This is a designated initializer. You can use ``initWithConfiguration:`` to
  initialize an instance with a configuration.
  @seealso initWithConfiguration:
 */
@@ -59,7 +59,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @abstract Returns a web extension controller initialized with the specified configuration.
  @param configuration The configuration for the new web extension controller.
  @result An initialized web extension controller, or nil if the object could not be initialized.
- @discussion This is a designated initializer. You can use @link -init: @/link to initialize an
+ @discussion This is a designated initializer. You can use ``init:`` to initialize an
  instance with the default configuration. The initializer copies the specified configuration, so mutating
  the configuration after invoking the initializer has no effect on the web extension controller.
  @seealso init
@@ -106,7 +106,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param URL The URL to lookup.
  @result An extension context or `nil` if no match was found.
  @discussion This method is useful for determining the extension context to use when about to navigate to an extension URL. For example,
- you could use this method to retrieve the appropriate extension context and then use its `webViewConfiguration` property to configure a
+ you could use this method to retrieve the appropriate extension context and then use its ``webViewConfiguration`` property to configure a
  web view for loading that URL.
  */
 - (nullable WKWebExtensionContext *)extensionContextForURL:(NSURL *)URL NS_SWIFT_NAME(extensionContext(for:));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.h
@@ -33,8 +33,8 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 @class WKWebExtensionController;
 
 /*!
- @abstract A `WKWebExtensionControllerConfiguration` object with which to initialize a web extension controller.
- @discussion Contains properties used to configure a @link WKWebExtensionController @/link.
+ @abstract A ``WKWebExtensionControllerConfiguration`` object with which to initialize a web extension controller.
+ @discussion Contains properties used to configure a ``WKWebExtensionController``.
 */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtensionController.Configuration)
@@ -45,7 +45,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtensionController.Configuration)
 
 /*!
  @abstract Returns a new default configuration that is persistent and not unique.
- @discussion If a @link WKWebExtensionController @/link is associated with a persistent configuration,
+ @discussion If a ``WKWebExtensionController`` is associated with a persistent configuration,
  data will be written to the file system in a common location. When using multiple extension controllers, each
  controller should use a unique configuration to avoid conflicts.
  @seealso configurationWithIdentifier:
@@ -54,14 +54,14 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtensionController.Configuration)
 
 /*!
  @abstract Returns a new non-persistent configuration.
- @discussion If a @link WKWebExtensionController @/link is associated with a non-persistent configuration,
+ @discussion If a ``WKWebExtensionController`` is associated with a non-persistent configuration,
  no data will be written to the file system. This is useful for extensions in "private browsing" situations.
 */
 + (instancetype)nonPersistentConfiguration;
 
 /*!
  @abstract Returns a new configuration that is persistent and unique for the specified identifier.
- @discussion If a @link WKWebExtensionController @/link is associated with a unique persistent configuration,
+ @discussion If a ``WKWebExtensionController`` is associated with a unique persistent configuration,
  data will be written to the file system in a unique location based on the specified identifier.
  @seealso defaultConfiguration
 */
@@ -79,7 +79,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtensionController.Configuration)
 /*!
  @abstract The default data store for website data and cookie access in extension contexts.
  @discussion This property sets the primary data store for managing website data, including cookies, which extensions can access,
- subject to the granted permissions within the extension contexts. Defaults to `WKWebsiteDataStore.defaultDataStore`.
+ subject to the granted permissions within the extension contexts. Defaults to ``WKWebsiteDataStore.defaultDataStore``.
  @note In addition to this data store, extensions can also access other data stores, such as non-persistent ones, for any open tabs.
  */
 @property (nonatomic, null_resettable, retain) WKWebsiteDataStore *defaultWebsiteDataStore;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationPrivate.h
@@ -31,7 +31,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
  @abstract Returns a new configuration that is persistent and uses a temporary directory.
- @discussion This method creates a configuration for a `WKWebExtensionController` that is persistent during the session
+ @discussion This method creates a configuration for a ``WKWebExtensionController`` that is persistent during the session
  and uses a temporary directory for storage. This is ideal for scenarios that require temporary data persistence, such as testing.
  Each instance is created with a unique temporary directory.
 */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
@@ -51,8 +51,8 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @return The array of ordered open windows.
  @discussion This method should be implemented by the app to provide the extension with the ordered open windows. Depending on your
  app's requirements, you may return different windows for each extension or the same windows for all extensions. The first window in the returned
- array must correspond to the currently focused window and match the result of `webExtensionController:focusedWindowForExtensionContext:`.
- If `webExtensionController:focusedWindowForExtensionContext:` returns `nil`, indicating that no window has focus or the focused
+ array must correspond to the currently focused window and match the result of ``webExtensionController:focusedWindowForExtensionContext:``.
+ If ``webExtensionController:focusedWindowForExtensionContext:`` returns `nil`, indicating that no window has focus or the focused
  window is not visible to the extension, the first window in the list returned by this method will be considered the presumed focused window. An empty result
  indicates no open windows are available for the extension. Defaults to an empty array if not implemented.
  @seealso webExtensionController:focusedWindowForExtensionContext:
@@ -63,9 +63,9 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when an extension context requests the currently focused window.
  @param controller The web extension controller that is managing the extension.
  @param extensionContext The context in which the web extension is running.
- @return The window that is currently focused, or \c nil if no window is focused or the focused window is not visible to the extension.
+ @return The window that is currently focused, or `nil` if no window is focused or the focused window is not visible to the extension.
  @discussion This method can be optionally implemented by the app to designate the window currently in focus to the extension.
- If not implemented, the first window in the result of `webExtensionController:openWindowsForExtensionContext:` is used.
+ If not implemented, the first window in the result of ``webExtensionController:openWindowsForExtensionContext:`` is used.
  @seealso webExtensionController:openWindowsForExtensionContext:
  */
 - (nullable id <WKWebExtensionWindow>)webExtensionController:(WKWebExtensionController *)controller focusedWindowForExtensionContext:(WKWebExtensionContext *)extensionContext NS_SWIFT_NAME(webExtensionController(_:focusedWindowFor:));
@@ -104,7 +104,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @discussion This method should be implemented by the app to handle requests to display the extension's options page. The app can decide
  how and where to display the options page (e.g., in a new tab or a separate window). The app should call the completion handler once the options
  page is visible to the user, or with an error if the operation was declined or failed. If not implemented, the options page will be opened in a new tab
- using the `webExtensionController:openNewTabUsingConfiguration:forExtensionContext:completionHandler:` delegate method.
+ using the ``webExtensionController:openNewTabUsingConfiguration:forExtensionContext:completionHandler:`` delegate method.
  */
 - (void)webExtensionController:(WKWebExtensionController *)controller openOptionsPageForExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(webExtensionController(_:openOptionsPageFor:completionHandler:));
 
@@ -156,8 +156,8 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param action The action for which the popup is requested.
  @param context The context within which the web extension is running.
  @param completionHandler A block to be called once the popup display operation is completed.
- @discussion This method is called in response to the extension's scripts or when invoking `performActionForTab:` if the action has a popup.
- The associated tab, if applicable, can be located through the `associatedTab` property of the `action` parameter. This delegate method is
+ @discussion This method is called in response to the extension's scripts or when invoking ``performActionForTab:`` if the action has a popup.
+ The associated tab, if applicable, can be located through the ``associatedTab`` property of the `action` parameter. This delegate method is
  called when the web view for the popup is fully loaded and ready to display. Implementing this method is needed if the app intends to support
  programmatically showing the popup by the extension, although it is recommended for handling both programmatic and user-initiated cases.
  */
@@ -173,7 +173,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @discussion This method should be implemented by the app to handle one-off messages to applications.
  If not implemented, the default behavior is to pass the message to the app extension handler within the extension's bundle,
  if the extension was loaded from an app extension bundle; otherwise, no action is performed if not implemented.
- @note The reply message must be JSON-serializable according to `+[NSJSONSerialization isValidJSONObject:]` method.
+ @note The reply message must be JSON-serializable according to ``NSJSONSerialization``.
  */
 - (void)webExtensionController:(WKWebExtensionController *)controller sendMessage:(id)message toApplicationWithIdentifier:(nullable NSString *)applicationIdentifier forExtensionContext:(WKWebExtensionContext *)extensionContext replyHandler:(void (^)(id WK_NULLABLE_RESULT replyMessage, NSError * _Nullable error))replyHandler NS_SWIFT_NAME(webExtensionController(_:sendMessage:toApplicationWithIdentifier:for:replyHandler:)) WK_SWIFT_ASYNC(5);
 
@@ -185,7 +185,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param completionHandler A block to be called when the connection is ready to use, taking an optional error object
  as a parameter. If the connection is successfully established, the error parameter should be \c nil.
  @discussion This method should be implemented by the app to handle establishing connections to applications.
- The provided `WKWebExtensionPort` object can be used to handle message sending, receiving, and disconnection.
+ The provided ``WKWebExtensionPort`` object can be used to handle message sending, receiving, and disconnection.
  You should retain the port object for as long as the connection remains active. Releasing the port will disconnect it.
  If not implemented, the default behavior is to pass the messages to the app extension handler within the extension's bundle,
  if the extension was loaded from an app extension bundle; otherwise, no action is performed if not implemented.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.h
@@ -30,17 +30,15 @@
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract Indicates a `WKWebExtensionDataRecord` error. */
+/*! @abstract Indicates a ``WKWebExtensionDataRecord`` error. */
 WK_EXTERN NSErrorDomain const WKWebExtensionDataRecordErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by NSError to indicate errors in the `WKWebExtensionDataRecord` domain.
+ @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionDataRecord`` domain.
  @constant WKWebExtensionDataRecordErrorUnknown  Indicates that an unknown error occurred.
-
- @constant WKWebExtensionDataRecordErrorLocalStorageFailed  Indicates a failure occurred when either deleting or calculating local storage.
- @constant WKWebExtensionDataRecordErrorSessionStorageFailed  Indicates a failure occurred when either deleting or calculating session storage.
- @constant WKWebExtensionDataRecordErrorSyncStorageFailed  Indicates a failure occurred when either deleting or calculating sync storage.
-
+ @constant WKWebExtensionDataRecordErrorLocalStorageFailed  Indicates a failure occurred when either deleting or calculating `local` storage.
+ @constant WKWebExtensionDataRecordErrorSessionStorageFailed  Indicates a failure occurred when either deleting or calculating `session` storage.
+ @constant WKWebExtensionDataRecordErrorSyncStorageFailed  Indicates a failure occurred when either deleting or calculating `sync` storage.
  */
 typedef NS_ERROR_ENUM(WKWebExtensionDataRecordErrorDomain, WKWebExtensionDataRecordError) {
     WKWebExtensionDataRecordErrorUnknown,
@@ -50,7 +48,7 @@ typedef NS_ERROR_ENUM(WKWebExtensionDataRecordErrorDomain, WKWebExtensionDataRec
 } NS_SWIFT_NAME(WKWebExtensionDataRecord.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract A `WKWebExtensionDataRecord` object represents a record of stored data for a specific web extension context.
+ @abstract A ``WKWebExtensionDataRecord`` object represents a record of stored data for a specific web extension context.
  @discussion Contains properties and methods to query the data types and sizes.
 */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.h
@@ -26,7 +26,7 @@
 #import <Foundation/Foundation.h>
 #import <WebKit/WKFoundation.h>
 
-/*! @abstract Constants for specifying data types for a @link WKWebExtensionContext @/link. */
+/*! @abstract Constants for specifying data types for a ``WKWebExtensionDataRecord``. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 typedef NSString * WKWebExtensionDataType NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(WKWebExtension.DataType);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
@@ -30,11 +30,11 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class WKWebExtension;
 
-/*! @abstract Indicates a @link WKWebExtensionMatchPattern @/link error. */
+/*! @abstract Indicates a ``WKWebExtensionMatchPattern`` error. */
 WK_EXTERN NSErrorDomain const WKWebExtensionMatchPatternErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by NSError to indicate errors in the @link WKWebExtensionMatchPattern @/link domain.
+ @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionMatchPattern`` domain.
  @constant WKWebExtensionMatchPatternErrorUnknown  Indicates that an unknown error occurred.
  @constant WKWebExtensionMatchPatternErrorInvalidScheme  Indicates that the scheme component was invalid.
  @constant WKWebExtensionMatchPatternErrorInvalidHost  Indicates that the host component was invalid.
@@ -48,7 +48,7 @@ typedef NS_ERROR_ENUM(WKWebExtensionMatchPatternErrorDomain, WKWebExtensionMatch
 } NS_SWIFT_NAME(WKWebExtensionMatchPattern.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by @link WKWebExtensionMatchPattern @/link to indicate matching options.
+ @abstract Constants used by ``WKWebExtensionMatchPattern`` to indicate matching options.
  @constant WKWebExtensionMatchPatternOptionsNone  Indicates no special matching options.
  @constant WKWebExtensionMatchPatternOptionsIgnoreSchemes  Indicates that the scheme components should be ignored while matching.
  @constant WKWebExtensionMatchPatternOptionsIgnorePaths  Indicates that the host components should be ignored while matching.
@@ -62,7 +62,7 @@ typedef NS_OPTIONS(NSUInteger, WKWebExtensionMatchPatternOptions) {
 } NS_SWIFT_NAME(WKWebExtensionMatchPattern.Options) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract A `WKWebExtensionMatchPattern` object represents a way to specify groups of URLs.
+ @abstract A ``WKWebExtensionMatchPattern`` object represents a way to specify groups of URLs.
  @discussion All match patterns are specified as strings. Apart from the special `<all_urls>` pattern, match patterns
  consist of three parts: scheme, host, and path.
  */
@@ -103,16 +103,16 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MatchPattern)
 
 /*!
  @abstract Returns a pattern object for the specified pattern string.
- @param error Set to \c nil or an \c NSError instance if an error occurred.
- @result A pattern object, or `nil` if the pattern string is invalid and `error` will be set.
+ @param error Set to \c nil or an error instance if an error occurred.
+ @result A pattern object, or `nil` if the pattern string is invalid and an error will be set.
  @seealso initWithString:
  */
 - (nullable instancetype)initWithString:(NSString *)string error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Returns a pattern object for the specified scheme, host, and path strings.
- @param error Set to \c nil or an \c NSError instance if an error occurred.
- @result A pattern object, or `nil` if any of the strings are invalid and `error` will be set.
+ @param error Set to \c nil or an error instance if an error occurred.
+ @result A pattern object, or `nil` if any of the strings are invalid and an error will be set.
  @seealso initWithScheme:host:path:
  */
 - (nullable instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error NS_DESIGNATED_INITIALIZER;
@@ -120,13 +120,13 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MatchPattern)
 /*! @abstract The original pattern string. */
 @property (nonatomic, readonly, copy) NSString *string;
 
-/*! @abstract The scheme part of the pattern string, unless `matchesAllURLs` is `YES`. */
+/*! @abstract The scheme part of the pattern string, unless ``matchesAllURLs`` is `YES`. */
 @property (nonatomic, nullable, readonly, copy) NSString *scheme;
 
-/*! @abstract The host part of the pattern string, unless `matchesAllURLs` is `YES`. */
+/*! @abstract The host part of the pattern string, unless ``matchesAllURLs`` is `YES`. */
 @property (nonatomic, nullable, readonly, copy) NSString *host;
 
-/*! @abstract The path part of the pattern string, unless `matchesAllURLs` is `YES`. */
+/*! @abstract The path part of the pattern string, unless ``matchesAllURLs`` is `YES`. */
 @property (nonatomic, nullable, readonly, copy) NSString *path;
 
 /*! @abstract If the pattern is `<all_urls>`. */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
@@ -28,11 +28,11 @@
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-/*! @abstract Indicates a `WKWebExtensionMessagePort` error. */
+/*! @abstract Indicates a ``WKWebExtensionMessagePort`` error. */
 WK_EXTERN NSErrorDomain const WKWebExtensionMessagePortErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by NSError to indicate errors in the `WKWebExtensionMessagePort` domain.
+ @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionMessagePort`` domain.
  @constant WKWebExtensionMessagePortErrorUnknown  Indicates that an unknown error occurred.
  @constant WKWebExtensionMessagePortErrorNotConnected  Indicates that the message port is disconnected.
  @constant WKWebExtensionMessagePortErrorMessageInvalid Indicates that the message is invalid. The message must be an object that is JSON-serializable.
@@ -44,7 +44,7 @@ typedef NS_ERROR_ENUM(WKWebExtensionMessagePortErrorDomain, WKWebExtensionMessag
 } NS_SWIFT_NAME(WKWebExtensionMessagePort.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract A `WKWebExtensionMessagePort` object manages message-based communication with a web extension.
+ @abstract A ``WKWebExtensionMessagePort`` object manages message-based communication with a web extension.
  @discussion Contains properties and methods to handle message exchanges with a web extension.
 */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -80,7 +80,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MessagePort)
  @abstract Sends a message to the connected web extension.
  @param message The JSON-serializable message to be sent.
  @param completionHandler An optional block to be invoked after the message is sent, taking an optional error object.
- @note The message must be JSON-serializable according to `+[NSJSONSerialization isValidJSONObject:]` method.
+ @note The message must be JSON-serializable according to ``NSJSONSerialization``.
  */
 - (void)sendMessage:(nullable id)message completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(sendMessage(_:completionHandler:));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.h
@@ -26,7 +26,7 @@
 #import <Foundation/Foundation.h>
 #import <WebKit/WKFoundation.h>
 
-/*! @abstract Constants for specifying permission in a @link WKWebExtensionContext @/link. */
+/*! @abstract Constants for specifying permission in a ``WKWebExtensionContext``. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 typedef NSString * WKWebExtensionPermission NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(WKWebExtension.Permission);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
@@ -36,7 +36,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
  @param appExtensionBundle The bundle to use for the new web extension.
- @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @param error Set to \c nil or an error instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  */
 - (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_DESIGNATED_INITIALIZER;
@@ -44,7 +44,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
  @param resourceBaseURL The directory URL to use for the new web extension.
- @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @param error Set to \c nil or an error instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @discussion The URL must be a file URL that points to a directory containing a `manifest.json` file.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTab.h
@@ -41,7 +41,7 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract Constants used by @link WKWebExtensionController @/link and @link WKWebExtensionContext @/link to indicate tab changes.
+ @abstract Constants used by ``WKWebExtensionController @/link and @link WKWebExtensionContext`` to indicate tab changes.
  @constant WKWebExtensionTabChangedPropertiesNone  Indicates nothing changed.
  @constant WKWebExtensionTabChangedPropertiesLoading  Indicates the loading state changed.
  @constant WKWebExtensionTabChangedPropertiesMuted  Indicates the muted state changed.
@@ -66,7 +66,7 @@ typedef NS_OPTIONS(NSUInteger, WKWebExtensionTabChangedProperties) {
     WKWebExtensionTabChangedPropertiesZoomFactor   = 1 << 9,
 } NS_SWIFT_NAME(WKWebExtension.TabChangedProperties) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-/*! @abstract A class conforming to the `WKWebExtensionTab` protocol represents a tab to web extensions. */
+/*! @abstract A class conforming to the ``WKWebExtensionTab`` protocol represents a tab to web extensions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
 @protocol WKWebExtensionTab <NSObject>
 @optional
@@ -82,9 +82,9 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
 /*!
  @abstract Called when the index of the tab in the window is needed.
  @param context The context in which the web extension is running.
- @return The index of the tab in the window, or `NSNotFound` if the tab is not currently in a window.
+ @return The index of the tab in the window, or ``NSNotFound`` if the tab is not currently in a window.
  @discussion This method should be implemented for better performance. Defaults to the window's
- `tabsForWebExtensionContext:` method to find the index if not implemented.
+ ``tabsForWebExtensionContext:`` method to find the index if not implemented.
  */
 - (NSUInteger)indexInWindowForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(indexInWindow(for:));
 
@@ -113,7 +113,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the web view for the tab is needed.
  @param context The context in which the web extension is running.
  @return The web view for the tab.
- @discussion The web view's `WKWebViewConfiguration` must have its `webExtensionController` property set to match
+ @discussion The web view's ``WKWebViewConfiguration`` must have its ``webExtensionController`` property set to match
  the controller of the given context; otherwise `nil` will be used. Defaults to `nil` if not implemented. If `nil`, some critical features
  will not be available for this tab, such as content injection or modification.
  */
@@ -123,7 +123,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the title of the tab is needed.
  @param context The context in which the web extension is running.
  @return The title of the tab.
- @discussion Defaults to `title` of the tab's web view if not implemented.
+ @discussion Defaults to ``title`` of the tab's web view if not implemented.
  */
 - (nullable NSString *)titleForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(title(for:));
 
@@ -219,7 +219,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the zoom factor of the tab is needed.
  @param context The context in which the web extension is running.
  @return The zoom factor of the tab.
- @discussion Defaults to `pageZoom` of the tab's web view if not implemented.
+ @discussion Defaults to ``pageZoom`` of the tab's web view if not implemented.
  @seealso setZoomFactor:forWebExtensionContext:completionHandler:
  */
 - (double)zoomFactorForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(zoomFactor(for:));
@@ -230,7 +230,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Sets `pageZoom` of the tab's web view if not implemented.
+ @discussion Sets ``pageZoom`` of the tab's web view if not implemented.
  @seealso zoomFactorForWebExtensionContext:
  */
 - (void)setZoomFactor:(double)zoomFactor forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(setZoomFactor(_:for:completionHandler:));
@@ -256,7 +256,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called to check if the tab has finished loading.
  @param context The context in which the web extension is running.
  @return `YES` if the tab has finished loading, `NO` otherwise.
- @discussion Defaults to `isLoading` of the tab's web view if not implemented.
+ @discussion Defaults to ``isLoading`` of the tab's web view if not implemented.
  */
 - (BOOL)isLoadingCompleteForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(isLoadingComplete(for:));
 
@@ -290,7 +290,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
  @discussion If the tab is already loading a page, calling this method should stop the current page from loading and start
- loading the new URL. Loads the URL in the tab's web view via `loadRequest:` if not implemented.
+ loading the new URL. Loads the URL in the tab's web view via ``loadRequest:`` if not implemented.
  */
 - (void)loadURL:(NSURL *)url forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(loadURL(_:for:completionHandler:));
 
@@ -300,7 +300,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Reloads the tab's web view via `reload` or `reloadFromOrigin` if not implemented.
+ @discussion Reloads the tab's web view via ``reload`` or ``reloadFromOrigin`` if not implemented.
  */
 - (void)reloadFromOrigin:(BOOL)fromOrigin forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(reload(fromOrigin:for:completionHandler:));
 
@@ -309,7 +309,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Navigates to the previous page in the tab's web view via `goBack` if not implemented.
+ @discussion Navigates to the previous page in the tab's web view via ``goBack`` if not implemented.
  */
 - (void)goBackForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(goBack(for:completionHandler:));
 
@@ -318,7 +318,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Navigates to the next page in the tab's web view via `goForward` if not implemented.
+ @discussion Navigates to the next page in the tab's web view via ``goForward`` if not implemented.
  */
 - (void)goForwardForWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(goForward(for:completionHandler:));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.h
@@ -32,7 +32,7 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract A `WKWebExtensionTabConfiguration` object encapsulates configuration options for a tab in an extension.
+ @abstract A ``WKWebExtensionTabConfiguration`` object encapsulates configuration options for a tab in an extension.
  @discussion This class holds various options that influence the behavior and initial state of a tab.
  The app retains the discretion to disregard any or all of these options, or even opt not to create a tab.
  */
@@ -75,7 +75,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.TabConfiguration)
 /*!
  @abstract Indicates whether the tab should be added to the current tab selection.
  @discussion If this property is `YES`, the tab should be part of the current selection, but not necessarily
- become the active tab unless `shouldBeActive` is also `YES`. If this property is `NO`, the tab shouldn't
+ become the active tab unless ``shouldBeActive`` is also `YES`. If this property is `NO`, the tab shouldn't
  be part of the current selection.
  */
 @property (nonatomic, readonly) BOOL shouldAddToSelection;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindow.h
@@ -32,7 +32,7 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract Constants used by @link WKWebExtensionWindow @/link to indicate the type of a window.
+ @abstract Constants used by ``WKWebExtensionWindow`` to indicate the type of a window.
  @constant WKWebExtensionWindowTypeNormal  Indicates a normal window.
  @constant WKWebExtensionWindowTypePopup  Indicates a popup window.
  */
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, WKWebExtensionWindowType) {
 } NS_SWIFT_NAME(WKWebExtension.WindowType) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
- @abstract Constants used by @link WKWebExtensionWindow @/link to indicate possible states of a window.
+ @abstract Constants used by ``WKWebExtensionWindow`` to indicate possible states of a window.
  @constant WKWebExtensionWindowStateNormal  Indicates a window is in its normal state.
  @constant WKWebExtensionWindowStateMinimized  Indicates a window is minimized.
  @constant WKWebExtensionWindowStateMaximized  Indicates a window is maximized.
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSInteger, WKWebExtensionWindowState) {
     WKWebExtensionWindowStateFullscreen,
 } NS_SWIFT_NAME(WKWebExtension.WindowState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-/*! @abstract A class conforming to the `WKWebExtensionWindow` protocol represents a window to web extensions. */
+/*! @abstract A class conforming to the ``WKWebExtensionWindow`` protocol represents a window to web extensions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
 @protocol WKWebExtensionWindow <NSObject>
 @optional
@@ -80,7 +80,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the type of the window is needed.
  @param context The context in which the web extension is running.
  @return The type of the window.
- @discussion Defaults to`WKWebExtensionWindowTypeNormal` if not implemented.
+ @discussion Defaults to``WKWebExtensionWindowTypeNormal`` if not implemented.
  */
 - (WKWebExtensionWindowType)windowTypeForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(windowType(for:));
 
@@ -88,7 +88,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the state of the window is needed.
  @param context The context in which the web extension is running.
  @return The state of the window.
- @discussion Defaults to`WKWebExtensionWindowStateNormal` if not implemented.
+ @discussion Defaults to``WKWebExtensionWindowStateNormal`` if not implemented.
  */
 - (WKWebExtensionWindowState)windowStateForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(windowState(for:));
 
@@ -98,7 +98,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param state The new state of the window.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion The implementation of `windowStateForWebExtensionContext:` is a prerequisite.
+ @discussion The implementation of ``windowStateForWebExtensionContext:`` is a prerequisite.
  Without it, this method will not be called.
  @seealso windowStateForWebExtensionContext:
  */
@@ -110,8 +110,8 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @return `YES` if the window is private, `NO` otherwise.
  @discussion Defaults to `NO` if not implemented. This value is cached and will not change for the duration of the window or its contained tabs.
  @note To ensure proper isolation between private and non-private data, web views associated with private data must use a
- different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
- website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
+ different ``WKUserContentController``. Likewise, to be identified as a private web view and to ensure that cookies and other
+ website data is not shared, private web views must be configured to use a non-persistent ``WKWebsiteDataStore``.
  */
 - (BOOL)isPrivateForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(isPrivate(for:));
 
@@ -120,7 +120,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the screen frame containing the window is needed.
  @param context The context associated with the running web extension.
  @return The frame for the screen containing the window.
- @discussion Defaults to `CGRectNull` if not implemented.
+ @discussion Defaults to ``CGRectNull`` if not implemented.
  */
 - (CGRect)screenFrameForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(screenFrame(for:));
 #endif // TARGET_OS_OSX
@@ -129,7 +129,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the frame of the window is needed.
  @param context The context in which the web extension is running.
  @return The frame of the window, in screen coordinates
- @discussion Defaults to `CGRectNull` if not implemented.
+ @discussion Defaults to ``CGRectNull`` if not implemented.
  */
 - (CGRect)frameForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(frame(for:));
 
@@ -139,8 +139,8 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param frame The new frame of the window, in screen coordinates.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion On macOS, the implementation of both `frameForWebExtensionContext:` and `screenFrameForWebExtensionContext:`
- are prerequisites. On iOS, iPadOS, and visionOS, only `frameForWebExtensionContext:` is a prerequisite. Without the respective method(s),
+ @discussion On macOS, the implementation of both ``frameForWebExtensionContext:`` and ``screenFrameForWebExtensionContext:``
+ are prerequisites. On iOS, iPadOS, and visionOS, only ``frameForWebExtensionContext:`` is a prerequisite. Without the respective method(s),
  this method will not be called.
  @seealso frameForWebExtensionContext:
  @seealso screenFrameForWebExtensionContext:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.h
@@ -33,7 +33,7 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract A `WKWebExtensionWindowConfiguration` object encapsulates configuration options for a window in an extension.
+ @abstract A ``WKWebExtensionWindowConfiguration`` object encapsulates configuration options for a window in an extension.
  @discussion This class holds various options that influence the behavior and initial state of a window.
  The app retains the discretion to disregard any or all of these options, or even opt not to create a window.
  */
@@ -59,14 +59,14 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.WindowConfiguration)
 
 /*!
  @abstract Indicates the URLs that the window should initially load as tabs.
- @discussion If `tabURLs` and `tabs` are both empty, the app's default "start page" should appear in a tab.
+ @discussion If ``tabURLs`` and ``tabs`` are both empty, the app's default "start page" should appear in a tab.
  @seealso tabs
  */
 @property (nonatomic, readonly, copy) NSArray<NSURL *> *tabURLs;
 
 /*!
  @abstract Indicates the existing tabs that should be moved to the window.
- @discussion If `tabs` and `tabURLs` are both empty, the app's default "start page" should appear in a tab.
+ @discussion If ``tabs`` and ``tabURLs`` are both empty, the app's default "start page" should appear in a tab.
  @seealso tabURLs
  */
 @property (nonatomic, readonly, copy) NSArray<id <WKWebExtensionTab>> *tabs;
@@ -77,8 +77,8 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.WindowConfiguration)
 /*!
  @abstract Indicates whether the window should be private.
  @note To ensure proper isolation between private and non-private data, web views associated with private data must use a
- different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
- website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
+ different ``WKUserContentController``. Likewise, to be identified as a private web view and to ensure that cookies and other
+ website data is not shared, private web views must be configured to use a non-persistent ``WKWebsiteDataStore``.
  */
 @property (nonatomic, readonly) BOOL shouldBePrivate;
 


### PR DESCRIPTION
#### 64dcfec215ad425f82292aa591c6c94554641cba
<pre>
Use double-backticks in Web Extension Headers docs for symbols and methods.
<a href="https://webkit.org/b/278174">https://webkit.org/b/278174</a>
<a href="https://rdar.apple.com/problem/133961517">rdar://problem/133961517</a>

Reviewed by Jeff Miller.

Using double backticks is recommended for symbols and methods, and are highlighted
differently in Xcode, and developers can jump to the definition with command-click.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/282305@main">https://commits.webkit.org/282305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb7f61b2ce47558de3f0dac722930a7ce395f5ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15371 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/49818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65844 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/49818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/49818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/49818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/6721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/6753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9453 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->