### PR TITLE
Add CookieStoreManagerEnabled feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1926,12 +1926,12 @@ CookieStoreAPIExtendedAttributesEnabled:
     WebCore:
       default: false
 
-CookieStoreAPIServiceWorkerEnabled:
+CookieStoreManagerEnabled:
   type: bool
   category: dom
   status: testable
-  humanReadableName: "Cookie Store API for Service Workers"
-  humanReadableDescription: "Enable Cookie Store API for Service Workers"
+  humanReadableName: "Cookie Store API CookieStoreManager"
+  humanReadableDescription: "Enable Cookie Store API CookieStoreManager which controls cookie change subscriptions for Service Workers"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/Modules/cookie-store/CookieStoreManager.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreManager.idl
@@ -26,7 +26,7 @@
 // https://wicg.github.io/cookie-store/#cookiestoremanager
 
 [
-    EnabledBySetting=CookieStoreAPIEnabled&CookieStoreAPIServiceWorkerEnabled,
+    EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled,
     Exposed=(ServiceWorker,Window),
     SecureContext
 ] interface CookieStoreManager {

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.idl
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.idl
@@ -26,7 +26,7 @@
 // https://wicg.github.io/cookie-store/#extendablecookiechangeevent
 
 [
-    EnabledBySetting=CookieStoreAPIEnabled&CookieStoreAPIServiceWorkerEnabled,
+    EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled,
     Exposed=ServiceWorker
 ] interface ExtendableCookieChangeEvent : ExtendableEvent {
     constructor([AtomString] DOMString type, optional ExtendableCookieChangeEventInit eventInitDict = {});

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.idl
@@ -37,9 +37,9 @@
 
     [NewObject] Promise<undefined> skipWaiting();
 
-    [EnabledBySetting=CookieStoreAPIEnabled&CookieStoreAPIServiceWorkerEnabled] readonly attribute CookieStore cookieStore;
+    [EnabledBySetting=CookieStoreAPIEnabled] readonly attribute CookieStore cookieStore;
 
-    [EnabledBySetting=CookieStoreAPIEnabled&CookieStoreAPIServiceWorkerEnabled] attribute EventHandler oncookiechange;
+    [EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled] attribute EventHandler oncookiechange;
     attribute EventHandler oninstall;
     attribute EventHandler onactivate;
     attribute EventHandler onfetch;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
@@ -41,7 +41,7 @@
     readonly attribute USVString scope;
     readonly attribute ServiceWorkerUpdateViaCache updateViaCache;
 
-    [EnabledBySetting=CookieStoreAPIEnabled&CookieStoreAPIServiceWorkerEnabled] readonly attribute CookieStoreManager cookies;
+    [EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled] readonly attribute CookieStoreManager cookies;
 
     [NewObject] Promise<undefined> update();
     [NewObject] Promise<boolean> unregister();


### PR DESCRIPTION
#### da6bddd2e4c193b8e6aa8064ebc233d05382ec39
<pre>
Add CookieStoreManagerEnabled feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=278245">https://bugs.webkit.org/show_bug.cgi?id=278245</a>
<a href="https://rdar.apple.com/134075274">rdar://134075274</a>

Reviewed by Chris Dumez and Sihui Liu.

This patch adds a new feature flag that surrounds the functionality
of allowing service workers to subscribe to cookie change notifications.
Since we intend to expose the Cookie Store API to service workers, there
is no need for the CookieStoreAPIServiceWorkerEnabled flag, since we
have the CookieStoreAPIEnabled flag.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/cookie-store/CookieStoreManager.idl:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.idl:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.idl:
* Source/WebCore/workers/service/ServiceWorkerRegistration.idl:

Canonical link: <a href="https://commits.webkit.org/282371@main">https://commits.webkit.org/282371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a82bdc6f84649b97f1343682ad5ea4b0628e3da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9358 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11852 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12421 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56051 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68657 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62184 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11808 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54579 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58261 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13963 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5751 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/83947 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38117 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14775 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->