### PR TITLE
[JSC] Update wpt/wasm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/assertions.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/assertions.js
@@ -6,6 +6,7 @@ function assert_function_name(fn, name, description) {
   assert_true(propdesc.configurable, "configurable", `${description} name should be configurable`);
   assert_equals(propdesc.value, name, `${description} name should be ${name}`);
 }
+globalThis.assert_function_name = assert_function_name;
 
 function assert_function_length(fn, length, description) {
   const propdesc = Object.getOwnPropertyDescriptor(fn, "length");
@@ -15,6 +16,7 @@ function assert_function_length(fn, length, description) {
   assert_true(propdesc.configurable, "configurable", `${description} length should be configurable`);
   assert_equals(propdesc.value, length, `${description} length should be ${length}`);
 }
+globalThis.assert_function_length = assert_function_length;
 
 function assert_exported_function(fn, { name, length }, description) {
   if (WebAssembly.Function === undefined) {
@@ -28,6 +30,7 @@ function assert_exported_function(fn, { name, length }, description) {
   assert_function_name(fn, name, description);
   assert_function_length(fn, length, description);
 }
+globalThis.assert_exported_function = assert_exported_function;
 
 function assert_Instance(instance, expected_exports) {
   assert_equals(Object.getPrototypeOf(instance), WebAssembly.Instance.prototype,
@@ -77,6 +80,7 @@ function assert_Instance(instance, expected_exports) {
     }
   }
 }
+globalThis.assert_Instance = assert_Instance;
 
 function assert_WebAssemblyInstantiatedSource(actual, expected_exports={}) {
   assert_equals(Object.getPrototypeOf(actual), Object.prototype,
@@ -98,3 +102,4 @@ function assert_WebAssemblyInstantiatedSource(actual, expected_exports={}) {
   assert_true(instance.configurable, "instance: configurable");
   assert_Instance(instance.value, expected_exports);
 }
+globalThis.assert_WebAssemblyInstantiatedSource = assert_WebAssemblyInstantiatedSource;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/bad-imports.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/bad-imports.js
@@ -183,3 +183,4 @@ function test_bad_imports(t) {
       });
   }
 }
+globalThis.test_bad_imports = test_bad_imports;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/compile.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/compile.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_Module(module) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate-bad-imports.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate-bad-imports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/bad-imports.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/instanceTestFactory.js

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/multi-value.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/multi-value.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/toStringTag.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/toStringTag.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 "use strict";
 // https://webidl.spec.whatwg.org/#es-namespaces

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/validate.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/validate.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 let emptyModuleBinary;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/basic.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/basic.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_throws_wasm(fn, message) {
@@ -13,11 +13,11 @@ function assert_throws_wasm(fn, message) {
 promise_test(async () => {
   const kSig_v_r = makeSig([kWasmExternRef], []);
   const builder = new WasmModuleBuilder();
-  const except = builder.addTag(kSig_v_r);
+  const tagIndex = builder.addTag(kSig_v_r);
   builder.addFunction("throw_param", kSig_v_r)
     .addBody([
       kExprLocalGet, 0,
-      kExprThrow, except,
+      kExprThrow, tagIndex,
     ])
     .exportFunc();
   const buffer = builder.toBuffer();
@@ -44,11 +44,11 @@ promise_test(async () => {
 
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
-  const except = builder.addTag(kSig_v_a);
+  const tagIndex = builder.addTag(kSig_v_a);
   builder.addFunction("throw_null", kSig_v_v)
     .addBody([
       kExprRefNull, kAnyFuncCode,
-      kExprThrow, except,
+      kExprThrow, tagIndex,
     ])
     .exportFunc();
   const buffer = builder.toBuffer();
@@ -58,11 +58,11 @@ promise_test(async () => {
 
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
-  const except = builder.addTag(kSig_v_i);
+  const tagIndex = builder.addTag(kSig_v_i);
   builder.addFunction("throw_int", kSig_v_v)
     .addBody([
       ...wasmI32Const(7),
-      kExprThrow, except,
+      kExprThrow, tagIndex,
     ])
     .exportFunc();
   const buffer = builder.toBuffer();
@@ -73,12 +73,12 @@ promise_test(async () => {
 promise_test(async () => {
   const builder = new WasmModuleBuilder();
   const fnIndex = builder.addImport("module", "fn", kSig_v_v);
-  const except = builder.addTag(kSig_v_r);
+  const tagIndex= builder.addTag(kSig_v_r);
   builder.addFunction("catch_exception", kSig_r_v)
     .addBody([
       kExprTry, kWasmStmt,
         kExprCallFunction, fnIndex,
-      kExprCatch, except,
+      kExprCatch, tagIndex,
         kExprReturn,
       kExprEnd,
       kExprRefNull, kExternRefCode,

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 test(() => {
@@ -18,8 +18,8 @@ test(() => {
 }, "No arguments");
 
 test(() => {
-  const argument = new WebAssembly.Tag({ parameters: [] });
-  assert_throws_js(TypeError, () => WebAssembly.Exception(argument));
+  const tag = new WebAssembly.Tag({ parameters: [] });
+  assert_throws_js(TypeError, () => WebAssembly.Exception(tag));
 }, "Calling");
 
 test(() => {
@@ -53,10 +53,10 @@ test(() => {
     ["i64", undefined],
   ];
   for (const typeAndArg of typesAndArgs) {
-    const exn = new WebAssembly.Tag({ parameters: [typeAndArg[0]] });
+    const tag = new WebAssembly.Tag({ parameters: [typeAndArg[0]] });
     assert_throws_js(
       TypeError,
-      () => new WebAssembly.Exception(exn, typeAndArg[1])
+      () => new WebAssembly.Exception(tag, typeAndArg[1])
     );
   }
 }, "Invalid exception argument");

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any-expected.txt
@@ -2,6 +2,8 @@
 PASS Missing arguments
 PASS Invalid exception argument
 PASS Index out of bounds
-PASS Getting out-of-range argument
+FAIL Getting out-of-range argument assert_throws_js: function "() => exn.getArg(tag, value)" threw object "TypeError: Expect an integer argument in the range: [0, 2^32 - 1]" ("TypeError") expected instance of function "function RangeError() {
+    [native code]
+}" ("RangeError")
 PASS getArg
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {
@@ -43,7 +43,7 @@ test(() => {
   const tag = new WebAssembly.Tag({ parameters: [] });
   const exn = new WebAssembly.Exception(tag, []);
   for (const value of outOfRangeValues) {
-    assert_throws_js(TypeError, () => exn.getArg(tag, value));
+    assert_throws_js(RangeError, () => exn.getArg(tag, value));
   }
 }, "Getting out-of-range argument");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.worker-expected.txt
@@ -2,6 +2,8 @@
 PASS Missing arguments
 PASS Invalid exception argument
 PASS Index out of bounds
-PASS Getting out-of-range argument
+FAIL Getting out-of-range argument assert_throws_js: function "() => exn.getArg(tag, value)" threw object "TypeError: Expect an integer argument in the range: [0, 2^32 - 1]" ("TypeError") expected instance of function "function RangeError() {
+    [native code]
+}" ("RangeError")
 PASS getArg
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Identity check
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.js
@@ -1,0 +1,61 @@
+// META: global=window,dedicatedworker,jsshell,shadowrealm
+// META: script=/wasm/jsapi/assertions.js
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+test(() => {
+  const tag = new WebAssembly.Tag({ parameters: ["i32"] });
+  const exn = new WebAssembly.Exception(tag, [42]);
+  const exn_same_payload = new WebAssembly.Exception(tag, [42]);
+  const exn_diff_payload = new WebAssembly.Exception(tag, [53]);
+
+  const builder = new WasmModuleBuilder();
+  const jsfuncIndex = builder.addImport("module", "jsfunc", kSig_v_v);
+  const tagIndex = builder.addImportedTag("module", "tag", kSig_v_i);
+  const imports = {
+    module: {
+      jsfunc: function() { throw exn; },
+      tag: tag
+    }
+  };
+
+  builder
+    .addFunction("catch_rethrow", kSig_v_v)
+    .addBody([
+      kExprTry, kWasmStmt,
+        kExprCallFunction, jsfuncIndex,
+      kExprCatch, tagIndex,
+        kExprDrop,
+        kExprRethrow, 0x00,
+      kExprEnd
+    ])
+    .exportFunc();
+
+  builder
+    .addFunction("catch_all_rethrow", kSig_v_v)
+    .addBody([
+      kExprTry, kWasmStmt,
+        kExprCallFunction, jsfuncIndex,
+      kExprCatchAll,
+        kExprRethrow, 0x00,
+      kExprEnd
+    ])
+    .exportFunc();
+
+  const buffer = builder.toBuffer();
+  WebAssembly.instantiate(buffer, imports).then(result => {
+    try {
+      result.instance.exports.catch_rethrow();
+    } catch (e) {
+      assert_equals(e, exn);
+      assert_not_equals(e, exn_same_payload);
+      assert_not_equals(e, exn_diff_payload);
+    }
+    try {
+      result.instance.exports.catch_all_rethrow();
+    } catch (e) {
+      assert_equals(e, exn);
+      assert_not_equals(e, exn_same_payload);
+      assert_not_equals(e, exn_diff_payload);
+    }
+  });
+}, "Identity check");

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Identity check
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/is.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/is.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/toString.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/toString.tentative.any.js
@@ -1,10 +1,10 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { parameters: [] };
   const tag = new WebAssembly.Tag(argument);
-  const exception = new WebAssembly.Exception(tag, []);
-  assert_class_string(exception, "WebAssembly.Exception");
+  const exn = new WebAssembly.Exception(tag, []);
+  assert_class_string(exn, "WebAssembly.Exception");
 }, "Object.prototype.toString on an Exception");
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/w3c-import.log
@@ -17,5 +17,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/basic.tentative.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js
+/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/is.tentative.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/toString.tentative.any.js

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function addxy(x, y) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function addxy(x, y) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function testfunc(n) {}

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function addNumbers(x, y, z) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.html
@@ -1,2 +1,1 @@
-<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.worker-expected.txt
@@ -1,0 +1,13 @@
+
+PASS anyref casts
+PASS eqref casts
+PASS structref casts
+PASS arrayref casts
+PASS i31ref casts
+PASS funcref casts
+PASS externref casts
+PASS null casts
+PASS concrete struct casts
+PASS concrete array casts
+PASS concrete func casts
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.html
@@ -1,2 +1,1 @@
-<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.worker-expected.txt
@@ -1,0 +1,21 @@
+
+PASS property access
+PASS property assignment (strict mode)
+PASS property assignment (non-strict mode)
+PASS ownPropertyNames
+PASS defineProperty
+PASS delete (strict mode)
+PASS delete (non-strict mode)
+PASS getPrototypeOf
+PASS setPrototypeOf
+PASS isExtensible
+PASS preventExtensions
+PASS sealing
+PASS typeof
+PASS toString
+PASS valueOf
+PASS GC objects as map keys
+PASS GC objects as set element
+PASS GC objects as weak map keys
+PASS GC objects as weak set element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html
@@ -1,2 +1,1 @@
-<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.html
@@ -1,2 +1,1 @@
-<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true,--useWasmExtendedConstantExpressions=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.worker-expected.txt
@@ -1,0 +1,8 @@
+
+PASS i31ref conversion to Number
+PASS Number conversion to i31ref
+PASS Check i31ref argument type
+PASS Numbers in i31 range are i31ref, not hostref
+PASS i31ref global
+PASS i31ref table
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/w3c-import.log
@@ -1,0 +1,19 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.js
+/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.js
+/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.js

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/constructor.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_Global(actual, expected) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/toString.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { "value": "i32" };

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/type.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const thisValues = [

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/valueOf.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/valueOf.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { "value": "i32" };

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-bad-imports.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-bad-imports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/bad-imports.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function getExports() {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/instanceTestFactory.js

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/exports.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/exports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 let emptyModuleBinary;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/toString.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instanceTestFactory.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instanceTestFactory.js
@@ -759,3 +759,5 @@ const instanceTestFactory = [
     }
   ],
 ];
+
+globalThis.instanceTestFactory = instanceTestFactory;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/interface.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/interface.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function test_operations(object, object_name, operations) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor-shared.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor-shared.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/memory/assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor-types.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor-types.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/memory/assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/memory/assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/grow.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/grow.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/type.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/constructor.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/customSections.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/customSections.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_ArrayBuffer(buffer, expected) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/exports.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/exports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 let emptyModuleBinary;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/imports.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/imports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_ModuleImportDescriptor(import_, expected) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any-expected.txt
@@ -1,0 +1,6 @@
+
+PASS AbstractModuleSource is not a global
+FAIL AbstractModuleSource intrinsic assert_equals: expected "AbstractModuleSource" but got ""
+FAIL AbstractModuleSourceProto intrinsic assert_not_equals: got disallowed value object "[object Object]"
+FAIL AbstractModuleSourceProto toStringTag brand check undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(AbstractModuleSource.prototype, Symbol.toStringTag)')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.js
@@ -1,0 +1,35 @@
+// META: global=window,dedicatedworker,jsshell,shadowrealm
+// META: script=/wasm/jsapi/wasm-module-builder.js
+// META: script=/wasm/jsapi/assertions.js
+
+let emptyModuleBinary;
+setup(() => {
+  emptyModuleBinary = new WasmModuleBuilder().toBuffer();
+});
+
+test(() => {
+  assert_equals(typeof AbstractModuleSource, "undefined");
+}, "AbstractModuleSource is not a global");
+
+test(() => {
+  const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
+  assert_equals(AbstractModuleSource.name, "AbstractModuleSource");
+  assert_not_equals(AbstractModuleSource, Function);
+}, "AbstractModuleSource intrinsic");
+
+test(() => {
+  const AbstractModuleSourceProto = Object.getPrototypeOf(WebAssembly.Module.prototype);
+  assert_not_equals(AbstractModuleSourceProto, Object.prototype);
+  const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
+  assert_equals(AbstractModuleSource.prototype, AbstractModuleSourceProto);
+}, "AbstractModuleSourceProto intrinsic");
+
+test(() => {
+  const module = new WebAssembly.Module(emptyModuleBinary);
+
+  const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
+  const toStringTag = Object.getOwnPropertyDescriptor(AbstractModuleSource.prototype, Symbol.toStringTag).get;
+
+  assert_equals(toStringTag.call(module), "WebAssembly.Module");
+  assert_throws_js(TypeError, () => toStringTag.call({}));
+}, "AbstractModuleSourceProto toStringTag brand check");

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.worker-expected.txt
@@ -1,0 +1,6 @@
+
+PASS AbstractModuleSource is not a global
+FAIL AbstractModuleSource intrinsic assert_equals: expected "AbstractModuleSource" but got ""
+FAIL AbstractModuleSourceProto intrinsic assert_not_equals: got disallowed value object "[object Object]"
+FAIL AbstractModuleSourceProto toStringTag brand check undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(AbstractModuleSource.prototype, Symbol.toStringTag)')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/toString.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/w3c-import.log
@@ -18,4 +18,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/customSections.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/exports.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/imports.any.js
+/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/toString.any.js

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/prototypes.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/prototypes.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/constructor-types.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/constructor-types.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/table/assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/constructor.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/table/assertions.js

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/get-set.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/get-set.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/grow.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/grow.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=assertions.js
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/length.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/length.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const thisValues = [

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/toString.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/type.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/constructor.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/toString.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/toString.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { parameters: [] };

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/type.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/wasm-module-builder.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/wasm-module-builder.js
@@ -1487,6 +1487,7 @@ class WasmModuleBuilder {
     return new WebAssembly.Module(this.toBuffer(debug));
   }
 }
+globalThis.WasmModuleBuilder = WasmModuleBuilder;
 
 function wasmSignedLeb(val, max_len = 5) {
   let res = [];
@@ -1503,10 +1504,12 @@ function wasmSignedLeb(val, max_len = 5) {
   throw new Error(
       'Leb value <' + val + '> exceeds maximum length of ' + max_len);
 }
+globalThis.wasmSignedLeb = wasmSignedLeb;
 
 function wasmI32Const(val) {
   return [kExprI32Const, ...wasmSignedLeb(val, 5)];
 }
+globalThis.wasmI32Const = wasmI32Const;
 
 function wasmF32Const(f) {
   // Write in little-endian order at offset 0.
@@ -1515,6 +1518,7 @@ function wasmF32Const(f) {
     kExprF32Const, byte_view[0], byte_view[1], byte_view[2], byte_view[3]
   ];
 }
+globalThis.wasmI32Const = wasmI32Const;
 
 function wasmF64Const(f) {
   // Write in little-endian order at offset 0.
@@ -1524,3 +1528,4 @@ function wasmF64Const(f) {
     byte_view[3], byte_view[4], byte_view[5], byte_view[6], byte_view[7]
   ];
 }
+globalThis.wasmF64Const = wasmF64Const;

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/w3c-import.log
@@ -47,5 +47,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/wasm-js-cycle.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/wasm-js-cycle.wasm
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker-helper.js
+/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker-source-phase.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker.wasm

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker-source-phase.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker-source-phase.js
@@ -1,0 +1,10 @@
+import source modSource from "./worker.wasm";
+import { pm } from "./worker-helper.js";
+assert_true(modSource instanceof WebAssembly.Module);
+assert_true(await import.source("./worker.wasm") === modSource);
+
+await WebAssembly.instantiate(modSource, {
+  "./worker-helper.js": {
+    "pm": pm
+  }
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker.js
@@ -1,1 +1,2 @@
-import * as mod from "./worker.wasm"
+import * as mod from "./worker.wasm";
+assert_true(await import("./worker.wasm") === mod);

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
+
+
+FAIL Importing a WebAssembly module should be allowed by script-src CSP. assert_array_equals: lengths differ, expected array ["executed"] length 1, got [] length 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>script-src allows Wasm execution</title>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    setup({allow_uncaught_exception: true});
+
+    const test_load = async_test(
+        "Importing a WebAssembly module should be allowed by script-src CSP.");
+
+    window.log = [];
+    document.addEventListener("securitypolicyviolation", (e) => {
+      window.log.push(e.violatedDirective);
+    });
+
+    window.addEventListener("load", test_load.step_func_done(ev => {
+      assert_array_equals(log, ["executed"]);
+    }));
+</script>
+<script type="module" src="./resources/execute-start.wasm"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://127.0.0.1/resources/execute-start.wasm because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://127.0.0.1/resources/execute-start.wasm because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS Importing a WebAssembly module should be guarded by script-src CSP.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>script-src blocks Wasm execution</title>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    setup({allow_uncaught_exception: true});
+
+    const test_load = async_test(
+        "Importing a WebAssembly module should be guarded by script-src CSP.");
+
+    window.log = [];
+    document.addEventListener("securitypolicyviolation", (e) => {
+      window.log.push(e.violatedDirective);
+    });
+
+    window.addEventListener("load", test_load.step_func_done(ev => {
+      assert_array_equals(log, ["script-src-elem"]);
+    }));
+</script>
+<script type="module" src="https://{{hosts[alt][]}}/resources/execute-start.wasm"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'exportedNamesSource'. Expected 'from' before imported module name.
+
+Harness Error (FAIL), message = SyntaxError: Unexpected identifier 'exportedNamesSource'. Expected 'from' before imported module name.
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Source phase imports</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type=module>
+setup({ single_test: true });
+
+import source exportedNamesSource from "./resources/exported-names.wasm";
+
+assert_true(exportedNamesSource instanceof WebAssembly.Module);
+const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
+assert_equals(AbstractModuleSource.name, "AbstractModuleSource");
+assert_true(exportedNamesSource instanceof AbstractModuleSource);
+
+assert_array_equals(WebAssembly.Module.exports(exportedNamesSource).map(({ name }) => name).sort(),
+                    ["func", "glob", "mem", "tab"]);
+
+const wasmImportFromWasmSource = await import.source("./resources/wasm-import-from-wasm.wasm");
+
+assert_true(wasmImportFromWasmSource instanceof WebAssembly.Module);
+
+let logged = false;
+const instance = await WebAssembly.instantiate(wasmImportFromWasmSource, {
+  "./wasm-export-to-wasm.wasm": {
+    log () {
+      logged = true;
+    }
+  }
+});
+instance.exports.logExec();
+assert_true(logged);
+
+done();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/w3c-import.log
@@ -22,9 +22,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/module-parse-error.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resolve-export.js
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resolve-export.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/wasm-import-wasm-export.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/wasm-import.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/wasm-js-cycle.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/wasm-to-wasm-link-error.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'modSource'. Expected 'from' before imported module name.
+
+Harness Error (TIMEOUT), message = null
+
+NOTRUN Testing import of WebAssembly source phase from JavaScript worker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>Testing import of WebAssembly source phase from JavaScript worker</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type=module>
+setup({ single_test: true });
+const worker = new Worker("resources/worker-source-phase.js", { type: "module" });
+worker.onmessage = (msg) => {
+  assert_equals(msg.data, 42);
+  done();
+}
+</script>


### PR DESCRIPTION
#### 3137d424cdf8e769a79a8379198ed620b8de39f1
<pre>
[JSC] Update wpt/wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=278203">https://bugs.webkit.org/show_bug.cgi?id=278203</a>
<a href="https://rdar.apple.com/133998295">rdar://133998295</a>

Reviewed by Mark Lam.

Import latest wpt/wasm tests.

* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/assertions.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/bad-imports.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/compile.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate-bad-imports.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/multi-value.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/toStringTag.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/constructor/validate.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/basic.tentative.any.js:
(promise_test.async const):
(promise_test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/constructor.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.js: Added.
(test.const.imports.module.jsfunc):
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/identity.tentative.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/is.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/toString.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/call.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/constructor.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/table.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/function/type.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/constructor.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/toString.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/type.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-get-set.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/valueOf.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-bad-imports.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor-caching.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/constructor.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/exports.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instance/toString.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/instanceTestFactory.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/interface.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor-shared.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor-types.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/constructor.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/grow.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/type.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/constructor.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/customSections.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/exports.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/imports.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.js: Added.
(setup):
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/moduleSource.tentative.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/toString.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/module/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/prototypes.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/constructor-types.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/constructor.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/get-set.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/grow.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/length.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/toString.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/table/type.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/constructor.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/toString.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/tag/type.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/wasm-module-builder.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker-source-phase.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/resources/worker.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-allows-wasm.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/source-phase.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/282330@main">https://commits.webkit.org/282330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/359bdfe6f655d9d04ab84770c3653058bfe16bad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13724 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9276 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31355 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68551 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58184 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5667 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9468 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38012 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40203 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->