### PR TITLE
AX: Crash when committing the selected list item value to its combobox with VoiceOver.

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2802,13 +2802,15 @@ Ref<Document> AXObjectCache::protectedDocument() const
 VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarkerData& textMarkerData)
 {
     RefPtr node = nodeForID(textMarkerData.axObjectID());
-    if (!node)
+    if (!node || node->isPseudoElement())
         return { };
 
-    if (node->isPseudoElement())
-        return { };
-
-    auto visiblePosition = VisiblePosition({ node.get(), textMarkerData.offset, textMarkerData.anchorType }, textMarkerData.affinity);
+    Position position;
+    if (textMarkerData.anchorType == Position::PositionIsOffsetInAnchor)
+        position = Position(node.get(), textMarkerData.offset, textMarkerData.anchorType);
+    else
+        position = Position(node.get(), textMarkerData.anchorType);
+    auto visiblePosition = VisiblePosition(position, textMarkerData.affinity);
     auto deepPosition = visiblePosition.deepEquivalent();
     if (deepPosition.isNull())
         return { };
@@ -2820,7 +2822,6 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
     auto* cache = renderer->document().axObjectCache();
     if (cache && !cache->m_idsInUse.contains(textMarkerData.axObjectID()))
         return { };
-
     return visiblePosition;
 }
 


### PR DESCRIPTION
#### ea87264857546b31336641b9888c5c6aa78f2d77
<pre>
AX: Crash when committing the selected list item value to its combobox with VoiceOver.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272043">https://bugs.webkit.org/show_bug.cgi?id=272043</a>
&lt;<a href="https://rdar.apple.com/problem/125793838">rdar://problem/125793838</a>&gt;

Reviewed by Chris Fleizach and Tyler Wilcock.

AXObjectCache::visiblePositionForTextMarkerData was creating a Position with PositionIsOffsetInAnchor regardless the anchorType passed in the TextMarkerData. This patch fixes this by using the appropriate Position constructor depending on the anchor type.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea87264857546b31336641b9888c5c6aa78f2d77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66967 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50747 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9353 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11854 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68662 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58263 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5755 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->