### PR TITLE
Build fix: Move Inspector::RemoteInspector destructor to source file for upstream clang

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -42,6 +42,10 @@ bool RemoteInspector::startEnabled = true;
 std::atomic<bool> RemoteInspector::needMachSandboxExtension = false;
 #endif
 
+#if !PLATFORM(COCOA)
+RemoteInspector::~RemoteInspector() = default;
+#endif
+
 void RemoteInspector::startDisabled()
 {
     RemoteInspector::startEnabled = false;

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -131,6 +131,8 @@ public:
     static RemoteInspector& singleton();
     friend class LazyNeverDestroyed<RemoteInspector>;
 
+    virtual ~RemoteInspector();
+
     void registerTarget(RemoteControllableTarget*);
     void unregisterTarget(RemoteControllableTarget*);
     void updateTarget(RemoteControllableTarget*);

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -61,6 +61,8 @@
 
 namespace Inspector {
 
+RemoteInspector::~RemoteInspector() = default;
+
 static void convertNSNullToNil(__strong NSNumber *& number)
 {
     if ([number isEqual:[NSNull null]])


### PR DESCRIPTION
#### 446379687a696e1302ef66f18079c77bad2f0fe0
<pre>
Build fix: Move Inspector::RemoteInspector destructor to source file for upstream clang
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278275">https://bugs.webkit.org/show_bug.cgi?id=278275</a>&gt;
&lt;<a href="https://rdar.apple.com/134140254">rdar://134140254</a>&gt;

Reviewed by Devin Rousso.

In upstream clang, destructors require full class definitions for any
instance variable that is destructed.  In most cases, moving the
destructor out of the header will fix this build failure without
increasing header parsing time.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp:
(Inspector::RemoteInspector::~RemoteInspector):
- Move destructor here for non-Apple ports.
* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
- Declare virtual destructor.
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::~RemoteInspector):
- Move destructor here for Apple ports.  We must declare the destructor
  here because the xpc_object_t parameter in
  RemoteInspector::xpcConnectionUnhandledMessage() has a different type
  in C++ (void*) vs. Objective-C++ (NSObject&lt;OS_xpc_object&gt;*), which
  results in a link error if the destructor is compiled in
  RemoteInspector.cpp but xpcConnectionUnhandledMessage() is compiled in
  RemoteInspectorCocoa.mm.

Canonical link: <a href="https://commits.webkit.org/282391@main">https://commits.webkit.org/282391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12698ceb2404d079038a9c7e9d02cc6247138835

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13655 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50803 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11940 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12531 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56161 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62294 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58324 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5834 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84057 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38227 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14800 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->