### PR TITLE
Remove Cookie Store API Extended Attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (string) "localhost" but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (string) "localhost" but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -16,7 +16,7 @@ FAIL cookieStore.set default domain is null and differs from current hostname as
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /
-PASS cookieStore.set adds / to path that does not end with /
+FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected (string) "/cookie-store/" but got (undefined) undefined
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -16,7 +16,7 @@ FAIL cookieStore.set default domain is null and differs from current hostname as
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /
-PASS cookieStore.set adds / to path that does not end with /
+FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected (string) "/cookie-store/" but got (undefined) undefined
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1897,20 +1897,6 @@ CookieStoreAPIEnabled:
     WebCore:
       default: false
 
-CookieStoreAPIExtendedAttributesEnabled:
-  type: bool
-  category: dom
-  status: testable
-  humanReadableName: "Cookie Store API Extended Attributes"
-  humanReadableDescription: "Enable Extended Attributes of the Cookie Store API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 CookieStoreAPIServiceWorkerEnabled:
   type: bool
   category: dom

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.h
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.h
@@ -39,31 +39,11 @@ struct CookieListItem {
     CookieListItem(Cookie&& cookie)
         : name(WTFMove(cookie.name))
         , value(WTFMove(cookie.value))
-        , domain(WTFMove(cookie.domain))
-        , path(WTFMove(cookie.path))
-        , expires(cookie.expires)
-        , secure(cookie.secure)
     {
-        switch (cookie.sameSite) {
-        case Cookie::SameSitePolicy::Strict:
-            sameSite = CookieSameSite::Strict;
-            break;
-        case Cookie::SameSitePolicy::Lax:
-            sameSite = CookieSameSite::Lax;
-            break;
-        case Cookie::SameSitePolicy::None:
-            sameSite = CookieSameSite::None;
-            break;
-        }
     }
 
     String name;
     String value;
-    String domain;
-    String path;
-    std::optional<DOMHighResTimeStamp> expires;
-    bool secure { false };
-    CookieSameSite sameSite { CookieSameSite::Strict };
 };
 
 }

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.idl
@@ -33,9 +33,4 @@ typedef double DOMHighResTimeStamp;
 ] dictionary CookieListItem {
     USVString name;
     USVString value;
-    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] USVString? domain;
-    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] USVString path;
-    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] DOMHighResTimeStamp? expires;
-    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] boolean secure = false;
-    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] CookieSameSite sameSite = "strict";
 };


### PR DESCRIPTION
#### 7f0cfaf9724b6b7ee3dae686e08c8abd4e778c49
<pre>
Remove Cookie Store API Extended Attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=278198">https://bugs.webkit.org/show_bug.cgi?id=278198</a>
<a href="https://rdar.apple.com/133994044">rdar://133994044</a>

Reviewed by NOBODY (OOPS!).

The document.cookie API exposes only the `name` and `value`
attributes of the cookie. Our position is that we want to do
the same for the new Cookie Store API. Since we do not want
to expose any extra cookie metadata through this API, this
patch removes those extra attributes and their feature flag.
See <a href="https://github.com/WebKit/standards-positions/issues/36">https://github.com/WebKit/standards-positions/issues/36</a>

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/cookie-store/CookieListItem.h:
(WebCore::CookieListItem::CookieListItem):
(): Deleted.
* Source/WebCore/Modules/cookie-store/CookieListItem.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f0cfaf9724b6b7ee3dae686e08c8abd4e778c49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50671 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9272 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65894 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31350 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11755 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12305 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55935 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68540 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62068 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58179 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5662 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38001 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14750 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->