### PR TITLE
Remove/Unexpose SVGDocument IDL

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt
@@ -7,7 +7,7 @@ PASS SVGColor interface must be removed
 PASS SVGColorProfileElement interface must be removed
 PASS SVGColorProfileRule interface must be removed
 PASS SVGCursorElement interface must be removed
-FAIL SVGDocument interface must be removed assert_false: expected false got true
+PASS SVGDocument interface must be removed
 PASS SVGElementInstanceList interface must be removed
 PASS SVGExternalResourcesRequired interface must be removed
 PASS SVGFontElement interface must be removed

--- a/LayoutTests/svg/hittest/resources/svg-tooltip.js
+++ b/LayoutTests/svg/hittest/resources/svg-tooltip.js
@@ -11,7 +11,7 @@
 // Returns true if an element can return a title or not
 function canReturnTitle(element)
 {
-  if (!element || element.tagName == "svg" && element.ownerDocument instanceof SVGDocument)
+  if (!element || element.tagName == "svg" && element.ownerDocument instanceof XMLDocument)
       return false;
 
   return true;

--- a/Source/WebCore/dom/XMLDocument.idl
+++ b/Source/WebCore/dom/XMLDocument.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://dom.spec.whatwg.org/#xmldocument
+
 [
     CustomToJSObject,
-    LegacyWindowAlias=SVGDocument,
     Exposed=Window
 ] interface XMLDocument : Document {
 };


### PR DESCRIPTION
#### 2330d8fd04640de7fc3f4e334498a07513141880
<pre>
Remove/Unexpose SVGDocument IDL

<a href="https://bugs.webkit.org/show_bug.cgi?id=269627">https://bugs.webkit.org/show_bug.cgi?id=269627</a>
<a href="https://rdar.apple.com/123121696">rdar://123121696</a>

Reviewed by Darin Adler.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

We already removed it in 178778@main but we had `LegacyWindowAlias` set
on `XMLDocument` interface but it is not on &apos;XMLDocument&apos; specification [1]:

[1] <a href="https://dom.spec.whatwg.org/#xmldocument">https://dom.spec.whatwg.org/#xmldocument</a>

This patch removes it and progress web platform test as well.

Credits to @karlcow for suggesting fix for `svg-tooltip.js`.

* Source/WebCore/dom/XMLDocument.idl:
* LayoutTests/svg/hittest/resources/svg-tooltip.js: Updated
* LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288135@main">https://commits.webkit.org/288135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efcb569607a7f143a0da07539d24ca42aef951f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31291 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17823 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14426 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/448 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14565 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->