### PR TITLE
[JSC] OOB PutByVal to TypedArray do not need to do anything more

### DIFF
--- a/JSTests/microbenchmarks/typed-array-put-by-val-oob-detach.js
+++ b/JSTests/microbenchmarks/typed-array-put-by-val-oob-detach.js
@@ -1,0 +1,18 @@
+function test1(array, value) {
+    array[value] = 42;
+}
+noInline(test1);
+
+function test2(array, value) {
+    "use strict";
+    array[value] = 42;
+}
+noInline(test2);
+
+var array = new Int32Array([1, 2, 3, 4, 5]);
+array.buffer.transfer();
+
+for (var i = 0; i < 1e5; ++i) {
+    test1(array, i & 0b111);
+    test2(array, i & 0b111);
+}

--- a/JSTests/microbenchmarks/typed-array-put-by-val-oob.js
+++ b/JSTests/microbenchmarks/typed-array-put-by-val-oob.js
@@ -1,0 +1,17 @@
+function test1(array, value) {
+    array[value] = 42;
+}
+noInline(test1);
+
+function test2(array, value) {
+    "use strict";
+    array[value] = 42;
+}
+noInline(test2);
+
+var array = new Int32Array([1, 2, 3, 4, 5]);
+
+for (var i = 0; i < 1e5; ++i) {
+    test1(array, i & 0b111);
+    test2(array, i & 0b111);
+}

--- a/JSTests/stress/typed-array-put-by-val-oob-detach.js
+++ b/JSTests/stress/typed-array-put-by-val-oob-detach.js
@@ -1,0 +1,18 @@
+function test1(array, value) {
+    array[value] = 42;
+}
+noInline(test1);
+
+function test2(array, value) {
+    "use strict";
+    array[value] = 42;
+}
+noInline(test2);
+
+var array = new Int32Array([1, 2, 3, 4, 5]);
+array.buffer.transfer();
+
+for (var i = 0; i < 1e5; ++i) {
+    test1(array, i & 0b111);
+    test2(array, i & 0b111);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1609,7 +1609,6 @@ public:
     void compileGetIndexedPropertyStorage(Node*);
     void compileResolveRope(Node*);
     JITCompiler::Jump jumpForTypedArrayOutOfBounds(Node*, GPRReg baseGPR, GPRReg indexGPR, GPRReg scratchGPR, GPRReg scratch2GPR);
-    JITCompiler::Jump jumpForTypedArrayIsDetachedIfOutOfBounds(Node*, GPRReg baseGPR, JITCompiler::Jump outOfBounds);
     void compileGetTypedArrayByteOffset(Node*);
 #if USE(LARGE_TYPED_ARRAYS)
     void compileGetTypedArrayByteOffsetAsInt52(Node*);


### PR DESCRIPTION
#### 4e87c5073b3ed5648e47a3ffe1f5128a5fdd81f8
<pre>
[JSC] OOB PutByVal to TypedArray do not need to do anything more
<a href="https://bugs.webkit.org/show_bug.cgi?id=278182">https://bugs.webkit.org/show_bug.cgi?id=278182</a>
<a href="https://rdar.apple.com/133971914">rdar://133971914</a>

Reviewed by Keith Miller.

OOB PutByVal onto TypedArray does not need to do anything. We remove OSR exit for detached array (we do not need it), and IC is also changed to be more efficient.

                                                  ToT                     Patched

    typed-array-put-by-val-oob               1.1416+-0.0120     ^      1.0989+-0.0124        ^ definitely 1.0388x faster
    typed-array-put-by-val-oob-detach       21.2081+-0.0142     ^      1.1120+-0.0181        ^ definitely 19.0722x faster

* JSTests/microbenchmarks/typed-array-put-by-val-oob-detach.js: Added.
(test1):
(test2):
* JSTests/microbenchmarks/typed-array-put-by-val-oob.js: Added.
(test1):
(test2):
* JSTests/stress/typed-array-put-by-val-oob-detach.js: Added.
(test1):
(test2):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compilePutByValForIntTypedArray):
(JSC::DFG::SpeculativeJIT::jumpForTypedArrayIsDetachedIfOutOfBounds): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compilePutByVal):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/282326@main">https://commits.webkit.org/282326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9229aad324b9aee0aea18844b863f3dca59d996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13694 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54404 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11736 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12286 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55916 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68521 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62049 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6752 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58168 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5644 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83812 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9466 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37982 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14746 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->