### PR TITLE
Defer GC while compiling wasm modules

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -628,6 +628,8 @@ private:
     JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(GCDeferralContext*, const JSCell*, size_t);
     JS_EXPORT_PRIVATE void deprecatedReportExtraMemorySlowCase(size_t);
     
+    size_t totalBytesAllocatedThisCycle() { return m_nonOversizedBytesAllocatedThisCycle + m_oversizedBytesAllocatedThisCycle; }
+
     bool shouldCollectInCollectorThread(const AbstractLocker&);
     void collectInCollectorThread();
     
@@ -777,7 +779,10 @@ private:
     size_t m_sizeAfterLastEdenCollect { 0 };
     size_t m_sizeBeforeLastEdenCollect { 0 };
 
-    size_t m_bytesAllocatedThisCycle { 0 };
+    size_t m_oversizedBytesAllocatedThisCycle { 0 };
+    size_t m_lastOversidedAllocationThisCycle { 0 };
+
+    size_t m_nonOversizedBytesAllocatedThisCycle { 0 };
     size_t m_bytesAbandonedSinceLastFullCollect { 0 };
     size_t m_maxEdenSize;
     size_t m_maxEdenSizeWhenCritical;

--- a/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
@@ -74,7 +74,7 @@ void SpaceTimeMutatorScheduler::beginCollection()
     m_state = Stopped;
     m_startTime = MonotonicTime::now();
 
-    m_bytesAllocatedThisCycleAtTheBeginning = m_heap.m_bytesAllocatedThisCycle;
+    m_bytesAllocatedThisCycleAtTheBeginning = bytesAllocatedThisCycleImpl();
     m_bytesAllocatedThisCycleAtTheEnd = 
         Options::concurrentGCMaxHeadroom() *
         std::max<double>(m_bytesAllocatedThisCycleAtTheBeginning, m_heap.m_maxEdenSize);
@@ -156,7 +156,7 @@ void SpaceTimeMutatorScheduler::endCollection()
 
 double SpaceTimeMutatorScheduler::bytesAllocatedThisCycleImpl()
 {
-    return m_heap.m_bytesAllocatedThisCycle;
+    return m_heap.totalBytesAllocatedThisCycle();
 }
 
 double SpaceTimeMutatorScheduler::bytesSinceBeginningOfCycle(const Snapshot& snapshot)

--- a/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
@@ -73,7 +73,7 @@ void StochasticSpaceTimeMutatorScheduler::beginCollection()
     RELEASE_ASSERT(m_state == Normal);
     m_state = Stopped;
 
-    m_bytesAllocatedThisCycleAtTheBeginning = m_heap.m_bytesAllocatedThisCycle;
+    m_bytesAllocatedThisCycleAtTheBeginning = bytesAllocatedThisCycleImpl();
     m_bytesAllocatedThisCycleAtTheEnd = 
         Options::concurrentGCMaxHeadroom() *
         std::max<double>(m_bytesAllocatedThisCycleAtTheBeginning, m_heap.m_maxEdenSize);
@@ -185,7 +185,7 @@ void StochasticSpaceTimeMutatorScheduler::endCollection()
 
 double StochasticSpaceTimeMutatorScheduler::bytesAllocatedThisCycleImpl()
 {
-    return m_heap.m_bytesAllocatedThisCycle;
+    return m_heap.totalBytesAllocatedThisCycle();
 }
 
 double StochasticSpaceTimeMutatorScheduler::bytesSinceBeginningOfCycle(const Snapshot& snapshot)

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -142,6 +142,28 @@ WTF_EXPORT_PRIVATE void printInternal(PrintStream&, RawHex);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, RawPointer);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, FixedWidthDouble);
 
+template<typename... Values>
+class ConditionalDump {
+public:
+    explicit ConditionalDump(bool shouldPrint, const Values&... values)
+        : m_shouldPrint(shouldPrint)
+        , m_values(values...)
+    { }
+
+    void dump(PrintStream& out) const
+    {
+        if (!m_shouldPrint)
+            return;
+        std::apply([&] (const auto&... values) {
+            out.print(values...);
+        }, m_values);
+    }
+
+private:
+    bool m_shouldPrint;
+    std::tuple<const Values&...> m_values;
+};
+
 template<typename Enum>
 requires (std::is_enum_v<std::decay_t<Enum>>)
 void printInternal(PrintStream& out, Enum e)
@@ -410,6 +432,7 @@ void printInternal(PrintStream& out, const std::optional<T>& value)
 } // namespace WTF
 
 using WTF::boolForPrinting;
+using WTF::ConditionalDump;
 using WTF::ScopedEnumDump;
 using WTF::EnumDumpWithDefault;
 using WTF::CharacterDump;

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -206,7 +206,8 @@ void OpportunisticTaskScheduler::FullGCActivityCallback::doCollection(JSC::VM& v
             return;
         }
 
-        if (++m_deferCount < deferCountThreshold) {
+        // deferredWorkTimer->hasImminentlyScheduledWork() typically means a wasm compilation is happening right now so we REALLY don't want to GC now.
+        if (++m_deferCount < deferCountThreshold || vm.deferredWorkTimer->hasImminentlyScheduledWork()) {
             m_delay = delay;
             setTimeUntilFire(delay);
             return;
@@ -249,7 +250,8 @@ void OpportunisticTaskScheduler::EdenGCActivityCallback::doCollection(JSC::VM& v
             return;
         }
 
-        if (++m_deferCount < deferCountThreshold) {
+        // deferredWorkTimer->hasImminentlyScheduledWork() typically means a wasm compilation is happening right now so we REALLY don't want to GC now.
+        if (++m_deferCount < deferCountThreshold || vm.deferredWorkTimer->hasImminentlyScheduledWork()) {
             m_delay = delay;
             setTimeUntilFire(delay);
             return;


### PR DESCRIPTION
#### cb65a1a9caa7c9e6dcd70d1548ebf9e354a69031
<pre>
Defer GC while compiling wasm modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=278183">https://bugs.webkit.org/show_bug.cgi?id=278183</a>
<a href="https://rdar.apple.com/133973759">rdar://133973759</a>

Reviewed by Yusuke Suzuki.

Right now when we start to compile a wasm module we typically end up allocating a
Wasm::Memory. Since Wasm::Memories tend to be VERY large (some multiple of 64KB)
this typically triggers a GC. However since most of the additional memory is from
a Wasm::Memory, which likely won&apos;t be free for a while we don&apos;t collect much and
spend a lot of critical CPU time GCing. We could have just deferred GC by forcing
GC to be deferred but that felt overly aggressive. Instead this patch introduces
a concept of oversized allocations which is anything &gt;= 64KB (smaller numbers
weren&apos;t sufficient). When the last oversized allocation is more than 1/3 of the
total bytes allocated this cycle we now defer GC.

Just deferring GC from collectIfNecessaryOrDefer was still insufficient to stop
GCs during compilation. We also have to force OpportunisticTaskScheduler to defer
timer based GCs while wasm compilation is going on.

This seems to be a .5-1% JetStream progression and weirdly might also be a
RAMification win too. Also seems neutral for other memory tests and Speedometer.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::reportAbandonedObjectGraph):
(JSC::Heap::runBeginPhase):
(JSC::Heap::willStartCollection):
(JSC::Heap::updateAllocationLimits):
(JSC::Heap::didAllocate):
(JSC::Heap::collectIfNecessaryOrDefer):
* Source/JavaScriptCore/heap/Heap.h:
(JSC::Heap::totalBytesAllocatedThisCycle):
* Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp:
(JSC::SpaceTimeMutatorScheduler::beginCollection):
(JSC::SpaceTimeMutatorScheduler::bytesAllocatedThisCycleImpl):
* Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp:
(JSC::StochasticSpaceTimeMutatorScheduler::beginCollection):
(JSC::StochasticSpaceTimeMutatorScheduler::bytesAllocatedThisCycleImpl):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::performOpportunisticallyScheduledTasks):
* Source/WTF/wtf/PrintStream.h:
(WTF::ConditionalDump::ConditionalDump):
(WTF::ConditionalDump::dump const):
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::FullGCActivityCallback::doCollection):
(WebCore::OpportunisticTaskScheduler::EdenGCActivityCallback::doCollection):

Canonical link: <a href="https://commits.webkit.org/282325@main">https://commits.webkit.org/282325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ddee80599fd16681b6b723f82f6b0d8adc93652

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13703 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39208 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12295 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/55925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57458 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68530 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62058 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54470 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5655 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37991 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14748 "Found 8 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-multi-value-exception-in-iterator.js.wasm-slow-memory (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->