### PR TITLE
FragmentDirectiveGenerator: Selecting the first two or three words of the first sentence in a paragraph results in the whole page highlighting

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix-expected.txt
@@ -1,0 +1,1 @@
+:~:text=This,-is%20a%20very

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we don't emit an empty prefix at the start of a document</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.setStart(document.body.childNodes[0], 0);
+    range.setEnd(document.body.childNodes[0], 4);
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>This is a very simple document. There is no text before 'this'.</body>
+</html>
+

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.h
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.h
@@ -33,18 +33,11 @@ namespace WebCore {
 
 struct SimpleRange;
 
-struct TextDirective {
-    String textStart;
-    String textEnd;
-    String prefix;
-    String suffix;
-};
-
 class FragmentDirectiveGenerator {
 public:
     WEBCORE_EXPORT explicit FragmentDirectiveGenerator(const SimpleRange&);
 
-    URL urlWithFragment() const { return m_urlWithFragment; };
+    URL urlWithFragment() const { return m_urlWithFragment; }
 
 private:
     FragmentDirectiveGenerator() = delete;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -88,6 +88,7 @@
 #include "FloatQuad.h"
 #include "FontCache.h"
 #include "FormController.h"
+#include "FragmentDirectiveGenerator.h"
 #include "FrameLoader.h"
 #include "FullscreenManager.h"
 #include "GCObservation.h"
@@ -2505,6 +2506,13 @@ Vector<Internals::TextIteratorState> Internals::statesOfTextIterator(const Range
     for (TextIterator it(simpleRange); !it.atEnd(); it.advance())
         states.append({ it.text().toString(), createLiveRange(it.range()) });
     return states;
+}
+
+String Internals::textFragmentDirectiveForRange(const Range& range)
+{
+    auto simpleRange = makeSimpleRange(range);
+    simpleRange.start.document().updateLayout();
+    return FragmentDirectiveGenerator(simpleRange).urlWithFragment().string();
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -405,6 +405,8 @@ public:
     };
     Vector<TextIteratorState> statesOfTextIterator(const Range&);
 
+    String textFragmentDirectiveForRange(const Range&);
+
     ExceptionOr<void> setDelegatesScrolling(bool enabled);
 
     ExceptionOr<uint64_t> lastSpellCheckRequestSequence();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -633,6 +633,8 @@ enum RenderingMode {
     Range? rangeOfStringNearLocation(Range range, DOMString text, long targetOffset);
     sequence<TextIteratorState> statesOfTextIterator(Range range);
 
+    DOMString textFragmentDirectiveForRange(Range range);
+
     undefined setDelegatesScrolling(boolean enabled);
 
     unsigned long long lastSpellCheckRequestSequence();


### PR DESCRIPTION
#### 0b92e6db304e4326e077b979552ef80ba56d5a1a
<pre>
FragmentDirectiveGenerator: Selecting the first two or three words of the first sentence in a paragraph results in the whole page highlighting
<a href="https://bugs.webkit.org/show_bug.cgi?id=278257">https://bugs.webkit.org/show_bug.cgi?id=278257</a>
<a href="https://rdar.apple.com/133772459">rdar://133772459</a>

Reviewed by Wenson Hsieh and Megan Gardner.

The bug in the title results from our unconditional generation of a prefix (or suffix)
fragment component in the case where there is no possible prefix or suffix.

Avoid generating empty components, and to do so, reorganize the generation code a bit.

Add a test for this case (and make FragmentDirectiveGenerator trivially testable).

* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html: Added.
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):
* Source/WebCore/dom/FragmentDirectiveGenerator.h:
(WebCore::FragmentDirectiveGenerator::urlWithFragment const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::textFragmentDirectiveForRange):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/282375@main">https://commits.webkit.org/282375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/211dcdaf8f7ac52db853d88a783f29e114d6c523

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13884 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9380 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66065 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54554 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11888 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12476 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6942 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54615 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5787 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->