### PR TITLE
Eagerly initialize TZoneHeapManager.

### DIFF
--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -56,7 +56,14 @@
 #define USE_LIBPAS_THREAD_SUSPEND_LOCK 1
 #include <bmalloc/pas_thread_suspend_lock.h>
 #endif
+#if USE(TZONE_MALLOC)
+#if BUSE(TZONE)
+#include <bmalloc/TZoneHeapManager.h>
+#else
+#error USE(TZONE_MALLOC) requires BUSE(TZONE)
 #endif
+#endif // USE(TZONE_MALLOC)
+#endif // !USE(SYSTEM_MALLOC)
 
 namespace WTF {
 
@@ -495,6 +502,9 @@ void initialize()
     std::call_once(onceKey, [] {
         setPermissionsOfConfigPage();
         Config::initialize();
+#if USE(TZONE_MALLOC)
+        bmalloc::api::TZoneHeapManager::singleton(); // Force initialization.
+#endif
         Gigacage::ensureGigacage();
         Config::AssertNotFrozenScope assertScope;
 #if !HAVE(FAST_TLS) && !OS(WINDOWS)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -191,10 +191,13 @@
         (iokit-property "MetalPluginName")
     )
 
-    (allow sysctl-read
-        (sysctl-name
-            "kern.bootsessionuuid"
-            "kern.boottime"))
+    (allow sysctl-read (sysctl-name "kern.bootsessionuuid"))
+#if HAVE(SANDBOX_STATE_FLAGS)
+    (with-filter (require-not (webcontent-process-launched))
+        (allow sysctl-read (sysctl-name "kern.boottime")))
+#else
+    (allow sysctl-read (sysctl-name "kern.boottime"))
+#endif
 
     (mobile-preferences-read
         "com.apple.Metal" ;; <rdar://problem/25535471>

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -437,7 +437,6 @@
         "hw.tbfrequency_compat"
         "hw.vectorunit"
         "kern.bootargs" ;; <rdar://problem/47738015>
-        "kern.boottime"
         "kern.hostname"
         "kern.hv_vmm_present"
         "kern.maxfilesperproc"
@@ -460,6 +459,13 @@
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
 )
+
+#if HAVE(SANDBOX_STATE_FLAGS)
+(with-filter (require-not (webcontent-process-launched))
+    (allow sysctl-read (sysctl-name "kern.boottime")))
+#else
+(allow sysctl-read (sysctl-name "kern.boottime"))
+#endif
 
 (deny sysctl-read (with no-report)
     (sysctl-name


### PR DESCRIPTION
#### 5548011945e1a4ab98fd5981c8400adb9aab7aa2
<pre>
Eagerly initialize TZoneHeapManager.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278177">https://bugs.webkit.org/show_bug.cgi?id=278177</a>
<a href="https://rdar.apple.com/133963518">rdar://133963518</a>

Reviewed by Keith Miller and Per Arne Vollan.

If TZoneHeap is in use, we&apos;ll always need to initialize the TZoneHeapManager anyway.  So, there&apos;s
no point in letting its initialization be lazy.  This also allows us to further restrict the
sandbox allowance of kern.boottime to only during initialization time.

In this patch, we also add a build time check to ensure that BUSE_TZONE is true if USE_TZONE_MALLOC
is true.  This helps ensures that the 2 flags are always set consistently.

* Source/WTF/wtf/Threading.cpp:
(WTF::initialize):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/282313@main">https://commits.webkit.org/282313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/591b66c31135a6586635f4070a8ba1179ce40088

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13360 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50631 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9226 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12236 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55866 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68471 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/61999 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57946 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58135 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5603 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83762 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9456 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37932 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14737 "Found 1 new JSC stress test failure: stress/proxy-set.js.default (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->