### PR TITLE
text-autospace: implement ideograph-alpha for complex path within an text run

### DIFF
--- a/Source/WTF/wtf/text/CharacterProperties.h
+++ b/Source/WTF/wtf/text/CharacterProperties.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <unicode/uchar.h>
+#include <unicode/uscript.h>
 #include <wtf/text/StringCommon.h>
 
 namespace WTF {
@@ -113,6 +114,48 @@ inline bool isPrivateUseAreaCharacter(char32_t character)
     return block == UBLOCK_PRIVATE_USE_AREA || block == UBLOCK_SUPPLEMENTARY_PRIVATE_USE_AREA_A || block == UBLOCK_SUPPLEMENTARY_PRIVATE_USE_AREA_B;
 }
 
+inline bool isPunctuation(char32_t character)
+{
+    return U_GET_GC_MASK(character) & U_GC_P_MASK;
+}
+
+inline bool isOpeningPunctuation(uint32_t generalCategoryMask)
+{
+    return generalCategoryMask & U_GC_PS_MASK;
+}
+
+inline bool isClosingPunctuation(uint32_t generalCategoryMask)
+{
+    return generalCategoryMask & U_GC_PE_MASK;
+}
+
+inline bool isOfScriptType(char32_t codePoint, UScriptCode scriptType)
+{
+    UErrorCode error = U_ZERO_ERROR;
+    UScriptCode script = uscript_getScript(codePoint, &error);
+    if (error != U_ZERO_ERROR) {
+        LOG_ERROR("got ICU error while trying to look at scripts: %d", error);
+        return false;
+    }
+    return script == scriptType;
+}
+
+inline UEastAsianWidth eastAsianWidth(char32_t character)
+{
+    return static_cast<UEastAsianWidth>(u_getIntPropertyValue(character, UCHAR_EAST_ASIAN_WIDTH));
+}
+
+inline bool isEastAsianFullWidth(char32_t character)
+{
+    return eastAsianWidth(character) == UEastAsianWidth::U_EA_FULLWIDTH;
+}
+
+inline bool isCJKSymbolOrPunctuation(char32_t character)
+{
+    // CJK Symbols and Punctuation block (U+3000–U+303F)
+    return character >= 0x3000 && character <= 0x303F;
+}
+
 } // namespace WTF
 
 using WTF::isEmojiGroupCandidate;
@@ -125,3 +168,9 @@ using WTF::isEmojiModifierBase;
 using WTF::isDefaultIgnorableCodePoint;
 using WTF::isControlCharacter;
 using WTF::isPrivateUseAreaCharacter;
+using WTF::isPunctuation;
+using WTF::isOpeningPunctuation;
+using WTF::isClosingPunctuation;
+using WTF::isOfScriptType;
+using WTF::isEastAsianFullWidth;
+using WTF::isCJKSymbolOrPunctuation;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2646,6 +2646,7 @@ platform/text/QuotedPrintable.cpp
 platform/text/SegmentedString.cpp
 platform/text/TextBoundaries.cpp
 platform/text/TextFlags.cpp
+platform/text/TextSpacing.cpp
 platform/video-codecs/BitReader.cpp
 platform/xr/openxr/OpenXRInput.cpp
 platform/xr/openxr/OpenXRInputSource.cpp

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -33,6 +33,7 @@
 #include "TextBreakingPositionCache.h"
 #include "TextUtil.h"
 #include "UnicodeBidi.h"
+#include "platform/text/TextSpacing.h"
 #include <wtf/Scope.h>
 #include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -679,6 +680,7 @@ static inline bool canCacheMeasuredWidthOnInlineTextItem(const InlineTextBox& in
 
 void InlineItemsBuilder::computeInlineTextItemWidths(InlineItemList& inlineItemList)
 {
+    TextSpacing::SpacingState spacingState;
     for (auto& inlineItem : inlineItemList) {
         auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem);
         if (!inlineTextItem)
@@ -690,7 +692,8 @@ void InlineItemsBuilder::computeInlineTextItemWidths(InlineItemList& inlineItemL
         auto needsMeasuring = length && !inlineTextItem->isZeroWidthSpaceSeparator();
         if (!needsMeasuring || !canCacheMeasuredWidthOnInlineTextItem(inlineTextBox, inlineTextItem->isWhitespace()))
             continue;
-        inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + length, { }));
+        inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + length, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState));
+        spacingState.lastCharacterClassFromPreviousRun = inlineItem.style().textAutospace().isNoAutospace() ? TextSpacing::CharacterClass::Undefined : TextSpacing::characterClass(inlineTextBox.content().characterAt(start + length - 1));
     }
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -37,6 +37,7 @@
 #include "RenderStyleInlines.h"
 #include "SurrogatePairAwareTextIterator.h"
 #include "TextRun.h"
+#include "TextSpacing.h"
 #include "WidthIterator.h"
 #include <unicode/ubidi.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -51,7 +52,7 @@ static inline InlineLayoutUnit spaceWidth(const FontCascade& fontCascade, bool c
     return fontCascade.widthOfSpaceString();
 }
 
-InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization)
+InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization, TextSpacing::SpacingState spacingState)
 {
     if (from == to)
         return 0;
@@ -82,6 +83,8 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
         auto run = WebCore::TextRun { StringView(text).substring(from, to - from), contentLogicalLeft, { }, ExpansionBehavior::defaultBehavior(), directionalOverride ? style.direction() : TextDirection::LTR, directionalOverride };
         if (!style.collapseWhiteSpace() && style.tabSize())
             run.setTabSize(true, style.tabSize());
+        // FIXME: consider moving this to TextRun ctor
+        run.setTextSpacingState(spacingState);
         width = fontCascade.width(run);
     }
 
@@ -98,7 +101,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const Fon
     return TextUtil::width(inlineTextItem, fontCascade, inlineTextItem.start(), inlineTextItem.end(), contentLogicalLeft);
 }
 
-InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization)
+InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization, TextSpacing::SpacingState spacingState)
 {
     RELEASE_ASSERT(from >= inlineTextItem.start());
     RELEASE_ASSERT(to <= inlineTextItem.end());
@@ -116,7 +119,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const Fon
             return std::max(0.f, width);
         }
     }
-    return width(inlineTextItem.inlineTextBox(), fontCascade, from, to, contentLogicalLeft, useTrailingWhitespaceMeasuringOptimization);
+    return width(inlineTextItem.inlineTextBox(), fontCascade, from, to, contentLogicalLeft, useTrailingWhitespaceMeasuringOptimization, spacingState);
 }
 
 InlineLayoutUnit TextUtil::trailingWhitespaceWidth(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, size_t startPosition, size_t endPosition)

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -35,6 +35,10 @@
 
 namespace WebCore {
 
+namespace TextSpacing {
+struct SpacingState;
+}
+
 class RenderStyle;
 class TextRun;
 
@@ -48,8 +52,8 @@ class TextUtil {
 public:
     enum class UseTrailingWhitespaceMeasuringOptimization : bool { No, Yes };
     static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, InlineLayoutUnit contentLogicalLeft);
-    static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes);
-    static InlineLayoutUnit width(const InlineTextBox&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes);
+    static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { });
+    static InlineLayoutUnit width(const InlineTextBox&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { });
 
     static InlineLayoutUnit trailingWhitespaceWidth(const InlineTextBox&, const FontCascade&, size_t startPosition, size_t endPosition);
 

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -124,6 +124,7 @@ ComplexTextController::ComplexTextController(const FontCascade& font, const Text
     , m_expansion(run.expansion())
     , m_mayUseNaturalWritingDirection(mayUseNaturalWritingDirection)
     , m_forTextEmphasis(forTextEmphasis)
+    , m_textSpacingState(run.textSpacingState())
 {
     computeExpansionOpportunity();
 
@@ -554,7 +555,10 @@ void ComplexTextController::advance(unsigned offset, GlyphBuffer* glyphBuffer, G
                 return;
 
             if (glyphBuffer && !m_characterInCurrentGlyph) {
+                ASSERT(m_textAutoSpaceSpacings.isEmpty() || m_textAutoSpaceSpacings.size() == m_adjustedBaseAdvances.size());
+                auto textAutoSpaceSpacing = m_textAutoSpaceSpacings.isEmpty() ? 0.0 : m_textAutoSpaceSpacings[glyphIndexIntoComplexTextController];
                 auto currentGlyphOrigin = glyphOrigin(glyphIndexIntoComplexTextController);
+                currentGlyphOrigin.move(textAutoSpaceSpacing, 0);
                 GlyphBufferAdvance paintAdvance = makeGlyphBufferAdvance(adjustedBaseAdvance);
                 if (!glyphIndexIntoCurrentRun) {
                     // The first layout advance of every run includes the "initial layout advance." However, here, we need
@@ -572,7 +576,7 @@ void ComplexTextController::advance(unsigned offset, GlyphBuffer* glyphBuffer, G
                     setHeight(paintAdvance, height(paintAdvance) - glyphOrigin(glyphIndexIntoComplexTextController + 1).y() + m_complexTextRuns[currentRunIndex + 1]->initialAdvance().height());
                 }
                 setHeight(paintAdvance, -height(paintAdvance)); // Increasing y points down
-                glyphBuffer->add(m_adjustedGlyphs[glyphIndexIntoComplexTextController], complexTextRun.font(), paintAdvance, complexTextRun.indexAt(m_glyphInCurrentRun));
+                glyphBuffer->add(m_adjustedGlyphs[glyphIndexIntoComplexTextController], complexTextRun.font(), paintAdvance, complexTextRun.indexAt(m_glyphInCurrentRun), FloatPoint(textAutoSpaceSpacing, 0));
             }
 
             unsigned oldCharacterInCurrentGlyph = m_characterInCurrentGlyph;
@@ -633,6 +637,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
     bool runForbidsLeftExpansion = m_run.expansionBehavior().left == ExpansionBehavior::Behavior::Forbid;
     bool runForbidsRightExpansion = m_run.expansionBehavior().right == ExpansionBehavior::Behavior::Forbid;
 
+    TextSpacing::CharacterClass previousCharacterClass = m_textSpacingState.lastCharacterClassFromPreviousRun;
     // We are iterating in glyph order, not string order. Compare this to WidthIterator::advanceInternal()
     for (size_t runIndex = 0; runIndex < runCount; ++runIndex) {
         ComplexTextRun& complexTextRun = *m_complexTextRuns[runIndex];
@@ -748,6 +753,18 @@ void ComplexTextController::adjustGlyphsAndAdvances()
                     afterExpansion = false;
             }
 
+            const auto& textAutoSpace =  m_font.textAutospace();
+            float textAutoSpaceSpacing = 0;
+            auto characterClass = TextSpacing::CharacterClass::Undefined;
+            if (!textAutoSpace.isNoAutospace())
+                characterClass = TextSpacing::characterClass(character);
+            if (textAutoSpace.shouldApplySpacing(previousCharacterClass, characterClass)) {
+                textAutoSpaceSpacing = complexTextRun.textAutospaceSize();
+                advance.expand(textAutoSpaceSpacing, 0);
+            }
+            if (!textAutoSpace.isNoAutospace())
+                m_textAutoSpaceSpacings.append(textAutoSpaceSpacing);
+
             m_totalAdvance += advance;
 
             if (m_forTextEmphasis) {
@@ -763,7 +780,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             if (auto* origins = complexTextRun.glyphOrigins()) {
                 ASSERT(m_glyphOrigins.size() < m_adjustedBaseAdvances.size());
                 m_glyphOrigins.grow(m_adjustedBaseAdvances.size());
-                m_glyphOrigins[m_glyphOrigins.size() - 1] = origins[glyphIndex];
+                m_glyphOrigins[m_glyphOrigins.size() - 1] = origins[glyphIndex] + FloatSize(textAutoSpaceSpacing, 0);
                 ASSERT(m_glyphOrigins.size() == m_adjustedBaseAdvances.size());
             }
             m_adjustedGlyphs.append(glyph);
@@ -777,6 +794,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             glyphOrigin.move(advance);
 
             previousCharacterIndex = characterIndex;
+            previousCharacterClass = characterClass;
         }
         if (!isMonotonic)
             complexTextRun.setIsNonMonotonic();
@@ -793,6 +811,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(const Font& font, const UC
     , m_indexEnd(indexEnd)
     , m_stringLocation(stringLocation)
     , m_isLTR(ltr)
+    , m_textAutospaceSize(TextAutospace::textAutospaceSize(font))
 {
     auto runLengthInCodeUnits = m_indexEnd - m_indexBegin;
     m_coreTextIndices.reserveInitialCapacity(runLengthInCodeUnits);
@@ -832,6 +851,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(const Vector<FloatSize>& a
     , m_glyphCount(glyphs.size())
     , m_stringLocation(stringLocation)
     , m_isLTR(ltr)
+    , m_textAutospaceSize(TextAutospace::textAutospaceSize(font))
 {
 }
 

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -26,6 +26,7 @@
 
 #include "FloatPoint.h"
 #include "GlyphBuffer.h"
+#include "TextSpacing.h"
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
@@ -118,6 +119,7 @@ public:
         bool isLTR() const { return m_isLTR; }
         bool isMonotonic() const { return m_isMonotonic; }
         void setIsNonMonotonic();
+        float textAutospaceSize() const { return m_textAutospaceSize; }
 
     private:
         ComplexTextRun(CTRunRef, const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd);
@@ -144,6 +146,7 @@ public:
         unsigned m_stringLocation;
         bool m_isLTR;
         bool m_isMonotonic { true };
+        float m_textAutospaceSize { 0 };
     };
 private:
     void computeExpansionOpportunity();
@@ -169,6 +172,7 @@ private:
     Vector<FloatSize, 256> m_adjustedBaseAdvances;
     Vector<FloatPoint, 256> m_glyphOrigins;
     Vector<CGGlyph, 256> m_adjustedGlyphs;
+    Vector<float, 256> m_textAutoSpaceSpacings;
 
     Vector<UChar, 256> m_smallCapsBuffer;
 
@@ -217,6 +221,7 @@ private:
     bool m_isLTROnly { true };
     bool m_mayUseNaturalWritingDirection { false };
     bool m_forTextEmphasis { false };
+    TextSpacing::SpacingState m_textSpacingState;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -308,7 +308,7 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
     }
 
     bool hasWordSpacingOrLetterSpacing = wordSpacing() || letterSpacing();
-    float* cacheEntry = protectedFonts()->widthCache().add(run, std::numeric_limits<float>::quiet_NaN(), enableKerning() || requiresShaping(), hasWordSpacingOrLetterSpacing, glyphOverflow);
+    float* cacheEntry = protectedFonts()->widthCache().add(run, std::numeric_limits<float>::quiet_NaN(), enableKerning() || requiresShaping(), hasWordSpacingOrLetterSpacing, !textAutospace().isNoAutospace(), glyphOverflow);
     if (cacheEntry && !std::isnan(*cacheEntry))
         return *cacheEntry;
 
@@ -628,6 +628,10 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
 {
     if (s_codePath != CodePath::Auto)
         return s_codePath;
+
+    // FIXME: add support for text-autospace on simple path (rdar://133319627).
+    if (textAutospace().hasIdeographAlpha())
+        return CodePath::Complex;
 
 #if !USE(FREETYPE)
     // FIXME: Use the fast code path once it handles partial runs with kerning and ligatures. See http://webkit.org/b/100050

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -103,12 +103,12 @@ public:
         add(glyph, font, advance, offsetInString);
     }
 
-    void add(Glyph glyph, const Font& font, GlyphBufferAdvance advance, GlyphBufferStringOffset offsetInString)
+    void add(Glyph glyph, const Font& font, GlyphBufferAdvance advance, GlyphBufferStringOffset offsetInString, FloatPoint origin = { })
     {
         m_fonts.append(&font);
         m_glyphs.append(glyph);
         m_advances.append(advance);
-        m_origins.append(makeGlyphBufferOrigin());
+        m_origins.append(makeGlyphBufferOrigin(origin));
         m_offsetsInString.append(offsetInString);
     }
 

--- a/Source/WebCore/platform/graphics/TextRun.cpp
+++ b/Source/WebCore/platform/graphics/TextRun.cpp
@@ -38,6 +38,7 @@ struct ExpectedTextRunSize final : public CanMakeCheckedPtr<ExpectedTextRunSize>
     float float2;
     float float3;
     ExpansionBehavior expansionBehavior;
+    TextSpacing::SpacingState spacingState;
     unsigned bitfields : 5;
 };
 

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -25,6 +25,7 @@
 
 #include "TabSize.h"
 #include "TextFlags.h"
+#include "TextSpacing.h"
 #include "WritingMode.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/text/StringView.h>
@@ -155,6 +156,9 @@ public:
 
     const String& textAsString() const { return m_text; }
 
+    void setTextSpacingState(TextSpacing::SpacingState spacingState) { m_textSpacingState = spacingState; }
+    TextSpacing::SpacingState textSpacingState() const { return m_textSpacingState; }
+
 private:
     String m_text;
 
@@ -169,6 +173,9 @@ private:
 
     float m_expansion;
     ExpansionBehavior m_expansionBehavior;
+
+    TextSpacing::SpacingState m_textSpacingState;
+
     unsigned m_allowTabs : 1;
     unsigned m_direction : 1;
     unsigned m_directionalOverride : 1; // Was this direction set by an override character.

--- a/Source/WebCore/platform/graphics/TextRunHash.h
+++ b/Source/WebCore/platform/graphics/TextRunHash.h
@@ -54,7 +54,8 @@ inline bool TextRun::operator==(const TextRun& other) const
         && m_direction == other.m_direction
         && m_directionalOverride == other.m_directionalOverride
         && m_characterScanForCodePath == other.m_characterScanForCodePath
-        && m_disableSpacing == other.m_disableSpacing;
+        && m_disableSpacing == other.m_disableSpacing
+        && m_textSpacingState == other.m_textSpacingState;
 }
 
 struct TextRunHash {

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -45,6 +45,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
     , m_glyphCount(CTRunGetGlyphCount(ctRun))
     , m_stringLocation(stringLocation)
     , m_isLTR(!(CTRunGetStatus(ctRun) & kCTRunStatusRightToLeft))
+    , m_textAutospaceSize(TextAutospace::textAutospaceSize(font))
 {
     const CFIndex* coreTextIndicesPtr = CTRunGetStringIndicesPtr(ctRun);
     Vector<CFIndex> coreTextIndices;

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -142,6 +142,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const
     , m_glyphCount(hb_buffer_get_length(buffer))
     , m_stringLocation(stringLocation)
     , m_isLTR(HB_DIRECTION_IS_FORWARD(hb_buffer_get_direction(buffer)))
+    , m_textAutospaceSize(TextAutospace::textAutospaceSize(font))
 {
     if (!m_glyphCount)
         return;

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -51,6 +51,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const
     , m_glyphCount(hb_buffer_get_length(buffer))
     , m_stringLocation(stringLocation)
     , m_isLTR(HB_DIRECTION_IS_FORWARD(hb_buffer_get_direction(buffer)))
+    , m_textAutospaceSize(TextAutospace::textAutospaceSize(font))
 {
     if (!m_glyphCount)
         return;

--- a/Source/WebCore/platform/text/TextSpacing.cpp
+++ b/Source/WebCore/platform/text/TextSpacing.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextSpacing.h"
+
+#include "Font.h"
+
+namespace WebCore {
+
+using namespace TextSpacing;
+
+bool TextAutospace::shouldApplySpacing(CharacterClass firstCharacterClass, CharacterClass secondCharacterClass) const
+{
+    constexpr uint8_t ideographAlphaMask = static_cast<uint8_t>(CharacterClass::Ideograph) | static_cast<uint8_t>(CharacterClass::NonIdeographLetter);
+    if (hasIdeographAlpha())
+        return (static_cast<uint8_t>(firstCharacterClass) | static_cast<uint8_t>(secondCharacterClass)) == ideographAlphaMask;
+    return false;
+}
+
+float TextAutospace::textAutospaceSize(const Font& font)
+{
+    // https://www.w3.org/TR/css-text-4/#text-autospace-property
+    // The amount of space introduced by these keywords is 1/8 of the CJK advance measure, i.e 0.125ic.
+    return 0.125 * font.fontMetrics().ideogramWidth().value_or(0);
+}
+
+namespace TextSpacing {
+
+bool isIdeograph(char32_t character)
+{
+    // Lowest possible ideographic codepoint
+    if (character < 0x2E80)
+        return false;
+
+    // All characters in the range of U+3041 to U+30FF, except those that belong to Unicode Punctuation [P*]
+    if ((character >= 0x3041 && character <= 0x30FF) && !isPunctuation(character))
+        return true;
+    // CJK Strokes (U+31C0 to U+31EF).
+    if (character >= 0x31C0 && character <= 0x31EF)
+        return true;
+    // Katakana Phonetic Extensions (U+31F0 to U+31FF)
+    if (character >= 0x31F0 && character <= 0x31FF)
+        return true;
+    if (isOfScriptType(character, UScriptCode::USCRIPT_HAN))
+        return true;
+
+    return false;
+}
+
+static bool isNonIdeographicNumeral(char32_t character, uint32_t generalCategoryMask)
+{
+    // FIXME: Should also check that it is not: upright in vertical text flow using the text-orientation property or the text-combine-upright property.
+    return (generalCategoryMask & U_GC_ND_MASK) && !isEastAsianFullWidth(character);
+}
+
+// Classes are defined at https://www.w3.org/TR/css-text-4/#text-spacing-classes
+CharacterClass characterClass(char32_t character)
+{
+    auto generalCategoryMask = U_GET_GC_MASK(character);
+    if (isIdeograph(character))
+        return CharacterClass::Ideograph;
+
+    // We already know it is not an Ideograph from here
+    // FIXME: Should also check that it is not: upright in vertical text flow using the text-orientation property or the text-combine-upright property.
+    if (generalCategoryMask & (U_GC_M_MASK | U_GC_L_MASK)) {
+        if (!isEastAsianFullWidth(character))
+            return CharacterClass::NonIdeographLetter;
+        // General Category M/L won't apply to anything else
+        return CharacterClass::Undefined;
+    }
+
+    if (isNonIdeographicNumeral(character, generalCategoryMask))
+        return CharacterClass::NonIdeographNumeral;
+
+    if (generalCategoryMask & U_GC_P_MASK) {
+        if (isCJKSymbolOrPunctuation(character) || isEastAsianFullWidth(character)) {
+            if (isOpeningPunctuation(generalCategoryMask))
+                return CharacterClass::FullWidthOpeningPunctuation;
+            if (isClosingPunctuation(generalCategoryMask))
+                return CharacterClass::FullWidthClosingPunctuation;
+        }
+        if (character == leftSingleQuotationMark || character == leftDoubleQuotationMark)
+            return CharacterClass::FullWidthOpeningPunctuation;
+        if (character == rightSingleQuotationMark || character == rightDoubleQuotationMark)
+            return CharacterClass::FullWidthClosingPunctuation;
+    }
+    // FIXME: implement remaining classes for text-autospace: punctuation
+    return CharacterClass::Undefined;
+}
+
+} // namespace TextSpacing
+} // namespace WebCore


### PR DESCRIPTION
#### 9a0477f0216ba3650747c597973d4829fdb9b7af
<pre>
text-autospace: implement ideograph-alpha for complex path within an text run
<a href="https://bugs.webkit.org/show_bug.cgi?id=277716">https://bugs.webkit.org/show_bug.cgi?id=277716</a>
<a href="https://rdar.apple.com/133309470">rdar://133309470</a>

Reviewed by Matthieu Dubet.

We are relanding this patch as its first version was reverted due to performance
reasons. On the current iteration we are avoiding classifying characters when
not needed (text-autospace: no-autospace). We also won&apos;t keep the parralel
vector for the added spacing in such a case.

Original patch description:

This patch implements the processing of text-autospace: ideogram-alpha
only within an element. We don&apos;t yet handle element boundaries here.

Although we pass SpacingState context from one ComplexTextController
to another, we do that here in a limited way, only for measuring text for
layout and for painting. There are other places in code which this will
be necessary, for example, for handling element boundaries.

1. During the construction of ComplexTextController, we call ::adjustGlyphsAndAdvances
which already iterates through glyphs and adjust spacing for other reasons.
Now we process each pair of characters related to these glyphs here, adding the
spacing necessary before the &quot;current&quot; character.  For that reason, the SpacingState
stores information about the previous character of a run. We also save the measured
spacing in a new parallel vector m_textAutoSpaceSpacings. At this phase we can
only manipulate a glyph advance, however, for adding space &quot;before&quot; a glyph,
we need to move the glyph to the logical right, which is done later on ::advance.

2. ComplexTextController::advance is called for both layout and painting, but during
painting it has access to a GlyphBuffer and it add glyphs into it. We are introducing
a new GlyphBuffer::add function that also takes the glyph&apos;s origin, so we can manipulate
the origin as necessary by adding the previous calculated spacing.

3. Doing #1 and #2 is already enough for painting the extra spacing between relevant characters
according to their classes. Howeverm the width measured during layout would be broken because
IFC splits text content into inlineTextItem(s) and measure the width of each item independently.
This means that we already have to handle SpacingState passing here, otherwise we are not able
to handle spacing between characters on the boundary of different InlineTextItem.

* Source/WTF/wtf/text/CharacterProperties.h:
(WTF::isPunctuation):
(WTF::isOpeningPunctuation):
(WTF::isClosingPunctuation):
(WTF::isOfScriptType):
(WTF::eastAsianWidth):
(WTF::isEastAsianFullWidth):
(WTF::isCJKSymbolOrPunctuation):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidths):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::width):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
(WebCore::Layout::TextUtil::width):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::ComplexTextController):
(WebCore::ComplexTextController::advance):
(WebCore::ComplexTextController::adjustGlyphsAndAdvances):
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
* Source/WebCore/platform/graphics/ComplexTextController.h:
(WebCore::ComplexTextController::ComplexTextRun::textAutospaceSize const):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::width const):
(WebCore::FontCascade::codePath const):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::add):
* Source/WebCore/platform/graphics/TextRun.cpp:
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::add):
(WebCore::WidthCache::invalidateCacheForTextSpacing):
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
* Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
* Source/WebCore/platform/text/TextSpacing.cpp: Added.
(WebCore::TextAutospace::shouldApplySpacing const):
(WebCore::TextAutospace::textAutospaceSize):
(WebCore::TextSpacing::isIdeograph):
(WebCore::TextSpacing::isNonIdeographicNumeral):
(WebCore::TextSpacing::characterClass):
* Source/WebCore/platform/text/TextSpacing.h:
(WebCore::TextAutospace::hasIdeographAlpha const):
(WebCore::TextAutospace::hasIdeographNumeric const):

Canonical link: <a href="https://commits.webkit.org/282511@main">https://commits.webkit.org/282511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f6c2cc7d44bcc057cb47b818a1b07a68d5ded5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9657 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54870 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12220 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12840 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/56472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69077 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62604 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54941 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6093 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84366 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14865 "Found 1 new JSC stress test failure: stress/proxy-set.js.mini-mode (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39616 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->