### PR TITLE
Web Inspector: Glitches when trying to edit a style from a style sheet that has an @import statement

### DIFF
--- a/LayoutTests/inspector/css/setStyleText-expected.txt
+++ b/LayoutTests/inspector/css/setStyleText-expected.txt
@@ -1,0 +1,246 @@
+Tests for the CSS.setStyleText command.
+
+
+== Running test suite: CSS.setStyleText
+-- Running test case: CSS.setStyleText with @import rule and nested styles
+Fetching author CSS rules for body and target element (div#x)...
+
+Modifying style text for color "red"...
+Modifying style text for color "yellow"...
+Modifying style text for color "lime"...
+Modifying style text for color "blue"...
+Modifying style text for color "magenta"...
+
+Author CSS rules after modifications:
+[
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": "<filtered>"
+    },
+    "sourceLine": "<filtered>",
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "background-color",
+          "value": "red",
+          "text": "background-color: red;",
+          "range": "<filtered>",
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": "<filtered>",
+      "cssText": "background-color: red;"
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "isImplicitlyNested": false
+  },
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": "<filtered>"
+    },
+    "sourceLine": "<filtered>",
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "background-color",
+          "value": "lime",
+          "text": "background-color: lime;",
+          "range": "<filtered>",
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": "<filtered>",
+      "cssText": "background-color: lime;\n#x {background-color: yellow;}\n"
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "isImplicitlyNested": false
+  },
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": "<filtered>"
+    },
+    "sourceLine": "<filtered>",
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "background-color",
+          "value": "blue",
+          "text": "background-color: blue;",
+          "range": "<filtered>",
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": "<filtered>",
+      "cssText": "background-color: blue;\n#x {background-color: magenta;}\n"
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "groupings": [
+      {
+        "type": "media-rule",
+        "ruleId": "<filtered>",
+        "text": "(width >= 0)",
+        "range": "<filtered>",
+        "sourceURL": "<filtered>"
+      }
+    ],
+    "isImplicitlyNested": false
+  },
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "#x",
+          "specificity": [
+            1,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "& #x",
+      "range": "<filtered>"
+    },
+    "sourceLine": "<filtered>",
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "background-color",
+          "value": "yellow",
+          "text": "background-color: yellow;",
+          "range": "<filtered>",
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": "<filtered>",
+      "cssText": "background-color: yellow;"
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "groupings": [
+      {
+        "type": "style-rule",
+        "ruleId": "<filtered>",
+        "text": "body",
+        "range": "<filtered>",
+        "sourceURL": "<filtered>"
+      }
+    ],
+    "isImplicitlyNested": false
+  },
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "#x",
+          "specificity": [
+            1,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "& #x",
+      "range": "<filtered>"
+    },
+    "sourceLine": "<filtered>",
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "background-color",
+          "value": "magenta",
+          "text": "background-color: magenta;",
+          "range": "<filtered>",
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": "<filtered>",
+      "cssText": "background-color: magenta;"
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "groupings": [
+      {
+        "type": "style-rule",
+        "ruleId": "<filtered>",
+        "text": "body",
+        "range": "<filtered>",
+        "sourceURL": "<filtered>"
+      },
+      {
+        "type": "media-rule",
+        "ruleId": "<filtered>",
+        "text": "(width >= 0)",
+        "range": "<filtered>",
+        "sourceURL": "<filtered>"
+      }
+    ],
+    "isImplicitlyNested": false
+  }
+]
+

--- a/LayoutTests/inspector/css/setStyleText.html
+++ b/LayoutTests/inspector/css/setStyleText.html
@@ -1,0 +1,100 @@
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<style>
+    @import url("resources/external.css");
+    body {
+        #x {
+            color: yellow;
+        }
+        color: lime;
+    }
+    @media (width >= 0) {
+        body {
+            color: blue;
+            #x {
+                color: magenta;
+            }
+        }
+    }
+</style>
+<script>
+function test() {
+    let suite = ProtocolTest.createAsyncSuite("CSS.setStyleText");
+
+    suite.addTestCase({
+        name: "CSS.setStyleText with @import rule and nested styles",
+        description: "Test that CSS.setStyleText works OK when there are @import rules and nested styles",
+        test: async () => {
+            ProtocolTest.log("Fetching author CSS rules for body and target element (div#x)...");
+            await InspectorProtocol.awaitCommand({ method: "Page.enable" });
+            let { root } = await InspectorProtocol.awaitCommand({ method: "DOM.getDocument" });
+            let body = await InspectorProtocol.awaitCommand({
+                method: "DOM.querySelector",
+                params: { nodeId: root.nodeId, selector: "body" },
+            });
+            let myDiv = await InspectorProtocol.awaitCommand({
+                method: "DOM.querySelector",
+                params: { nodeId: root.nodeId, selector: "div#x" },
+            });
+
+            const getAuthorRulesMatchingElement = async (element) => {
+                let { matchedCSSRules } = await InspectorProtocol.awaitCommand({
+                    method: "CSS.getMatchedStylesForNode",
+                    params: { nodeId: element.nodeId },
+                });
+                return matchedCSSRules
+                    .map(({ rule }) => rule)
+                    .filter((rule) => rule.origin === "author");
+            };
+
+            const getAllAuthorRules = async () => {
+                let myElements = [body, myDiv];
+                return (await Promise.all(myElements.map(getAuthorRulesMatchingElement))).flat();
+            };
+
+            const modifyBackgroundColorStyle = async (targetColor) => {
+                for (let rule of await getAllAuthorRules()) {
+                    let styleDeclaration = rule.style;
+                    let value = styleDeclaration.cssProperties[0].value;
+                    if (value !== targetColor)
+                        continue;
+
+                    await InspectorProtocol.awaitCommand({
+                        method: "CSS.setStyleText",
+                        params: {
+                            styleId: styleDeclaration.styleId,
+                            text: `background-color: ${value};`,
+                        },
+                    });
+                    return;
+                }
+                throw new Error(`Style with color "${targetColor}" was not found.`);
+            };
+
+            ProtocolTest.log("");
+            for (let targetColor of ["red", "yellow", "lime", "blue", "magenta"]) {
+                ProtocolTest.log(`Modifying style text for color "${targetColor}"...`);
+                await modifyBackgroundColorStyle(targetColor);
+            }
+
+            const filteredValueReplacer = (key, value) => {
+                if (["ruleId", "styleId", "range", "sourceLine", "sourceURL"].includes(key))
+                    return "<filtered>";
+                return value;
+            };
+            ProtocolTest.log("");
+            ProtocolTest.log("Author CSS rules after modifications:");
+            ProtocolTest.json(await getAllAuthorRules(), filteredValueReplacer);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for the CSS.setStyleText command.</p>
+<div id="x"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -179,8 +179,7 @@ public:
     Ref<Inspector::Protocol::CSS::CSSStyle> buildObjectForStyle(CSSStyleDeclaration*);
     RefPtr<Inspector::Protocol::CSS::Grouping> buildObjectForGrouping(CSSRule*);
 
-    enum class IsUndo : bool { No, Yes };
-    virtual ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newText, String* oldText, IsUndo = IsUndo::No);
+    virtual ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newStyleDeclarationText, String* outOldStyleDeclarationText, const String* newRuleText, String* outOldRuleText);
 
     virtual ExceptionOr<String> text() const;
     virtual CSSStyleDeclaration* styleForId(const InspectorCSSId&) const;
@@ -211,7 +210,6 @@ private:
     bool ensureText() const;
     bool ensureSourceData();
     void ensureFlatRules() const;
-    bool styleSheetTextWithChangedStyle(CSSStyleDeclaration*, const String& newStyleText, String* result);
     bool originalStyleSheetText(String* result) const;
     bool resourceStyleSheetText(String* result) const;
     bool inlineStyleSheetText(String* result) const;
@@ -241,7 +239,7 @@ public:
     void didModifyElementAttribute();
     ExceptionOr<String> text() const final;
     CSSStyleDeclaration* styleForId(const InspectorCSSId& id) const final { ASSERT_UNUSED(id, !id.ordinal()); return &inlineStyle(); }
-    ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newText, String* oldText, InspectorStyleSheet::IsUndo = InspectorStyleSheet::IsUndo::No) final;
+    ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newStyleDeclarationText, String* outOldStyleDeclarationText, const String* newRuleText, String* outOldRuleText);
 
 private:
     InspectorStyleSheetForInlineStyle(InspectorPageAgent*, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -157,7 +157,7 @@ public:
     SetStyleTextAction(InspectorStyleSheet* styleSheet, const InspectorCSSId& cssId, const String& text)
         : InspectorCSSAgent::StyleSheetAction(styleSheet)
         , m_cssId(cssId)
-        , m_text(text)
+        , m_newStyleDeclarationText(text)
     {
     }
 
@@ -168,12 +168,22 @@ public:
 
     ExceptionOr<void> undo() override
     {
-        return m_styleSheet->setRuleStyleText(m_cssId, m_oldText, nullptr, InspectorStyleSheet::IsUndo::Yes);
+        return m_styleSheet->setRuleStyleText(
+            m_cssId,
+            m_oldStyleDeclarationText,
+            nullptr, /* outOldStyleDeclarationText */
+            &m_oldRuleText,
+            nullptr /* outOldRuleText */);
     }
 
     ExceptionOr<void> redo() override
     {
-        return m_styleSheet->setRuleStyleText(m_cssId, m_text, &m_oldText);
+        return m_styleSheet->setRuleStyleText(
+            m_cssId,
+            m_newStyleDeclarationText,
+            &m_oldStyleDeclarationText,
+            nullptr, /* newRuleText */
+            &m_oldRuleText);
     }
 
     String mergeId() override
@@ -187,13 +197,14 @@ public:
         ASSERT(action->mergeId() == mergeId());
 
         SetStyleTextAction* other = static_cast<SetStyleTextAction*>(action.get());
-        m_text = other->m_text;
+        m_newStyleDeclarationText = other->m_newStyleDeclarationText;
     }
 
 private:
     InspectorCSSId m_cssId;
-    String m_text;
-    String m_oldText;
+    String m_newStyleDeclarationText;
+    String m_oldStyleDeclarationText;
+    String m_oldRuleText;
 };
 
 class InspectorCSSAgent::SetRuleHeaderTextAction final : public InspectorCSSAgent::StyleSheetAction {


### PR DESCRIPTION
#### 227d5b5816c0493843f5ec63f3aaa869c631e2b8
<pre>
Web Inspector: Glitches when trying to edit a style from a style sheet that has an @import statement
<a href="https://rdar.apple.com/125185110">rdar://125185110</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271403">https://bugs.webkit.org/show_bug.cgi?id=271403</a>

Reviewed by BJ Burg.

This commit optimizes the handling of CSS.setStyleText by using CSSOM
to update the style declaration text directly, to avoid re-parsing the
entire style sheet.

The observed glitch is a combination of two bugs, both due to having to
re-parse for any style edits:

   1. In the backend, when a style sheet with @import statements is
      re-parsed, it (not just the @import-ed ones) may get removed and
      re-added, causing the CSS agent to mistakenly send
      StyleSheetRemoved and StyleSheetAdded events for that parent
      style sheet. (<a href="https://webkit.org/b/279773)">https://webkit.org/b/279773)</a>

   2. Due to @import-ed style sheets receiving new IDs as a result of
      re-parsing, the frontend thinks any edit to the parent style sheet
      is a &quot;significant change.&quot; (Source: <a href="https://github.com/WebKit/WebKit/blob/24b5b087d18d4baa487dd73905c46589fa353da3/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js#L267)">https://github.com/WebKit/WebKit/blob/24b5b087d18d4baa487dd73905c46589fa353da3/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js#L267)</a>
      Handling a significant change triggers a re-render of the entire
      styles panel.

Adjacent to this glitch, there&apos;s another notable consequence involving
re-parsing:

   3. Re-parsing an @import-ed style sheet uses its original text from
      its source, meaning editing the parent style sheet will suddenly
      revert all edits made to any @import-ed style sheets.

By avoiding re-parsing for style declaration edits, we fix the immediate
glitch in the simplest fashion and move towards a more efficient
approach to handle editing. This commit is a step in the direction of
eliminating re-parsing for all style editing functions in the inspector:
   1. Editing the style declaration text is addressed by this PR.
   2. Editing the header of a style rule is already done through CSSOM: <a href="https://github.com/WebKit/WebKit/blob/6277bccb19de5ebd68797f369f8ff24fc4417f2e/Source/WebCore/inspector/InspectorStyleSheet.cpp#L1116-L1119.">https://github.com/WebKit/WebKit/blob/6277bccb19de5ebd68797f369f8ff24fc4417f2e/Source/WebCore/inspector/InspectorStyleSheet.cpp#L1116-L1119.</a>
   3. Editing the header of a non-style rule isn&apos;t directly supported by
      CSSOM but can be achieved equivalently by removing and
      re-inserting the updated rule using CSSOM.
   4. Adding and 5. removing rules can be optimized to use CSSOM in a
      similar way to this patch.

(Functions 3, 4, and 5 may still malfunction with @import rules after
this patch due to <a href="https://webkit.org/b/279773">https://webkit.org/b/279773</a> as they&apos;re still done by
re-parsing.)

* Source/WebCore/inspector/InspectorStyleSheet.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::computeCanonicalRuleText):
(WebCore::InspectorStyleSheet::setRuleStyleText):
   - Still canonicalize the rule body text to enable showing it in the
     Sources tab, but don&apos;t re-parse the whole style sheet just to apply
     the styles. Use CSSOM&apos;s support for that.

(WebCore::InspectorStyleSheetForInlineStyle::setRuleStyleText):
   - Adapt to the signature change of setRuleStyleText.

(WebCore::InspectorStyleSheet::styleSheetTextWithChangedStyle): Deleted.
   - Unused.

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
   - Add field to record the old rule body text to enable faithful
     undoing.

* LayoutTests/inspector/css/setStyleText-expected.txt: Added.
* LayoutTests/inspector/css/setStyleText.html: Added.

Canonical link: <a href="https://commits.webkit.org/283950@main">https://commits.webkit.org/283950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4e77566189a29f888693c8cf63c450e8bf8f76c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/20473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/18975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/69952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/18782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/54270 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/12683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/58656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/73587 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58730 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/61745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3236 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43023 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->