### PR TITLE
[GTK][WPE] Add GLDisplay wrapper

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2161,6 +2161,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/egl/GLContext.h
     platform/graphics/egl/GLContextWrapper.h
+    platform/graphics/egl/GLDisplay.h
     platform/graphics/egl/GLFence.h
 
     platform/graphics/filters/DistantLightSource.h

--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -39,6 +39,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextLibWPE.cpp
     platform/graphics/egl/GLContextWrapper.cpp
+    platform/graphics/egl/GLDisplay.cpp
 
     platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -56,6 +56,7 @@ list(APPEND WebCore_SOURCES
 
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextWrapper.cpp
+    platform/graphics/egl/GLDisplay.cpp
     platform/graphics/egl/GLFence.cpp
     platform/graphics/egl/GLFenceEGL.cpp
     platform/graphics/egl/GLFenceGL.cpp

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -62,6 +62,7 @@ platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
+platform/graphics/egl/GLDisplay.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/GLFenceEGL.cpp @no-unify
 platform/graphics/egl/GLFenceGL.cpp @no-unify

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -63,6 +63,7 @@ platform/graphics/wpe/SystemFontDatabaseWPE.cpp
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
+platform/graphics/egl/GLDisplay.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/GLFenceEGL.cpp @no-unify
 platform/graphics/egl/GLFenceGL.cpp @no-unify

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GLDisplay.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
@@ -94,30 +95,16 @@ public:
     EGLDisplay eglDisplay() const;
     bool eglCheckVersion(int major, int minor) const;
 
-    struct EGLExtensions {
-        bool KHR_image_base { false };
-        bool KHR_fence_sync { false };
-        bool KHR_surfaceless_context { false };
-        bool KHR_wait_sync { false };
-        bool EXT_image_dma_buf_import { false };
-        bool EXT_image_dma_buf_import_modifiers { false };
-        bool MESA_image_dma_buf_export { false };
-        bool ANDROID_native_fence_sync { false };
-    };
-    const EGLExtensions& eglExtensions() const;
+    const GLDisplay::Extensions& eglExtensions() const;
 
     EGLImage createEGLImage(EGLContext, EGLenum target, EGLClientBuffer, const Vector<EGLAttrib>&) const;
     bool destroyEGLImage(EGLImage) const;
 #if USE(GBM)
-    struct DMABufFormat {
-        uint32_t fourcc { 0 };
-        Vector<uint64_t, 1> modifiers;
-    };
-    const Vector<DMABufFormat>& dmabufFormats();
+    const Vector<GLDisplay::DMABufFormat>& dmabufFormats();
 #endif
 
 #if PLATFORM(GTK)
-    virtual EGLDisplay gtkEGLDisplay() { return nullptr; }
+    virtual GLDisplay* gtkEGLDisplay() { return nullptr; }
 #endif
 
 #if ENABLE(WEBGL)
@@ -155,7 +142,7 @@ protected:
     GRefPtr<GdkDisplay> m_sharedDisplay;
 #endif
 
-    EGLDisplay m_eglDisplay;
+    std::unique_ptr<GLDisplay> m_eglDisplay;
     bool m_eglDisplayOwned { true };
     std::unique_ptr<GLContext> m_sharingGLContext;
 
@@ -178,15 +165,9 @@ private:
     void terminateEGLDisplay();
 
     bool m_eglDisplayInitialized { false };
-    int m_eglMajorVersion { 0 };
-    int m_eglMinorVersion { 0 };
-    EGLExtensions m_eglExtensions;
 #if ENABLE(WEBGL) && !PLATFORM(WIN)
     mutable EGLDisplay m_angleEGLDisplay { nullptr };
     EGLContext m_angleSharingGLContext { nullptr };
-#endif
-#if USE(GBM)
-    Vector<DMABufFormat> m_dmabufFormats;
 #endif
 
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "GLDisplay.h"
+
+#include "GLContext.h"
+#include <wtf/text/StringView.h>
+
+#if USE(LIBEPOXY)
+#include <epoxy/egl.h>
+#else
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#endif
+
+#if USE(GBM)
+#include <drm_fourcc.h>
+#endif
+
+#if !USE(LIBEPOXY)
+typedef EGLImage (EGLAPIENTRYP PFNEGLCREATEIMAGEPROC) (EGLDisplay, EGLContext, EGLenum, EGLClientBuffer, const EGLAttrib*);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLDESTROYIMAGEPROC) (EGLDisplay, EGLImage);
+#ifndef EGL_KHR_image_base
+#define EGL_KHR_image_base 1
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay, EGLImage);
+typedef EGLImageKHR (EGLAPIENTRYP PFNEGLCREATEIMAGEKHRPROC) (EGLDisplay, EGLContext, EGLenum target, EGLClientBuffer, const EGLint* attribList);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay, EGLImageKHR);
+#endif
+#endif
+
+namespace WebCore {
+
+std::unique_ptr<GLDisplay> GLDisplay::create(EGLDisplay eglDisplay)
+{
+    if (eglDisplay == EGL_NO_DISPLAY)
+        return nullptr;
+
+    if (eglInitialize(eglDisplay, nullptr, nullptr) == EGL_FALSE)
+        return nullptr;
+
+    return makeUnique<GLDisplay>(eglDisplay);
+}
+
+GLDisplay::GLDisplay(EGLDisplay eglDisplay)
+    : m_display(eglDisplay)
+{
+    EGLint majorVersion, minorVersion;
+    eglInitialize(m_display, &majorVersion, &minorVersion);
+    m_version.major = majorVersion;
+    m_version.minor = minorVersion;
+
+    const char* extensionsString = eglQueryString(m_display, EGL_EXTENSIONS);
+    auto displayExtensions = StringView::fromLatin1(extensionsString).split(' ');
+    auto findExtension = [&](auto extensionName) {
+        return std::any_of(displayExtensions.begin(), displayExtensions.end(), [&](auto extensionEntry) {
+            return extensionEntry == extensionName;
+        });
+    };
+
+    m_extensions.KHR_image_base = findExtension("EGL_KHR_image_base"_s);
+    m_extensions.KHR_surfaceless_context = findExtension("EGL_KHR_surfaceless_context"_s);
+    m_extensions.KHR_fence_sync = findExtension("EGL_KHR_fence_sync"_s);
+    m_extensions.KHR_wait_sync = findExtension("EGL_KHR_wait_sync"_s);
+    m_extensions.ANDROID_native_fence_sync = findExtension("EGL_ANDROID_native_fence_sync"_s);
+    m_extensions.EXT_image_dma_buf_import = findExtension("EGL_EXT_image_dma_buf_import"_s);
+    m_extensions.EXT_image_dma_buf_import_modifiers = findExtension("EGL_EXT_image_dma_buf_import_modifiers"_s);
+    m_extensions.MESA_image_dma_buf_export = findExtension("EGL_MESA_image_dma_buf_export"_s);
+}
+
+void GLDisplay::terminate()
+{
+    if (m_display == EGL_NO_DISPLAY)
+        return;
+
+    eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglTerminate(m_display);
+    m_display = EGL_NO_DISPLAY;
+}
+
+bool GLDisplay::checkVersion(int major, int minor) const
+{
+    return (m_version.major > major) || ((m_version.major == major) && (m_version.minor >= minor));
+}
+
+EGLImage GLDisplay::createImage(EGLContext context, EGLenum target, EGLClientBuffer clientBuffer, const Vector<EGLAttrib>& attributes) const
+{
+    if (m_display == EGL_NO_DISPLAY)
+        return EGL_NO_IMAGE;
+
+    if (checkVersion(1, 5)) {
+        static PFNEGLCREATEIMAGEPROC s_eglCreateImage = reinterpret_cast<PFNEGLCREATEIMAGEPROC>(eglGetProcAddress("eglCreateImage"));
+        if (s_eglCreateImage)
+            return s_eglCreateImage(m_display, context, target, clientBuffer, attributes.isEmpty() ? nullptr : attributes.data());
+        return EGL_NO_IMAGE;
+    }
+
+    if (!m_extensions.KHR_image_base)
+        return EGL_NO_IMAGE;
+
+    Vector<EGLint> intAttributes = attributes.map<Vector<EGLint>>([] (EGLAttrib value) {
+        return value;
+    });
+    static PFNEGLCREATEIMAGEKHRPROC s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
+    if (s_eglCreateImageKHR)
+        return s_eglCreateImageKHR(m_display, context, target, clientBuffer, intAttributes.isEmpty() ? nullptr : intAttributes.data());
+    return EGL_NO_IMAGE_KHR;
+}
+
+bool GLDisplay::destroyImage(EGLImage image) const
+{
+    if (m_display == EGL_NO_DISPLAY)
+        return false;
+
+    if (checkVersion(1, 5)) {
+        static PFNEGLDESTROYIMAGEPROC s_eglDestroyImage = reinterpret_cast<PFNEGLDESTROYIMAGEPROC>(eglGetProcAddress("eglDestroyImage"));
+        if (s_eglDestroyImage)
+            return s_eglDestroyImage(m_display, image);
+        return false;
+    }
+
+    if (!m_extensions.KHR_image_base)
+        return false;
+
+    static PFNEGLDESTROYIMAGEKHRPROC s_eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
+    if (s_eglDestroyImageKHR)
+        return s_eglDestroyImageKHR(m_display, image);
+    return false;
+}
+
+#if USE(GBM)
+const Vector<GLDisplay::DMABufFormat>& GLDisplay::dmabufFormats()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [this] {
+        if (m_display == EGL_NO_DISPLAY)
+            return;
+
+        if (!m_extensions.EXT_image_dma_buf_import)
+            return;
+
+        static PFNEGLQUERYDMABUFFORMATSEXTPROC s_eglQueryDmaBufFormatsEXT = reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(eglGetProcAddress("eglQueryDmaBufFormatsEXT"));
+        if (!s_eglQueryDmaBufFormatsEXT)
+            return;
+
+        EGLint formatsCount;
+        if (!s_eglQueryDmaBufFormatsEXT(m_display, 0, nullptr, &formatsCount) || !formatsCount)
+            return;
+
+        Vector<EGLint> formats(formatsCount);
+        if (!s_eglQueryDmaBufFormatsEXT(m_display, formatsCount, reinterpret_cast<EGLint*>(formats.data()), &formatsCount))
+            return;
+
+        static PFNEGLQUERYDMABUFMODIFIERSEXTPROC s_eglQueryDmaBufModifiersEXT = m_extensions.EXT_image_dma_buf_import_modifiers ?
+            reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(eglGetProcAddress("eglQueryDmaBufModifiersEXT")) : nullptr;
+
+        // For now we only support formats that can be created with a single GBM buffer for all planes.
+        static const Vector<EGLint> s_supportedFormats = {
+            DRM_FORMAT_XRGB8888, DRM_FORMAT_RGBX8888, DRM_FORMAT_XBGR8888, DRM_FORMAT_BGRX8888,
+            DRM_FORMAT_ARGB8888, DRM_FORMAT_RGBA8888, DRM_FORMAT_ABGR8888, DRM_FORMAT_BGRA8888,
+            DRM_FORMAT_RGB565,
+            DRM_FORMAT_XRGB2101010, DRM_FORMAT_XBGR2101010, DRM_FORMAT_ARGB2101010, DRM_FORMAT_ABGR2101010,
+            DRM_FORMAT_XRGB16161616F, DRM_FORMAT_XBGR16161616F, DRM_FORMAT_ARGB16161616F, DRM_FORMAT_ABGR16161616F
+        };
+
+        m_dmabufFormats = WTF::compactMap(s_supportedFormats, [&](auto format) -> std::optional<DMABufFormat> {
+            if (!formats.contains(format))
+                return std::nullopt;
+
+            Vector<uint64_t, 1> dmabufModifiers = { DRM_FORMAT_MOD_INVALID };
+            if (s_eglQueryDmaBufModifiersEXT) {
+                EGLint modifiersCount;
+                if (s_eglQueryDmaBufModifiersEXT(m_display, format, 0, nullptr, nullptr, &modifiersCount) && modifiersCount) {
+                    Vector<EGLuint64KHR> modifiers(modifiersCount);
+                    if (s_eglQueryDmaBufModifiersEXT(m_display, format, modifiersCount, reinterpret_cast<EGLuint64KHR*>(modifiers.data()), nullptr, &modifiersCount)) {
+                        dmabufModifiers.grow(modifiersCount);
+                        for (int i = 0; i < modifiersCount; ++i)
+                            dmabufModifiers[i] = modifiers[i];
+                    }
+                }
+            }
+            return DMABufFormat { static_cast<uint32_t>(format), WTFMove(dmabufModifiers) };
+        });
+    });
+    return m_dmabufFormats;
+}
+#endif // USE(GBM)
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.h
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/Noncopyable.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+typedef intptr_t EGLAttrib;
+typedef void* EGLClientBuffer;
+typedef void* EGLContext;
+typedef void* EGLDisplay;
+typedef void* EGLImage;
+typedef unsigned EGLenum;
+
+namespace WebCore {
+
+class GLDisplay {
+    WTF_MAKE_NONCOPYABLE(GLDisplay); WTF_MAKE_FAST_ALLOCATED;
+public:
+    static std::unique_ptr<GLDisplay> create(EGLDisplay);
+    explicit GLDisplay(EGLDisplay);
+    ~GLDisplay() = default;
+
+    EGLDisplay eglDisplay() const { return m_display; }
+    bool checkVersion(int major, int minor) const;
+
+    void terminate();
+
+    EGLImage createImage(EGLContext, EGLenum, EGLClientBuffer, const Vector<EGLAttrib>&) const;
+    bool destroyImage(EGLImage) const;
+
+    struct Extensions {
+        bool KHR_image_base { false };
+        bool KHR_fence_sync { false };
+        bool KHR_surfaceless_context { false };
+        bool KHR_wait_sync { false };
+        bool EXT_image_dma_buf_import { false };
+        bool EXT_image_dma_buf_import_modifiers { false };
+        bool MESA_image_dma_buf_export { false };
+        bool ANDROID_native_fence_sync { false };
+    };
+    const Extensions& extensions() const { return m_extensions; }
+
+#if USE(GBM)
+    struct DMABufFormat {
+        uint32_t fourcc { 0 };
+        Vector<uint64_t, 1> modifiers;
+    };
+    const Vector<DMABufFormat>& dmabufFormats();
+#endif
+
+private:
+    EGLDisplay m_display { nullptr };
+    struct {
+        int major { 0 };
+        int minor { 0 };
+    } m_version;
+    Extensions m_extensions;
+
+#if USE(GBM)
+    Vector<DMABufFormat> m_dmabufFormats;
+#endif
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
@@ -40,9 +40,9 @@ PlatformDisplaySurfaceless::PlatformDisplaySurfaceless()
 {
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
-        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+        m_eglDisplay = GLDisplay::create(eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr));
     else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
-        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+        m_eglDisplay = GLDisplay::create(eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr));
 
     PlatformDisplay::initializeEGLDisplay();
 

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
@@ -42,9 +42,9 @@ PlatformDisplayGBM::PlatformDisplayGBM(struct gbm_device* device)
 {
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
-        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR, device, nullptr);
+        m_eglDisplay = GLDisplay::create(eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR, device, nullptr));
     else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
-        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, device, nullptr);
+        m_eglDisplay = GLDisplay::create(eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, device, nullptr));
 
     PlatformDisplay::initializeEGLDisplay();
 

--- a/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
@@ -87,13 +87,13 @@ PlatformDisplayLibWPE::PlatformDisplayLibWPE(int hostFd)
             }();
 
         if (getPlatformDisplay)
-            m_eglDisplay = getPlatformDisplay(eglPlatform, eglNativeDisplay, nullptr);
+            m_eglDisplay = GLDisplay::create(getPlatformDisplay(eglPlatform, eglNativeDisplay, nullptr));
     }
 #endif
 
-    if (m_eglDisplay == EGL_NO_DISPLAY)
-        m_eglDisplay = eglGetDisplay(eglNativeDisplay);
-    if (m_eglDisplay == EGL_NO_DISPLAY) {
+    if (!m_eglDisplay)
+        m_eglDisplay = GLDisplay::create(eglGetDisplay(eglNativeDisplay));
+    if (!m_eglDisplay) {
         WTFLogAlways("PlatformDisplayLibWPE: could not create the EGL display: %s.", GLContext::lastErrorString());
         return;
     }
@@ -101,7 +101,7 @@ PlatformDisplayLibWPE::PlatformDisplayLibWPE(int hostFd)
     PlatformDisplay::initializeEGLDisplay();
 
 #if ENABLE(WEBGL)
-    if (m_eglDisplay != EGL_NO_DISPLAY) {
+    if (m_eglDisplay) {
         m_anglePlatform = eglPlatform;
         m_angleNativeDisplay = eglNativeDisplay;
     }
@@ -117,7 +117,7 @@ PlatformDisplayLibWPE::~PlatformDisplayLibWPE()
 void PlatformDisplayLibWPE::initializeEGLDisplay()
 {
     if (!m_backend)
-        m_eglDisplay = eglGetCurrentDisplay();
+        m_eglDisplay = GLDisplay::create(eglGetCurrentDisplay());
     PlatformDisplay::initializeEGLDisplay();
 }
 

--- a/Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.h
+++ b/Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.h
@@ -53,7 +53,7 @@ private:
     Type type() const final { return PlatformDisplay::Type::Wayland; }
 
 #if PLATFORM(GTK)
-    EGLDisplay gtkEGLDisplay() override;
+    GLDisplay* gtkEGLDisplay() override;
 #endif
     void initializeEGLDisplay() override;
 

--- a/Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp
+++ b/Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp
@@ -41,7 +41,7 @@ void PlatformDisplayWin::initializeEGLDisplay()
         EGL_FALSE,
         EGL_NONE,
     };
-    m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, attributes);
+    m_eglDisplay = GLDisplay::create(eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, attributes));
 
     PlatformDisplay::initializeEGLDisplay();
 }

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
@@ -56,7 +56,7 @@ private:
     Type type() const override { return PlatformDisplay::Type::X11; }
 
 #if PLATFORM(GTK)
-    EGLDisplay gtkEGLDisplay() override;
+    GLDisplay* gtkEGLDisplay() override;
 #endif
     void initializeEGLDisplay() override;
 


### PR DESCRIPTION
#### 04dd368b15065ab5dad288e2d5043a052a35591e
<pre>
[GTK][WPE] Add GLDisplay wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=278227">https://bugs.webkit.org/show_bug.cgi?id=278227</a>

Reviewed by Adrian Perez de Castro.

Similar to GLContext but for EGLDisplay. For now it will be used
internally by PlatformDisplay, but the plan is to use it from gtk
specific code in the UI process once we remove the remaining gtk code
from PlatformDisplay.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::PlatformDisplay):
(WebCore::PlatformDisplay::~PlatformDisplay):
(WebCore::PlatformDisplay::eglDisplay const):
(WebCore::PlatformDisplay::eglCheckVersion const):
(WebCore::PlatformDisplay::eglExtensions const):
(WebCore::PlatformDisplay::initializeEGLDisplay):
(WebCore::PlatformDisplay::terminateEGLDisplay):
(WebCore::PlatformDisplay::createEGLImage const):
(WebCore::PlatformDisplay::destroyEGLImage const):
(WebCore::PlatformDisplay::dmabufFormats):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
(WebCore::PlatformDisplay::gtkEGLDisplay):
* Source/WebCore/platform/graphics/egl/GLDisplay.cpp: Added.
(WebCore::GLDisplay::create):
(WebCore::GLDisplay::GLDisplay):
(WebCore::GLDisplay::terminate):
(WebCore::GLDisplay::checkVersion const):
(WebCore::GLDisplay::createImage const):
(WebCore::GLDisplay::destroyImage const):
(WebCore::GLDisplay::dmabufFormats):
* Source/WebCore/platform/graphics/egl/GLDisplay.h: Added.
(WebCore::GLDisplay::eglDisplay const):
(WebCore::GLDisplay::extensions const):
* Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp:
(WebCore::PlatformDisplaySurfaceless::PlatformDisplaySurfaceless):
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp:
(WebCore::PlatformDisplayGBM::PlatformDisplayGBM):
* Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp:
(WebCore::PlatformDisplayLibWPE::PlatformDisplayLibWPE):
(WebCore::PlatformDisplayLibWPE::initializeEGLDisplay):
* Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.cpp:
(WebCore::PlatformDisplayWayland::gtkEGLDisplay):
(WebCore::PlatformDisplayWayland::initializeEGLDisplay):
* Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.h:
* Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp:
(WebCore::PlatformDisplayWin::initializeEGLDisplay):
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::gtkEGLDisplay):
(WebCore::PlatformDisplayX11::initializeEGLDisplay):
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h:

Canonical link: <a href="https://commits.webkit.org/282388@main">https://commits.webkit.org/282388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e2c7eba6bf3c1f001f1c1f786f679477c7e7bd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50715 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12378 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68614 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58029 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58226 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5716 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38074 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->