### PR TITLE
Share rowSpan/colSpan implementations in HTMLTableCellElement and MathMLElement

### DIFF
--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -41,16 +41,6 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLTableCellElement);
 
 using namespace HTMLNames;
 
-// These limits are defined in the HTML specification:
-// - https://html.spec.whatwg.org/#dom-tdth-colspan
-// - https://html.spec.whatwg.org/#dom-tdth-rowspan
-static const unsigned minColspan = 1;
-static const unsigned maxColspan = 1000;
-static const unsigned defaultColspan = 1;
-static const unsigned minRowspan = 0;
-static const unsigned maxRowspan = 65534;
-static const unsigned defaultRowspan = 1;
-
 Ref<HTMLTableCellElement> HTMLTableCellElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new HTMLTableCellElement(tagName, document));
@@ -64,7 +54,7 @@ HTMLTableCellElement::HTMLTableCellElement(const QualifiedName& tagName, Documen
 
 unsigned HTMLTableCellElement::colSpan() const
 {
-    return clampHTMLNonNegativeIntegerToRange(attributeWithoutSynchronization(colspanAttr), minColspan, maxColspan, defaultColspan);
+    return clampHTMLNonNegativeIntegerToRange(attributeWithoutSynchronization(colspanAttr), HTMLTableCellElementConstants::minColspan, HTMLTableCellElementConstants::maxColspan, HTMLTableCellElementConstants::defaultColspan);
 }
 
 unsigned HTMLTableCellElement::rowSpan() const
@@ -75,7 +65,7 @@ unsigned HTMLTableCellElement::rowSpan() const
 
 unsigned HTMLTableCellElement::rowSpanForBindings() const
 {
-    return clampHTMLNonNegativeIntegerToRange(attributeWithoutSynchronization(rowspanAttr), minRowspan, maxRowspan, defaultRowspan);
+    return clampHTMLNonNegativeIntegerToRange(attributeWithoutSynchronization(rowspanAttr), HTMLTableCellElementConstants::minRowspan, HTMLTableCellElementConstants::maxRowspan, HTMLTableCellElementConstants::defaultRowspan);
 }
 
 int HTMLTableCellElement::cellIndex() const

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -29,6 +29,18 @@
 
 namespace WebCore {
 
+namespace HTMLTableCellElementConstants {
+// These limits are defined in the HTML specification:
+// - https://html.spec.whatwg.org/#dom-tdth-colspan
+// - https://html.spec.whatwg.org/#dom-tdth-rowspan
+static constexpr unsigned minColspan = 1;
+static constexpr unsigned maxColspan = 1000;
+static constexpr unsigned defaultColspan = 1;
+static constexpr unsigned minRowspan = 0;
+static constexpr unsigned maxRowspan = 65534;
+static constexpr unsigned defaultRowspan = 1;
+}
+
 class HTMLTableCellElement final : public HTMLTablePartElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLTableCellElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableCellElement);

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -38,6 +38,7 @@
 #include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
+#include "HTMLTableCellElement.h"
 #include "MathMLNames.h"
 #include "MouseEvent.h"
 #include "NodeName.h"
@@ -75,8 +76,7 @@ unsigned MathMLElement::rowSpan() const
     if (!hasTagName(mtdTag))
         return 1u;
     auto& rowSpanValue = attributeWithoutSynchronization(rowspanAttr);
-    static const unsigned maxRowspan = 8190; // This constant comes from HTMLTableCellElement.
-    return std::max(1u, std::min(limitToOnlyHTMLNonNegative(rowSpanValue, 1u), maxRowspan));
+    return std::max(1u, std::min(limitToOnlyHTMLNonNegative(rowSpanValue, 1u), HTMLTableCellElementConstants::maxRowspan));
 }
 
 void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)


### PR DESCRIPTION
#### 2f11bf64ad6f77e1bfefdab24d3b1996422c23d1
<pre>
Share rowSpan/colSpan implementations in HTMLTableCellElement and MathMLElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=155487">https://bugs.webkit.org/show_bug.cgi?id=155487</a>
&lt;<a href="https://rdar.apple.com/133910791">rdar://133910791</a>&gt;

Reviewed by NOBODY (OOPS!).

Small fix to keep the values between HTMLTableCellElement and
MathMLElement in sync, done by moving the definition of the constants
into a namespace.

* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::colSpan const):
(WebCore::HTMLTableCellElement::rowSpanForBindings const):
* Source/WebCore/html/HTMLTableCellElement.h:
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::rowSpan const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f11bf64ad6f77e1bfefdab24d3b1996422c23d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50779 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31464 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12484 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68720 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58297 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5801 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38180 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->