### PR TITLE
SimulateClickOverText.ClickTargets* API tests fail with debug assertions

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9865,7 +9865,7 @@ void WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction(co
         if (!target)
             continue;
 
-        auto textRects = RenderObject::absoluteTextRects(range, {
+        auto textRects = RenderObject::absoluteBorderAndTextRects(range, {
             RenderObject::BoundingRectBehavior::RespectClipping,
             RenderObject::BoundingRectBehavior::UseVisibleBounds,
             RenderObject::BoundingRectBehavior::IgnoreTinyRects,
@@ -9873,13 +9873,13 @@ void WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction(co
         });
 
         auto indexOfFirstRelevantTextRect = textRects.findIf([&](auto& textRect) {
-            return unobscuredContentRect.intersects(textRect);
+            return unobscuredContentRect.intersects(enclosingIntRect(textRect));
         });
 
         if (indexOfFirstRelevantTextRect == notFound)
             continue;
 
-        candidates.append({ target.releaseNonNull(), textRects[indexOfFirstRelevantTextRect].center() });
+        candidates.append({ target.releaseNonNull(), roundedIntPoint(textRects[indexOfFirstRelevantTextRect].center()) });
     }
 
     removeNonHitTestableCandidates();


### PR DESCRIPTION
#### 8421fbee7147dcdb93db4df38a273e55ca967eec
<pre>
SimulateClickOverText.ClickTargets* API tests fail with debug assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=278255">https://bugs.webkit.org/show_bug.cgi?id=278255</a>

Reviewed by Richard Robinson.

These API tests were hitting a debug assertion in `RenderObject::absoluteTextRects`, due to the fact
that both `UseVisibleBounds` and `IgnoreTinyRects` options were being ignored when calling into that
method.

Fix this by using `absoluteBorderAndTextRects` instead, which both honors the two options above when
computing the bounding rect, and fulfills the same purpose as `absoluteTextRects`.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction):

Canonical link: <a href="https://commits.webkit.org/282374@main">https://commits.webkit.org/282374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41e2e2f9e9958faf562f1dae991df6387880e153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13572 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13856 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39325 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54535 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.GrandfatherCallback (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36015 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12448 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68684 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6914 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13969 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5769 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38144 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->