### PR TITLE
Remove NetworkNotificationManager dependency on NetworkSession

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -89,6 +89,7 @@
 #include <WebCore/ResourceLoadStatistics.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SameSiteInfo.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/SecurityPolicy.h>
 #include <optional>
 #include <wtf/HashSet.h>
@@ -1647,7 +1648,9 @@ void NetworkConnectionToWebProcess::navigatorGetPushPermissionState(URL&& scopeU
         return;
     }
 
-    session->notificationManager().getPushPermissionState(WTFMove(scopeURL), WTFMove(completionHandler));
+    session->notificationManager().getPermissionState(SecurityOriginData::fromURL(scopeURL), [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState state) mutable {
+        completionHandler(static_cast<uint8_t>(state));
+    });
 }
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -122,6 +122,21 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(NetworkProcess& ne
     return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.standardVolumeCapacity, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel, parameters.storageSiteValidationEnabled);
 }
 
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+static WebPushD::WebPushDaemonConnectionConfiguration configurationWithHostAuditToken(NetworkProcess& networkProcess, WebPushD::WebPushDaemonConnectionConfiguration configuration)
+{
+#if PLATFORM(COCOA)
+    auto token = networkProcess.parentProcessConnection()->getAuditToken();
+    if (token) {
+        Vector<uint8_t> auditTokenData(sizeof(*token));
+        memcpy(auditTokenData.data(), &(*token), sizeof(*token));
+        configuration.hostAppAuditTokenData = WTFMove(auditTokenData);
+    }
+#endif
+    return configuration;
+}
+#endif
+
 NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
     : m_sessionID(parameters.sessionID)
     , m_networkProcess(networkProcess)
@@ -145,7 +160,7 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
     , m_inspectionForServiceWorkersAllowed(parameters.inspectionForServiceWorkersAllowed)
     , m_storageManager(createNetworkStorageManager(networkProcess, parameters))
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    , m_notificationManager(*this, parameters.webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration { parameters.webPushDaemonConnectionConfiguration })
+    , m_notificationManager(parameters.webPushMachServiceName, parameters.sessionID.isEphemeral(), configurationWithHostAuditToken(networkProcess, parameters.webPushDaemonConnectionConfiguration))
 #endif
 {
     if (!m_sessionID.isEphemeral()) {

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -41,9 +41,6 @@ namespace WebKit::WebPushD {
 void Connection::newConnectionWasInitialized() const
 {
     ASSERT(m_connection);
-    if (networkSession().sessionID().isEphemeral())
-        return;
-
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(m_configuration));
 }
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -43,21 +43,12 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkNotificationManager);
 
-NetworkNotificationManager::NetworkNotificationManager(NetworkSession& networkSession, const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
-    : m_networkSession(networkSession)
+// FIXME: instead of passing in ephemeral session state, we should probably just avoid constructing this object altogether.
+NetworkNotificationManager::NetworkNotificationManager(const String& webPushMachServiceName, bool isEphemeralSession, WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
+    : m_isEphemeralSession(isEphemeralSession)
 {
-    if (!m_networkSession.sessionID().isEphemeral() && !webPushMachServiceName.isEmpty()) {
-#if PLATFORM(COCOA)
-        auto token = m_networkSession.networkProcess().parentProcessConnection()->getAuditToken();
-        if (token) {
-            Vector<uint8_t> auditTokenData(sizeof(*token));
-            memcpy(auditTokenData.data(), &(*token), sizeof(*token));
-            configuration.hostAppAuditTokenData = WTFMove(auditTokenData);
-        }
-#endif
-
-        m_connection = makeUnique<WebPushD::Connection>(webPushMachServiceName.utf8(), *this, WTFMove(configuration));
-    }
+    if (!webPushMachServiceName.isEmpty() && !isEphemeralSession)
+        m_connection = makeUnique<WebPushD::Connection>(webPushMachServiceName.utf8(), WTFMove(configuration));
 }
 
 void NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin(const SecurityOriginData& origin, bool enabled, CompletionHandler<void()>&& completionHandler)
@@ -90,10 +81,8 @@ void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(c
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessages(), WTFMove(replyHandler));
 }
 
-void NetworkNotificationManager::showNotification(IPC::Connection&, const WebCore::NotificationData& notification, RefPtr<NotificationResources>&& notificationResources, CompletionHandler<void()>&& completionHandler)
+void NetworkNotificationManager::showNotification(const WebCore::NotificationData& notification, RefPtr<NotificationResources>&& notificationResources, CompletionHandler<void()>&& completionHandler)
 {
-    RELEASE_ASSERT(m_networkSession.networkProcess().builtInNotificationsEnabled());
-
     if (!m_connection) {
         completionHandler();
         return;
@@ -102,10 +91,13 @@ void NetworkNotificationManager::showNotification(IPC::Connection&, const WebCor
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::ShowNotification { notification, notificationResources }, WTFMove(completionHandler));
 }
 
+void NetworkNotificationManager::showNotification(IPC::Connection&, const WebCore::NotificationData& notification, RefPtr<NotificationResources>&& notificationResources, CompletionHandler<void()>&& completionHandler)
+{
+    showNotification(notification, WTFMove(notificationResources), WTFMove(completionHandler));
+}
+
 void NetworkNotificationManager::getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    RELEASE_ASSERT(m_networkSession.networkProcess().builtInNotificationsEnabled());
-
     if (!m_connection) {
         completionHandler(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "No active connection to webpushd"_s }));
         return;
@@ -136,9 +128,7 @@ void NetworkNotificationManager::didDestroyNotification(const WTF::UUID&)
 
 void NetworkNotificationManager::requestPermission(WebCore::SecurityOriginData&& origin, CompletionHandler<void(bool)>&& completionHandler)
 {
-    RELEASE_ASSERT(m_networkSession.networkProcess().builtInNotificationsEnabled());
-
-    if (m_networkSession.sessionID().isEphemeral())
+    if (m_isEphemeralSession)
         return completionHandler(false);
 
     if (!m_connection) {
@@ -179,7 +169,7 @@ void NetworkNotificationManager::unsubscribeFromPushService(URL&& scopeURL, std:
 
 void NetworkNotificationManager::getPushSubscription(URL&& scopeURL, CompletionHandler<void(Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    if (m_networkSession.sessionID().isEphemeral()) {
+    if (m_isEphemeralSession) {
         completionHandler(std::optional<WebCore::PushSubscriptionData> { });
         return;
     }
@@ -190,23 +180,6 @@ void NetworkNotificationManager::getPushSubscription(URL&& scopeURL, CompletionH
     }
 
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushSubscription(WTFMove(scopeURL)), WTFMove(completionHandler));
-}
-
-void NetworkNotificationManager::getPushPermissionState(URL&& scopeURL, CompletionHandler<void(Expected<uint8_t, WebCore::ExceptionData>&&)>&& completionHandler)
-{
-    if (m_networkSession.sessionID().isEphemeral()) {
-        completionHandler(static_cast<uint8_t>(PushPermissionState::Denied));
-        return;
-    }
-
-    if (!m_connection) {
-        completionHandler(makeUnexpected(ExceptionData { ExceptionCode::AbortError, "No connection to push daemon"_s }));
-        return;
-    }
-
-    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WebCore::SecurityOriginData::fromURL(scopeURL)), [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState state) mutable {
-        completionHandler(static_cast<uint8_t>(state));
-    });
 }
 
 void NetworkNotificationManager::incrementSilentPushCount(WebCore::SecurityOriginData&& origin, CompletionHandler<void(unsigned)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -37,22 +37,11 @@ namespace WebKit::WebPushD {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Connection);
 
-Connection::Connection(CString&& machServiceName, NetworkNotificationManager& manager, WebPushDaemonConnectionConfiguration&& configuration)
+Connection::Connection(CString&& machServiceName, WebPushDaemonConnectionConfiguration&& configuration)
     : Daemon::ConnectionToMachService<ConnectionTraits>(WTFMove(machServiceName))
-    , m_notificationManager(manager)
     , m_configuration(WTFMove(configuration))
 {
     LOG(Push, "Creating WebPushD connection to mach service: %s", this->machServiceName().data());
-}
-
-NetworkSession& Connection::networkSession() const
-{
-    return m_notificationManager.networkSession();
-}
-
-void Connection::debugMessage(const String& message)
-{
-    networkSession().networkProcess().broadcastConsoleMessage(networkSession().sessionID(), MessageSource::Other, JSC::MessageLevel::Info, message);
 }
 
 } // namespace WebKit::WebPushD

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -55,10 +55,7 @@ struct ConnectionTraits {
 class Connection : public Daemon::ConnectionToMachService<ConnectionTraits>, public IPC::MessageSender {
     WTF_MAKE_TZONE_ALLOCATED(Connection);
 public:
-    Connection(CString&& machServiceName, NetworkNotificationManager&, WebPushDaemonConnectionConfiguration&&);
-
-    void debugMessage(const String&);
-    void setConfiguration(WebPushDaemonConnectionConfiguration&&);
+    Connection(CString&& machServiceName, WebPushDaemonConnectionConfiguration&&);
 
 private:
     void newConnectionWasInitialized() const final;
@@ -66,11 +63,7 @@ private:
     OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
     void connectionReceivedEvent(xpc_object_t) final { }
 #endif
-    void sendDebugModeIsEnabledMessageIfNecessary() const;
 
-    NetworkSession& networkSession() const;
-
-    NetworkNotificationManager& m_notificationManager;
     WebPushDaemonConnectionConfiguration m_configuration;
 
     // IPC::MessageSender

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
@@ -53,7 +53,6 @@ private:
     OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
     void connectionReceivedEvent(xpc_object_t) final;
 #endif
-    void sendDebugModeIsEnabledMessageIfNecessary() const;
 
     WeakPtr<NetworkSession> m_networkSession;
 };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -631,7 +631,9 @@ void WebSWServerConnection::getPushPermissionState(WebCore::ServiceWorkerRegistr
         return;
     }
 
-    session()->notificationManager().getPushPermissionState(registration->scopeURLWithoutFragment(), WTFMove(completionHandler));
+    session()->notificationManager().getPermissionState(SecurityOriginData::fromURL( registration->scopeURLWithoutFragment()), [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState state) mutable {
+        completionHandler(static_cast<uint8_t>(state));
+    });
 #endif
 }
 


### PR DESCRIPTION
#### 020436abf345ae2df9bb772cb0ce94ac4219cbf4
<pre>
Remove NetworkNotificationManager dependency on NetworkSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=278252">https://bugs.webkit.org/show_bug.cgi?id=278252</a>
<a href="https://rdar.apple.com/problem/134081837">rdar://problem/134081837</a>

Reviewed by Sihui Liu.

We want to be able to create a NetworkNotificationManager object without a corresponding
NetworkSession. This removes that dependency. As part of that project we also need certain methods
of NetworkNotificationManager to be public instead of private, so I also changed the visibility of
those methods.

I also did some drive-by cleanup:

- getPushPermissionState and getPermissionState did the exact same thing, so I removed the former.
- WebPushD::Connection similarly had a dependency on NetworkSession that I removed.
- Removed several unused methods in WebPushD::Connection (e.g. debug message logging)

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::navigatorGetPushPermissionState):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::configurationWithHostAuditToken):
(WebKit::NetworkSession::NetworkSession):
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::newConnectionWasInitialized const):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::NetworkNotificationManager):
(WebKit::NetworkNotificationManager::showNotification):
(WebKit::NetworkNotificationManager::getNotifications):
(WebKit::NetworkNotificationManager::requestPermission):
(WebKit::NetworkNotificationManager::getPushSubscription):
(WebKit::NetworkNotificationManager::getPushPermissionState): Deleted.
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
(WebKit::NetworkNotificationManager::networkSession const): Deleted.
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp:
(WebKit::WebPushD::Connection::Connection):
(WebKit::WebPushD::Connection::networkSession const): Deleted.
(WebKit::WebPushD::Connection::debugMessage): Deleted.
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::getPushPermissionState):

Canonical link: <a href="https://commits.webkit.org/282444@main">https://commits.webkit.org/282444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f35c3f128e500712e81b0d36e4f1904b59ccfc30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13789 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66250 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54712 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36193 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12661 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54780 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5948 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39437 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->