### PR TITLE
[css-anchor-position-1] Refactor style & layout interleaving for anchor positioning

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -39,14 +39,19 @@ namespace Style {
 
 class BuilderState;
 
+enum class AnchorPositionResolutionStage : uint8_t {
+    Initial,
+    FinishedCollectingAnchorNames,
+    FoundAnchors,
+    Resolved,
+};
+
 struct AnchorPositionedState {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     HashMap<String, WeakRef<Element, WeakPtrImplWithEventTargetData>> anchorElements;
     HashSet<String> anchorNames;
-    bool finishedCollectingAnchorNames { false };
-    bool readyToBeResolved { false };
-    bool hasBeenResolved { false };
+    AnchorPositionResolutionStage stage;
 };
 
 using AnchorsForAnchorName = HashMap<String, Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>>;
@@ -55,6 +60,7 @@ using AnchorPositionedStates = WeakHashMap<Element, std::unique_ptr<AnchorPositi
 class AnchorPositionEvaluator {
 public:
     static Length resolveAnchorValue(const BuilderState&, const CSSAnchorValue&);
+    static void findAnchorsForAnchorPositionedElement(Ref<const Element> anchorPositionedElement);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -142,8 +142,6 @@ private:
     const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
 
     AnchorPositionedElementAction updateAnchorPositioningState(Element&, const RenderStyle*);
-    void findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const Element* containingBlock);
-    std::optional<Ref<Element>> findLastAcceptableAnchorWithName(String anchorName, const Element* containingBlock);
 
     struct QueryContainerState {
         Change change { Change::None };


### PR DESCRIPTION
#### f13cf97dc5768aba702ade6543d9a617348dc13d
<pre>
[css-anchor-position-1] Refactor style &amp; layout interleaving for anchor positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=278218">https://bugs.webkit.org/show_bug.cgi?id=278218</a>
<a href="https://rdar.apple.com/134015009">rdar://134015009</a>

Reviewed by Antti Koivisto.

The current `AnchorPositionedState` uses booleans to represent stages of
the anchor-positioned element resolution process. This uses more space
than necessary while introducing the potential for bugs via inconsistent
combinations of boolean states. This is fixed by introducing an enum
class that represents each stage of the resolution process.

Style::TreeResolver also houses static functions and class methods related
to anchor positioning that really should belong in AnchorPositionEvaluator.
(Hence, this patch moves those methods to AnchorPositionEvaluator.)

A notable functional change introduced by this patch is an explicit
check to make sure that anchor elements have up-to-date RenderTree
information before using them as valid anchor targets.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
(WebCore::Style::elementIsInContainingBlockChain):
(WebCore::Style::isAcceptableAnchorElement):
(WebCore::Style::findLastAcceptableAnchorWithName):
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
* Source/WebCore/style/AnchorPositionEvaluator.h:
(): Deleted.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::findAnchorsForAnchorPositionedElement): Deleted.
(WebCore::Style::elementIsInContainingBlockChain): Deleted.
(WebCore::Style::TreeResolver::findLastAcceptableAnchorWithName): Deleted.
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/282349@main">https://commits.webkit.org/282349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f66259428f2a0a7876b0690b4755eab11c892b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13793 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39279 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35968 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57516 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11780 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6883 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5722 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38081 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->