### PR TITLE
CSP: External script with matching SRI hash is blocked when 'strict-dynamic' is present in script-src

### DIFF
--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -271,7 +271,6 @@ void ContentSecurityPolicy::didReceiveHeader(const String& header, ContentSecuri
             begin = buffer.position();
         }
     });
-    
 
     if (m_scriptExecutionContext)
         applyPolicyToScriptExecutionContext();
@@ -413,7 +412,7 @@ static Vector<ContentSecurityPolicyHash> generateHashesForContent(const StringVi
 bool ContentSecurityPolicy::allowJavaScriptURLs(const String& contextURL, const OrdinalNumber& contextLine, const String& source, Element* element) const
 {
     bool didNotifyInspector = false;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, URL(), "Refused to execute a script"_s, "its hash or 'unsafe-inline'"_s);
         reportViolation(violatedDirective, "inline"_s, consoleMessage, contextURL, source, TextPosition(contextLine, OrdinalNumber()), URL(), nullptr, element);
         if (!didNotifyInspector && violatedDirective.directiveList().isReportOnly()) {
@@ -431,7 +430,7 @@ bool ContentSecurityPolicy::allowInlineEventHandlers(const String& contextURL, c
     if (overrideContentSecurityPolicy || m_policies.isEmpty())
         return true;
     bool didNotifyInspector = false;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, URL(), "Refused to execute a script for an inline event handler"_s, "'unsafe-inline'"_s);
         reportViolation(violatedDirective, "inline"_s, consoleMessage, contextURL, source, TextPosition(contextLine, OrdinalNumber()), URL(), nullptr, element);
         if (!didNotifyInspector && !violatedDirective.directiveList().isReportOnly()) {
@@ -479,10 +478,10 @@ bool ContentSecurityPolicy::shouldPerformEarlyCSPCheck() const
 
 bool ContentSecurityPolicy::allowNonParserInsertedScripts(const URL& sourceURL, const URL& contextURL, const OrdinalNumber& contextLine, const String& nonce, const StringView& scriptContent, ParserInserted parserInserted) const
 {
-    if (!shouldPerformEarlyCSPCheck() || m_policies.isEmpty())
+    if (shouldPerformEarlyCSPCheck() || m_policies.isEmpty())
         return true;
 
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         TextPosition sourcePosition(contextLine, OrdinalNumber());
         const auto message = sourceURL.isEmpty() ? "Refused to execute a script"_s : "Refused to load"_s;
         String consoleMessage = consoleMessageForViolation(violatedDirective, sourceURL, message);
@@ -499,7 +498,7 @@ bool ContentSecurityPolicy::allowInlineScript(const String& contextURL, const Or
     if (overrideContentSecurityPolicy || shouldPerformEarlyCSPCheck() || m_policies.isEmpty())
         return true;
     bool didNotifyInspector = false;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, URL(), "Refused to execute a script"_s, "its hash, its nonce, or 'unsafe-inline'"_s);
         reportViolation(violatedDirective, "inline"_s, consoleMessage, contextURL, scriptContent, TextPosition(contextLine, OrdinalNumber()), URL(), nullptr, &element);
         if (!didNotifyInspector && !violatedDirective.directiveList().isReportOnly()) {
@@ -519,7 +518,7 @@ bool ContentSecurityPolicy::allowInlineStyle(const String& contextURL, const Ord
         return true;
     if (m_overrideInlineStyleAllowed)
         return true;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, URL(), "Refused to apply a stylesheet"_s, "its hash, its nonce, or 'unsafe-inline'"_s);
         reportViolation(violatedDirective, "inline"_s, consoleMessage, contextURL, styleContent, TextPosition(contextLine, OrdinalNumber()), URL(), nullptr, &element);
     };
@@ -538,7 +537,7 @@ bool ContentSecurityPolicy::allowEval(JSC::JSGlobalObject* state, LogToConsole s
     if (m_policies.isEmpty() || overrideContentSecurityPolicy)
         return true;
     bool didNotifyInspector = false;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = shouldLogToConsole == LogToConsole::Yes ? consoleMessageForViolation(violatedDirective, URL(), "Refused to execute a script"_s, "'unsafe-eval'"_s) : String();
         reportViolation(violatedDirective, "eval"_s, consoleMessage, state, codeContent);
         if (!didNotifyInspector && !violatedDirective.directiveList().isReportOnly()) {
@@ -558,7 +557,7 @@ bool ContentSecurityPolicy::allowFrameAncestors(const LocalFrame& frame, const U
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, url.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -586,7 +585,7 @@ bool ContentSecurityPolicy::allowFrameAncestors(const Vector<Ref<SecurityOrigin>
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, url.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -599,7 +598,7 @@ bool ContentSecurityPolicy::allowPluginType(const String& type, const String& ty
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s, "its MIME type"_s);
         reportViolation(violatedDirective, url.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -616,7 +615,7 @@ bool ContentSecurityPolicy::allowObjectFromSource(const URL& url, RedirectRespon
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
     const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -629,7 +628,7 @@ bool ContentSecurityPolicy::allowChildFrameFromSource(const URL& url, RedirectRe
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, url.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -643,7 +642,7 @@ bool ContentSecurityPolicy::allowResourceFromSource(const URL& url, RedirectResp
     String sourceURL;
     const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -658,7 +657,7 @@ bool ContentSecurityPolicy::allowWorkerFromSource(const URL& url, RedirectRespon
     String sourceURL;
     const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         auto consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -676,7 +675,7 @@ bool ContentSecurityPolicy::allowScriptFromSource(const URL& url, RedirectRespon
     String sourceURL;
     const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -703,7 +702,7 @@ bool ContentSecurityPolicy::allowStyleFromSource(const URL& url, RedirectRespons
     String sourceURL;
     const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
         reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -735,7 +734,7 @@ bool ContentSecurityPolicy::allowConnectToSource(const URL& url, RedirectRespons
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to connect to"_s);
         reportViolation(violatedDirective, url.string(), consoleMessage, sourceURL, StringView(), sourcePosition, preRedirectURL);
     };
@@ -755,7 +754,7 @@ bool ContentSecurityPolicy::allowBaseURI(const URL& url, bool overrideContentSec
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to change the document base URL to"_s);
         reportViolation(violatedDirective, url.string(), consoleMessage, sourceURL, StringView(), sourcePosition);
     };
@@ -767,7 +766,7 @@ AllowTrustedTypePolicy ContentSecurityPolicy::allowTrustedTypesPolicy(const Stri
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());
     AllowTrustedTypePolicy details = AllowTrustedTypePolicy::Allowed;
-    auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
+    auto handleViolatedDirective = [&](const ContentSecurityPolicyDirective& violatedDirective) {
         String consoleMessage = makeString(violatedDirective.directiveList().isReportOnly() ? "[Report Only] "_s : ""_s,
             "Refused to create a TrustedTypePolicy named '"_s, value, "' because it violates the following Content Security Policy directive: \""_s, violatedDirective.text(), '"');
         reportViolation(violatedDirective, "trusted-types-policy"_s, consoleMessage, sourceURL, StringView(value), sourcePosition);
@@ -907,7 +906,7 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
 
     // FIXME: Is it policy to not use the status code for HTTPS, or is that a bug?
     unsigned short httpStatusCode = m_selfSourceProtocol == "http"_s ? m_httpStatusCode : 0;
-    
+
     // WPT indicate modern Reporting API expect valid status code, regardless of protocol:
     //     content-security-policy/reporting-api/report-to-directive-allowed-in-meta.https.sub.html
     //     content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html
@@ -932,7 +931,7 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
 
     violationEventInit.disposition = violatedDirectiveList.isReportOnly() ? SecurityPolicyViolationEventDisposition::Report : SecurityPolicyViolationEventDisposition::Enforce;
     violationEventInit.statusCode = httpStatusCode;
-    violationEventInit.lineNumber =  info.lineNumber;
+    violationEventInit.lineNumber = info.lineNumber;
     violationEventInit.columnNumber = info.columnNumber;
     violationEventInit.sample = info.sample;
     violationEventInit.bubbles = true;
@@ -1151,7 +1150,7 @@ void ContentSecurityPolicy::setUpgradeInsecureRequests(bool upgradeInsecureReque
         upgradeURL.setProtocol("http"_s);
     else if (upgradeURL.protocolIs("wss"_s))
         upgradeURL.setProtocol("ws"_s);
-    
+
     m_insecureNavigationRequestsToUpgrade.add(SecurityOriginData::fromURL(upgradeURL));
 }
 


### PR DESCRIPTION
#### 6d16cbfb00aef33414c93296f273b755a7e8c081
<pre>
CSP: External script with matching SRI hash is blocked when &apos;strict-dynamic&apos; is present in script-src

<a href="https://bugs.webkit.org/show_bug.cgi?id=270784">https://bugs.webkit.org/show_bug.cgi?id=270784</a>
<a href="https://rdar.apple.com/problem/124410909">rdar://problem/124410909</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

This addresses an issue where Safari was unexpectedly blocking external
scripts with valid SRI hashes when the &apos;strict-dynamic&apos; directive was
included in the CSP.

Amend changes:

Combined changes:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::copyStateFrom):
(WebCore::ContentSecurityPolicy::inheritHeadersFrom):
(WebCore::ContentSecurityPolicy::createPolicyForPluginDocumentFrom):
(WebCore::ContentSecurityPolicy::didReceiveHeaders):
(WebCore::ContentSecurityPolicy::didReceiveHeader):
(WebCore::parseSubResourceIntegrityIntoDigests):
(WebCore::generateHashesForContent):
(WebCore::ContentSecurityPolicy::allowJavaScriptURLs const):
(WebCore::ContentSecurityPolicy::allowInlineEventHandlers const):
(WebCore::ContentSecurityPolicy::allowNonParserInsertedScripts const):
(WebCore::ContentSecurityPolicy::allowInlineScript const):
(WebCore::ContentSecurityPolicy::allowInlineStyle const):
(WebCore::ContentSecurityPolicy::allowEval const):
(WebCore::ContentSecurityPolicy::allowFrameAncestors const):
(WebCore::ContentSecurityPolicy::allowPluginType const):
(WebCore::ContentSecurityPolicy::allowObjectFromSource const):
(WebCore::ContentSecurityPolicy::allowChildFrameFromSource const):
(WebCore::ContentSecurityPolicy::allowResourceFromSource const):
(WebCore::ContentSecurityPolicy::allowWorkerFromSource const):
(WebCore::ContentSecurityPolicy::allowScriptFromSource const):
(WebCore::ContentSecurityPolicy::allowStyleFromSource const):
(WebCore::ContentSecurityPolicy::allowConnectToSource const):
(WebCore::ContentSecurityPolicy::allowBaseURI const):
(WebCore::ContentSecurityPolicy::allowTrustedTypesPolicy const):
(WebCore::ContentSecurityPolicy::createURLForReporting const):
(WebCore::ContentSecurityPolicy::reportViolation const):
(WebCore::ContentSecurityPolicy::setUpgradeInsecureRequests):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d16cbfb00aef33414c93296f273b755a7e8c081

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13952 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50814 "Found 21 new test failures: imported/w3c/web-platform-tests/content-security-policy/default-src/default-src-strict_dynamic_and_unsafe_inline.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-report-only-policy-works-with-external-hash-policy.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_discard_source_expressions.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html ... (failure)") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66133 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39397 "Found 60 new test failures: editing/selection/ios/look-up-selected-text.html http/tests/app-privacy-report/app-attribution-beacon-isappinitiated.html http/tests/blink/sendbeacon/beacon-cookie.html http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31500 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36082 "Found 21 new test failures: imported/w3c/web-platform-tests/content-security-policy/default-src/default-src-strict_dynamic_and_unsafe_inline.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_discard_source_expressions.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_double_policy_honor_source_expressions.sub.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11950 "Found 60 new test failures: fonts/font-weight-invalid-crash.html fonts/ligature.html fullscreen/full-screen-document-background-color.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57622 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12279 "Found 60 new test failures: http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7010 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11892 "Found 60 new test failures: fast/forms/password-scrolled-after-caps-lock-toggled.html http/tests/media/fairplay/fps-mse-multi-key-renewal.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58127 "Found 82 new test failures: http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58336 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5844 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->