### PR TITLE
Stop using a LegacyNullableObjectIdentifier for ElementIdentifier

### DIFF
--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -74,7 +74,6 @@ public:
 
     RawValue toUInt64() const { return toRawValue(); } // Use `toRawValue` instead.
     RawValue toRawValue() const { return m_identifier; }
-    explicit operator bool() const { return m_identifier; }
 
     String loggingString() const
     {
@@ -107,7 +106,6 @@ public:
     bool isHashTableDeletedValue() const { return m_identifier == hashTableDeletedValue(); }
 
     RawValue toRawValue() const { return m_identifier; }
-    explicit operator bool() const { return m_identifier; }
 
     String loggingString() const
     {
@@ -149,21 +147,18 @@ public:
     explicit constexpr ObjectIdentifierGeneric(RawValue identifier)
         : ObjectIdentifierGenericBase<RawValue>(identifier)
     {
+        ASSERT(supportsNullState == SupportsObjectIdentifierNullState::Yes || !!identifier);
     }
 
     bool isValid() const requires(supportsNullState == SupportsObjectIdentifierNullState::Yes) { return ObjectIdentifierGenericBase<RawValue>::isValidIdentifier(ObjectIdentifierGenericBase<RawValue>::toRawValue()); }
+    explicit operator bool() const requires(supportsNullState == SupportsObjectIdentifierNullState::Yes) { return ObjectIdentifierGenericBase<RawValue>::toRawValue(); }
 
     ObjectIdentifierGeneric() requires (supportsNullState == SupportsObjectIdentifierNullState::Yes) = default;
 
     ObjectIdentifierGeneric(HashTableDeletedValueType) : ObjectIdentifierGenericBase<RawValue>(HashTableDeletedValue) { }
 
-    std::optional<ObjectIdentifierGeneric> asOptional() const requires(supportsNullState == SupportsObjectIdentifierNullState::Yes)
-    {
-        return *this ? std::optional { *this } : std::nullopt;
-    }
-
     struct MarkableTraits {
-        static bool isEmptyValue(ObjectIdentifierGeneric identifier) { return !identifier; }
+        static bool isEmptyValue(ObjectIdentifierGeneric identifier) { return !identifier.toRawValue(); }
         static constexpr ObjectIdentifierGeneric emptyValue() { return ObjectIdentifierGeneric(InvalidIdValue); }
     };
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10449,7 +10449,7 @@ MessagePortChannelProvider& Document::messagePortChannelProvider()
 #if USE(SYSTEM_PREVIEW)
 void Document::dispatchSystemPreviewActionEvent(const SystemPreviewInfo& systemPreviewInfo, const String& message)
 {
-    RefPtr element = Element::fromIdentifier(systemPreviewInfo.element.elementIdentifier);
+    RefPtr element = systemPreviewInfo.element.elementIdentifier ? Element::fromIdentifier(*systemPreviewInfo.element.elementIdentifier) : nullptr;
     if (!is<HTMLAnchorElement>(element))
         return;
 

--- a/Source/WebCore/dom/ElementContext.h
+++ b/Source/WebCore/dom/ElementContext.h
@@ -39,7 +39,7 @@ struct ElementContext {
 
     PageIdentifier webPageIdentifier;
     ScriptExecutionContextIdentifier documentIdentifier;
-    ElementIdentifier elementIdentifier;
+    Markable<ElementIdentifier> elementIdentifier;
 
     ~ElementContext() = default;
 

--- a/Source/WebCore/dom/ElementIdentifier.h
+++ b/Source/WebCore/dom/ElementIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class ElementIdentifierType { };
-using ElementIdentifier = LegacyNullableObjectIdentifier<ElementIdentifierType>;
+using ElementIdentifier = ObjectIdentifier<ElementIdentifierType>;
 
 }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1541,7 +1541,6 @@ void DocumentLoader::detachFromFrame(LoadWillContinueInAnotherProcess loadWillCo
 
 void DocumentLoader::setNavigationID(NavigationIdentifier navigationID)
 {
-    ASSERT(navigationID);
     m_navigationID = navigationID;
 }
 

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1397,8 +1397,8 @@ void ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions(Doc
 
     if (RefPtr loader = document.loader(); loader && !m_didCollectInitialAdjustments) {
         m_initialVisibilityAdjustmentSelectors = loader->visibilityAdjustmentSelectors();
-        m_visibilityAdjustmentSelectors.appendVector(m_initialVisibilityAdjustmentSelectors.map([](auto& selectors) -> std::pair<ElementIdentifier, TargetedElementSelectors> {
-            return { { }, selectors };
+        m_visibilityAdjustmentSelectors.appendVector(m_initialVisibilityAdjustmentSelectors.map([](auto& selectors) -> std::pair<Markable<ElementIdentifier>, TargetedElementSelectors> {
+            return { std::nullopt, selectors };
         }));
         m_startTimeForSelectorBasedVisibilityAdjustment = ApproximateTime::now();
         m_didCollectInitialAdjustments = true;
@@ -1669,8 +1669,8 @@ bool ElementTargetingController::resetVisibilityAdjustments(const Vector<Targete
             auto foundElement = findElementFromSelectors(selectors).element;
             return foundElement && elementsToReset.contains(*foundElement);
         });
-        m_visibilityAdjustmentSelectors = m_initialVisibilityAdjustmentSelectors.map([](auto& selectors) -> std::pair<ElementIdentifier, TargetedElementSelectors> {
-            return { { }, selectors };
+        m_visibilityAdjustmentSelectors = m_initialVisibilityAdjustmentSelectors.map([](auto& selectors) -> std::pair<Markable<ElementIdentifier>, TargetedElementSelectors> {
+            return { std::nullopt, selectors };
         });
     } else {
         // There are no initial adjustments after resetting.

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -97,7 +97,7 @@ private:
     HashMap<ElementIdentifier, IntRect> m_recentAdjustmentClientRects;
     ApproximateTime m_startTimeForSelectorBasedVisibilityAdjustment;
     Timer m_selectorBasedVisibilityAdjustmentTimer;
-    Vector<std::pair<ElementIdentifier, TargetedElementSelectors>> m_visibilityAdjustmentSelectors;
+    Vector<std::pair<Markable<ElementIdentifier>, TargetedElementSelectors>> m_visibilityAdjustmentSelectors;
     Vector<TargetedElementSelectors> m_initialVisibilityAdjustmentSelectors;
     Region m_adjustmentClientRegion;
     Region m_repeatedAdjustmentClientRegion;

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -46,7 +46,7 @@ struct SnapOffset {
     T offset;
     ScrollSnapStop stop;
     bool hasSnapAreaLargerThanViewport;
-    ElementIdentifier snapTargetID;
+    Markable<ElementIdentifier> snapTargetID;
     bool isFocused;
     Vector<size_t> snapAreaIndices;
 };

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -101,7 +101,7 @@ bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis,
     auto snapOffsets = snapOffsetsForAxis(axis);
     
     auto found = std::find_if(snapOffsets.begin(), snapOffsets.end(), [boxID](SnapOffset<LayoutUnit> p) -> bool {
-        return p.snapTargetID == boxID;
+        return *p.snapTargetID == boxID;
     });
     if (found == snapOffsets.end()) {
         setActiveSnapIndexForAxis(axis, std::nullopt);
@@ -130,7 +130,7 @@ HashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const 
     for (auto offset : horizontalOffsets) {
         if (!offset.snapTargetID)
             continue;
-        snappedBoxIDs.add(offset.snapTargetID);
+        snappedBoxIDs.add(*offset.snapTargetID);
         for (auto i : offset.snapAreaIndices)
             snappedBoxIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
     }
@@ -138,7 +138,7 @@ HashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const 
     for (auto offset : verticalOffsets) {
         if (!offset.snapTargetID)
             continue;
-        snappedBoxIDs.add(offset.snapTargetID);
+        snappedBoxIDs.add(*offset.snapTargetID);
         for (auto i : offset.snapAreaIndices)
             snappedBoxIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
     }
@@ -164,16 +164,16 @@ static ElementIdentifier chooseBoxToResnapTo(const HashSet<ElementIdentifier>& s
     ASSERT(snappedBoxes.size());
 
     auto found = std::find_if(horizontalOffsets.begin(), horizontalOffsets.end(), [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
-        return snappedBoxes.contains(p.snapTargetID) && p.isFocused;
+        return snappedBoxes.contains(*p.snapTargetID) && p.isFocused;
     });
     if (found != horizontalOffsets.end())
-        return found->snapTargetID;
+        return *found->snapTargetID;
     
     found = std::find_if(verticalOffsets.begin(), verticalOffsets.end(), [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
-        return snappedBoxes.contains(p.snapTargetID) && p.isFocused;
+        return snappedBoxes.contains(*p.snapTargetID) && p.isFocused;
     });
     if (found != verticalOffsets.end())
-        return found->snapTargetID;
+        return *found->snapTargetID;
     
     return *snappedBoxes.begin();
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3092,7 +3092,7 @@ uint64_t Internals::elementIdentifier(Element& element) const
 
 bool Internals::isElementAlive(uint64_t elementIdentifier) const
 {
-    return Element::fromIdentifier(LegacyNullableObjectIdentifier<ElementIdentifierType>(elementIdentifier));
+    return Element::fromIdentifier(ObjectIdentifier<ElementIdentifierType>(elementIdentifier));
 }
 
 uint64_t Internals::pageIdentifier(const Document& document) const

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -63,7 +63,6 @@ header: <wtf/ObjectIdentifier.h>
 template: class WebKit::WebURLSchemeHandler
 template: enum class WebCore::AXIDType
 template: enum class WebCore::BackgroundFetchRecordIdentifierType
-template: enum class WebCore::ElementIdentifierType
 template: enum class WebCore::FetchIdentifierType
 template: enum class WebCore::ImageDecoderIdentifierType
 template: enum class WebCore::ImageOverlayDataDetectionResultIdentifierType
@@ -160,6 +159,7 @@ template: struct WebKit::WebTransportStreamIdentifierType
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
 
+template: enum class WebCore::ElementIdentifierType
 template: struct WebCore::NavigationIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1977,7 +1977,7 @@ struct WebCore::ElementContext {
     WebCore::FloatRect boundingRect;
     WebCore::PageIdentifier webPageIdentifier;
     WebCore::ScriptExecutionContextIdentifier documentIdentifier;
-    WebCore::ElementIdentifier elementIdentifier;
+    Markable<WebCore::ElementIdentifier> elementIdentifier;
 };
 
 struct WebCore::ElementAnimationContext {
@@ -4154,7 +4154,7 @@ enum class WebCore::ScrollSnapStop : bool;
     float offset;
     WebCore::ScrollSnapStop stop;
     bool hasSnapAreaLargerThanViewport;
-    WebCore::ElementIdentifier snapTargetID;
+    Markable<WebCore::ElementIdentifier> snapTargetID;
     bool isFocused;
     Vector<size_t> snapAreaIndices;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm
@@ -74,7 +74,7 @@
 
 - (NSUInteger)hash
 {
-    return _textInputContext.elementIdentifier.toUInt64();
+    return _textInputContext.elementIdentifier ? _textInputContext.elementIdentifier->toUInt64() : 0;
 }
 
 - (id)copyWithZone:(NSZone *)zone

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -405,7 +405,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
             return completionHandler();
 
         auto protectedThis = weakThis.get();
-        RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", protectedThis->m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+        RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", protectedThis->m_systemPreviewInfo.element.elementIdentifier ? protectedThis->m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
         auto request = WebCore::ResourceRequest(url);
         bool shouldRunAtForegroundPriority = false;
         protectedThis->m_webPageProxy.dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
@@ -473,7 +473,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
 
 void SystemPreviewController::loadStarted(const URL& localFileURL)
 {
-    RELEASE_LOG(SystemPreview, "SystemPreview load has started on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+    RELEASE_LOG(SystemPreview, "SystemPreview load has started on %lld", m_systemPreviewInfo.element.elementIdentifier ? m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
     m_localFileURL = localFileURL;
 
     // Take the local URL, but add on the fragment from the original request URL.
@@ -490,7 +490,7 @@ void SystemPreviewController::loadStarted(const URL& localFileURL)
 
 void SystemPreviewController::loadCompleted(const URL& localFileURL)
 {
-    RELEASE_LOG(SystemPreview, "SystemPreview load has finished on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+    RELEASE_LOG(SystemPreview, "SystemPreview load has finished on %lld", m_systemPreviewInfo.element.elementIdentifier ? m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
 
     ASSERT(equalIgnoringFragmentIdentifier(m_localFileURL, localFileURL));
 
@@ -511,7 +511,7 @@ void SystemPreviewController::loadCompleted(const URL& localFileURL)
 
 void SystemPreviewController::loadFailed()
 {
-    RELEASE_LOG(SystemPreview, "SystemPreview load has failed on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+    RELEASE_LOG(SystemPreview, "SystemPreview load has failed on %lld", m_systemPreviewInfo.element.elementIdentifier ? m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
 
 #if PLATFORM(VISION)
     if (m_state == State::Loading && [getASVLaunchPreviewClass() respondsToSelector:@selector(cancelPreviewApplicationWithURLs:error:completion:)])
@@ -538,7 +538,7 @@ void SystemPreviewController::loadFailed()
 
 void SystemPreviewController::end()
 {
-    RELEASE_LOG(SystemPreview, "SystemPreview ended on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+    RELEASE_LOG(SystemPreview, "SystemPreview ended on %lld", m_systemPreviewInfo.element.elementIdentifier ? m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
 
 #if !PLATFORM(VISION)
     m_qlPreviewControllerDelegate = nullptr;
@@ -586,7 +586,7 @@ void SystemPreviewController::setCompletionHandlerForLoadTesting(CompletionHandl
 
 void SystemPreviewController::triggerSystemPreviewAction()
 {
-    RELEASE_LOG(SystemPreview, "SystemPreview action was triggered on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+    RELEASE_LOG(SystemPreview, "SystemPreview action was triggered on %lld", m_systemPreviewInfo.element.elementIdentifier ? m_systemPreviewInfo.element.elementIdentifier->toUInt64() : 0);
 
     page().systemPreviewActionTriggered(m_systemPreviewInfo, "_apple_ar_quicklook_button_tapped"_s);
 }
@@ -599,7 +599,10 @@ void SystemPreviewController::triggerSystemPreviewActionWithTargetForTesting(uin
         return;
 
     m_systemPreviewInfo.isPreview = true;
-    m_systemPreviewInfo.element.elementIdentifier = LegacyNullableObjectIdentifier<WebCore::ElementIdentifierType>(elementID);
+    if (elementID)
+        m_systemPreviewInfo.element.elementIdentifier = ObjectIdentifier<WebCore::ElementIdentifierType>(elementID);
+    else
+        m_systemPreviewInfo.element.elementIdentifier = std::nullopt;
     m_systemPreviewInfo.element.documentIdentifier = { *uuid, m_webPageProxy.legacyMainFrameProcess().coreProcessIdentifier() };
     m_systemPreviewInfo.element.webPageIdentifier = LegacyNullableObjectIdentifier<WebCore::PageIdentifierType>(pageID);
     triggerSystemPreviewAction();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -576,7 +576,6 @@ void NetworkProcessProxy::didBlockLoadToKnownTracker(WebPageProxyIdentifier page
 
 void NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation(WebPageProxyIdentifier pageID, WebCore::NavigationIdentifier navigationID, BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, const WebCore::RegistrableDomain& responseDomain, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&& completionHandler)
 {
-    ASSERT(navigationID);
     RELEASE_LOG(ProcessSwapping, "%p - NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation: pageID=%" PRIu64 ", navigationID=%" PRIu64 ", browsingContextGroupSwitchDecision=%u, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, this, pageID.toUInt64(), navigationID.toUInt64(), (unsigned)browsingContextGroupSwitchDecision, existingNetworkResourceLoadIdentifierToResume.toUInt64());
     if (auto page = pageID ? WebProcessProxy::webPage(pageID) : nullptr)
         page->triggerBrowsingContextGroupSwitchForNavigation(navigationID, browsingContextGroupSwitchDecision, responseDomain, existingNetworkResourceLoadIdentifierToResume, WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -329,7 +329,7 @@ inline bool ProvisionalPageProxy::validateInput(FrameIdentifier frameID, const s
     if (!m_mainFrame || m_mainFrame->frameID() != frameID)
         return false;
 
-    return !navigationID || !*navigationID || *navigationID == m_navigationID;
+    return !navigationID || *navigationID == m_navigationID;
 }
 
 void ProvisionalPageProxy::didPerformClientRedirect(const String& sourceURLString, const String& destinationURLString, FrameIdentifier frameID)

--- a/Source/WebKit/UIProcess/WebNavigationState.cpp
+++ b/Source/WebKit/UIProcess/WebNavigationState.cpp
@@ -91,13 +91,11 @@ Ref<API::Navigation> WebNavigationState::createSimulatedLoadWithDataNavigation(W
 
 API::Navigation* WebNavigationState::navigation(WebCore::NavigationIdentifier navigationID)
 {
-    RELEASE_ASSERT(navigationID);
     return m_navigations.get(navigationID);
 }
 
 RefPtr<API::Navigation> WebNavigationState::takeNavigation(WebCore::NavigationIdentifier navigationID)
 {
-    RELEASE_ASSERT(navigationID);
     ASSERT(m_navigations.contains(navigationID));
     
     return m_navigations.take(navigationID);
@@ -105,7 +103,6 @@ RefPtr<API::Navigation> WebNavigationState::takeNavigation(WebCore::NavigationId
 
 void WebNavigationState::didDestroyNavigation(WebCore::ProcessIdentifier processID, WebCore::NavigationIdentifier navigationID)
 {
-    RELEASE_ASSERT(navigationID);
     auto it = m_navigations.find(navigationID);
     if (it != m_navigations.end() && (*it).value->processID() == processID)
         m_navigations.remove(it);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -75,11 +75,10 @@ struct TileForGridHash {
 };
 
 template<> struct HashTraits<WebKit::TileForGrid> : GenericHashTraits<WebKit::TileForGrid> {
-    static const bool emptyValueIsZero = false;
-    static WebKit::TileForGrid emptyValue()  { return { WebCore::TileGridIdentifier { std::numeric_limits<uint64_t>::max() }, { -1, -1 } }; }
-    static WebKit::TileForGrid deletedValue() { return { WebCore::TileGridIdentifier { 0 }, { -1, -1 } }; }
-    static void constructDeletedValue(WebKit::TileForGrid& tileForGrid) { tileForGrid = deletedValue(); }
-    static bool isDeletedValue(const WebKit::TileForGrid& tileForGrid) { return tileForGrid == deletedValue(); }
+    static constexpr bool emptyValueIsZero = true;
+    static WebKit::TileForGrid emptyValue() { return { HashTraits<WebCore::TileGridIdentifier>::emptyValue(), { 0, 0 } }; }
+    static void constructDeletedValue(WebKit::TileForGrid& tileForGrid) { HashTraits<WebCore::TileGridIdentifier>::constructDeletedValue(tileForGrid.gridIdentifier); }
+    static bool isDeletedValue(const WebKit::TileForGrid& tileForGrid) { return tileForGrid.gridIdentifier.isHashTableDeletedValue(); }
 };
 template<> struct DefaultHash<WebKit::TileForGrid> : TileForGridHash { };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -215,10 +215,8 @@ void WebLocalFrameLoaderClient::detachedFromParent3()
 
 void WebLocalFrameLoaderClient::documentLoaderDetached(WebCore::NavigationIdentifier navigationID, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
-    if (RefPtr page = m_frame->page(); page && loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No) {
-        ASSERT(navigationID);
+    if (RefPtr page = m_frame->page(); page && loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No)
         page->send(Messages::WebPageProxy::DidDestroyNavigation(navigationID));
-    }
 }
 
 void WebLocalFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceRequest& request)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8642,7 +8642,7 @@ RefPtr<Element> WebPage::elementForContext(const ElementContext& elementContext)
     if (elementContext.webPageIdentifier != m_identifier)
         return nullptr;
 
-    RefPtr element = Element::fromIdentifier(elementContext.elementIdentifier);
+    RefPtr element = elementContext.elementIdentifier ? Element::fromIdentifier(*elementContext.elementIdentifier) : nullptr;
     if (!element)
         return nullptr;
 


### PR DESCRIPTION
#### 46ad92f74292ea05158ea59c554642b739a2e8f2
<pre>
Stop using a LegacyNullableObjectIdentifier for ElementIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=278278">https://bugs.webkit.org/show_bug.cgi?id=278278</a>

Reviewed by Brady Eidson.

Stop using a LegacyNullableObjectIdentifier for ElementIdentifier and
use an ObjectIdentifier instead.

* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifierGenericBase&lt;uint64_t&gt;::toRawValue const):
(WTF::ObjectIdentifierGenericBase&lt;UUID&gt;::toRawValue const):
(WTF::ObjectIdentifierGeneric::ObjectIdentifierGeneric):
(WTF::ObjectIdentifierGeneric::requires):
(WTF::ObjectIdentifierGeneric::MarkableTraits::isEmptyValue):
(WTF::ObjectIdentifierGenericBase&lt;uint64_t&gt;::operator bool const): Deleted.
(WTF::ObjectIdentifierGenericBase&lt;UUID&gt;::operator bool const): Deleted.
* Source/WebCore/dom/ElementIdentifier.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setNavigationID):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
(WebCore::ElementTargetingController::resetVisibilityAdjustments):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::preserveCurrentTargetForAxis):
(WebCore::ScrollSnapAnimatorState::currentlySnappedBoxes const):
(WebCore::chooseBoxToResnapTo):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isElementAlive const):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm:
(-[_WKTextInputContext boundingRect]):
(-[_WKTextInputContext _textInputContext]):
(-[_WKTextInputContext isEqual:]):
(-[_WKTextInputContext hash]):
* Source/WebKit/UIProcess/Cocoa/WKTextPlaceholder.mm:
(-[WKTextPlaceholder elementContext]):
(-[WKTextPlaceholder rects]):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::validateInput):
* Source/WebKit/UIProcess/WebNavigationState.cpp:
(WebKit::WebNavigationState::navigation):
(WebKit::WebNavigationState::takeNavigation):
(WebKit::WebNavigationState::didDestroyNavigation):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::documentLoaderDetached):

Canonical link: <a href="https://commits.webkit.org/282407@main">https://commits.webkit.org/282407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fbfb411995b873338e443f054fbd1974aa5236e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50828 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12556 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56186 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68792 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62319 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58141 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58352 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5857 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84082 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38252 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14810 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->