### PR TITLE
Update meeting registration to include attendance preference

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/meeting-registration/admin.php
+++ b/Websites/webkit.org/wp-content/plugins/meeting-registration/admin.php
@@ -62,8 +62,8 @@
                 <th>GitHub</th>
                 <th>Slack</th>
                 <th>Interests</th>
-                <th>Optional</th>
                 <th>Contributor</th>
+                <th>In-person</th>
             </tr>
         </thead>
         <tbody>
@@ -81,8 +81,9 @@
             </td>
             <td><?php echo esc_html($registration->contributor_slack); ?></td>
             <td><?php echo apply_filters('the_content', esc_html($registration->contributor_interests)); ?></td>
-            <td><?php if ($registration->contributor_optingame === "on"):?><div class="checked-box"></div><?php endif; ?></td>
             <td><?php if ($registration->contributor_claim === "on"):?><div class="checked-box"></div><?php endif; ?></td>
+            <td><?php if ($registration->contributor_attendance === "in-person"):?><div class="checked-box"></div><?php endif; ?></td>
+            
         </tr>
         <?php endforeach; ?>
         </tbody>

--- a/Websites/webkit.org/wp-content/plugins/meeting-registration/form.php
+++ b/Websites/webkit.org/wp-content/plugins/meeting-registration/form.php
@@ -44,6 +44,17 @@
     cursor: pointer;
 }
 
+#registration label ~ ul {
+    list-style: none;
+    padding-left: 0;
+    margin-top: 0;
+}
+
+#registration input[type=checkbox],
+#registration input[type=radio] {
+    vertical-align: middle;
+}
+
 @supports selector(label:has(~ input:focus)) {
     #registration label {
         font-size: 1.7rem;
@@ -103,14 +114,13 @@
     <div class="form-field form-toggle">
         <label class="form-label" for="contributor-toggle"><input type="checkbox" id="contributor-toggle" name="claim" <?php echo WebKit_Meeting_Registration::is_contributor() ? ' checked="checked"' : ''; ?>> I am a WebKit contributor</label>
     </div>
-
+    
     <div class="form-field form-toggle">
-        <strong>OPTIONAL</strong><br>
-        Join us for a fun after-meeting community experience in the form of a bluffing/social deduction game. <a href="/meeting/social" target="_blank">Learn more details here</a>.
-    </div>
-
-    <div class="form-field form-toggle">
-        <label class="form-label" for="game-toggle"><input type="checkbox" id="game-toggle" name="optingame"> Participate in the after-meeting online game experience</label>
+        <label class="form-label" for="contributor-attendance">Please let us know your attendance preference so that we can plan appropriately:</label>
+        <ul>
+            <li><label class="form-label"><input type="radio" id="contributor-attendance" name="attendance" value="in-person"> I will attend in-person.</label></li>
+            <li><label class="form-label"><input type="radio" id="contributor-attendance" name="attendance" value="online"> I will attend online.</label></li>
+        </ul>
     </div>
 
     <div class="alignright">

--- a/Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php
@@ -23,6 +23,7 @@ class WebKit_Meeting_Registration {
         'affiliation' => FILTER_SANITIZE_STRING,
         'interests'   => FILTER_SANITIZE_STRING,
         'claim'       => FILTER_SANITIZE_STRING,
+        'attendance'  => FILTER_SANITIZE_STRING,
         'optingame'   => FILTER_SANITIZE_STRING
     ];
 
@@ -118,7 +119,7 @@ class WebKit_Meeting_Registration {
         add_shortcode('contributors-meeting-registration-form', ['WebKit_Meeting_Registration', 'form_shortcode']);
     }
 
-    public function registration_shortcode($atts, $content) {
+    public static function registration_shortcode($atts, $content) {
         $registration = self::registration();
 
         if (!empty($registration))
@@ -131,7 +132,7 @@ class WebKit_Meeting_Registration {
             return '<p>' . $content . '</p>';
     }
 
-    public function form_shortcode($atts, $content) {
+    public static function form_shortcode($atts, $content) {
         if (!class_exists('GitHubOAuthPlugin'))
             return '';
 


### PR DESCRIPTION
#### cdc168a373034c0fec2df5e07b6d713adcc68969
<pre>
Update meeting registration to include attendance preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=278251">https://bugs.webkit.org/show_bug.cgi?id=278251</a>

Reviewed by Aditya Keerthi.

* Websites/webkit.org/wp-content/plugins/meeting-registration/admin.php:
* Websites/webkit.org/wp-content/plugins/meeting-registration/form.php:
* Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php:

Canonical link: <a href="https://commits.webkit.org/283103@main">https://commits.webkit.org/283103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebcd80f18fbe70e7760a392d2380c7deb92c7f33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17864 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/15856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/69274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/15856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68316 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/69274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/37910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/14733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/70979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/9202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/70979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/9234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/70979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/1275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9891 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/41250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->