### PR TITLE
Add fast/dom/frame-load-reentrancy.html

### DIFF
--- a/LayoutTests/fast/dom/frame-load-reentrancy-expected.txt
+++ b/LayoutTests/fast/dom/frame-load-reentrancy-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: first error HierarchyRequestError: The operation would yield an incorrect node tree.
+CONSOLE MESSAGE: This test passes if it does not crash or overly recurse.
+CONSOLE MESSAGE: first error HierarchyRequestError: The operation would yield an incorrect node tree.
+CONSOLE MESSAGE: This test passes if it does not crash or overly recurse.
+CONSOLE MESSAGE: first error HierarchyRequestError: The operation would yield an incorrect node tree.
+CONSOLE MESSAGE: second error TypeError: Argument 1 ('node') to Node.appendChild must be an instance of Node
+CONSOLE MESSAGE: This test passes if it does not crash or overly recurse.
+

--- a/LayoutTests/fast/dom/frame-load-reentrancy.html
+++ b/LayoutTests/fast/dom/frame-load-reentrancy.html
@@ -1,0 +1,15 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+function loadEventHandler() {
+    try { dlElement.appendChild(dataElement) } catch (e) { console.log("first error " + e) }
+    try { document.head.appendChild(anchorElement) } catch (e) { console.log("second error " + e) }
+    // Checking for window.testRunner or calling dumpAsText changes whether this test originally crashed.
+    console.log("This test passes if it does not crash or overly recurse.");
+}
+</script>
+<data id="dataElement"></h3>
+<a id="anchorElement">
+<dl id="dlElement">
+<iframe onload="loadEventHandler()"></iframe>
+<a></a>


### PR DESCRIPTION
#### f8062c8640ee1cde10d6730ed5687b720f9fc0d5
<pre>
Add fast/dom/frame-load-reentrancy.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=278262">https://bugs.webkit.org/show_bug.cgi?id=278262</a>
&lt;<a href="https://rdar.apple.com/132615936">rdar://132615936</a>&gt;

Reviewed by Chris Dumez.

Exported the test from the Apple internal repository.

* LayoutTests/fast/dom/frame-load-reentrancy-expected.txt: Added.
* LayoutTests/fast/dom/frame-load-reentrancy.html: Added.

Canonical link: <a href="https://commits.webkit.org/282381@main">https://commits.webkit.org/282381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68cede4bcc9d6027aa51d62ced8c2915d6bc5592

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67013 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13596 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13880 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9376 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11842 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54619 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5789 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9496 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38168 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40359 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->