### PR TITLE
Enable `::target-text` by default

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3447,10 +3447,11 @@ imported/w3c/web-platform-tests/css/css-pseudo/slider/slider-track-001.html [ Im
 imported/w3c/web-platform-tests/css/css-pseudo/slider/slider-track-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/slider/slider-track-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/svg-text-selection-002.html [ ImageOnlyFailure ]
-# WPT support ::target-text (webkit.org/b/236817)
+# Implement highlight pseudo-element cascade / painting behaviors (webkit.org/b/278216)
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-009.html [ ImageOnlyFailure ]
+# Incorrect test, needs WPT resync (webkit.org/b/277692)
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-dynamic-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/selection-background-painting-order.html [ ImageOnlyFailure ]
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6857,7 +6857,7 @@ TabsToLinks:
 
 TargetTextPseudoElementEnabled:
   type: bool
-  status: testable
+  status: stable
   category: css
   humanReadableName: "::target-text pseudo-element"
   humanReadableDescription: "Enable the ::target-text CSS pseudo-element"
@@ -6865,9 +6865,9 @@ TargetTextPseudoElementEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 TelephoneNumberParsingEnabled:
   type: bool


### PR DESCRIPTION
#### f77d4048340302fbea5f774abfed8dfa3b5ee7fb
<pre>
Enable `::target-text` by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=278210">https://bugs.webkit.org/show_bug.cgi?id=278210</a>
<a href="https://rdar.apple.com/134010063">rdar://134010063</a>

Reviewed by Abrar Rahman Protyasha, Richard Robinson and Tim Nguyen.

Allow authors to style text fragments that have been scrolled to.

* LayoutTests/TestExpectations:

The remaining test failures are common to all highlight pseudo-elements, or
incorrect tests that require a re-sync.

target-text-004.html: currentColor on a highlight pseudo-element’s color
property should represent the color of the next active highlight pseudo-element
layer below. This is unimplemented for all the other highlight pseudos, which
are already enabled. See <a href="https://drafts.csswg.org/css-pseudo/#highlight-text.">https://drafts.csswg.org/css-pseudo/#highlight-text.</a>

target-text-005.html: Highlight pseudo-elements should have a relative,
overlayed, paint order. See <a href="https://drafts.csswg.org/css-pseudo/#highlight-backgrounds.">https://drafts.csswg.org/css-pseudo/#highlight-backgrounds.</a>

target-text-009.html: Non-inherited properties that apply to highlights should
be inherited when using highlight styles. For example, `p::selection`&apos;s
background-color should apply to a `&lt;span&gt;` child of a `&lt;p&gt;`. Only Chrome
implements this behavior. See <a href="https://drafts.csswg.org/css-pseudo/#highlight-cascade.">https://drafts.csswg.org/css-pseudo/#highlight-cascade.</a>

target-text-dynamic-004.html: This test is incorrect. It attempts to assert a
style on a `&lt;span&gt;` element when the document doesn&apos;t contain any. This was fixed
upstream in `51725f0`. The corrected version of the test is passing, and will
be imported into the tree in <a href="https://webkit.org/b/277692.">https://webkit.org/b/277692.</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

The feature remains disabled in WebKitLegacy, matching `ScrollToTextFragmentEnabled`.

Canonical link: <a href="https://commits.webkit.org/282356@main">https://commits.webkit.org/282356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc795674353d9f25c37e2ec6d701d5aab0ac6d7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13474 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50702 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12350 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/55980 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68597 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62113 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58020 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5692 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83876 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9480 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38046 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14758 "Found 1472 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->