### PR TITLE
Include a NavigationActivation object in the 'page swap' event.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation-expected.txt
@@ -1,11 +1,3 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on navigation from script Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-navigation.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on navigation from script Test timed out
+PASS pageswap on navigation from script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect-expected.txt
@@ -1,11 +1,3 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on navigation with same-origin redirect Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-push-with-redirect.html?new", "push", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on navigation with same-origin redirect Test timed out
+PASS pageswap on navigation with same-origin redirect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation-expected.txt
@@ -1,11 +1,3 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?new", "replace", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on replace navigation from script Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "http://localhost:8800/css/css-view-transitions/navigation/pageswap-replace-navigation.html?new", "replace", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on replace navigation from script Test timed out
+PASS pageswap on replace navigation from script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt
@@ -1,11 +1,3 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'e.activation.entry')
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-...
 
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on traverse navigation from script Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pageswap", "transition", "pagehide"] length 3
-
-TIMEOUT pageswap on traverse navigation from script Test timed out
+PASS pageswap on traverse navigation from script
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -170,6 +170,7 @@
 #include "MouseEventWithHitTestResults.h"
 #include "MutationEvent.h"
 #include "NameNodeList.h"
+#include "NavigationActivation.h"
 #include "NavigationDisabler.h"
 #include "NavigationScheduler.h"
 #include "Navigator.h"
@@ -8109,7 +8110,7 @@ void Document::transferViewTransitionParams(Document& newDocument)
     newDocument.m_inboundViewTransitionParams = std::exchange(m_inboundViewTransitionParams, nullptr);
 }
 
-void Document::dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition)
+void Document::dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&& activation)
 {
     if (!settings().crossDocumentViewTransitionsEnabled())
         return;
@@ -8117,6 +8118,7 @@ void Document::dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition)
     RefPtr<ViewTransition> oldViewTransition;
 
     PageSwapEvent::Init swapInit;
+    swapInit.activation = WTFMove(activation);
     if (canTriggerCrossDocumentViewTransition && globalObject()) {
         oldViewTransition = ViewTransition::setupCrossDocumentViewTransition(*this);
         swapInit.viewTransition = oldViewTransition;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -191,6 +191,7 @@ class MediaQueryList;
 class MediaQueryMatcher;
 class MessagePortChannelProvider;
 class MouseEventWithHitTestResults;
+class NavigationActivation;
 class NodeFilter;
 class NodeIterator;
 class NodeList;
@@ -1384,7 +1385,7 @@ public:
     void queueTaskToDispatchEventOnWindow(TaskSource, Ref<Event>&&);
     void dispatchPageshowEvent(PageshowEventPersistence);
     void dispatchPagehideEvent(PageshowEventPersistence);
-    void dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition);
+    void dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&&);
     void transferViewTransitionParams(Document&);
     WEBCORE_EXPORT void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&);
     void enqueueHashchangeEvent(const String& oldURL, const String& newURL);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -93,6 +93,7 @@
 #include "MemoryCache.h"
 #include "MemoryRelease.h"
 #include "Navigation.h"
+#include "NavigationActivation.h"
 #include "NavigationDisabler.h"
 #include "NavigationNavigationType.h"
 #include "NavigationScheduler.h"
@@ -2246,6 +2247,34 @@ void FrameLoader::commitProvisionalLoad()
         frame->document() ? frame->document()->url().stringCenterEllipsizedToLength().utf8().data() : "",
         pdl ? pdl->url().stringCenterEllipsizedToLength().utf8().data() : "<no provisional DocumentLoader>", cachedPage.get());
 
+    if (RefPtr document = m_frame->document()) {
+        bool canTriggerCrossDocumentViewTransition = false;
+        RefPtr<NavigationActivation> activation;
+        if (pdl) {
+            canTriggerCrossDocumentViewTransition = pdl->navigationCanTriggerCrossDocumentViewTransition(*document);
+
+            RefPtr domWindow = document->domWindow();
+            auto navigationAPIType = pdl->triggeringAction().navigationAPIType();
+            if (domWindow && navigationAPIType) {
+                // FIXME: The NavigationActivation for pageswap should be created after the global
+                // history update, but before the unload event (which might be delayed). Those steps
+                // are currently intertwined, so this creates a fake/detached new history entry to
+                // use for this purpose.
+                RefPtr<HistoryItem> newItem;
+                if (RefPtr page = frame->page(); page && *navigationAPIType != NavigationNavigationType::Reload)
+                    newItem = frame->checkedHistory()->createItemWithLoader(page->historyItemClient(), pdl.get());
+
+                activation = domWindow->protectedNavigation()->createForPageswapEvent(newItem.get(), pdl.get());
+            }
+        }
+        document->dispatchPageswapEvent(canTriggerCrossDocumentViewTransition, WTFMove(activation));
+
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#deactivate-a-document-for-a-cross-document-navigation
+        // FIXME: If the pageswap event resulted in starting a view-transition, then the
+        // 'proceedWithNavigationAfterViewTransitionCapture' steps should proceed after the next
+        // rendering update (which includes firing the unload event for the old Document).
+    }
+
     if (RefPtr document = frame->document()) {
         // In the case where we're restoring from a cached page, our document will not
         // be connected to its frame yet, so the following call with be a no-op. We will
@@ -2393,13 +2422,6 @@ void FrameLoader::transitionToCommitted(CachedPage* cachedPage)
 
     m_client->setCopiesOnScroll();
     m_frame->checkedHistory()->updateForCommit();
-
-    if (RefPtr document = m_frame->document()) {
-        bool canTriggerCrossDocumentViewTransition = false;
-        if (m_provisionalDocumentLoader)
-            canTriggerCrossDocumentViewTransition = m_provisionalDocumentLoader->navigationCanTriggerCrossDocumentViewTransition(*document);
-        document->dispatchPageswapEvent(canTriggerCrossDocumentViewTransition);
-    }
 
     // The call to closeURL() invokes the unload event handler, which can execute arbitrary
     // JavaScript. If the script initiates a new load, we need to abandon the current load,

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -116,7 +116,7 @@ Ref<Frame> HistoryController::protectedFrame() const
 /*
  There is a race condition between the layout and load completion that affects restoring the scroll position.
  We try to restore the scroll position at both the first layout and upon load completion.
- 
+
  1) If first layout happens before the load completes, we want to restore the scroll position then so that the
  first time we draw the page is already scrolled to the right place, instead of starting at the top and later
  jumping down.  It is possible that the old scroll position is past the part of the doc laid out so far, in
@@ -251,7 +251,7 @@ void HistoryController::restoreDocumentState()
     case FrameLoadType::Standard:
         break;
     }
-    
+
     RefPtr currentItem = m_currentItem;
     if (!currentItem)
         return;
@@ -314,7 +314,7 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, Sh
     LOG(History, "HistoryController %p goToItem %p type=%d", this, &targetItem, static_cast<int>(type));
 
     ASSERT(!m_frame->tree().parent());
-    
+
     // shouldGoToHistoryItem is a private delegate method. This is needed to fix:
     // <rdar://problem/3951283> can view pages from the back/forward cache that should be disallowed by Parental Controls
     // Ultimately, history item navigations should go through the policy delegate. That's covered in:
@@ -385,7 +385,7 @@ void HistoryController::updateForReload()
 
     if (RefPtr currentItem = m_currentItem) {
         BackForwardCache::singleton().remove(*currentItem);
-    
+
         if (frame->loader().loadType() == FrameLoadType::Reload || frame->loader().loadType() == FrameLoadType::ReloadFromOrigin)
             saveScrollPositionAndViewStateToItem(currentItem.get());
 
@@ -689,12 +689,11 @@ void HistoryController::setProvisionalItem(RefPtr<HistoryItem>&& item)
     m_provisionalItem = WTFMove(item);
 }
 
-void HistoryController::initializeItem(HistoryItem& item)
+void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader> documentLoader)
 {
     RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
     if (!frame)
         return;
-    RefPtr documentLoader = frame->loader().documentLoader();
     ASSERT(documentLoader);
 
     URL unreachableURL = documentLoader->unreachableURL();
@@ -715,11 +714,11 @@ void HistoryController::initializeItem(HistoryItem& item)
     // deal with such things, so we nip that in the bud here.
     // Later we may want to learn to live with nil for URL.
     // See bug 3368236 and related bugs for more information.
-    if (url.isEmpty()) 
+    if (url.isEmpty())
         url = aboutBlankURL();
     if (originalURL.isEmpty())
         originalURL = aboutBlankURL();
-    
+
     StringWithDirection title = documentLoader->title();
 
     item.setURL(url);
@@ -741,11 +740,23 @@ void HistoryController::initializeItem(HistoryItem& item)
 Ref<HistoryItem> HistoryController::createItem(HistoryItemClient& client)
 {
     Ref item = HistoryItem::create(client);
-    initializeItem(item);
-    
+
+    if (RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr())) {
+        RefPtr documentLoader = frame->loader().documentLoader();
+        initializeItem(item, documentLoader);
+    }
+
     // Set the item for which we will save document state
     setCurrentItem(item.copyRef());
-    
+
+    return item;
+}
+
+Ref<HistoryItem> HistoryController::createItemWithLoader(HistoryItemClient& client, DocumentLoader* documentLoader)
+{
+    Ref item = HistoryItem::create(client);
+    initializeItem(item, documentLoader);
+
     return item;
 }
 
@@ -889,7 +900,7 @@ void HistoryController::updateCurrentItem()
         // dependent on the document.
         bool isTargetItem = currentItem->isTargetItem();
         currentItem->reset();
-        initializeItem(*currentItem);
+        initializeItem(*currentItem, documentLoader);
         currentItem->setIsTargetItem(isTargetItem);
     } else {
         // Even if the final URL didn't change, the form data may have changed.

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -94,12 +94,14 @@ public:
 
     void setDefersLoading(bool);
 
+    Ref<HistoryItem> createItemWithLoader(HistoryItemClient&, DocumentLoader*);
+
 private:
     friend class Page;
     bool shouldStopLoadingForHistoryItem(HistoryItem&) const;
     void goToItem(HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
 
-    void initializeItem(HistoryItem&);
+    void initializeItem(HistoryItem&, RefPtr<DocumentLoader>);
     Ref<HistoryItem> createItem(HistoryItemClient&);
     Ref<HistoryItem> createItemTree(HistoryItemClient&, LocalFrame& targetFrame, bool clipAtTarget);
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -146,6 +146,8 @@ public:
     void updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems, HistoryItem& reactivatedItem);
     void updateForActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 
+    RefPtr<NavigationActivation> createForPageswapEvent(HistoryItem* newItem, DocumentLoader*);
+
     void abortOngoingNavigationIfNeeded();
 
     std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);


### PR DESCRIPTION
#### 392522f03118c2441c27bb304d97f4d70e342318
<pre>
Include a NavigationActivation object in the &apos;page swap&apos; event.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278199">https://bugs.webkit.org/show_bug.cgi?id=278199</a>
&lt;<a href="https://rdar.apple.com/133993708">rdar://133993708</a>&gt;

Reviewed by Charlie Wolfe.

This creates a NavigationActivation object for the pageswap event (for same
origin navigations), as required by the spec.

The code for dispatching pageswap gets moved slightly earlier in the commit
process, to be before BackForwardCache::singleton().addIfCacheable. This code
mutates the global history, but also can fire the unload event if the old page
got put into the BF cache. Moving the pageswap event earlier guarantees that it
always happens before unload. It also makes the global history easier to reason
about, even if it doesn&apos;t match what the spec wants (as described in the inline
FIXME).

This code should work even with the Navigation API setting disabled, as its an
important feature for cross-document view-transitions (and demos are relying on
being able to access the new/old URLS).

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchPageswapEvent):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::restoreDocumentState):
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::updateForReload):
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::createItem):
(WebCore::HistoryController::createNewItem):
(WebCore::HistoryController::updateCurrentItem):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::createForPageswapEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/282953@main">https://commits.webkit.org/282953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aa111e01af4e53c830445a76e43b34ef27e981e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52053 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14230 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70478 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56106 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/848 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->