### PR TITLE
Fix JITless Wasm to JS stack parameter handling.

### DIFF
--- a/JSTests/wasm/stress/cc-int-to-int-memory.js
+++ b/JSTests/wasm/stress/cc-int-to-int-memory.js
@@ -15,9 +15,58 @@ let wat = `
 )
 `
 
+let wat2 = `
+(module
+    (type $sig_test (func (param i32) (result i32)))
+    (import "o" "tbl" (table $t 1 funcref))
+    (import "o" "test" (func $test (param $x i32) (result i32)))
+    (import "o" "callee" (func $callee (param $x i32) (result i32)))
+
+    (memory 1)
+
+    (data (i32.const 0) "\\3B")
+
+    (func $test2 (export "test2") (param $x i32) (result i32)
+        (i32.add (local.get $x) (i32.load (i32.const 0)))
+    )
+
+    (func $test3 (export "test3") (param $x i32) (result i32)
+        (i32.add (local.get $x) (i32.load (i32.const 0)))
+    )
+
+    (func (export "test_with_call") (param $x i32) (result i32)
+        (i32.load (i32.const 0))
+        (call $test (i32.const 1))
+        (i32.load (i32.const 0))
+        (i32.add)
+        (i32.add)
+    )
+
+    (func (export "test_with_call_to_js") (param $x i32) (result i32)
+        (i32.load (i32.const 0))
+        (call $test (i32.const 1))
+        (i32.load (i32.const 0))
+        (i32.const 5)
+        (call $callee)
+        (i32.load (i32.const 0))
+        (i32.add)
+        (i32.add)
+        (i32.add)
+        (i32.add)
+    )
+)
+`
+
 async function test() {
     const instance = await instantiate(wat, {}, { simd: true })
     const { test } = instance.exports
+    let tbl = new WebAssembly.Table({ initial: 1, element: "funcref" })
+    tbl.set(0, test)
+    function callee(x) {
+        return x + test();
+    }
+    const instance2 = await instantiate(wat2, { o: { test, tbl, callee } }, { simd: true })
+    const { test2, test3, test_with_call, test_with_call_to_js } = instance2.exports
 
     for (let i = 0; i < 10000; ++i) {
         assert.eq(test(5), 42 + 5)
@@ -27,6 +76,10 @@ async function test() {
         assert.eq(test({ }, 10), 42 + 0)
         assert.eq(test(20.1, 10), 42 + 20)
         assert.eq(test(10, 20.1), 42 + 10)
+
+        assert.eq(test2(5), 59 + 5)
+        assert.eq(test_with_call(1), 59 + 59 + 42 + 1)
+        assert.eq(test_with_call_to_js(1), 59 + 59 + 59 + 42 + 1 + 5 + 42)
     }
 }
 

--- a/JSTests/wasm/stress/cc-parameters-overwhelming-to-js.js
+++ b/JSTests/wasm/stress/cc-parameters-overwhelming-to-js.js
@@ -1,0 +1,62 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $sig_test (func (param i32) (result i32)))
+
+    (import "o" "callee" (func $callee
+        (param $a i32) (param $b i32) (param $c i32) (param $d i32) (param $e i32) (param $f i32) (param $g i32) (param $h i32) (param $i i32) (param $j i32) (param $k i32) (param $l i32) (param $m i32) (param $n i32) (param $o i32) (param $p i32)
+        (result i32))
+    )
+
+    (func $test (export "test") (param $x i32) (result i32)
+        (i32.const 0)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.const 4)
+        (i32.const 5)
+        (i32.const 6)
+        (i32.const 7)
+        (i32.const 8)
+        (i32.const 9)
+        (i32.const 10)
+        (i32.const 11)
+        (i32.const 12)
+        (i32.const 13)
+        (i32.const 14)
+        (i32.const 15)
+        (call $callee)
+    )
+)
+`
+
+function callee(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {
+    assert.eq(a, 0);
+    assert.eq(b, 1);
+    assert.eq(c, 2);
+    assert.eq(d, 3);
+    assert.eq(e, 4);
+    assert.eq(f, 5);
+    assert.eq(g, 6);
+    assert.eq(h, 7);
+    assert.eq(i, 8);
+    assert.eq(j, 9);
+    assert.eq(k, 10);
+    assert.eq(l, 11);
+    assert.eq(m, 12);
+    assert.eq(n, 13);
+    assert.eq(o, 14);
+    assert.eq(p, 15);
+    return 42;
+}
+
+async function test() {
+    const instance = await instantiate(wat, { o: { callee } })
+    const { test } = instance.exports
+
+    assert.eq(test(5), 42)
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -326,8 +326,9 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, 
     const auto& signature = *typeDefinition.as<FunctionSignature>();
     unsigned argCount = signature.argumentCount();
 
-    const auto& wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
-    const auto& jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
+    const auto& wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
+    const auto& jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
+    const auto& jsCallerCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
 
     if (Options::useWasmSIMD() && (wasmCC.argumentsOrResultsIncludeV128))
         OPERATION_RETURN(scope, 0);
@@ -335,7 +336,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, 
     for (unsigned argNum = 0; argNum < argCount; ++argNum) {
         Type argType = signature.argumentType(argNum);
         auto wasmParam = wasmCC.params[argNum].location;
-        auto dst = jsCC.params[argNum].location.offsetFromSP();
+        auto dst = jsCC.params[argNum].location.offsetFromFP();
 
         switch (argType.kind) {
         case TypeKind::Void:
@@ -361,38 +362,44 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, 
         case TypeKind::Funcref:
         case TypeKind::I32: {
             if (wasmParam.isStackArgument()) {
-                uint32_t raw = *access.operator()<uint32_t>(cfr, wasmParam.offsetFromFP());
+                uint64_t raw = *access.operator()<uint64_t>(cfr, wasmParam.offsetFromSP() + sizeof(CallerFrameAndPC));
 #if USE(JSVALUE64)
                 if (argType.isI32())
-                    *access.operator()<uint64_t>(sp, dst) = raw | JSValue::NumberTag;
+                    *access.operator()<uint64_t>(calleeFrame, dst) = static_cast<uint32_t>(raw) | JSValue::NumberTag;
 #else
                 if (false);
 #endif
                 else
-                    *access.operator()<uint64_t>(sp, dst) = raw;
+                    *access.operator()<uint64_t>(calleeFrame, dst) = raw;
             } else {
-                auto raw = *access.operator()<uint32_t>(argumentRegisters, wasmParam.jsr().payloadGPR() * sizeof(UCPURegister));
+                auto raw = *access.operator()<uint64_t>(argumentRegisters, wasmParam.jsr().payloadGPR() * sizeof(UCPURegister));
 #if USE(JSVALUE64)
                 if (argType.isI32())
-                    *access.operator()<uint64_t>(sp, dst) = raw | JSValue::NumberTag;
+                    *access.operator()<uint64_t>(calleeFrame, dst) = static_cast<uint32_t>(raw) | JSValue::NumberTag;
                 else
-                    *access.operator()<uint64_t>(sp, dst) = raw;
+                    *access.operator()<uint64_t>(calleeFrame, dst) = raw;
 #else
-                *access.operator()<uint32_t>(sp, dst) = raw;
+                *access.operator()<uint32_t>(calleeFrame, dst) = raw;
 #endif
             }
             break;
         }
         case TypeKind::I64: {
-            auto result = JSBigInt::makeHeapBigIntOrBigInt32(instance->globalObject(), *access.operator()<int64_t>(argumentRegisters, gprToIndex(wasmParam.jsr().payloadGPR()) * bytesForWidth(Width::Width64)));
-            OPERATION_RETURN_IF_EXCEPTION(scope, 0);
-            *access.operator()<uint64_t>(sp, dst) = JSValue::encode(result);
+            if (wasmParam.isStackArgument()) {
+                auto result = JSBigInt::makeHeapBigIntOrBigInt32(instance->globalObject(), *access.operator()<int64_t>(cfr, wasmParam.offsetFromSP() + sizeof(CallerFrameAndPC)));
+                OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+                *access.operator()<uint64_t>(calleeFrame, dst) = JSValue::encode(result);
+            } else {
+                auto result = JSBigInt::makeHeapBigIntOrBigInt32(instance->globalObject(), *access.operator()<int64_t>(argumentRegisters, gprToIndex(wasmParam.jsr().payloadGPR()) * bytesForWidth(Width::Width64)));
+                OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+                *access.operator()<uint64_t>(calleeFrame, dst) = JSValue::encode(result);
+            }
             break;
         }
         case TypeKind::F32: {
             float val;
             if (wasmParam.isStackArgument())
-                val = *access.operator()<float>(cfr, wasmParam.offsetFromFP());
+                val = *access.operator()<float>(cfr, wasmParam.offsetFromSP() + sizeof(CallerFrameAndPC));
             else
                 val = *access.operator()<float>(argumentRegisters, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(wasmParam.fpr()) * bytesForWidth(Width::Width64));
 
@@ -401,13 +408,13 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, 
 #if USE(JSVALUE64)
             raw += JSValue::DoubleEncodeOffset;
 #endif
-            *access.operator()<uint64_t>(sp, dst) = raw;
+            *access.operator()<uint64_t>(calleeFrame, dst) = raw;
             break;
         }
         case TypeKind::F64:
             double val;
             if (wasmParam.isStackArgument())
-                val = *access.operator()<double>(cfr, wasmParam.offsetFromFP());
+                val = *access.operator()<double>(cfr, wasmParam.offsetFromSP() + sizeof(CallerFrameAndPC));
             else
                 val = *access.operator()<double>(argumentRegisters, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(wasmParam.fpr()) * bytesForWidth(Width::Width64));
 
@@ -416,7 +423,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, EncodedJSValue, 
 #if USE(JSVALUE64)
             raw += JSValue::DoubleEncodeOffset;
 #endif
-            *access.operator()<uint64_t>(sp, dst) = raw;
+            *access.operator()<uint64_t>(calleeFrame, dst) = raw;
             break;
         }
     }
@@ -458,6 +465,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValu
     };
 
     void* registerSpace = sp;
+    void* callerStackFrame = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(cfr) + sizeof(CallerFrameAndPC));
 
     auto scope = DECLARE_THROW_SCOPE(instance->vm());
 
@@ -470,8 +478,8 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValu
 
     auto* globalObject = instance->globalObject();
 
-    auto wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
-    auto jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
+    auto wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
+    auto jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
 
     JSValue returned = *(reinterpret_cast<JSValue*>(registerSpace));
 
@@ -658,7 +666,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, EncodedJSValu
             else if (rep.location.isFPR())
                 *access.operator()<uint64_t>(registerSpace, GPRInfo::numberOfArgumentRegisters * sizeof(UCPURegister) + fprToIndex(rep.location.fpr()) * bytesForWidth(Width::Width64)) = unboxedValue;
             else
-                *access.operator()<uint64_t>(cfr, rep.location.offsetFromFP()) = unboxedValue;
+                *access.operator()<uint64_t>(callerStackFrame, rep.location.offsetFromSP()) = unboxedValue;
         }
     }
 


### PR DESCRIPTION
#### 5d23096ae0a41ec4503ef776e1a4a93ac7ce51db
<pre>
Fix JITless Wasm to JS stack parameter handling.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278188">https://bugs.webkit.org/show_bug.cgi?id=278188</a>
<a href="https://rdar.apple.com/133985209">rdar://133985209</a>

Reviewed by Yusuke Suzuki.

Previously, the Wasm to JS operation used isStackArgument. However, since the calling convention is reversed (Wasm is the caller), it is no longer a stack argument, and is just a stack location, meaning that we need to use isStack.

* JSTests/wasm/stress/cc-int-to-int-memory.js:
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.func.test.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.let.wat2.module.type.sig_test.func.param.i32.result.i32.import.string_appeared_here.string_appeared_here.table.t.1.funcref.import.string_appeared_here.string_appeared_here.func.test.param.x.i32.result.i32.import.string_appeared_here.string_appeared_here.func.callee.param.x.i32.result.i32.memory.1.data.i32.const.0.string_appeared_here.func.test2.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.func.test3.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.func.export.string_appeared_here.param.x.i32.result.i32.i32.load.i32.const.0.call.test.i32.const.1.i32.load.i32.const.0.i32.add.i32.add.func.export.string_appeared_here.param.x.i32.result.i32.i32.load.i32.const.0.call.test.i32.const.1.i32.load.i32.const.0.i32.const.5.call.callee.i32.load.i32.const.0.i32.add.i32.add.i32.add.i32.add.async test.callee):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.func.test.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.let.wat2.module.type.sig_test.func.param.i32.result.i32.import.string_appeared_here.string_appeared_here.table.t.1.funcref.import.string_appeared_here.string_appeared_here.func.test.param.x.i32.result.i32.import.string_appeared_here.string_appeared_here.func.callee.param.x.i32.result.i32.memory.1.data.i32.const.0.string_appeared_here.func.test2.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.func.test3.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.func.export.string_appeared_here.param.x.i32.result.i32.i32.load.i32.const.0.call.test.i32.const.1.i32.load.i32.const.0.i32.add.i32.add.func.export.string_appeared_here.param.x.i32.result.i32.i32.load.i32.const.0.call.test.i32.const.1.i32.load.i32.const.0.i32.const.5.call.callee.i32.load.i32.const.0.i32.add.i32.add.i32.add.i32.add.async test):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.func.test.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.async test): Deleted.
* JSTests/wasm/stress/cc-parameters-overwhelming-to-js.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.sig_test.func.param.i32.result.i32.import.string_appeared_here.string_appeared_here.func.callee.param.a.i32.param.b.i32.param.c.i32.param.d.i32.param.e.i32.param.f.i32.param.g.i32.param.h.i32.param.i.i32.param.j.i32.param.k.i32.param.l.i32.param.m.i32.param.n.i32.param.o.i32.param.p.i32.result.i32.func.test.export.string_appeared_here.param.x.i32.result.i32.i32.const.0.i32.const.1.i32.const.2.i32.const.3.i32.const.4.i32.const.5.i32.const.6.i32.const.7.i32.const.8.i32.const.9.i32.const.10.i32.const.11.i32.const.12.i32.const.13.i32.const.14.i32.const.15.call.callee.callee):
(async test):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/282429@main">https://commits.webkit.org/282429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4b800f7b3dc09e7391dc5007908a77366b9bd57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67019 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50776 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9385 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12478 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56108 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62241 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5791 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38174 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14783 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->