### PR TITLE
[Writing Tools] Affordance doesn't show up when hovering over multiple lines of text containing newlines

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6966,20 +6966,28 @@ void WebPage::firstRectForCharacterRangeAsync(const EditingRange& editingRange, 
 
     auto rect = RefPtr(frame->view())->contentsToWindow(frame->editor().firstRectForRange(*range));
     auto startPosition = makeContainerOffsetPosition(range->start);
-    auto lineEndPosition = endOfLine(startPosition);
-    if (lineEndPosition.isNull())
-        lineEndPosition = startPosition;
-    auto lineEndBoundary = makeBoundaryPoint(lineEndPosition);
-    if (!lineEndBoundary)
+
+    auto endPosition = endOfLine(startPosition);
+    if (endPosition.isNull())
+        endPosition = startPosition;
+    else if (endPosition.affinity() == Affinity::Downstream && inSameLine(startPosition, endPosition)) {
+        auto nextLineStartPosition = positionOfNextBoundaryOfGranularity(endPosition, TextGranularity::LineGranularity, SelectionDirection::Forward);
+        if (nextLineStartPosition.isNotNull() && endPosition < nextLineStartPosition)
+            endPosition = nextLineStartPosition;
+    }
+
+    auto endBoundary = makeBoundaryPoint(endPosition);
+    if (!endBoundary)
         return completionHandler({ }, editingRange);
 
-    auto rangeForFirstLine = EditingRange::fromRange(*frame, makeSimpleRange(range->start, WTFMove(lineEndBoundary)));
+    auto rangeForFirstLine = EditingRange::fromRange(*frame, makeSimpleRange(range->start, WTFMove(endBoundary)));
 
     rangeForFirstLine.location = std::min(std::max(rangeForFirstLine.location, editingRange.location), editingRange.location + editingRange.length);
     rangeForFirstLine.length = std::min(rangeForFirstLine.location + rangeForFirstLine.length, editingRange.location + editingRange.length) - rangeForFirstLine.location;
 
     completionHandler(rect, rangeForFirstLine);
 }
+
 void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<CharacterRange>>& annotations, const EditingRange& selection, const EditingRange& replacementEditingRange)
 {
     platformWillPerformEditingCommand();

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
@@ -108,6 +108,18 @@
     return result;
 }
 
+- (NSRange)_selectedRange
+{
+    __block bool done = false;
+    __block NSRange result;
+    [static_cast<id<NSTextInputClient_Async>>(self) selectedRangeWithCompletionHandler:^(NSRange selectedRange) {
+        result = selectedRange;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result;
+}
+
 @end
 
 @interface SetMarkedTextWithNoAttributedStringTestCandidate : NSTextCheckingResult
@@ -351,7 +363,7 @@ TEST(WKWebViewMacEditingTests, FirstRectForCharacterRange)
         EXPECT_EQ(18, firstRect.size.height);
 
         EXPECT_EQ(0U, actualRange.location);
-        EXPECT_EQ(10U, actualRange.length);
+        EXPECT_EQ(11U, actualRange.length);
     }
     {
         auto [firstRect, actualRange] = [webView _firstRectForCharacterRange:NSMakeRange(0, 5)];
@@ -399,6 +411,121 @@ TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeInTextArea)
     EXPECT_GT(rectAfterTyping.size.height, 0);
     EXPECT_EQ(rangeAfterTyping.location, 1U);
     EXPECT_EQ(rangeAfterTyping.length, 0U);
+}
+
+TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeWithNewlinesAndWrapping)
+{
+    Vector<std::pair<NSRect, NSRange>> expectedRectsAndRanges = {
+        { { { 8.f, 574.f }, { 328.f, 18.f } }, { 0, 51 } },
+        { { { 8.f, 556.f }, { 719.f, 18.f } }, { 51, 111 } },
+        { { { 8.f, 538.f }, { 770.f, 18.f } }, { 162, 122 } },
+        { { { 8.f, 520.f }, { 764.f, 18.f } }, { 284, 125 } },
+        { { { 8.f, 502.f }, { 232.f, 18.f } }, { 409, 36 } }
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView _setEditable:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body><div>Lorem ipsum dolor sit amet, consectetur adipiscing</div><div>elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div></body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+
+    [webView selectAll:nil];
+
+    NSRange selectedRange = [webView _selectedRange];
+    NSRange remainingRange = selectedRange;
+
+    NSUInteger lineCount = 0;
+    while (remainingRange.length) {
+        auto [firstRect, actualRange] = [webView _firstRectForCharacterRange:remainingRange];
+
+        auto [expectedRect, expectedRange] = expectedRectsAndRanges[lineCount];
+
+        EXPECT_TRUE(NSEqualRects(expectedRect, firstRect));
+        EXPECT_TRUE(NSEqualRanges(expectedRange, actualRange));
+
+        remainingRange.location += actualRange.length;
+        remainingRange.length -= actualRange.length;
+
+        lineCount++;
+    }
+
+    EXPECT_EQ(5U, lineCount);
+}
+
+TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeForPartialLineWithNewlinesAndWrapping)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView _setEditable:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body><div>Lorem ipsum dolor sit amet, consectetur adipiscing</div><div>elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div></body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+
+    [webView selectAll:nil];
+
+    NSRange characterRange = NSMakeRange(175, 31);
+    NSRect expectedRect = NSMakeRect(87.f, 538.f, 192.f, 18.f);
+
+    auto [firstRect, actualRange] = [webView _firstRectForCharacterRange:characterRange];
+    EXPECT_TRUE(NSEqualRects(expectedRect, firstRect));
+    EXPECT_TRUE(NSEqualRanges(characterRange, actualRange));
+}
+
+TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeWithNewlinesAndWrappingLineBreakAfterWhiteSpace)
+{
+    Vector<std::pair<NSRect, NSRange>> expectedRectsAndRanges = {
+        { { { 8.f, 574.f }, { 328.f, 18.f } }, { 0, 51 } },
+        { { { 8.f, 556.f }, { 723.f, 18.f } }, { 51, 111 } },
+        { { { 8.f, 538.f }, { 774.f, 18.f } }, { 162, 122 } },
+        { { { 8.f, 520.f }, { 768.f, 18.f } }, { 284, 125 } },
+        // FIXME: <http://webkit.org/b/278181> The size of the rect for the last line is incorrect.
+        { { { 8.f, 502.f }, { 768.f, 36.f } }, { 409, 36 } }
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView _setEditable:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body style='line-break: after-white-space;'><div>Lorem ipsum dolor sit amet, consectetur adipiscing</div><div>elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div></body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+
+    [webView selectAll:nil];
+
+    NSRange selectedRange = [webView _selectedRange];
+    NSRange remainingRange = selectedRange;
+
+    NSUInteger lineCount = 0;
+    while (remainingRange.length) {
+        auto [firstRect, actualRange] = [webView _firstRectForCharacterRange:remainingRange];
+
+        auto [expectedRect, expectedRange] = expectedRectsAndRanges[lineCount];
+
+        EXPECT_TRUE(NSEqualRects(expectedRect, firstRect));
+        EXPECT_TRUE(NSEqualRanges(expectedRange, actualRange));
+
+        remainingRange.location += actualRange.length;
+        remainingRange.length -= actualRange.length;
+
+        lineCount++;
+    }
+
+    EXPECT_EQ(5U, lineCount);
+}
+
+TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeForPartialLineWithNewlinesAndWrappingLineBreakAfterWhiteSpace)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView _setEditable:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body style='line-break: after-white-space;'><div>Lorem ipsum dolor sit amet, consectetur adipiscing</div><div>elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div></body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+
+    [webView selectAll:nil];
+
+    NSRange characterRange = NSMakeRange(175, 31);
+    NSRect expectedRect = NSMakeRect(87.f, 538.f, 192.f, 18.f);
+
+    auto [firstRect, actualRange] = [webView _firstRectForCharacterRange:characterRange];
+    EXPECT_TRUE(NSEqualRects(expectedRect, firstRect));
+    EXPECT_TRUE(NSEqualRanges(characterRange, actualRange));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 93a8eb15de1e5ec7797e38c9b601ec1a58546019
<pre>
[Writing Tools] Affordance doesn&apos;t show up when hovering over multiple lines of text containing newlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=278186">https://bugs.webkit.org/show_bug.cgi?id=278186</a>
<a href="https://rdar.apple.com/129721335">rdar://129721335</a>

Reviewed by Wenson Hsieh.

Writing Tools determines whether to show an affordance when hovering over the
current selection using `-[NSTextInputClient_Async firstRectForCharacterRange:completionHandler:]`
to compute the number of lines. If the number of lines in greater than a defined
threshold, the affordance is displayed.

The idea behind using `firstRectForCharacterRange` to compute the number of lines
is to iteratively call the method, using the returned `actualRange` to keep track
of the remaining &quot;unprocessed&quot; range. However, this approach is currently breaking
down, as Writing Tools is observing that an `actualRange` with zero length ends up
getting returned when a newline is encountered.

However, the underlying issue is that WebKit&apos;s computation of `actualRange` is
currently incorrect. When a line ends with a newline, the newline should be
included in the length of the range. Currently, it is not, as range determination
is simply done using `endOfLine`, and newlines are only included when going to
the start of the next line. This discrepency results in Writing Tools starting to
request incorrect ranges, and the wrong information is processed.

Fix by ensuring that the `actualRange` for `firstRectForCharacterRange` includes
newlines for lines that end with one.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::firstRectForCharacterRangeAsync):

If `endOfLine` has upstream affinity, then no changes are necessary, as there are
no characters between the line boundary.

However, if the returned value is on the same line, and has downstream affinity,
get the start of the next line using `positionOfNextBoundaryOfGranularity`. This
ensures that the newline character between lines is included in the length of
the returned range.

* Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm:
(-[WKWebView _selectedRange]):
(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRange)):

Rebaseline to account for that fact that the newline character is included in the
length.

(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeWithNewlinesAndWrapping)):

Test that `firstRectForCharacterRange` can be used to count lines for content with
newlines and line wrapping.

(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeForPartialLineWithNewlinesAndWrapping)):

Ensure the changes do not break scenarios where rects are requested for the middle
of the line.

(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeWithNewlinesAndWrappingLineBreakAfterWhiteSpace)):

Test that `firstRectForCharacterRange` can be used to count lines for content with
newlines, line wrapping, and `line-break: after-white-space`. Importantly, this
tests that going to the start of the next line is not attempted when line wrapping
is performed and the line ends with a space.

(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeForPartialLineWithNewlinesAndWrappingLineBreakAfterWhiteSpace)):

Ensure the changes do not break scenarios where rects are requested for the middle

of the line and `line-break: after-white-space` is used.
Canonical link: <a href="https://commits.webkit.org/282327@main">https://commits.webkit.org/282327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c0ee40153c6ccf49428c59f3923b2b48cc9f951

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13394 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13678 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50651 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 25 flakes 79 failures 6 missing results; Uploaded test results; 24 flakes 55 failures 6 missing results; Compiled WebKit (warnings); 3 flakes 55 failures 6 missing results; Running analyze-layout-tests-results") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31329 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12270 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68505 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57964 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54445 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58154 "Found 2 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13936 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5628 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37966 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->