### PR TITLE
Propagate aborted state to dependent signals before firing events

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt
@@ -9,4 +9,6 @@ PASS AbortSignal.any() signals are composable (using AbortController)
 PASS AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)
 PASS AbortSignal.any() works with intermediate signals (using AbortController)
 PASS Abort events for AbortSignal.any() signals fire in the right order (using AbortController)
+PASS Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)
+PASS Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt
@@ -9,4 +9,6 @@ PASS AbortSignal.any() signals are composable (using AbortController)
 PASS AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)
 PASS AbortSignal.any() works with intermediate signals (using AbortController)
 PASS Abort events for AbortSignal.any() signals fire in the right order (using AbortController)
+PASS Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)
+PASS Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/resources/abort-signal-any-tests.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/resources/abort-signal-any-tests.js
@@ -182,4 +182,43 @@ function abortSignalAnyTests(signalInterface, controllerInterface) {
     controller.abort();
     assert_equals(result, "01234");
   }, `Abort events for ${desc} signals fire in the right order ${suffix}`);
+
+  test(t => {
+    const controller = new controllerInterface();
+    const signal1 = signalInterface.any([controller.signal]);
+    const signal2 = signalInterface.any([signal1]);
+    let eventFired = false;
+
+    controller.signal.addEventListener('abort', () => {
+      const signal3 = signalInterface.any([signal2]);
+      assert_true(controller.signal.aborted);
+      assert_true(signal1.aborted);
+      assert_true(signal2.aborted);
+      assert_true(signal3.aborted);
+      eventFired = true;
+    });
+
+    controller.abort();
+    assert_true(eventFired, "event fired");
+  }, `Dependent signals for ${desc} are marked aborted before abort events fire ${suffix}`);
+
+  test(t => {
+    const controller1 = new controllerInterface();
+    const controller2 = new controllerInterface();
+    const signal = signalInterface.any([controller1.signal, controller2.signal]);
+    let count = 0;
+
+    controller1.signal.addEventListener('abort', () => {
+      controller2.abort("reason 2");
+    });
+
+    signal.addEventListener('abort', () => {
+      count++;
+    });
+
+    controller1.abort("reason 1");
+    assert_equals(count, 1);
+    assert_true(signal.aborted);
+    assert_equals(signal.reason, "reason 1");
+  }, `Dependent signals for ${desc} are aborted correctly for reentrant aborts ${suffix}`);
 }

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -88,13 +88,16 @@ private:
     void addSourceSignal(AbortSignal&);
     void addDependentSignal(AbortSignal&);
 
+    void markAborted(JSC::JSValue);
+    void runAbortSteps();
+
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::AbortSignal; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;
-    
+
     Vector<std::pair<uint32_t, Algorithm>> m_algorithms;
     WeakPtr<AbortSignal, WeakPtrImplWithEventTargetData> m_followingSignal;
     AbortSignalSet m_sourceSignals;
@@ -110,4 +113,3 @@ private:
 WebCoreOpaqueRoot root(AbortSignal*);
 
 } // namespace WebCore
-


### PR DESCRIPTION
#### 107874a6f093539d8b84cffb0454e954c4e7dee6
<pre>
Propagate aborted state to dependent signals before firing events
<a href="https://bugs.webkit.org/show_bug.cgi?id=278159">https://bugs.webkit.org/show_bug.cgi?id=278159</a>

Reviewed by Chris Dumez.

The implementation and spec assert that dependent signals are aborted
if any of their sources are aborted. However, the intermediate states do not
reflect this during the abort process. Since we iterate through all the dependent
signals, updating the state and then firing the event.

An updated spec is about to land to address this by first propagating
the abort state to any dependent signals, and only then run the
abort steps (run algorithms and fire events).

Worthy notes:
- Dependent signals do not themselves have dependent signals, which
  means it&apos;s unnecessary to call &quot;signal abort recursively&quot;.
- This approach retains the existing event dispatch order while
  ensuring the abort state is synced before any JS runs.

DOM spec PR: <a href="https://github.com/whatwg/dom/pull/1295">https://github.com/whatwg/dom/pull/1295</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/resources/abort-signal-any-tests.js:
  Ported wpt tests from Chromium&apos;s PR addressing this same concern. The
  tests:
  - `Dependent signals for ${desc} are marked aborted before abort events fire ${suffix}` and
  - `Dependent signals for ${desc} are aborted correctly for reentrant aborts ${suffix}`.
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::any):
  `check-webkit-style` did not like the `findIf` with `[whitespace/newline]`.
(WebCore::AbortSignal::signalAbort):
  Collect the dependent signals to abort into a vector, then
  mark those as aborted, then
  run the signal&apos;s abort steps, and finally
  run the dependent signals&apos; abort steps.
(WebCore::AbortSignal::markAborted):
  Added this convenience method to set both the `reason` and then
  `m_aborted` state.
(WebCore::AbortSignal::runAbortSteps):
* Source/WebCore/dom/AbortSignal.h:

Canonical link: <a href="https://commits.webkit.org/282387@main">https://commits.webkit.org/282387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887ebeec4aad12c4ff994fc37c96f2c16d6238a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50771 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9378 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68703 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58087 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58292 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5784 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9499 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->