### PR TITLE
Add a member of the thumb position to SliderTrackPart

### DIFF
--- a/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
@@ -33,19 +33,20 @@ namespace WebCore {
 
 Ref<SliderTrackPart> SliderTrackPart::create(StyleAppearance type)
 {
-    return adoptRef(*new SliderTrackPart(type, { }, { }, { }));
+    return adoptRef(*new SliderTrackPart(type, { }, { }, { }, 0));
 }
 
-Ref<SliderTrackPart> SliderTrackPart::create(StyleAppearance type, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios)
+Ref<SliderTrackPart> SliderTrackPart::create(StyleAppearance type, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios, double thumbPosition)
 {
-    return adoptRef(*new SliderTrackPart(type, thumbSize, trackBounds, WTFMove(tickRatios)));
+    return adoptRef(*new SliderTrackPart(type, thumbSize, trackBounds, WTFMove(tickRatios), thumbPosition));
 }
 
-SliderTrackPart::SliderTrackPart(StyleAppearance type, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios)
+SliderTrackPart::SliderTrackPart(StyleAppearance type, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios, double thumbPosition)
     : ControlPart(type)
     , m_thumbSize(thumbSize)
     , m_trackBounds(trackBounds)
     , m_tickRatios(WTFMove(tickRatios))
+    , m_thumbPosition(thumbPosition)
 {
     ASSERT(type == StyleAppearance::SliderHorizontal || type == StyleAppearance::SliderVertical);
 }

--- a/Source/WebCore/platform/graphics/controls/SliderTrackPart.h
+++ b/Source/WebCore/platform/graphics/controls/SliderTrackPart.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class SliderTrackPart : public ControlPart {
 public:
     static Ref<SliderTrackPart> create(StyleAppearance);
-    WEBCORE_EXPORT static Ref<SliderTrackPart> create(StyleAppearance, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios);
+    WEBCORE_EXPORT static Ref<SliderTrackPart> create(StyleAppearance, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios, double thumbPosition);
 
     IntSize thumbSize() const { return m_thumbSize; }
     void setThumbSize(IntSize thumbSize) { m_thumbSize = thumbSize; }
@@ -44,18 +44,22 @@ public:
     const Vector<double>& tickRatios() const { return m_tickRatios; }
     void setTickRatios(Vector<double>&& tickRatios) { m_tickRatios = WTFMove(tickRatios); }
 
+    double thumbPosition() const { return m_thumbPosition; }
+    void setThumbPosition(double thumbPosition) { m_thumbPosition = thumbPosition; }
+
 #if ENABLE(DATALIST_ELEMENT)
     void drawTicks(GraphicsContext&, const FloatRect&, const ControlStyle&) const;
 #endif
 
 private:
-    SliderTrackPart(StyleAppearance, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios);
+    SliderTrackPart(StyleAppearance, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios, double thumbPosition);
 
     std::unique_ptr<PlatformControl> createPlatformControl() override;
 
     IntSize m_thumbSize;
     IntRect m_trackBounds;
     Vector<double> m_tickRatios;
+    double m_thumbPosition;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -484,11 +484,15 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
         trackBounds.moveBy(-sliderBounds.location());
     }
 
+    double minimum = input.minimum();
+    double maximum = input.maximum();
+    double thumbPosition = 0;
+    if (maximum > minimum)
+        thumbPosition = (input.valueAsNumber() - minimum) / (maximum - minimum);
+
     Vector<double> tickRatios;
 #if ENABLE(DATALIST_ELEMENT)
     if (auto dataList = input.dataList()) {
-        double minimum = input.minimum();
-        double maximum = input.maximum();
 
         for (auto& optionElement : dataList->suggestions()) {
             auto optionValue = input.listOptionValueAsDouble(optionElement);
@@ -502,6 +506,7 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
 
     sliderTrackPart.setThumbSize(thumbSize);
     sliderTrackPart.setTrackBounds(trackBounds);
+    sliderTrackPart.setThumbPosition(thumbPosition);
     sliderTrackPart.setTickRatios(WTFMove(tickRatios));
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3582,6 +3582,7 @@ enum class WebCore::ApplePayButtonStyle : uint8_t {
     WebCore::IntSize thumbSize();
     WebCore::IntRect trackBounds();
     Vector<double> tickRatios();
+    double thumbPosition();
 }
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SwitchThumbPart {


### PR DESCRIPTION
#### e3d6b9efe3ac444be7289cd6720bcd8266047542
<pre>
Add a member of the thumb position to SliderTrackPart
<a href="https://bugs.webkit.org/show_bug.cgi?id=278206">https://bugs.webkit.org/show_bug.cgi?id=278206</a>

Reviewed by Aditya Keerthi.

Added thumbPosition member to SliderTrackPart. This is needed for
Adwaita theme to implement (<a href="https://webkit.org/b/278154).">https://webkit.org/b/278154).</a>

* Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp:
(WebCore::SliderTrackPart::create):
(WebCore::SliderTrackPart::SliderTrackPart):
* Source/WebCore/platform/graphics/controls/SliderTrackPart.h:
(WebCore::SliderTrackPart::thumbPosition const):
(WebCore::SliderTrackPart::setThumbPosition):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSliderTrackPartForRenderer):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/282329@main">https://commits.webkit.org/282329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e644503ceb2c6d780c719d98e31452516fbdf363

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54431 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/35926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11763 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12325 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12094 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/57996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54491 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5674 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9467 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38021 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40212 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->