### PR TITLE
[JSC] Not using PolymorphicAccess in Handler IC

### DIFF
--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
@@ -90,10 +90,9 @@ CheckPrivateBrandStatus::CheckPrivateBrandStatus(StubInfoSummary summary, Struct
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-CheckPrivateBrandStatus CheckPrivateBrandStatus::computeForStubInfoWithoutExitSiteFeedback(
-    const ConcurrentJSLocker&, CodeBlock* block, StructureStubInfo* stubInfo)
+CheckPrivateBrandStatus CheckPrivateBrandStatus::computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker& locker, CodeBlock* block, StructureStubInfo* stubInfo)
 {
-    StubInfoSummary summary = StructureStubInfo::summary(block->vm(), stubInfo);
+    StubInfoSummary summary = StructureStubInfo::summary(locker, block->vm(), stubInfo);
     if (!isInlineable(summary))
         return CheckPrivateBrandStatus(summary, *stubInfo);
 
@@ -104,9 +103,9 @@ CheckPrivateBrandStatus CheckPrivateBrandStatus::computeForStubInfoWithoutExitSi
         return CheckPrivateBrandStatus(NoInformation);
 
     case CacheType::Stub: {
-        PolymorphicAccess* list = stubInfo->m_stub.get();
-        for (unsigned listIndex = 0; listIndex < list->size(); ++listIndex) {
-            const AccessCase& access = list->at(listIndex);
+        auto list = stubInfo->listedAccessCases(locker);
+        for (unsigned listIndex = 0; listIndex < list.size(); ++listIndex) {
+            const AccessCase& access = *list.at(listIndex);
 
             Structure* structure = access.structure();
             ASSERT(structure);

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -130,7 +130,7 @@ class PolymorphicAccess {
 public:
     friend class InlineCacheCompiler;
 
-    using ListType = Vector<Ref<AccessCase>, 16>;
+    using ListType = Vector<Ref<AccessCase>, 4>;
 
     PolymorphicAccess();
     ~PolymorphicAccess();
@@ -143,6 +143,8 @@ public:
     unsigned size() const { return m_list.size(); }
     const AccessCase& at(unsigned i) const { return m_list[i].get(); }
     const AccessCase& operator[](unsigned i) const { return m_list[i].get(); }
+    AccessCase& at(unsigned i) { return m_list[i].get(); }
+    AccessCase& operator[](unsigned i) { return m_list[i].get(); }
 
     DECLARE_VISIT_AGGREGATE;
 
@@ -235,6 +237,12 @@ public:
     StructureID newStructureID() const { return u.s2.m_newStructureID; }
 
     CacheType cacheType() const { return m_cacheType; }
+
+    DECLARE_VISIT_AGGREGATE;
+
+    // This returns true if it has marked everything it will ever marked. This can be used as an
+    // optimization to then avoid calling this method again during the fixpoint.
+    template<typename Visitor> void propagateTransitions(Visitor&) const;
 
 private:
     InlineCacheHandler()
@@ -382,7 +390,7 @@ public:
     VM& vm() { return m_vm; }
 
     AccessGenerationResult compile(const GCSafeConcurrentJSLocker&, PolymorphicAccess&, CodeBlock*);
-    AccessGenerationResult compileHandler(const GCSafeConcurrentJSLocker&, PolymorphicAccess&, CodeBlock*, Ref<AccessCase>&&);
+    AccessGenerationResult compileHandler(const GCSafeConcurrentJSLocker&, Vector<AccessCase*, 16>&&, CodeBlock*, AccessCase&);
 
     static MacroAssemblerCodeRef<JITThunkPtrTag> generateSlowPathCode(VM&, AccessType);
     static Ref<InlineCacheHandler> generateSlowPathHandler(VM&, AccessType);
@@ -399,7 +407,7 @@ private:
     CallSiteIndex callSiteIndexForExceptionHandlingOrOriginal();
     const ScalarRegisterSet& liveRegistersToPreserveAtExceptionHandlingCallSite();
 
-    AccessGenerationResult compileOneAccessCaseHandler(PolymorphicAccess&, CodeBlock*, AccessCase&, Vector<WatchpointSet*, 8>&&);
+    AccessGenerationResult compileOneAccessCaseHandler(const Vector<AccessCase*, 16>&, CodeBlock*, AccessCase&, Vector<WatchpointSet*, 8>&&);
 
     void emitDOMJITGetter(JSGlobalObject*, const DOMJIT::GetterSetter*, GPRReg baseForGetGPR);
     void emitModuleNamespaceLoad(ModuleNamespaceAccessCase&, MacroAssembler::JumpList& fallThrough);
@@ -410,7 +418,7 @@ private:
     void generateAccessCase(unsigned index, AccessCase&);
 
     MacroAssemblerCodeRef<JITStubRoutinePtrTag> compileGetByDOMJITHandler(CodeBlock*, const DOMJIT::GetterSetter*, std::optional<bool> isSymbol);
-    RefPtr<AccessCase> tryFoldToMegamorphic(CodeBlock*, std::span<const Ref<AccessCase>>);
+    template<typename Container> RefPtr<AccessCase> tryFoldToMegamorphic(CodeBlock*, const Container&);
 
     VM& m_vm;
     JSGlobalObject* const m_globalObject;

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
@@ -90,10 +90,9 @@ SetPrivateBrandStatus::SetPrivateBrandStatus(StubInfoSummary summary, StructureS
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-SetPrivateBrandStatus SetPrivateBrandStatus::computeForStubInfoWithoutExitSiteFeedback(
-    const ConcurrentJSLocker&, CodeBlock* block, StructureStubInfo* stubInfo)
+SetPrivateBrandStatus SetPrivateBrandStatus::computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker& locker, CodeBlock* block, StructureStubInfo* stubInfo)
 {
-    StubInfoSummary summary = StructureStubInfo::summary(block->vm(), stubInfo);
+    StubInfoSummary summary = StructureStubInfo::summary(locker, block->vm(), stubInfo);
     if (!isInlineable(summary))
         return SetPrivateBrandStatus(summary, *stubInfo);
 
@@ -104,10 +103,10 @@ SetPrivateBrandStatus SetPrivateBrandStatus::computeForStubInfoWithoutExitSiteFe
         return SetPrivateBrandStatus(NoInformation);
 
     case CacheType::Stub: {
-        PolymorphicAccess* list = stubInfo->m_stub.get();
+        auto list = stubInfo->listedAccessCases(locker);
 
-        for (unsigned listIndex = 0; listIndex < list->size(); ++listIndex) {
-            const AccessCase& access = list->at(listIndex);
+        for (unsigned listIndex = 0; listIndex < list.size(); ++listIndex) {
+            const AccessCase& access = *list.at(listIndex);
 
             Structure* structure = access.structure();
             ASSERT(structure);

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -144,9 +144,9 @@ public:
     // This returns true if it has marked everything that it will ever mark.
     template<typename Visitor> void propagateTransitions(Visitor&);
         
-    StubInfoSummary summary(VM&) const;
+    StubInfoSummary summary(const ConcurrentJSLocker&, VM&) const;
     
-    static StubInfoSummary summary(VM&, const StructureStubInfo*);
+    static StubInfoSummary summary(const ConcurrentJSLocker&, VM&, const StructureStubInfo*);
 
     CacheableIdentifier identifier() const { return m_identifier; }
 
@@ -233,7 +233,11 @@ public:
 
     bool useHandlerIC() const { return useDataIC && Options::useHandlerIC(); }
 
+    Vector<AccessCase*, 16> listedAccessCases(const AbstractLocker&) const;
+
 private:
+    AccessGenerationResult upgradeForPolyProtoIfNecessary(const GCSafeConcurrentJSLocker&, VM&, CodeBlock*, const Vector<AccessCase*, 16>&, AccessCase&);
+
     ALWAYS_INLINE bool considerRepatchingCacheImpl(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
     {
         DisallowGC disallowGC;
@@ -411,8 +415,8 @@ public:
     };
 
     JSGlobalObject* m_globalObject { nullptr };
-    std::unique_ptr<PolymorphicAccess> m_stub;
 private:
+    std::unique_ptr<PolymorphicAccess> m_stub;
     RefPtr<InlineCacheHandler> m_inlinedHandler;
     RefPtr<InlineCacheHandler> m_handler;
     // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.


### PR DESCRIPTION
#### e3098206e15faab0ba2e81ceb226134f6371999a
<pre>
[JSC] Not using PolymorphicAccess in Handler IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=278283">https://bugs.webkit.org/show_bug.cgi?id=278283</a>
<a href="https://rdar.apple.com/134159625">rdar://134159625</a>

Reviewed by Yijia Huang.

Handler IC is already keeping AccessCase information in handlers. Thus PolymorphicAccess is unnecessary abstraction.
This patch refactors the architecture so that we no longer have PolymorphicAccess in Handler IC. Once FTL moves to Handler IC,
64bit IC will completely remove PolymorphicAccess, using chain of handlers.

* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp:
(JSC::CheckPrivateBrandStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/DeleteByStatus.cpp:
(JSC::DeleteByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
(JSC::InByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::propagateTransitions const):
(JSC::InlineCacheHandler::visitAggregateImpl):
(JSC::InlineCacheCompiler::tryFoldToMegamorphic):
(JSC::InlineCacheCompiler::compileHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::InlineCacheHandler::visitWeak):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
(JSC::PolymorphicAccess::at):
(JSC::PolymorphicAccess::operator[]):
* Source/JavaScriptCore/bytecode/InstanceOfStatus.cpp:
(JSC::InstanceOfStatus::computeForStubInfo):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp:
(JSC::SetPrivateBrandStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::upgradeForPolyProtoIfNecessary):
(JSC::StructureStubInfo::addAccessCase):
(JSC::StructureStubInfo::reset):
(JSC::StructureStubInfo::visitAggregateImpl):
(JSC::StructureStubInfo::visitWeakReferences):
(JSC::StructureStubInfo::propagateTransitions):
(JSC::StructureStubInfo::summary const):
(JSC::StructureStubInfo::summary):
(JSC::StructureStubInfo::containsPC const):
(JSC::StructureStubInfo::listedAccessCases const):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:

Canonical link: <a href="https://commits.webkit.org/282431@main">https://commits.webkit.org/282431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae0370c2ff453b6d881edfffec3ef8183bf280aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50821 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9430 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11956 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12550 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56180 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68786 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62313 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58134 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58345 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5849 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84076 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9529 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38246 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->