### PR TITLE
[JSC] Remove obsoleted Temporal.Instant API

### DIFF
--- a/JSTests/stress/date-to-temporal-instant.js
+++ b/JSTests/stress/date-to-temporal-instant.js
@@ -40,9 +40,7 @@ function shouldThrow(func, errorType, message) {
     shouldBe(epochDateInstant.toString(), epochInstant.toString());
     shouldBe(epochDateInstant.epochNanoseconds, epochInstant.epochNanoseconds);
     
-    shouldBe(epochDateInstant.epochSeconds, 0);
     shouldBe(epochDateInstant.epochMilliseconds, 0);
-    shouldBe(epochDateInstant.epochMicroseconds, 0n);
     shouldBe(epochDateInstant.epochNanoseconds, 0n);
 
 }
@@ -54,9 +52,7 @@ function shouldThrow(func, errorType, message) {
     shouldBe(dateToInstant.toString(), temporalInstant.toString());
     shouldBe(dateToInstant.epochNanoseconds, temporalInstant.epochNanoseconds);
     
-    shouldBe(dateToInstant.epochSeconds, 1_000_000_000);
     shouldBe(dateToInstant.epochMilliseconds, 1_000_000_000_000);
-    shouldBe(dateToInstant.epochMicroseconds, 1_000_000_000_000_000n);
     shouldBe(dateToInstant.epochNanoseconds, 1_000_000_000_000_000_000n);
 }
 
@@ -67,9 +63,7 @@ function shouldThrow(func, errorType, message) {
     shouldBe(dateToInstant.toString(), temporalInstant.toString());
     shouldBe(dateToInstant.epochNanoseconds, temporalInstant.epochNanoseconds);
 
-    shouldBe(dateToInstant.epochSeconds, -1_000_000_000);
     shouldBe(dateToInstant.epochMilliseconds, -1_000_000_000_000);
-    shouldBe(dateToInstant.epochMicroseconds, -1_000_000_000_000_000n);
     shouldBe(dateToInstant.epochNanoseconds, -1_000_000_000_000_000_000n);
 }
 
@@ -80,9 +74,7 @@ function shouldThrow(func, errorType, message) {
     shouldBe(dateToInstant.toString(), temporalInstant.toString());
     shouldBe(dateToInstant.epochNanoseconds, temporalInstant.epochNanoseconds);
     
-    shouldBe(dateToInstant.epochSeconds, 86400_0000_0000);
     shouldBe(dateToInstant.epochMilliseconds, 86400_0000_0000_000);
-    shouldBe(dateToInstant.epochMicroseconds, 86400_0000_0000_000_000n);
     shouldBe(dateToInstant.epochNanoseconds, 86400_0000_0000_000_000_000n);
 }
 
@@ -93,8 +85,6 @@ function shouldThrow(func, errorType, message) {
     shouldBe(dateToInstant.toString(), temporalInstant.toString());
     shouldBe(dateToInstant.epochNanoseconds, temporalInstant.epochNanoseconds);
     
-    shouldBe(dateToInstant.epochSeconds, -86400_0000_0000);
     shouldBe(dateToInstant.epochMilliseconds, -86400_0000_0000_000);
-    shouldBe(dateToInstant.epochMicroseconds, -86400_0000_0000_000_000n);
     shouldBe(dateToInstant.epochNanoseconds, -86400_0000_0000_000_000_000n);
 }

--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -34,16 +34,12 @@ function shouldThrow(func, errorType, message) {
 {
     const instants = [
         new Temporal.Instant(0n),
-        Temporal.Instant.fromEpochSeconds(0),
         Temporal.Instant.fromEpochMilliseconds(0),
-        Temporal.Instant.fromEpochMicroseconds(0n),
         Temporal.Instant.fromEpochNanoseconds(0n),
         Temporal.Instant.from('1970-01-01T00:00:00Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, 0);
         shouldBe(instant.epochMilliseconds, 0);
-        shouldBe(instant.epochMicroseconds, 0n);
         shouldBe(instant.epochNanoseconds, 0n);
         shouldBe(instant.toString(), '1970-01-01T00:00:00Z');
         shouldBe(instant.toJSON(), '1970-01-01T00:00:00Z');
@@ -54,16 +50,12 @@ function shouldThrow(func, errorType, message) {
 {
     const instants = [
         new Temporal.Instant(1_000_000_000_000_000_000n),
-        Temporal.Instant.fromEpochSeconds(1_000_000_000),
         Temporal.Instant.fromEpochMilliseconds(1_000_000_000_000),
-        Temporal.Instant.fromEpochMicroseconds(1_000_000_000_000_000n),
         Temporal.Instant.fromEpochNanoseconds(1_000_000_000_000_000_000n),
         Temporal.Instant.from('2001-09-09T01:46:40Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, 1_000_000_000);
         shouldBe(instant.epochMilliseconds, 1_000_000_000_000);
-        shouldBe(instant.epochMicroseconds, 1_000_000_000_000_000n);
         shouldBe(instant.epochNanoseconds, 1_000_000_000_000_000_000n);
         shouldBe(instant.toString(), '2001-09-09T01:46:40Z');
         shouldBe(instant.toJSON(), '2001-09-09T01:46:40Z');
@@ -74,16 +66,12 @@ function shouldThrow(func, errorType, message) {
 {
     const instants = [
         new Temporal.Instant(-1_000_000_000_000_000_000n),
-        Temporal.Instant.fromEpochSeconds(-1_000_000_000),
         Temporal.Instant.fromEpochMilliseconds(-1_000_000_000_000),
-        Temporal.Instant.fromEpochMicroseconds(-1_000_000_000_000_000n),
         Temporal.Instant.fromEpochNanoseconds(-1_000_000_000_000_000_000n),
         Temporal.Instant.from('1938-04-24T22:13:20Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, -1_000_000_000);
         shouldBe(instant.epochMilliseconds, -1_000_000_000_000);
-        shouldBe(instant.epochMicroseconds, -1_000_000_000_000_000n);
         shouldBe(instant.epochNanoseconds, -1_000_000_000_000_000_000n);
         shouldBe(instant.toString(), '1938-04-24T22:13:20Z');
         shouldBe(instant.toJSON(), '1938-04-24T22:13:20Z');
@@ -98,9 +86,7 @@ function shouldThrow(func, errorType, message) {
         Temporal.Instant.from('2262-04-11T23:47:16.854775807Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, 9223372036);
         shouldBe(instant.epochMilliseconds, 9223372036854);
-        shouldBe(instant.epochMicroseconds, 9223372036854775n);
         shouldBe(instant.epochNanoseconds, 9223372036854775807n);
         shouldBe(instant.toString(), '2262-04-11T23:47:16.854775807Z');
         shouldBe(instant.toJSON(), '2262-04-11T23:47:16.854775807Z');
@@ -115,9 +101,7 @@ function shouldThrow(func, errorType, message) {
         Temporal.Instant.from('1677-09-21T00:12:43.145224192Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, -9223372036);
         shouldBe(instant.epochMilliseconds, -9223372036854);
-        shouldBe(instant.epochMicroseconds, -9223372036854775n);
         shouldBe(instant.epochNanoseconds, -9223372036854775808n);
         shouldBe(instant.toString(), '1677-09-21T00:12:43.145224192Z');
         shouldBe(instant.toJSON(), '1677-09-21T00:12:43.145224192Z');
@@ -128,16 +112,12 @@ function shouldThrow(func, errorType, message) {
 {
     const instants = [
         new Temporal.Instant(86400_0000_0000_000_000_000n),
-        Temporal.Instant.fromEpochSeconds(86400_0000_0000),
         Temporal.Instant.fromEpochMilliseconds(86400_0000_0000_000),
-        Temporal.Instant.fromEpochMicroseconds(86400_0000_0000_000_000n),
         Temporal.Instant.fromEpochNanoseconds(86400_0000_0000_000_000_000n),
         Temporal.Instant.from('+275760-09-13T00:00:00Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, 86400_0000_0000);
         shouldBe(instant.epochMilliseconds, 86400_0000_0000_000);
-        shouldBe(instant.epochMicroseconds, 86400_0000_0000_000_000n);
         shouldBe(instant.epochNanoseconds, 86400_0000_0000_000_000_000n);
         shouldBe(instant.toString(), '+275760-09-13T00:00:00Z');
         shouldBe(instant.toJSON(), '+275760-09-13T00:00:00Z');
@@ -148,16 +128,12 @@ function shouldThrow(func, errorType, message) {
 {
     const instants = [
         new Temporal.Instant(-86400_0000_0000_000_000_000n),
-        Temporal.Instant.fromEpochSeconds(-86400_0000_0000),
         Temporal.Instant.fromEpochMilliseconds(-86400_0000_0000_000),
-        Temporal.Instant.fromEpochMicroseconds(-86400_0000_0000_000_000n),
         Temporal.Instant.fromEpochNanoseconds(-86400_0000_0000_000_000_000n),
         Temporal.Instant.from('-271821-04-20T00:00:00Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochSeconds, -86400_0000_0000);
         shouldBe(instant.epochMilliseconds, -86400_0000_0000_000);
-        shouldBe(instant.epochMicroseconds, -86400_0000_0000_000_000n);
         shouldBe(instant.epochNanoseconds, -86400_0000_0000_000_000_000n);
         shouldBe(instant.toString(), '-271821-04-20T00:00:00Z');
         shouldBe(instant.toJSON(), '-271821-04-20T00:00:00Z');
@@ -180,25 +156,6 @@ function shouldThrow(func, errorType, message) {
 ].forEach(([ns, messageMatch = undefined]) => {
     shouldThrow(() => new Temporal.Instant(ns), RangeError, messageMatch);
     shouldThrow(() => Temporal.Instant.fromEpochNanoseconds(ns), RangeError, messageMatch);
-});
-
-[
-    // too large
-    [86400_0000_0000_000_001n, /\b8640000000000000001\b/],
-    // too small
-    [-86400_0000_0000_000_001n, /-8640000000000000001\b/],
-    // test maxuint64 specifically
-    [1n << 64n, /\b18446744073709551616\b/],
-    // test maxuint128 specifically
-    [1n << 128n, /\b340282366920938463463374607431768211456\b/],
-    // much larger than maxint128
-    [1n << 129n, /\b680564733841876926926749214863536422912\b/],
-    // smaller than minint128
-    [-1n << 129n, /-680564733841876926926749214863536422912\b/],
-    // behaves sensibly even when the bigint is really long
-    [BigInt('9'.repeat(1000))],
-].forEach(([µs, messageMatch = undefined]) => {
-    shouldThrow(() => Temporal.Instant.fromEpochMicroseconds(µs), RangeError, messageMatch);
 });
 
 // constructs from string

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -100,31 +100,15 @@ public:
     constexpr ExactTime(const ExactTime&) = default;
     constexpr explicit ExactTime(Int128 epochNanoseconds) : m_epochNanoseconds(epochNanoseconds) { }
 
-    static constexpr ExactTime fromEpochSeconds(int64_t epochSeconds)
-    {
-        return ExactTime(Int128 { epochSeconds } * ExactTime::nsPerSecond);
-    }
     static constexpr ExactTime fromEpochMilliseconds(int64_t epochMilliseconds)
     {
         return ExactTime(Int128 { epochMilliseconds } * ExactTime::nsPerMillisecond);
     }
-    static constexpr ExactTime fromEpochMicroseconds(int64_t epochMicroseconds)
-    {
-        return ExactTime(Int128 { epochMicroseconds } * ExactTime::nsPerMicrosecond);
-    }
     static ExactTime fromISOPartsAndOffset(int32_t y, uint8_t mon, uint8_t d, unsigned h, unsigned min, unsigned s, unsigned ms, unsigned micros, unsigned ns, int64_t offset);
 
-    int64_t epochSeconds() const
-    {
-        return static_cast<int64_t>(m_epochNanoseconds / ExactTime::nsPerSecond);
-    }
     int64_t epochMilliseconds() const
     {
         return static_cast<int64_t>(m_epochNanoseconds / ExactTime::nsPerMillisecond);
-    }
-    int64_t epochMicroseconds() const
-    {
-        return static_cast<int64_t>(m_epochNanoseconds / ExactTime::nsPerMicrosecond);
     }
     constexpr Int128 epochNanoseconds() const
     {

--- a/Source/JavaScriptCore/runtime/TemporalInstant.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.h
@@ -54,9 +54,7 @@ public:
 
     static TemporalInstant* toInstant(JSGlobalObject*, JSValue);
     static TemporalInstant* from(JSGlobalObject*, JSValue);
-    static TemporalInstant* fromEpochSeconds(JSGlobalObject*, JSValue);
     static TemporalInstant* fromEpochMilliseconds(JSGlobalObject*, JSValue);
-    static TemporalInstant* fromEpochMicroseconds(JSGlobalObject*, JSValue);
     static TemporalInstant* fromEpochNanoseconds(JSGlobalObject*, JSValue);
     static JSValue compare(JSGlobalObject*, JSValue, JSValue);
 

--- a/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
@@ -36,9 +36,7 @@ namespace JSC {
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(TemporalInstantConstructor);
 
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantConstructorFuncFrom);
-static JSC_DECLARE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochSeconds);
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochMilliseconds);
-static JSC_DECLARE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochMicroseconds);
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochNanoseconds);
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantConstructorFuncCompare);
 
@@ -53,9 +51,7 @@ const ClassInfo TemporalInstantConstructor::s_info = { "Function"_s, &Base::s_in
 /* Source for TemporalInstantConstructor.lut.h
 @begin temporalInstantConstructorTable
   from                   temporalInstantConstructorFuncFrom                   DontEnum|Function 1
-  fromEpochSeconds       temporalInstantConstructorFuncFromEpochSeconds       DontEnum|Function 1
   fromEpochMilliseconds  temporalInstantConstructorFuncFromEpochMilliseconds  DontEnum|Function 1
-  fromEpochMicroseconds  temporalInstantConstructorFuncFromEpochMicroseconds  DontEnum|Function 1
   fromEpochNanoseconds   temporalInstantConstructorFuncFromEpochNanoseconds   DontEnum|Function 1
   compare                temporalInstantConstructorFuncCompare                DontEnum|Function 2
 @end
@@ -116,19 +112,9 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFrom, (JSGlobalObject* gl
     return JSValue::encode(TemporalInstant::from(globalObject, callFrame->argument(0)));
 }
 
-JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochSeconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    return JSValue::encode(TemporalInstant::fromEpochSeconds(globalObject, callFrame->argument(0)));
-}
-
 JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochMilliseconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(TemporalInstant::fromEpochMilliseconds(globalObject, callFrame->argument(0)));
-}
-
-JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochMicroseconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    return JSValue::encode(TemporalInstant::fromEpochMicroseconds(globalObject, callFrame->argument(0)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochNanoseconds, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -44,9 +44,7 @@ static JSC_DECLARE_HOST_FUNCTION(temporalInstantPrototypeFuncToString);
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantPrototypeFuncToJSON);
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantPrototypeFuncToLocaleString);
 static JSC_DECLARE_HOST_FUNCTION(temporalInstantPrototypeFuncValueOf);
-static JSC_DECLARE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochSeconds);
 static JSC_DECLARE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMilliseconds);
-static JSC_DECLARE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMicroseconds);
 static JSC_DECLARE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochNanoseconds);
 
 }
@@ -69,9 +67,7 @@ const ClassInfo TemporalInstantPrototype::s_info = { "Temporal.Instant"_s, &Base
   toJSON             temporalInstantPrototypeFuncToJSON               DontEnum|Function 0
   toLocaleString     temporalInstantPrototypeFuncToLocaleString       DontEnum|Function 0
   valueOf            temporalInstantPrototypeFuncValueOf              DontEnum|Function 0
-  epochSeconds       temporalInstantPrototypeGetterEpochSeconds       DontEnum|ReadOnly|CustomAccessor
   epochMilliseconds  temporalInstantPrototypeGetterEpochMilliseconds  DontEnum|ReadOnly|CustomAccessor
-  epochMicroseconds  temporalInstantPrototypeGetterEpochMicroseconds  DontEnum|ReadOnly|CustomAccessor
   epochNanoseconds   temporalInstantPrototypeGetterEpochNanoseconds   DontEnum|ReadOnly|CustomAccessor
 @end
 */
@@ -275,18 +271,6 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncValueOf, (JSGlobalObject* g
     return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.valueOf must not be called. To compare Instant values, use Temporal.Instant.compare"_s);
 }
 
-JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochSeconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(JSValue::decode(thisValue));
-    if (!instant)
-        return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochSeconds called on value that's not a Instant"_s);
-
-    return JSValue::encode(jsNumber(instant->exactTime().epochSeconds()));
-}
-
 JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMilliseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -297,18 +281,6 @@ JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMilliseconds, (JSGlo
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochMilliseconds called on value that's not a Instant"_s);
 
     return JSValue::encode(jsNumber(instant->exactTime().epochMilliseconds()));
-}
-
-JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMicroseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(JSValue::decode(thisValue));
-    if (!instant)
-        return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochMicroseconds called on value that's not a Instant"_s);
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(JSBigInt::makeHeapBigIntOrBigInt32(globalObject, instant->exactTime().epochMicroseconds())));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochNanoseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))


### PR DESCRIPTION
#### eced8713a99937f4e6503c1531b7dcb5b0799d57
<pre>
[JSC] Remove obsoleted Temporal.Instant API
<a href="https://bugs.webkit.org/show_bug.cgi?id=278285">https://bugs.webkit.org/show_bug.cgi?id=278285</a>

Reviewed by Yusuke Suzuki.

At the TC39 meeting on 2024-06, it was decied to obsolete several Temporal APIs[1][2].

This patch removes the following for Temporal.Instant:

- Temporal.Instant.fromEpochSeconds
- Temporal.Instant.fromEpochMicroseconds
- Temporal.Instant.prototype.epochSeconds
- Temporal.Instant.prototype.epochMicroseconds

[1]: <a href="https://github.com/tc39/notes/blob/main/meetings/2024-06/june-12.md#temporal-stage-3-update-and-scope-reduction">https://github.com/tc39/notes/blob/main/meetings/2024-06/june-12.md#temporal-stage-3-update-and-scope-reduction</a>
[2]: <a href="https://github.com/tc39/proposal-temporal/pull/2895">https://github.com/tc39/proposal-temporal/pull/2895</a>

* JSTests/stress/date-to-temporal-instant.js:
(shouldBe):
* JSTests/stress/temporal-instant.js:
(shouldBe):
(instants.forEach):
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/TemporalInstant.cpp:
* Source/JavaScriptCore/runtime/TemporalInstant.h:
* Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp:
* Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp:

Canonical link: <a href="https://commits.webkit.org/282400@main">https://commits.webkit.org/282400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a20048ec141ec0c61a754dc2f588fb48e7746d7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13675 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50822 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11959 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12551 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56181 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68787 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62314 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54684 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58346 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5851 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84077 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9509 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38247 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14808 "Found 1473 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->