### PR TITLE
Avoid constructing an empty ObjectIdentifier in `[WKWebView _frames:]`

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2528,8 +2528,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
 - (void)_frames:(void (^)(_WKFrameTreeNode *))completionHandler
 {
-    _page->getAllFrames([completionHandler = makeBlockPtr(completionHandler), page = Ref { *_page.get() }] (WebKit::FrameTreeNodeData&& data) {
-        completionHandler(wrapper(API::FrameTreeNode::create(WTFMove(data), page.get())).get());
+    _page->getAllFrames([completionHandler = makeBlockPtr(completionHandler), page = Ref { *_page.get() }] (std::optional<WebKit::FrameTreeNodeData>&& data) {
+        completionHandler(data ? wrapper(API::FrameTreeNode::create(WTFMove(*data), page.get())).get() : nil);
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -98,7 +98,7 @@ void WebExtensionContext::webNavigationGetFrame(WebExtensionTabIdentifier tabIde
     }
 
     [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab, frameIdentifier](_WKFrameTreeNode *mainFrame) mutable {
-        if (!mainFrame.info.isMainFrame) {
+        if (!mainFrame) {
             RELEASE_LOG_INFO(Extensions, "Skipping frame traversal because the mainFrame is nil");
             completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"main frame not found"));
             return;
@@ -126,7 +126,7 @@ void WebExtensionContext::webNavigationGetAllFrames(WebExtensionTabIdentifier ta
     }
 
     [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab](_WKFrameTreeNode *mainFrame) mutable {
-        if (!mainFrame.info.isMainFrame) {
+        if (!mainFrame) {
             RELEASE_LOG_INFO(Extensions, "Skipping frame traversal because the mainFrame is nil");
             completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nil, @"main frame not found"));
             return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -124,7 +124,7 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
     });
 
     [webView _frames:makeBlockPtr([webView = RetainPtr { webView }, tab = Ref { tab }, context = Ref { context }, scriptPairs, executionWorld = Ref { executionWorld }, injectionResults, aggregator, parameters](_WKFrameTreeNode *mainFrame) mutable {
-        if (!mainFrame.info.isMainFrame) {
+        if (!mainFrame) {
             RELEASE_LOG_INFO(Extensions, "Not executing script because the mainFrame is nil");
             injectionResults->results.append(toInjectionResultParameters(nil, nil, @"Failed to execute script."));
             return;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5787,11 +5787,11 @@ void WebPageProxy::getContentsAsAttributedString(CompletionHandler<void(const We
 }
 #endif
 
-void WebPageProxy::getAllFrames(CompletionHandler<void(FrameTreeNodeData&&)>&& completionHandler)
+void WebPageProxy::getAllFrames(CompletionHandler<void(std::optional<FrameTreeNodeData>&&)>&& completionHandler)
 {
     RefPtr mainFrame = m_mainFrame;
     if (!mainFrame)
-        return completionHandler({ });
+        return completionHandler(std::nullopt);
     mainFrame->getFrameInfo(WTFMove(completionHandler));
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -681,7 +681,7 @@ public:
     void destroyInspectorTarget(IPC::Connection&, const String& targetId);
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
 
-    void getAllFrames(CompletionHandler<void(FrameTreeNodeData&&)>&&);
+    void getAllFrames(CompletionHandler<void(std::optional<FrameTreeNodeData>&&)>&&);
     void getAllFrameTrees(CompletionHandler<void(Vector<FrameTreeNodeData>&&)>&&);
 
 #if ENABLE(REMOTE_INSPECTOR)


### PR DESCRIPTION
#### b642c92f7e1a2a30601e5d5efba36a8fad62eaca
<pre>
Avoid constructing an empty ObjectIdentifier in `[WKWebView _frames:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=278212">https://bugs.webkit.org/show_bug.cgi?id=278212</a>
<a href="https://rdar.apple.com/134011145">rdar://134011145</a>

Reviewed by NOBODY (OOPS!).

If a web process crashes when handling the `GetFrameTree` message or the main frame has not been created
yet, `_frames:` will construct an empty `FrameTreeNodeData`. In the past, this has caused web process
crashes if the `FrameIdentifier` constructed in this empty object was sent to the web process. `_frames:`
should return nil instead of an empty object.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _frames:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContext::webNavigationGetFrame):
(WebKit::WebExtensionContext::webNavigationGetAllFrames):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getAllFrames):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b642c92f7e1a2a30601e5d5efba36a8fad62eaca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50691 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9297 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39243 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54448 "Found 2 new API test failures: TestWebKitAPI.URLSchemeHandler.Frames, TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosSwitchControlledVideoWhenScrolling (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35937 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12338 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57484 "Found 1 new API test failure: TestWebKitAPI.URLSchemeHandler.Frames (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58006 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58198 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5685 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38034 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->