### PR TITLE
Address additional API feedback for Web Extensions.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
@@ -38,7 +38,8 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*! @abstract Indicates a ``WKWebExtension`` error. */
-WK_EXTERN NSErrorDomain const WKWebExtensionErrorDomain NS_SWIFT_NAME(WKWebExtension.ErrorDomain) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN NSErrorDomain const WKWebExtensionErrorDomain NS_SWIFT_NAME(WKWebExtension.errorDomain) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtension`` domain.
@@ -64,7 +65,7 @@ typedef NS_ERROR_ENUM(WKWebExtensionErrorDomain, WKWebExtensionError) {
 
 /*! @abstract This notification is sent whenever a ``WKWebExtension`` has new errors or errors were cleared. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionErrorsWereUpdatedNotification NS_SWIFT_NAME(WKWebExtension.errorsWereUpdatedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionErrorsWereUpdatedNotification NS_SWIFT_NAME(WKWebExtension.errorsWereUpdatedNotification) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract A ``WKWebExtension`` object encapsulates a web extension’s resources that are defined by a `manifest.json`` file.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h
@@ -44,7 +44,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*! @abstract This notification is sent whenever a @link WKWebExtensionAction has changed properties. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionActionPropertiesDidChangeNotification NS_SWIFT_NAME(WKWebExtensionAction.propertiesDidChangeNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionActionPropertiesDidChangeNotification NS_SWIFT_NAME(WKWebExtensionAction.propertiesDidChangeNotification) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract A ``WKWebExtensionAction`` object encapsulates the properties for an individual web extension action.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
@@ -47,7 +47,8 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*! @abstract Indicates a ``WKWebExtensionContext`` error. */
-WK_EXTERN NSErrorDomain const WKWebExtensionContextErrorDomain NS_SWIFT_NAME(WKWebExtensionContext.ErrorDomain) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN NSErrorDomain const WKWebExtensionContextErrorDomain NS_SWIFT_NAME(WKWebExtensionContext.errorDomain) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionContext`` domain.
@@ -89,35 +90,35 @@ typedef NS_ENUM(NSInteger, WKWebExtensionContextPermissionStatus) {
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionsWereGrantedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionsWereGrantedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionsWereGrantedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionsWereGrantedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly denied permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionsWereDeniedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionsWereDeniedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionsWereDeniedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionsWereDeniedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextGrantedPermissionsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.grantedPermissionsWereRemovedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextGrantedPermissionsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.grantedPermissionsWereRemovedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed denied permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextDeniedPermissionsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.deniedPermissionsWereRemovedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextDeniedPermissionsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.deniedPermissionsWereRemovedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly granted permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionMatchPatternsWereGrantedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionMatchPatternsWereGrantedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly denied permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionMatchPatternsWereDeniedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification NS_SWIFT_NAME(WKWebExtensionContext.permissionMatchPatternsWereDeniedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed granted permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.grantedPermissionMatchPatternsWereRemovedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.grantedPermissionMatchPatternsWereRemovedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has newly removed denied permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.deniedPermissionMatchPatternsWereRemovedNotification);
+WK_EXTERN NSNotificationName const WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(WKWebExtensionContext.deniedPermissionMatchPatternsWereRemovedNotification) NS_SWIFT_NONISOLATED;
 
 /*! @abstract Constants for specifying ``WKWebExtensionContext`` information in notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
@@ -125,11 +126,11 @@ typedef NSString * WKWebExtensionContextNotificationUserInfoKey NS_TYPED_EXTENSI
 
 /*! @abstract The corresponding value represents the affected permissions in ``WKWebExtensionContext`` notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionContextNotificationUserInfoKey const WKWebExtensionContextNotificationUserInfoKeyPermissions;
+WK_EXTERN WKWebExtensionContextNotificationUserInfoKey const WKWebExtensionContextNotificationUserInfoKeyPermissions NS_SWIFT_NONISOLATED;
 
 /*! @abstract The corresponding value represents the affected permission match patterns in ``WKWebExtensionContext`` notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionContextNotificationUserInfoKey const WKWebExtensionContextNotificationUserInfoKeyMatchPatterns;
+WK_EXTERN WKWebExtensionContextNotificationUserInfoKey const WKWebExtensionContextNotificationUserInfoKeyMatchPatterns NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract A ``WKWebExtensionContext`` object represents the runtime environment for a web extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h
@@ -82,7 +82,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @result A Boolean value indicating if the context was successfully loaded.
  @seealso loadExtensionContext:
 */
-- (BOOL)loadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)error;
+- (BOOL)loadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)error NS_SWIFT_NAME(load(_:));
 
 /*!
  @abstract Unloads the specified extension context.
@@ -91,7 +91,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @result A Boolean value indicating if the context was successfully unloaded.
  @seealso unloadExtensionContext:
 */
-- (BOOL)unloadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)error;
+- (BOOL)unloadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)error NS_SWIFT_NAME(unload(_:));
 
 /*!
  @abstract Returns a loaded extension context for the specified extension.
@@ -127,29 +127,29 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 @property (class, nonatomic, readonly, copy) NSSet<WKWebExtensionDataType> *allExtensionDataTypes;
 
 /*!
-  @abstract Fetches data records containing the given extension data types for all known extensions.
-  @param dataTypes The extension data types to fetch records for.
-  @param completionHandler A block to invoke when the data records have been fetched.
-  @note The extension does not need to be loaded to be included in the result.
+ @abstract Fetches data records containing the given extension data types for all known extensions.
+ @param dataTypes The extension data types to fetch records for.
+ @param completionHandler A block to invoke when the data records have been fetched.
+ @note The extension does not need to be loaded to be included in the result.
 */
-- (void)fetchDataRecordsOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes completionHandler:(void (^)(NSArray<WKWebExtensionDataRecord *> *))completionHandler WK_SWIFT_ASYNC_NAME(dataRecords(ofTypes:));
+- (void)fetchDataRecordsOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes completionHandler:(void (^)(NSArray<WKWebExtensionDataRecord *> *))completionHandler NS_SWIFT_NAME(fetchDataRecords(ofTypes:completionHandler:)) WK_SWIFT_ASYNC_NAME(dataRecords(ofTypes:));
 
 /*!
-  @abstract Fetches a data record containing the given extension data types for a specific known web extension context.
-  @param dataTypes The extension data types to fetch records for.
-  @param extensionContext The specific web extension context to fetch records for.
-  @param completionHandler A block to invoke when the data record has been fetched.
-  @note The extension does not need to be loaded to be included in the result.
+ @abstract Fetches a data record containing the given extension data types for a specific known web extension context.
+ @param dataTypes The extension data types to fetch records for.
+ @param extensionContext The specific web extension context to fetch records for.
+ @param completionHandler A block to invoke when the data record has been fetched.
+ @note The extension does not need to be loaded to be included in the result.
 */
-- (void)fetchDataRecordOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(WKWebExtensionDataRecord * _Nullable))completionHandler WK_SWIFT_ASYNC_NAME(dataRecord(ofTypes:for:));
+- (void)fetchDataRecordOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(WKWebExtensionDataRecord * _Nullable))completionHandler NS_SWIFT_NAME(fetchDataRecord(ofTypes:for:completionHandler:)) WK_SWIFT_ASYNC_NAME(dataRecord(ofTypes:for:));
 
 /*!
-  @abstract Removes extension data of the given types for the given data records.
-  @param dataTypes The extension data types that should be removed.
-  @param dataRecords The extension data records to delete data for.
-  @param completionHandler A block to invoke when the data has been removed.
+ @abstract Removes extension data of the given types for the given data records.
+ @param dataTypes The extension data types that should be removed.
+ @param dataRecords The extension data records to delete data from.
+ @param completionHandler A block to invoke when the data has been removed.
 */
-- (void)removeDataOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes forDataRecords:(NSArray<WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)(void))completionHandler;
+- (void)removeDataOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes fromDataRecords:(NSArray<WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)(void))completionHandler NS_SWIFT_NAME(removeData(ofTypes:from:completionHandler:));
 
 /*!
  @abstract Should be called by the app when a new window is opened to fire appropriate events with all loaded web extensions.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
@@ -133,7 +133,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 + (NSSet<WKWebExtensionDataType> *)allExtensionDataTypes
 {
-    return [NSSet setWithObjects:WKWebExtensionDataTypeLocal, WKWebExtensionDataTypeSession, WKWebExtensionDataTypeSync, nil];
+    return [NSSet setWithObjects:WKWebExtensionDataTypeLocal, WKWebExtensionDataTypeSession, WKWebExtensionDataTypeSynchronized, nil];
 }
 
 - (void)fetchDataRecordsOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes completionHandler:(void (^)(NSArray<WKWebExtensionDataRecord *> *))completionHandler
@@ -160,7 +160,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
     });
 }
 
-- (void)removeDataOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes forDataRecords:(NSArray<WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)())completionHandler
+- (void)removeDataOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes fromDataRecords:(NSArray<WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)())completionHandler
 {
     NSParameterAssert([dataTypes isKindOfClass:NSSet.class]);
     NSParameterAssert([dataRecords isKindOfClass:NSArray.class]);
@@ -353,7 +353,7 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
     completionHandler(nil);
 }
 
-- (void)removeDataOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes forDataRecords:(NSArray<WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)())completionHandler
+- (void)removeDataOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes fromDataRecords:(NSArray<WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)())completionHandler
 {
     completionHandler();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.h
@@ -31,20 +31,21 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*! @abstract Indicates a ``WKWebExtensionDataRecord`` error. */
-WK_EXTERN NSErrorDomain const WKWebExtensionDataRecordErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN NSErrorDomain const WKWebExtensionDataRecordErrorDomain NS_SWIFT_NAME(WKWebExtensionDataRecord.errorDomain) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionDataRecord`` domain.
  @constant WKWebExtensionDataRecordErrorUnknown  Indicates that an unknown error occurred.
- @constant WKWebExtensionDataRecordErrorLocalStorageFailed  Indicates a failure occurred when either deleting or calculating `local` storage.
- @constant WKWebExtensionDataRecordErrorSessionStorageFailed  Indicates a failure occurred when either deleting or calculating `session` storage.
- @constant WKWebExtensionDataRecordErrorSyncStorageFailed  Indicates a failure occurred when either deleting or calculating `sync` storage.
+ @constant WKWebExtensionDataRecordErrorLocalStorageFailed  Indicates a failure occurred when either deleting or calculating local storage.
+ @constant WKWebExtensionDataRecordErrorSessionStorageFailed  Indicates a failure occurred when either deleting or calculating session storage.
+ @constant WKWebExtensionDataRecordErrorSynchronizedStorageFailed  Indicates a failure occurred when either deleting or calculating synchronized storage.
  */
 typedef NS_ERROR_ENUM(WKWebExtensionDataRecordErrorDomain, WKWebExtensionDataRecordError) {
-    WKWebExtensionDataRecordErrorUnknown,
+    WKWebExtensionDataRecordErrorUnknown = 1,
     WKWebExtensionDataRecordErrorLocalStorageFailed,
     WKWebExtensionDataRecordErrorSessionStorageFailed,
-    WKWebExtensionDataRecordErrorSyncStorageFailed,
+    WKWebExtensionDataRecordErrorSynchronizedStorageFailed,
 } NS_SWIFT_NAME(WKWebExtensionDataRecord.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
@@ -65,20 +66,24 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.DataRecord)
 @property (nonatomic, readonly, copy) NSString *uniqueIdentifier;
 
 /*! @abstract The set of data types contained in this data record. */
-@property (nonatomic, readonly, copy) NSSet<WKWebExtensionDataType> *dataTypes;
+@property (nonatomic, readonly, copy) NSSet<WKWebExtensionDataType> *containedDataTypes;
 
-/*! @abstract The total size of all data types contained in this data record. */
-@property (nonatomic, readonly) unsigned long long totalSize;
-
-/*! @abstract An array containing all errors that may have occurred when either calculating or deleting storage. */
+/*! @abstract An array of errors that may have occurred when either calculating or deleting storage. */
 @property (nonatomic, readonly, copy) NSArray<NSError *> *errors;
 
 /*!
- @abstract Retrieves the size of the specific data types in this data record.
+ @abstract The total size in bytes of all data types contained in this data record.
+ @seealso sizeInBytesOfTypes:
+ */
+@property (nonatomic, readonly) NSUInteger totalSizeInBytes;
+
+/*!
+ @abstract Retrieves the size in bytes of the specific data types in this data record.
  @param dataTypes The set of data types to measure the size for.
  @return The total size of the specified data types.
+ @seealso totalSizeInBytes
  */
-- (unsigned long long)sizeOfDataTypes:(NSSet<WKWebExtensionDataType> *)dataTypes;
+- (NSUInteger)sizeInBytesOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes NS_SWIFT_NAME(sizeInBytes(ofTypes:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
@@ -62,17 +62,17 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionDataRecord, WebExtensionData
     return _webExtensionDataRecord->uniqueIdentifier();
 }
 
-- (NSSet<WKWebExtensionDataType> *)dataTypes
+- (NSSet<WKWebExtensionDataType> *)containedDataTypes
 {
     return toAPI(_webExtensionDataRecord->types());
 }
 
-- (unsigned long long)totalSize
+- (NSUInteger)totalSizeInBytes
 {
     return _webExtensionDataRecord->totalSize();
 }
 
-- (unsigned long long)sizeOfDataTypes:(NSSet<WKWebExtensionDataType> *)dataTypes
+- (NSUInteger)sizeInBytesOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes
 {
     return _webExtensionDataRecord->sizeOfTypes(WebKit::toWebExtensionDataTypes(dataTypes));
 }
@@ -106,17 +106,17 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionDataRecord, WebExtensionData
     return nil;
 }
 
-- (NSSet<WKWebExtensionDataType> *)dataTypes
+- (NSSet<WKWebExtensionDataType> *)containedDataTypes
 {
     return nil;
 }
 
-- (unsigned long long)totalSize
+- (NSUInteger)totalSizeInBytes
 {
     return 0;
 }
 
-- (unsigned long long)sizeOfDataTypes:(NSSet<WKWebExtensionDataType> *)dataTypes
+- (NSUInteger)sizeInBytesOfTypes:(NSSet<WKWebExtensionDataType> *)dataTypes
 {
     return 0;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.h
@@ -28,16 +28,16 @@
 
 /*! @abstract Constants for specifying data types for a ``WKWebExtensionDataRecord``. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-typedef NSString * WKWebExtensionDataType NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(WKWebExtension.DataType);
+typedef NSString * WKWebExtensionDataType NS_TYPED_ENUM NS_SWIFT_NAME(WKWebExtension.DataType);
 
 /*! @abstract Specifies local storage, including `browser.storage.local`. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionDataType const WKWebExtensionDataTypeLocal;
+WK_EXTERN WKWebExtensionDataType const WKWebExtensionDataTypeLocal NS_SWIFT_NONISOLATED;
 
 /*! @abstract Specifies session storage, including `browser.storage.session`. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionDataType const WKWebExtensionDataTypeSession;
+WK_EXTERN WKWebExtensionDataType const WKWebExtensionDataTypeSession NS_SWIFT_NONISOLATED;
 
 /*! @abstract Specifies synchronized storage, including `browser.storage.sync`. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionDataType const WKWebExtensionDataTypeSync;
+WK_EXTERN WKWebExtensionDataType const WKWebExtensionDataTypeSynchronized NS_SWIFT_NONISOLATED;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.mm
@@ -35,7 +35,7 @@
 
 WKWebExtensionDataType const WKWebExtensionDataTypeLocal = @"local";
 WKWebExtensionDataType const WKWebExtensionDataTypeSession = @"session";
-WKWebExtensionDataType const WKWebExtensionDataTypeSync = @"sync";
+WKWebExtensionDataType const WKWebExtensionDataTypeSynchronized = @"synchronized";
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -51,7 +51,7 @@ OptionSet<WebExtensionDataType> toWebExtensionDataTypes(NSSet *types)
     if ([types containsObject:WKWebExtensionDataTypeSession])
         result.add(WebExtensionDataType::Session);
 
-    if ([types containsObject:WKWebExtensionDataTypeSync])
+    if ([types containsObject:WKWebExtensionDataTypeSynchronized])
         result.add(WebExtensionDataType::Sync);
 
     return result;
@@ -68,7 +68,7 @@ NSSet *toAPI(OptionSet<WebExtensionDataType> types)
         [result addObject:WKWebExtensionDataTypeSession];
 
     if (types.contains(WebExtensionDataType::Sync))
-        [result addObject:WKWebExtensionDataTypeSync];
+        [result addObject:WKWebExtensionDataTypeSynchronized];
 
     return [result copy];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
@@ -31,7 +31,8 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 @class WKWebExtension;
 
 /*! @abstract Indicates a ``WKWebExtensionMatchPattern`` error. */
-WK_EXTERN NSErrorDomain const WKWebExtensionMatchPatternErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN NSErrorDomain const WKWebExtensionMatchPatternErrorDomain NS_SWIFT_NAME(WKWebExtensionMatchPattern.errorDomain) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionMatchPattern`` domain.
@@ -41,7 +42,7 @@ WK_EXTERN NSErrorDomain const WKWebExtensionMatchPatternErrorDomain WK_API_AVAIL
  @constant WKWebExtensionMatchPatternErrorInvalidPath  Indicates that the path component was invalid.
  */
 typedef NS_ERROR_ENUM(WKWebExtensionMatchPatternErrorDomain, WKWebExtensionMatchPatternError) {
-    WKWebExtensionMatchPatternErrorUnknown,
+    WKWebExtensionMatchPatternErrorUnknown = 1,
     WKWebExtensionMatchPatternErrorInvalidScheme,
     WKWebExtensionMatchPatternErrorInvalidHost,
     WKWebExtensionMatchPatternErrorInvalidPath,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
@@ -29,7 +29,8 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*! @abstract Indicates a ``WKWebExtensionMessagePort`` error. */
-WK_EXTERN NSErrorDomain const WKWebExtensionMessagePortErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN NSErrorDomain const WKWebExtensionMessagePortErrorDomain NS_SWIFT_NAME(WKWebExtensionMessagePort.errorDomain) NS_SWIFT_NONISOLATED;
 
 /*!
  @abstract Constants used by ``NSError`` to indicate errors in the ``WKWebExtensionMessagePort`` domain.
@@ -38,7 +39,7 @@ WK_EXTERN NSErrorDomain const WKWebExtensionMessagePortErrorDomain WK_API_AVAILA
  @constant WKWebExtensionMessagePortErrorMessageInvalid Indicates that the message is invalid. The message must be an object that is JSON-serializable.
  */
 typedef NS_ERROR_ENUM(WKWebExtensionMessagePortErrorDomain, WKWebExtensionMessagePortError) {
-    WKWebExtensionMessagePortErrorUnknown,
+    WKWebExtensionMessagePortErrorUnknown = 1,
     WKWebExtensionMessagePortErrorNotConnected,
     WKWebExtensionMessagePortErrorMessageInvalid,
 } NS_SWIFT_NAME(WKWebExtensionMessagePort.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
@@ -84,9 +85,12 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MessagePort)
  */
 - (void)sendMessage:(nullable id)message completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(sendMessage(_:completionHandler:));
 
+/*! @abstract Disconnects the port, terminating all further messages. */
+- (void)disconnect NS_SWIFT_UNAVAILABLE("Use throwing version with nil");
+
 /*!
- @abstract Disconnects the port, terminating all further messages.
- @param error An optional error object indicating the reason for disconnection.
+ @abstract Disconnects the port, terminating all further messages with an optional error.
+ @param error An optional error indicating the reason for disconnection.
  */
 - (void)disconnectWithError:(nullable NSError *)error NS_SWIFT_NAME(disconnect(throwing:));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
@@ -81,6 +81,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
     });
 }
 
+- (void)disconnect
+{
+    [self disconnectWithError:nil];
+}
+
 - (void)disconnectWithError:(NSError *)error
 {
     _webExtensionMessagePort->disconnect(WebKit::toWebExtensionMessagePortError(error));
@@ -113,6 +118,10 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
 - (void)sendMessage:(id)message completionHandler:(void (^)(NSError *))completionHandler
 {
     completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
+}
+
+- (void)disconnect
+{
 }
 
 - (void)disconnectWithError:(NSError *)error

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.h
@@ -32,64 +32,64 @@ typedef NSString * WKWebExtensionPermission NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NA
 
 /*! @abstract The `activeTab` permission requests that when the user interacts with the extension, the extension is granted extra permissions for the active tab only. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionActiveTab;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionActiveTab NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `alarms` permission requests access to the `browser.alarms` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionAlarms;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionAlarms NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `clipboardWrite` permission requests access to write to the clipboard. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionClipboardWrite;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionClipboardWrite NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `contextMenus` permission requests access to the `browser.contextMenus` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionContextMenus;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionContextMenus NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `cookies` permission requests access to the `browser.cookies` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionCookies;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionCookies NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `declarativeNetRequest` permission requests access to the `browser.declarativeNetRequest` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionDeclarativeNetRequest;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionDeclarativeNetRequest NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `declarativeNetRequestFeedback` permission requests access to the `browser.declarativeNetRequest` APIs with extra information on matched rules. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionDeclarativeNetRequestFeedback;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionDeclarativeNetRequestFeedback NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `declarativeNetRequestWithHostAccess` permission requests access to the `browser.declarativeNetRequest` APIs with the ability to modify or redirect requests. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `menus` permission requests access to the `browser.menus` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionMenus;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionMenus NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `nativeMessaging` permission requests access to send messages to the App Extension bundle. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionNativeMessaging;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionNativeMessaging NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `scripting` permission requests access to the `browser.scripting` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionScripting;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionScripting NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `storage` permission requests access to the `browser.storage` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionStorage;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionStorage NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `tabs` permission requests access extra information on the `browser.tabs` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionTabs;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionTabs NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `unlimitedStorage` permission requests access to an unlimited quota on the `browser.storage.local` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionUnlimitedStorage;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionUnlimitedStorage NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `webNavigation` permission requests access to the `browser.webNavigation` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionWebNavigation;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionWebNavigation NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `webRequest` permission requests access to the `browser.webRequest` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionWebRequest;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionWebRequest NS_SWIFT_NONISOLATED;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h
@@ -27,8 +27,8 @@
 
 /*! @abstract The `notifications` permission requests access to the `browser.notifications` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionNotifications;
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionNotifications NS_SWIFT_NONISOLATED;
 
 /*! @abstract The `sidePanel` permission requests access to the `browser.sidePanel` APIs. */
-WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
-WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionSidePanel;
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN WKWebExtensionPermission const WKWebExtensionPermissionSidePanel NS_SWIFT_NONISOLATED;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataType.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataType.h
@@ -25,6 +25,7 @@
 
 #import <WebKit/WKWebExtensionDataType.h>
 
+#define _WKWebExtensionDataType WKWebExtensionDataType
 #define _WKWebExtensionDataTypeLocal WKWebExtensionDataTypeLocal
 #define _WKWebExtensionDataTypeSession WKWebExtensionDataTypeSession
-#define _WKWebExtensionDataTypeSync WKWebExtensionDataTypeSync
+#define _WKWebExtensionDataTypeSync WKWebExtensionDataTypeSynchronized

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
@@ -54,7 +54,7 @@ void WebExtensionDataRecord::addError(NSString *debugDescription, WebExtensionDa
         [m_errors.get() addObject:createDataRecordError(WKWebExtensionDataRecordErrorSessionStorageFailed, debugDescription)];
         break;
     case WebExtensionDataType::Sync:
-        [m_errors.get() addObject:createDataRecordError(WKWebExtensionDataRecordErrorSyncStorageFailed, debugDescription)];
+        [m_errors.get() addObject:createDataRecordError(WKWebExtensionDataRecordErrorSynchronizedStorageFailed, debugDescription)];
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -53,7 +53,7 @@ public:
     ~WebExtensionMessagePort();
 
     enum class ErrorType : uint8_t {
-        Unknown,
+        Unknown = 1,
         NotConnected,
         MessageInvalid,
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -1368,10 +1368,9 @@ TEST(WKWebExtensionAPIRuntime, ConnectNativeWithInvalidMessage)
 
             [messagePort sendMessage:@{ @"bad": NSUUID.UUID } completionHandler:^(NSError *error) {
                 EXPECT_NOT_NULL(error);
-                EXPECT_EQ(error.code, WKWebExtensionMessagePortErrorMessageInvalid);
             }];
 
-            [messagePort disconnectWithError:nil];
+            [messagePort disconnect];
 
             [manager done];
         };


### PR DESCRIPTION
#### 4605d704512807f9780e15e1e2094e272b7f9337
<pre>
Address additional API feedback for Web Extensions.
<a href="https://webkit.org/b/278191">https://webkit.org/b/278191</a>
<a href="https://rdar.apple.com/problem/133988536">rdar://problem/133988536</a>

Reviewed by Jeff Miller.

Adjusted the property and method names for WKWebExtensionDataRecord APIs.
Added NS_SWIFT_NONISOLATED to all string symbols.
Tweaked the NS_SWIFT_NAME for all ErrorDomains.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm:
(+[WKWebExtensionController allExtensionDataTypes]):
(-[WKWebExtensionController removeDataOfTypes:fromDataRecords:completionHandler:]):
(-[WKWebExtensionController removeDataOfTypes:forDataRecords:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm:
(-[WKWebExtensionDataRecord containedDataTypes]):
(-[WKWebExtensionDataRecord totalSizeInBytes]):
(-[WKWebExtensionDataRecord sizeInBytesOfTypes:]):
(-[WKWebExtensionDataRecord dataTypes]): Deleted.
(-[WKWebExtensionDataRecord totalSize]): Deleted.
(-[WKWebExtensionDataRecord sizeOfDataTypes:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataType.mm:
(WebKit::toWebExtensionDataTypes):
(WebKit::toAPI):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermission.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPermissionPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataType.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm:
(WebKit::WebExtensionDataRecord::addError):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm:
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, GetDataRecords)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecordsForMultipleContexts)):

Canonical link: <a href="https://commits.webkit.org/282402@main">https://commits.webkit.org/282402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5355842bce8a1c1ead435f0345f08319c4265fbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50774 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11890 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6945 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11849 "Found 1 new test failure: media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58295 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5792 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9510 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38175 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39255 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->