### PR TITLE
[view-transitions] Parse class selectors inside view transition pseudo-elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7571,7 +7571,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html [ ImageOn
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-old-main-new-iframe.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-old-main-old-iframe.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/paint-holding-in-iframe.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class.html [ ImageOnlyFailure ]
 
 # Timeouts
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
@@ -7598,18 +7597,14 @@ imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-pars
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html [ Skip ]
 
 # View transitions Level 2 - classes.
-imported/w3c/web-platform-tests/css/css-view-transitions/class-specificity.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-entry.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-wildcard.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-wildcard-no-star.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-multiple-vt-classes.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-new-with-class-old-without.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-view-transition-group.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-view-transition-image-pair.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-ident.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-partial.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-wildcard.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-old-with-class-new-without.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class-inside-shadow-important.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class-inside-shadow.html [ ImageOnlyFailure ]
 
 # View transitions Level 2 - cross document transitions.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes-expected.txt
@@ -3,164 +3,164 @@ PASS "::view-transition" should be a valid selector
 PASS ":root::view-transition" should be a valid selector
 PASS ".a::view-transition" should be a valid selector
 PASS "div ::view-transition" should be a valid selector
-FAIL "::view-transition-group(*.class)" should be a valid selector '::view-transition-group(*.class)' is not a valid selector.
-FAIL ":root::view-transition-group(*.class)" should be a valid selector ':root::view-transition-group(*.class)' is not a valid selector.
-FAIL ".a::view-transition-group(*.class)" should be a valid selector '.a::view-transition-group(*.class)' is not a valid selector.
-FAIL "div ::view-transition-group(*.class)" should be a valid selector 'div ::view-transition-group(*.class)' is not a valid selector.
-FAIL "::view-transition-group(*.class):only-child" should be a valid selector '::view-transition-group(*.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(*.class):only-child" should be a valid selector ':root::view-transition-group(*.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(*.class):only-child" should be a valid selector '.a::view-transition-group(*.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(*.class):only-child" should be a valid selector 'div ::view-transition-group(*.class):only-child' is not a valid selector.
-FAIL "::view-transition-group(*.class.class)" should be a valid selector '::view-transition-group(*.class.class)' is not a valid selector.
-FAIL ":root::view-transition-group(*.class.class)" should be a valid selector ':root::view-transition-group(*.class.class)' is not a valid selector.
-FAIL ".a::view-transition-group(*.class.class)" should be a valid selector '.a::view-transition-group(*.class.class)' is not a valid selector.
-FAIL "div ::view-transition-group(*.class.class)" should be a valid selector 'div ::view-transition-group(*.class.class)' is not a valid selector.
-FAIL "::view-transition-group(*.class.class):only-child" should be a valid selector '::view-transition-group(*.class.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(*.class.class):only-child" should be a valid selector ':root::view-transition-group(*.class.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(*.class.class):only-child" should be a valid selector '.a::view-transition-group(*.class.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(*.class.class):only-child" should be a valid selector 'div ::view-transition-group(*.class.class):only-child' is not a valid selector.
-FAIL "::view-transition-group(dashed-ident.someclass)" should be a valid selector '::view-transition-group(dashed-ident.someclass)' is not a valid selector.
-FAIL ":root::view-transition-group(dashed-ident.someclass)" should be a valid selector ':root::view-transition-group(dashed-ident.someclass)' is not a valid selector.
-FAIL ".a::view-transition-group(dashed-ident.someclass)" should be a valid selector '.a::view-transition-group(dashed-ident.someclass)' is not a valid selector.
-FAIL "div ::view-transition-group(dashed-ident.someclass)" should be a valid selector 'div ::view-transition-group(dashed-ident.someclass)' is not a valid selector.
-FAIL "::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector '::view-transition-group(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector ':root::view-transition-group(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector '.a::view-transition-group(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector 'div ::view-transition-group(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "::view-transition-group(dash-id.dash-id)" should be a valid selector '::view-transition-group(dash-id.dash-id)' is not a valid selector.
-FAIL ":root::view-transition-group(dash-id.dash-id)" should be a valid selector ':root::view-transition-group(dash-id.dash-id)' is not a valid selector.
-FAIL ".a::view-transition-group(dash-id.dash-id)" should be a valid selector '.a::view-transition-group(dash-id.dash-id)' is not a valid selector.
-FAIL "div ::view-transition-group(dash-id.dash-id)" should be a valid selector 'div ::view-transition-group(dash-id.dash-id)' is not a valid selector.
-FAIL "::view-transition-group(dash-id.dash-id):only-child" should be a valid selector '::view-transition-group(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(dash-id.dash-id):only-child" should be a valid selector ':root::view-transition-group(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(dash-id.dash-id):only-child" should be a valid selector '.a::view-transition-group(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(dash-id.dash-id):only-child" should be a valid selector 'div ::view-transition-group(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "::view-transition-group(foo.bar.baz)" should be a valid selector '::view-transition-group(foo.bar.baz)' is not a valid selector.
-FAIL ":root::view-transition-group(foo.bar.baz)" should be a valid selector ':root::view-transition-group(foo.bar.baz)' is not a valid selector.
-FAIL ".a::view-transition-group(foo.bar.baz)" should be a valid selector '.a::view-transition-group(foo.bar.baz)' is not a valid selector.
-FAIL "div ::view-transition-group(foo.bar.baz)" should be a valid selector 'div ::view-transition-group(foo.bar.baz)' is not a valid selector.
-FAIL "::view-transition-group(foo.bar.baz):only-child" should be a valid selector '::view-transition-group(foo.bar.baz):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(foo.bar.baz):only-child" should be a valid selector ':root::view-transition-group(foo.bar.baz):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(foo.bar.baz):only-child" should be a valid selector '.a::view-transition-group(foo.bar.baz):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(foo.bar.baz):only-child" should be a valid selector 'div ::view-transition-group(foo.bar.baz):only-child' is not a valid selector.
-FAIL "::view-transition-image-pair(*.class)" should be a valid selector '::view-transition-image-pair(*.class)' is not a valid selector.
-FAIL ":root::view-transition-image-pair(*.class)" should be a valid selector ':root::view-transition-image-pair(*.class)' is not a valid selector.
-FAIL ".a::view-transition-image-pair(*.class)" should be a valid selector '.a::view-transition-image-pair(*.class)' is not a valid selector.
-FAIL "div ::view-transition-image-pair(*.class)" should be a valid selector 'div ::view-transition-image-pair(*.class)' is not a valid selector.
-FAIL "::view-transition-image-pair(*.class):only-child" should be a valid selector '::view-transition-image-pair(*.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(*.class):only-child" should be a valid selector ':root::view-transition-image-pair(*.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(*.class):only-child" should be a valid selector '.a::view-transition-image-pair(*.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(*.class):only-child" should be a valid selector 'div ::view-transition-image-pair(*.class):only-child' is not a valid selector.
-FAIL "::view-transition-image-pair(*.class.class)" should be a valid selector '::view-transition-image-pair(*.class.class)' is not a valid selector.
-FAIL ":root::view-transition-image-pair(*.class.class)" should be a valid selector ':root::view-transition-image-pair(*.class.class)' is not a valid selector.
-FAIL ".a::view-transition-image-pair(*.class.class)" should be a valid selector '.a::view-transition-image-pair(*.class.class)' is not a valid selector.
-FAIL "div ::view-transition-image-pair(*.class.class)" should be a valid selector 'div ::view-transition-image-pair(*.class.class)' is not a valid selector.
-FAIL "::view-transition-image-pair(*.class.class):only-child" should be a valid selector '::view-transition-image-pair(*.class.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(*.class.class):only-child" should be a valid selector ':root::view-transition-image-pair(*.class.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(*.class.class):only-child" should be a valid selector '.a::view-transition-image-pair(*.class.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(*.class.class):only-child" should be a valid selector 'div ::view-transition-image-pair(*.class.class):only-child' is not a valid selector.
-FAIL "::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector '::view-transition-image-pair(dashed-ident.someclass)' is not a valid selector.
-FAIL ":root::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector ':root::view-transition-image-pair(dashed-ident.someclass)' is not a valid selector.
-FAIL ".a::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector '.a::view-transition-image-pair(dashed-ident.someclass)' is not a valid selector.
-FAIL "div ::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector 'div ::view-transition-image-pair(dashed-ident.someclass)' is not a valid selector.
-FAIL "::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector '::view-transition-image-pair(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector ':root::view-transition-image-pair(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector '.a::view-transition-image-pair(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector 'div ::view-transition-image-pair(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "::view-transition-image-pair(dash-id.dash-id)" should be a valid selector '::view-transition-image-pair(dash-id.dash-id)' is not a valid selector.
-FAIL ":root::view-transition-image-pair(dash-id.dash-id)" should be a valid selector ':root::view-transition-image-pair(dash-id.dash-id)' is not a valid selector.
-FAIL ".a::view-transition-image-pair(dash-id.dash-id)" should be a valid selector '.a::view-transition-image-pair(dash-id.dash-id)' is not a valid selector.
-FAIL "div ::view-transition-image-pair(dash-id.dash-id)" should be a valid selector 'div ::view-transition-image-pair(dash-id.dash-id)' is not a valid selector.
-FAIL "::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector '::view-transition-image-pair(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector ':root::view-transition-image-pair(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector '.a::view-transition-image-pair(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector 'div ::view-transition-image-pair(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "::view-transition-image-pair(foo.bar.baz)" should be a valid selector '::view-transition-image-pair(foo.bar.baz)' is not a valid selector.
-FAIL ":root::view-transition-image-pair(foo.bar.baz)" should be a valid selector ':root::view-transition-image-pair(foo.bar.baz)' is not a valid selector.
-FAIL ".a::view-transition-image-pair(foo.bar.baz)" should be a valid selector '.a::view-transition-image-pair(foo.bar.baz)' is not a valid selector.
-FAIL "div ::view-transition-image-pair(foo.bar.baz)" should be a valid selector 'div ::view-transition-image-pair(foo.bar.baz)' is not a valid selector.
-FAIL "::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector '::view-transition-image-pair(foo.bar.baz):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector ':root::view-transition-image-pair(foo.bar.baz):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector '.a::view-transition-image-pair(foo.bar.baz):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector 'div ::view-transition-image-pair(foo.bar.baz):only-child' is not a valid selector.
-FAIL "::view-transition-old(*.class)" should be a valid selector '::view-transition-old(*.class)' is not a valid selector.
-FAIL ":root::view-transition-old(*.class)" should be a valid selector ':root::view-transition-old(*.class)' is not a valid selector.
-FAIL ".a::view-transition-old(*.class)" should be a valid selector '.a::view-transition-old(*.class)' is not a valid selector.
-FAIL "div ::view-transition-old(*.class)" should be a valid selector 'div ::view-transition-old(*.class)' is not a valid selector.
-FAIL "::view-transition-old(*.class):only-child" should be a valid selector '::view-transition-old(*.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(*.class):only-child" should be a valid selector ':root::view-transition-old(*.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(*.class):only-child" should be a valid selector '.a::view-transition-old(*.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(*.class):only-child" should be a valid selector 'div ::view-transition-old(*.class):only-child' is not a valid selector.
-FAIL "::view-transition-old(*.class.class)" should be a valid selector '::view-transition-old(*.class.class)' is not a valid selector.
-FAIL ":root::view-transition-old(*.class.class)" should be a valid selector ':root::view-transition-old(*.class.class)' is not a valid selector.
-FAIL ".a::view-transition-old(*.class.class)" should be a valid selector '.a::view-transition-old(*.class.class)' is not a valid selector.
-FAIL "div ::view-transition-old(*.class.class)" should be a valid selector 'div ::view-transition-old(*.class.class)' is not a valid selector.
-FAIL "::view-transition-old(*.class.class):only-child" should be a valid selector '::view-transition-old(*.class.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(*.class.class):only-child" should be a valid selector ':root::view-transition-old(*.class.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(*.class.class):only-child" should be a valid selector '.a::view-transition-old(*.class.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(*.class.class):only-child" should be a valid selector 'div ::view-transition-old(*.class.class):only-child' is not a valid selector.
-FAIL "::view-transition-old(dashed-ident.someclass)" should be a valid selector '::view-transition-old(dashed-ident.someclass)' is not a valid selector.
-FAIL ":root::view-transition-old(dashed-ident.someclass)" should be a valid selector ':root::view-transition-old(dashed-ident.someclass)' is not a valid selector.
-FAIL ".a::view-transition-old(dashed-ident.someclass)" should be a valid selector '.a::view-transition-old(dashed-ident.someclass)' is not a valid selector.
-FAIL "div ::view-transition-old(dashed-ident.someclass)" should be a valid selector 'div ::view-transition-old(dashed-ident.someclass)' is not a valid selector.
-FAIL "::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector '::view-transition-old(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector ':root::view-transition-old(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector '.a::view-transition-old(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector 'div ::view-transition-old(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "::view-transition-old(dash-id.dash-id)" should be a valid selector '::view-transition-old(dash-id.dash-id)' is not a valid selector.
-FAIL ":root::view-transition-old(dash-id.dash-id)" should be a valid selector ':root::view-transition-old(dash-id.dash-id)' is not a valid selector.
-FAIL ".a::view-transition-old(dash-id.dash-id)" should be a valid selector '.a::view-transition-old(dash-id.dash-id)' is not a valid selector.
-FAIL "div ::view-transition-old(dash-id.dash-id)" should be a valid selector 'div ::view-transition-old(dash-id.dash-id)' is not a valid selector.
-FAIL "::view-transition-old(dash-id.dash-id):only-child" should be a valid selector '::view-transition-old(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(dash-id.dash-id):only-child" should be a valid selector ':root::view-transition-old(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(dash-id.dash-id):only-child" should be a valid selector '.a::view-transition-old(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(dash-id.dash-id):only-child" should be a valid selector 'div ::view-transition-old(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "::view-transition-old(foo.bar.baz)" should be a valid selector '::view-transition-old(foo.bar.baz)' is not a valid selector.
-FAIL ":root::view-transition-old(foo.bar.baz)" should be a valid selector ':root::view-transition-old(foo.bar.baz)' is not a valid selector.
-FAIL ".a::view-transition-old(foo.bar.baz)" should be a valid selector '.a::view-transition-old(foo.bar.baz)' is not a valid selector.
-FAIL "div ::view-transition-old(foo.bar.baz)" should be a valid selector 'div ::view-transition-old(foo.bar.baz)' is not a valid selector.
-FAIL "::view-transition-old(foo.bar.baz):only-child" should be a valid selector '::view-transition-old(foo.bar.baz):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(foo.bar.baz):only-child" should be a valid selector ':root::view-transition-old(foo.bar.baz):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(foo.bar.baz):only-child" should be a valid selector '.a::view-transition-old(foo.bar.baz):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(foo.bar.baz):only-child" should be a valid selector 'div ::view-transition-old(foo.bar.baz):only-child' is not a valid selector.
-FAIL "::view-transition-new(*.class)" should be a valid selector '::view-transition-new(*.class)' is not a valid selector.
-FAIL ":root::view-transition-new(*.class)" should be a valid selector ':root::view-transition-new(*.class)' is not a valid selector.
-FAIL ".a::view-transition-new(*.class)" should be a valid selector '.a::view-transition-new(*.class)' is not a valid selector.
-FAIL "div ::view-transition-new(*.class)" should be a valid selector 'div ::view-transition-new(*.class)' is not a valid selector.
-FAIL "::view-transition-new(*.class):only-child" should be a valid selector '::view-transition-new(*.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(*.class):only-child" should be a valid selector ':root::view-transition-new(*.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(*.class):only-child" should be a valid selector '.a::view-transition-new(*.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(*.class):only-child" should be a valid selector 'div ::view-transition-new(*.class):only-child' is not a valid selector.
-FAIL "::view-transition-new(*.class.class)" should be a valid selector '::view-transition-new(*.class.class)' is not a valid selector.
-FAIL ":root::view-transition-new(*.class.class)" should be a valid selector ':root::view-transition-new(*.class.class)' is not a valid selector.
-FAIL ".a::view-transition-new(*.class.class)" should be a valid selector '.a::view-transition-new(*.class.class)' is not a valid selector.
-FAIL "div ::view-transition-new(*.class.class)" should be a valid selector 'div ::view-transition-new(*.class.class)' is not a valid selector.
-FAIL "::view-transition-new(*.class.class):only-child" should be a valid selector '::view-transition-new(*.class.class):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(*.class.class):only-child" should be a valid selector ':root::view-transition-new(*.class.class):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(*.class.class):only-child" should be a valid selector '.a::view-transition-new(*.class.class):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(*.class.class):only-child" should be a valid selector 'div ::view-transition-new(*.class.class):only-child' is not a valid selector.
-FAIL "::view-transition-new(dashed-ident.someclass)" should be a valid selector '::view-transition-new(dashed-ident.someclass)' is not a valid selector.
-FAIL ":root::view-transition-new(dashed-ident.someclass)" should be a valid selector ':root::view-transition-new(dashed-ident.someclass)' is not a valid selector.
-FAIL ".a::view-transition-new(dashed-ident.someclass)" should be a valid selector '.a::view-transition-new(dashed-ident.someclass)' is not a valid selector.
-FAIL "div ::view-transition-new(dashed-ident.someclass)" should be a valid selector 'div ::view-transition-new(dashed-ident.someclass)' is not a valid selector.
-FAIL "::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector '::view-transition-new(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector ':root::view-transition-new(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector '.a::view-transition-new(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector 'div ::view-transition-new(dashed-ident.someclass):only-child' is not a valid selector.
-FAIL "::view-transition-new(dash-id.dash-id)" should be a valid selector '::view-transition-new(dash-id.dash-id)' is not a valid selector.
-FAIL ":root::view-transition-new(dash-id.dash-id)" should be a valid selector ':root::view-transition-new(dash-id.dash-id)' is not a valid selector.
-FAIL ".a::view-transition-new(dash-id.dash-id)" should be a valid selector '.a::view-transition-new(dash-id.dash-id)' is not a valid selector.
-FAIL "div ::view-transition-new(dash-id.dash-id)" should be a valid selector 'div ::view-transition-new(dash-id.dash-id)' is not a valid selector.
-FAIL "::view-transition-new(dash-id.dash-id):only-child" should be a valid selector '::view-transition-new(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(dash-id.dash-id):only-child" should be a valid selector ':root::view-transition-new(dash-id.dash-id):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(dash-id.dash-id):only-child" should be a valid selector '.a::view-transition-new(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(dash-id.dash-id):only-child" should be a valid selector 'div ::view-transition-new(dash-id.dash-id):only-child' is not a valid selector.
-FAIL "::view-transition-new(foo.bar.baz)" should be a valid selector '::view-transition-new(foo.bar.baz)' is not a valid selector.
-FAIL ":root::view-transition-new(foo.bar.baz)" should be a valid selector ':root::view-transition-new(foo.bar.baz)' is not a valid selector.
-FAIL ".a::view-transition-new(foo.bar.baz)" should be a valid selector '.a::view-transition-new(foo.bar.baz)' is not a valid selector.
-FAIL "div ::view-transition-new(foo.bar.baz)" should be a valid selector 'div ::view-transition-new(foo.bar.baz)' is not a valid selector.
-FAIL "::view-transition-new(foo.bar.baz):only-child" should be a valid selector '::view-transition-new(foo.bar.baz):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(foo.bar.baz):only-child" should be a valid selector ':root::view-transition-new(foo.bar.baz):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(foo.bar.baz):only-child" should be a valid selector '.a::view-transition-new(foo.bar.baz):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(foo.bar.baz):only-child" should be a valid selector 'div ::view-transition-new(foo.bar.baz):only-child' is not a valid selector.
+PASS "::view-transition-group(*.class)" should be a valid selector
+PASS ":root::view-transition-group(*.class)" should be a valid selector
+PASS ".a::view-transition-group(*.class)" should be a valid selector
+PASS "div ::view-transition-group(*.class)" should be a valid selector
+PASS "::view-transition-group(*.class):only-child" should be a valid selector
+PASS ":root::view-transition-group(*.class):only-child" should be a valid selector
+PASS ".a::view-transition-group(*.class):only-child" should be a valid selector
+PASS "div ::view-transition-group(*.class):only-child" should be a valid selector
+PASS "::view-transition-group(*.class.class)" should be a valid selector
+PASS ":root::view-transition-group(*.class.class)" should be a valid selector
+PASS ".a::view-transition-group(*.class.class)" should be a valid selector
+PASS "div ::view-transition-group(*.class.class)" should be a valid selector
+PASS "::view-transition-group(*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-group(*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-group(*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-group(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-group(dashed-ident.someclass)" should be a valid selector
+PASS ":root::view-transition-group(dashed-ident.someclass)" should be a valid selector
+PASS ".a::view-transition-group(dashed-ident.someclass)" should be a valid selector
+PASS "div ::view-transition-group(dashed-ident.someclass)" should be a valid selector
+PASS "::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector
+PASS ":root::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector
+PASS ".a::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector
+PASS "div ::view-transition-group(dashed-ident.someclass):only-child" should be a valid selector
+PASS "::view-transition-group(dash-id.dash-id)" should be a valid selector
+PASS ":root::view-transition-group(dash-id.dash-id)" should be a valid selector
+PASS ".a::view-transition-group(dash-id.dash-id)" should be a valid selector
+PASS "div ::view-transition-group(dash-id.dash-id)" should be a valid selector
+PASS "::view-transition-group(dash-id.dash-id):only-child" should be a valid selector
+PASS ":root::view-transition-group(dash-id.dash-id):only-child" should be a valid selector
+PASS ".a::view-transition-group(dash-id.dash-id):only-child" should be a valid selector
+PASS "div ::view-transition-group(dash-id.dash-id):only-child" should be a valid selector
+PASS "::view-transition-group(foo.bar.baz)" should be a valid selector
+PASS ":root::view-transition-group(foo.bar.baz)" should be a valid selector
+PASS ".a::view-transition-group(foo.bar.baz)" should be a valid selector
+PASS "div ::view-transition-group(foo.bar.baz)" should be a valid selector
+PASS "::view-transition-group(foo.bar.baz):only-child" should be a valid selector
+PASS ":root::view-transition-group(foo.bar.baz):only-child" should be a valid selector
+PASS ".a::view-transition-group(foo.bar.baz):only-child" should be a valid selector
+PASS "div ::view-transition-group(foo.bar.baz):only-child" should be a valid selector
+PASS "::view-transition-image-pair(*.class)" should be a valid selector
+PASS ":root::view-transition-image-pair(*.class)" should be a valid selector
+PASS ".a::view-transition-image-pair(*.class)" should be a valid selector
+PASS "div ::view-transition-image-pair(*.class)" should be a valid selector
+PASS "::view-transition-image-pair(*.class):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(*.class):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(*.class):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(*.class):only-child" should be a valid selector
+PASS "::view-transition-image-pair(*.class.class)" should be a valid selector
+PASS ":root::view-transition-image-pair(*.class.class)" should be a valid selector
+PASS ".a::view-transition-image-pair(*.class.class)" should be a valid selector
+PASS "div ::view-transition-image-pair(*.class.class)" should be a valid selector
+PASS "::view-transition-image-pair(*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
+PASS ":root::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
+PASS ".a::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
+PASS "div ::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
+PASS "::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(dashed-ident.someclass):only-child" should be a valid selector
+PASS "::view-transition-image-pair(dash-id.dash-id)" should be a valid selector
+PASS ":root::view-transition-image-pair(dash-id.dash-id)" should be a valid selector
+PASS ".a::view-transition-image-pair(dash-id.dash-id)" should be a valid selector
+PASS "div ::view-transition-image-pair(dash-id.dash-id)" should be a valid selector
+PASS "::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(dash-id.dash-id):only-child" should be a valid selector
+PASS "::view-transition-image-pair(foo.bar.baz)" should be a valid selector
+PASS ":root::view-transition-image-pair(foo.bar.baz)" should be a valid selector
+PASS ".a::view-transition-image-pair(foo.bar.baz)" should be a valid selector
+PASS "div ::view-transition-image-pair(foo.bar.baz)" should be a valid selector
+PASS "::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(foo.bar.baz):only-child" should be a valid selector
+PASS "::view-transition-old(*.class)" should be a valid selector
+PASS ":root::view-transition-old(*.class)" should be a valid selector
+PASS ".a::view-transition-old(*.class)" should be a valid selector
+PASS "div ::view-transition-old(*.class)" should be a valid selector
+PASS "::view-transition-old(*.class):only-child" should be a valid selector
+PASS ":root::view-transition-old(*.class):only-child" should be a valid selector
+PASS ".a::view-transition-old(*.class):only-child" should be a valid selector
+PASS "div ::view-transition-old(*.class):only-child" should be a valid selector
+PASS "::view-transition-old(*.class.class)" should be a valid selector
+PASS ":root::view-transition-old(*.class.class)" should be a valid selector
+PASS ".a::view-transition-old(*.class.class)" should be a valid selector
+PASS "div ::view-transition-old(*.class.class)" should be a valid selector
+PASS "::view-transition-old(*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-old(*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-old(*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-old(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-old(dashed-ident.someclass)" should be a valid selector
+PASS ":root::view-transition-old(dashed-ident.someclass)" should be a valid selector
+PASS ".a::view-transition-old(dashed-ident.someclass)" should be a valid selector
+PASS "div ::view-transition-old(dashed-ident.someclass)" should be a valid selector
+PASS "::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector
+PASS ":root::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector
+PASS ".a::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector
+PASS "div ::view-transition-old(dashed-ident.someclass):only-child" should be a valid selector
+PASS "::view-transition-old(dash-id.dash-id)" should be a valid selector
+PASS ":root::view-transition-old(dash-id.dash-id)" should be a valid selector
+PASS ".a::view-transition-old(dash-id.dash-id)" should be a valid selector
+PASS "div ::view-transition-old(dash-id.dash-id)" should be a valid selector
+PASS "::view-transition-old(dash-id.dash-id):only-child" should be a valid selector
+PASS ":root::view-transition-old(dash-id.dash-id):only-child" should be a valid selector
+PASS ".a::view-transition-old(dash-id.dash-id):only-child" should be a valid selector
+PASS "div ::view-transition-old(dash-id.dash-id):only-child" should be a valid selector
+PASS "::view-transition-old(foo.bar.baz)" should be a valid selector
+PASS ":root::view-transition-old(foo.bar.baz)" should be a valid selector
+PASS ".a::view-transition-old(foo.bar.baz)" should be a valid selector
+PASS "div ::view-transition-old(foo.bar.baz)" should be a valid selector
+PASS "::view-transition-old(foo.bar.baz):only-child" should be a valid selector
+PASS ":root::view-transition-old(foo.bar.baz):only-child" should be a valid selector
+PASS ".a::view-transition-old(foo.bar.baz):only-child" should be a valid selector
+PASS "div ::view-transition-old(foo.bar.baz):only-child" should be a valid selector
+PASS "::view-transition-new(*.class)" should be a valid selector
+PASS ":root::view-transition-new(*.class)" should be a valid selector
+PASS ".a::view-transition-new(*.class)" should be a valid selector
+PASS "div ::view-transition-new(*.class)" should be a valid selector
+PASS "::view-transition-new(*.class):only-child" should be a valid selector
+PASS ":root::view-transition-new(*.class):only-child" should be a valid selector
+PASS ".a::view-transition-new(*.class):only-child" should be a valid selector
+PASS "div ::view-transition-new(*.class):only-child" should be a valid selector
+PASS "::view-transition-new(*.class.class)" should be a valid selector
+PASS ":root::view-transition-new(*.class.class)" should be a valid selector
+PASS ".a::view-transition-new(*.class.class)" should be a valid selector
+PASS "div ::view-transition-new(*.class.class)" should be a valid selector
+PASS "::view-transition-new(*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-new(*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-new(*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-new(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-new(dashed-ident.someclass)" should be a valid selector
+PASS ":root::view-transition-new(dashed-ident.someclass)" should be a valid selector
+PASS ".a::view-transition-new(dashed-ident.someclass)" should be a valid selector
+PASS "div ::view-transition-new(dashed-ident.someclass)" should be a valid selector
+PASS "::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector
+PASS ":root::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector
+PASS ".a::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector
+PASS "div ::view-transition-new(dashed-ident.someclass):only-child" should be a valid selector
+PASS "::view-transition-new(dash-id.dash-id)" should be a valid selector
+PASS ":root::view-transition-new(dash-id.dash-id)" should be a valid selector
+PASS ".a::view-transition-new(dash-id.dash-id)" should be a valid selector
+PASS "div ::view-transition-new(dash-id.dash-id)" should be a valid selector
+PASS "::view-transition-new(dash-id.dash-id):only-child" should be a valid selector
+PASS ":root::view-transition-new(dash-id.dash-id):only-child" should be a valid selector
+PASS ".a::view-transition-new(dash-id.dash-id):only-child" should be a valid selector
+PASS "div ::view-transition-new(dash-id.dash-id):only-child" should be a valid selector
+PASS "::view-transition-new(foo.bar.baz)" should be a valid selector
+PASS ":root::view-transition-new(foo.bar.baz)" should be a valid selector
+PASS ".a::view-transition-new(foo.bar.baz)" should be a valid selector
+PASS "div ::view-transition-new(foo.bar.baz)" should be a valid selector
+PASS "::view-transition-new(foo.bar.baz):only-child" should be a valid selector
+PASS ":root::view-transition-new(foo.bar.baz):only-child" should be a valid selector
+PASS ".a::view-transition-new(foo.bar.baz):only-child" should be a valid selector
+PASS "div ::view-transition-new(foo.bar.baz):only-child" should be a valid selector
 

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -45,6 +45,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , targetTextPseudoElementEnabled(context.targetTextPseudoElementEnabled)
     , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
+    , viewTransitionClassesEnabled(viewTransitionsEnabled && context.propertySettings.viewTransitionClassesEnabled)
     , viewTransitionTypesEnabled(viewTransitionsEnabled && context.viewTransitionTypesEnabled)
 {
 }
@@ -62,6 +63,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , targetTextPseudoElementEnabled(document.settings().targetTextPseudoElementEnabled())
     , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
+    , viewTransitionClassesEnabled(viewTransitionsEnabled && document.settings().viewTransitionClassesEnabled())
     , viewTransitionTypesEnabled(viewTransitionsEnabled && document.settings().viewTransitionTypesEnabled())
 {
 }
@@ -81,6 +83,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.targetTextPseudoElementEnabled,
         context.thumbAndTrackPseudoElementsEnabled,
         context.viewTransitionsEnabled,
+        context.viewTransitionClassesEnabled,
         context.viewTransitionTypesEnabled
     );
 }

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -47,6 +47,7 @@ struct CSSSelectorParserContext {
     bool targetTextPseudoElementEnabled { false };
     bool thumbAndTrackPseudoElementsEnabled { false };
     bool viewTransitionsEnabled { false };
+    bool viewTransitionClassesEnabled { false };
     bool viewTransitionTypesEnabled { false };
 
     bool isHashTableDeletedValue { false };


### PR DESCRIPTION
#### bda8e40de683e7dafb985a698894760a6d54aa3b
<pre>
[view-transitions] Parse class selectors inside view transition pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=278222">https://bugs.webkit.org/show_bug.cgi?id=278222</a>
<a href="https://rdar.apple.com/134019937">rdar://134019937</a>

Reviewed by Simon Fraser.

Parse the following:
- ::view-transition-group(.foo.bar)
- ::view-transition-group(name.foo.bar)
- ::view-transition-group(*.foo.bar)

Also implement serialization and specificity.

<a href="https://drafts.csswg.org/css-view-transitions-2/#pseudo-element-class-additions">https://drafts.csswg.org/css-view-transitions-2/#pseudo-element-class-additions</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:

Canonical link: <a href="https://commits.webkit.org/282364@main">https://commits.webkit.org/282364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f0c7b049f2a2a6e870003cbf855fa0cb133a24f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66963 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13830 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54518 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11851 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57541 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68658 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6888 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54578 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5748 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->