### PR TITLE
Make fast/forms/form-submission-crash-4.html non-flaky

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8193,6 +8193,3 @@ webkit.org/b/275663 imported/w3c/web-platform-tests/webrtc-encoded-transform/scr
 
 # https://bugs.webkit.org/show_bug.cgi?id=266843 flakey tests with racey promise console.logs
 imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.html [ Skip ]
-
-# webkit.org/b/278195 NEW TEST(277207@main): [ MacOS iOS ] fast/forms/form-submission-crash-4.html is a flaky failure timeout (pre-existing failure in EWS)
-fast/forms/form-submission-crash-4.html [ Skip ]

--- a/LayoutTests/fast/forms/form-submission-crash-4.html
+++ b/LayoutTests/fast/forms/form-submission-crash-4.html
@@ -1,22 +1,24 @@
-<!DOCTYPE html>
 <script>
-if (window.testRunner) {
-  testRunner.waitUntilDone();
-  testRunner.dumpAsText();
+if (document.URL.indexOf('?') == -1) {
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
 }
 function runTest() {
   form.submit();
-  p.appendChild(object);
-  object.foo;
-  setTimeout(function() {
+  p.appendChild(form);
+  object.codeType = "image/gif";
+  if (document.URL.indexOf('?') == -1) {
     document.write("PASS if no crash");
-    testRunner.notifyDone();
-  }, 10);
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }
 }
 </script>
 <body onload=runTest()>
-  <p id="p"></p>
-  <object id="object" data="?foo=bar">
-    <form id="form"></form>
-  </object>
+<p id="p"></p>
+  <form action="?" id="form">
+    <object id="object" data="?">
+  </form>
 </body>


### PR DESCRIPTION
#### 3d749a5509536c23c63c35a8ee5e4fbf77035a34
<pre>
Make fast/forms/form-submission-crash-4.html non-flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=278228">https://bugs.webkit.org/show_bug.cgi?id=278228</a>

Reviewed by Chris Dumez.

Make fast/forms/form-submission-crash-4.html non-flaky by waiting
for the form to be submitted before marking the test as done.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/form-submission-crash-4.html:

Canonical link: <a href="https://commits.webkit.org/282389@main">https://commits.webkit.org/282389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17c42a6391fbbba114463486bfac57ab47c0b825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13507 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50722 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9330 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12383 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68619 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11779 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58035 "Found 1 new test failure: fast/forms/search/search-size-with-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58232 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5720 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38079 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->