### PR TITLE
[view-transitions] Implement matching for view transition classes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7596,16 +7596,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-pars
 # Test doesn't seem to pass on Chrome Canary.
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html [ Skip ]
 
-# View transitions Level 2 - classes.
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-entry.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-ident.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-partial.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-wildcard.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-old-with-class-new-without.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class-inside-shadow-important.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class-inside-shadow.html [ ImageOnlyFailure ]
-
 # View transitions Level 2 - cross document transitions.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html [ ImageOnlyFailure ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7555,16 +7555,16 @@ ViewGestureDebuggingEnabled:
 ViewTransitionClassesEnabled:
   type: bool
   category: animation
-  status: testable
+  status: stable
   humanReadableName: "View Transition Classes"
   humanReadableDescription: "Support specifying classes for view transitions"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 ViewTransitionTypesEnabled:
   type: bool

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -385,6 +385,13 @@ static void appendPossiblyQuotedIdentifier(StringBuilder& builder, const Possibl
         serializeString(identifier.identifier, builder);
 }
 
+WTF::TextStream& operator<<(WTF::TextStream& ts, PossiblyQuotedIdentifier identifier)
+{
+    StringBuilder builder;
+    appendPossiblyQuotedIdentifier(builder, identifier);
+    return ts << builder.toString();
+}
+
 static void appendCommaSeparatedPossiblyQuotedIdentifierList(StringBuilder& builder, const FixedVector<PossiblyQuotedIdentifier>& list)
 {
     builder.append(interleave(list, appendPossiblyQuotedIdentifier, ", "_s));

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -39,6 +39,8 @@ struct PossiblyQuotedIdentifier {
     bool isNull() const { return identifier.isNull(); }
 };
 
+WTF::TextStream& operator<<(WTF::TextStream&, PossiblyQuotedIdentifier);
+
 enum class SelectorSpecificityIncrement {
     ClassA = 0x10000,
     ClassB = 0x100,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1271,9 +1271,19 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (checkingContext.pseudoId != CSSSelector::pseudoId(selector.pseudoElement()) || !selector.argumentList())
                 return false;
 
-            // Wildcard always matches.
-            auto& argument = selector.argumentList()->first();
-            return argument == starAtom() || argument == checkingContext.pseudoElementNameArgument;
+            auto& list = *selector.argumentList();
+            auto& name = list.first();
+            if (name != starAtom() && name != checkingContext.pseudoElementNameArgument)
+                return false;
+
+            if (list.size() == 1)
+                return true;
+
+            return std::ranges::all_of(list.begin() + 1, list.end(),
+                [&](const PossiblyQuotedIdentifier& classSelector) {
+                    return checkingContext.classList.contains(classSelector.identifier);
+                }
+            );
         }
 
         default:

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -86,6 +86,7 @@ public:
         PseudoId pseudoId { PseudoId::None };
         AtomString pseudoElementNameArgument;
         std::optional<StyleScrollbarState> scrollbarState;
+        Vector<AtomString> classList;
         RefPtr<const ContainerNode> scope;
         const Element* hasScope { nullptr };
         bool matchesAllHasScopes { false };

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -66,6 +66,7 @@ public:
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
     WeakStyleable newElement;
+    Vector<AtomString> classList;
 
     RefPtr<MutableStyleProperties> groupStyleProperties;
 };

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -372,15 +372,15 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
 
 static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newStyle)
 {
-    const RenderStyle& currentStyle = renderer->style();
+    const auto& currentStyle = renderer->style();
 
-    const PseudoStyleCache* pseudoStyleCache = currentStyle.cachedPseudoStyles();
+    const auto* pseudoStyleCache = currentStyle.cachedPseudoStyles();
     if (!pseudoStyleCache)
         return false;
 
     for (auto& cache : pseudoStyleCache->styles) {
-        PseudoId pseudoId = cache->pseudoElementType();
-        std::unique_ptr<RenderStyle> newPseudoStyle = renderer->getUncachedPseudoStyle({ pseudoId }, newStyle, newStyle);
+        Style::PseudoElementIdentifier pseudoElementIdentifier { cache->pseudoElementType(), cache->pseudoElementNameArgument() };
+        auto newPseudoStyle = renderer->getUncachedPseudoStyle(pseudoElementIdentifier, newStyle, newStyle);
         if (!newPseudoStyle)
             return true;
         if (*newPseudoStyle != *cache) {

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -453,6 +453,21 @@ void ElementRuleCollector::matchUARules(const RuleSet& rules)
     sortAndTransferMatchedRules(DeclarationOrigin::UserAgent);
 }
 
+static Vector<AtomString> classListForNamedViewTransitionPseudoElement(const Document& document, const AtomString& name)
+{
+    auto* activeViewTransition = document.activeViewTransition();
+    if (!activeViewTransition)
+        return { };
+
+    ASSERT(!name.isNull());
+
+    auto* capturedElement = activeViewTransition->namedElements().find(name);
+    if (!capturedElement)
+        return { };
+
+    return capturedElement->classList;
+}
+
 inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned& specificity, ScopeOrdinal styleScopeOrdinal, const ContainerNode* scopingRoot)
 {
     // We know a sufficiently simple single part selector matches simply because we found it from the rule hash when filtering the RuleSet.
@@ -508,6 +523,8 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
         context.pseudoId = m_pseudoElementRequest->pseudoId();
         context.pseudoElementNameArgument = m_pseudoElementRequest->nameArgument();
         context.scrollbarState = m_pseudoElementRequest->scrollbarState();
+        if (isNamedViewTransitionPseudoElement(m_pseudoElementRequest->identifier()))
+            context.classList = classListForNamedViewTransitionPseudoElement(element().document(), context.pseudoElementNameArgument);
     }
     context.styleScopeOrdinal = styleScopeOrdinal;
     context.selectorMatchingState = m_selectorMatchingState;


### PR DESCRIPTION
#### 28a8cb798f0cf5d11677902f6f8f87820f6bb286
<pre>
[view-transitions] Implement matching for view transition classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=278223">https://bugs.webkit.org/show_bug.cgi?id=278223</a>
<a href="https://rdar.apple.com/134020027">rdar://134020027</a>

Reviewed by Darin Adler.

Implements matching as described in:
<a href="https://drafts.csswg.org/css-view-transitions-2/#shared-style-with-vt-classes">https://drafts.csswg.org/css-view-transitions-2/#shared-style-with-vt-classes</a>

* LayoutTests/TestExpectations:

Unskip all tests.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Enable by default, since all WPT pass.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/css/CSSSelector.h:

Add PossiblyQuotedIdentifier TextStream for easy debugging.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorChecker.h:

All classes in need to match in order for the styles to apply.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionClassList):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):

Captures the classList as described in <a href="https://drafts.csswg.org/css-view-transitions-2/#vt-class-algorithms">https://drafts.csswg.org/css-view-transitions-2/#vt-class-algorithms</a>

* Source/WebCore/dom/ViewTransition.h: Add classList to CapturedElement.

* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::pseudoStyleCacheIsInvalid):

Fix a bug in the cache where were passing a null name argument string.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::classListForNamedViewTransitionPseudoElement):
(WebCore::Style::ElementRuleCollector::ruleMatches):

Pass the classList to the SelectorChecker when checking the selector.

Canonical link: <a href="https://commits.webkit.org/282383@main">https://commits.webkit.org/282383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f4800cada96ae64f5e6591773e11fd9b7b9b848

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15614 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66087 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/11916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/56128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12245 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/62261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/6964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/6996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84024 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->