### PR TITLE
[WTF] Update simdutf

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 		E32AB5022B5CE35D00B9FAAE /* LazyUniqueRef.h in Headers */ = {isa = PBXBuildFile; fileRef = E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E336674A2722551100259122 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33667492722550900259122 /* Int128.cpp */; };
 		E336BD2F2BAB8A0400E8471C /* CharacterProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = E336BD2E2BAB8A0400E8471C /* CharacterProperties.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E34745D22945E33700F670F2 /* simdutf_impl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E34745D02945E33700F670F2 /* simdutf_impl.cpp */; };
+		E33E83ED2C719900002FBCCD /* simdutf_impl.cpp.h in Headers */ = {isa = PBXBuildFile; fileRef = E33E83EC2C719900002FBCCD /* simdutf_impl.cpp.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E34745D32945E33700F670F2 /* simdutf_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E34745D12945E33700F670F2 /* simdutf_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3618AB92AD8C4BA00DA7E43 /* ButterflyArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3618AB82AD8C4B900DA7E43 /* ButterflyArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E361DB532891159C00B2A2B8 /* FastFloat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E361DB512891159B00B2A2B8 /* FastFloat.cpp */; };
@@ -848,6 +848,7 @@
 		E38C82692BECAE9D0071EF52 /* SIMDHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38D6E271F5522E300A75CC4 /* StringBuilderJSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */; };
 		E392FA2722E92BFF00ECDC73 /* ResourceUsageCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */; };
+		E39664762C7198AA00F91F3A /* SIMDUTF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39664752C7198AA00F91F3A /* SIMDUTF.cpp */; };
 		E396C11D2BE885D9000CBAE1 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = E396C1192BE885D9000CBAE1 /* neon.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E396C11E2BE885D9000CBAE1 /* sve.h in Headers */ = {isa = PBXBuildFile; fileRef = E396C11A2BE885D9000CBAE1 /* sve.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3ABBABE2BE88FBE00D84916 /* simde.h in Headers */ = {isa = PBXBuildFile; fileRef = E3ABBABD2BE88FBE00D84916 /* simde.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1769,7 +1770,7 @@
 		E336BD2E2BAB8A0400E8471C /* CharacterProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CharacterProperties.h; sourceTree = "<group>"; };
 		E339C163244B4E8700359DA9 /* DataRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataRef.h; sourceTree = "<group>"; };
 		E33D5F871FBED66700BF625E /* RecursableLambda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecursableLambda.h; sourceTree = "<group>"; };
-		E34745D02945E33700F670F2 /* simdutf_impl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simdutf_impl.cpp; sourceTree = "<group>"; };
+		E33E83EC2C719900002FBCCD /* simdutf_impl.cpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = simdutf_impl.cpp.h; sourceTree = "<group>"; };
 		E34745D12945E33700F670F2 /* simdutf_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simdutf_impl.h; sourceTree = "<group>"; };
 		E34CD0D022810A020020D299 /* Packed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Packed.h; sourceTree = "<group>"; };
 		E3538D4C276220880075DA50 /* EmbeddedFixedVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmbeddedFixedVector.h; sourceTree = "<group>"; };
@@ -1805,6 +1806,7 @@
 		E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIMDHelpers.h; sourceTree = "<group>"; };
 		E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringBuilderJSON.cpp; sourceTree = "<group>"; };
 		E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceUsageCocoa.cpp; sourceTree = "<group>"; };
+		E39664752C7198AA00F91F3A /* SIMDUTF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SIMDUTF.cpp; sourceTree = "<group>"; };
 		E396C1192BE885D9000CBAE1 /* neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = neon.h; sourceTree = "<group>"; };
 		E396C11A2BE885D9000CBAE1 /* sve.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sve.h; sourceTree = "<group>"; };
 		E3A32BC31FC830E2007D7E76 /* JSValueMalloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSValueMalloc.h; sourceTree = "<group>"; };
@@ -2392,6 +2394,7 @@
 				0FEB3DCE1BB5D684009D7AAD /* SharedTask.h */,
 				862A8D32278DE74A0014120C /* SignedPtr.h */,
 				E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */,
+				E39664752C7198AA00F91F3A /* SIMDUTF.cpp */,
 				E38C7CD72C366A1800BB9B18 /* SIMDUTF.h */,
 				A8A4730A151A825B004123FF /* SimpleStats.h */,
 				795212021F42588800BD6421 /* SingleRootGraph.h */,
@@ -2972,7 +2975,7 @@
 		E34745CE2945E33600F670F2 /* simdutf */ = {
 			isa = PBXGroup;
 			children = (
-				E34745D02945E33700F670F2 /* simdutf_impl.cpp */,
+				E33E83EC2C719900002FBCCD /* simdutf_impl.cpp.h */,
 				E34745D12945E33700F670F2 /* simdutf_impl.h */,
 			);
 			path = simdutf;
@@ -3453,6 +3456,7 @@
 				E3ABBABE2BE88FBE00D84916 /* simde.h in Headers */,
 				E38C82692BECAE9D0071EF52 /* SIMDHelpers.h in Headers */,
 				E38C7CD82C366A1800BB9B18 /* SIMDUTF.h in Headers */,
+				E33E83ED2C719900002FBCCD /* simdutf_impl.cpp.h in Headers */,
 				E34745D32945E33700F670F2 /* simdutf_impl.h in Headers */,
 				E361DB63289115D000B2A2B8 /* simple_decimal_conversion.h in Headers */,
 				DD3DC8F727A4BF8E007E5B61 /* SimpleStats.h in Headers */,
@@ -4078,7 +4082,7 @@
 				0FA6F38F20CC580F00A03DCD /* SegmentedVector.cpp in Sources */,
 				A8A47421151A825B004123FF /* SHA1.cpp in Sources */,
 				5311BD531EA71CAD00525281 /* Signals.cpp in Sources */,
-				E34745D22945E33700F670F2 /* simdutf_impl.cpp in Sources */,
+				E39664762C7198AA00F91F3A /* SIMDUTF.cpp in Sources */,
 				A748745217A0BDAE00FA04CB /* SixCharacterHash.cpp in Sources */,
 				A8A47425151A825B004123FF /* SizeLimits.cpp in Sources */,
 				0FA6F39320CC73A300A03DCD /* SmallSet.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -535,6 +535,7 @@ set(WTF_SOURCES
     RefCountedLeakCounter.cpp
     RunLoop.cpp
     SHA1.cpp
+    SIMDUTF.cpp
     SafeStrerror.cpp
     Seconds.cpp
     SegmentedVector.cpp
@@ -583,8 +584,6 @@ set(WTF_SOURCES
     persistence/PersistentCoders.cpp
     persistence/PersistentDecoder.cpp
     persistence/PersistentEncoder.cpp
-
-    simdutf/simdutf_impl.cpp
 
     text/ASCIILiteral.cpp
     text/AtomString.cpp
@@ -743,7 +742,7 @@ else ()
     # We need to disable preprocessor related warnings manually here.
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
     set_source_files_properties(
-        simdutf/simdutf_impl.cpp
+        SIMDUTF.cpp
         text/Base64.cpp
         PROPERTIES COMPILE_FLAGS "-Wno-error=undef -Wno-undef")
 endif ()

--- a/Source/WTF/wtf/SIMDUTF.cpp
+++ b/Source/WTF/wtf/SIMDUTF.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/SIMDUTF.h>
+
+IGNORE_WARNINGS_BEGIN("error=undef")
+IGNORE_WARNINGS_BEGIN("undef")
+IGNORE_WARNINGS_BEGIN("missing-prototypes")
+IGNORE_WARNINGS_BEGIN("cast-qual")
+IGNORE_WARNINGS_BEGIN("cast-align")
+IGNORE_WARNINGS_BEGIN("documentation")
+
+#include <wtf/simdutf/simdutf_impl.cpp.h>
+
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END

--- a/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h
@@ -1,14 +1,6 @@
-/* auto-generated on 2024-08-06 09:11:19 -0400. Do not edit! */
+/* auto-generated on 2024-08-17 15:52:42 -0400. Do not edit! */
 /* begin file src/simdutf.cpp */
-#include <wtf/SIMDUTF.h>
-
-IGNORE_WARNINGS_BEGIN("error=undef")
-IGNORE_WARNINGS_BEGIN("undef")
-IGNORE_WARNINGS_BEGIN("missing-prototypes")
-IGNORE_WARNINGS_BEGIN("cast-qual")
-IGNORE_WARNINGS_BEGIN("cast-align")
-IGNORE_WARNINGS_BEGIN("documentation")
-
+// #include "simdutf.h"
 // We include base64_tables once.
 /* begin file src/tables/base64_tables.h */
 #ifndef SIMDUTF_BASE64_TABLES_H
@@ -5651,7 +5643,7 @@ result base64_tail_decode(char *dst, const char_type *src, size_t length, base64
       buffer[idx] = uint8_t(code);
       if (is_eight_byte(c) && code <= 63) {
         idx++;
-      } else if (code > 64 || !is_eight_byte(c)) {
+      } else if (code > 64 || !scalar::base64::is_eight_byte(c)) {
         return {INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       } else {
         // We have a space or a newline. We ignore it.
@@ -5706,7 +5698,7 @@ result base64_tail_decode(char *dst, const char_type *src, size_t length, base64
   }
 }
 
-// like base64_tail_decode, but it will not write past the end of the ouput buffer.
+// like base64_tail_decode, but it will not write past the end of the output buffer.
 // outlen is modified to reflect the number of bytes written.
 // This functions assumes that the padding (=) has been removed.
 template <class char_type>
@@ -5755,7 +5747,7 @@ result base64_tail_decode_safe(char *dst, size_t& outlen, const char_type *src, 
       buffer[idx] = uint8_t(code);
       if (is_eight_byte(c) && code <= 63) {
         idx++;
-      } else if (code > 64 || !is_eight_byte(c)) {
+      } else if (code > 64 || !scalar::base64::is_eight_byte(c)) {
         outlen = size_t(dst - dstinit);
         return {INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       } else {
@@ -13266,6 +13258,11 @@ inline result rewind_and_convert_with_errors(size_t prior_bytes, const char* buf
     unsigned char byte = buf[-static_cast<std::ptrdiff_t>(i)];
     found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
     if(found_leading_bytes) {
+      if(i > 0 && byte < 128) {
+        // If we had to go back and the leading byte is ascii
+        // then we can stop right away.
+        return result(error_code::TOO_LONG, 0-i+1);
+      }
       buf -= i;
       extra_len = i;
       break;
@@ -13542,6 +13539,11 @@ inline result rewind_and_convert_with_errors(size_t prior_bytes, const char* buf
     unsigned char byte = buf[-static_cast<std::ptrdiff_t>(i)];
     found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
     if(found_leading_bytes) {
+      if(i > 0 && byte < 128) {
+        // If we had to go back and the leading byte is ascii
+        // then we can stop right away.
+        return result(error_code::TOO_LONG, 0-i+1);
+      }
       buf -= i;
       extra_len = i;
       break;
@@ -13837,6 +13839,11 @@ inline result rewind_and_convert_with_errors(size_t prior_bytes, const char* buf
     unsigned char byte = buf[-static_cast<std::ptrdiff_t>(i)];
     found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
     if(found_leading_bytes) {
+      if(i > 0 && byte < 128) {
+        // If we had to go back and the leading byte is ascii
+        // then we can stop right away.
+        return result(error_code::TOO_LONG, 0-i+1);
+      }
       buf -= i;
       extra_len = i;
       break;
@@ -14120,25 +14127,31 @@ inline size_t convert_valid(const char32_t *buf, size_t len, char *latin1_output
   size_t pos = 0;
 
   while (pos < len) {
-  utf32_char = (uint32_t)data[pos];
+      utf32_char = (uint32_t) data[pos];
 
-  if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
-      uint64_t v;
-      ::memcpy(&v, data + pos, sizeof(uint64_t));
-      if ((v & 0xFFFFFF00FFFFFF00) == 0) {
-      *latin1_output++ = char(buf[pos]);
-      *latin1_output++ = char(buf[pos+1]);
-      pos += 2;
-      continue;
-    }
-  }
-  *latin1_output++ = (char)(utf32_char & 0xFF);
-  pos++;
-
+      if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
+          uint64_t v;
+          ::memcpy(&v, data + pos, sizeof(uint64_t));
+          if ((v & 0xFFFFFF00FFFFFF00) == 0) {
+              *latin1_output++ = char(buf[pos]);
+              *latin1_output++ = char(buf[pos + 1]);
+              pos += 2;
+              continue;
+          } else {
+              // output can not be represented in latin1
+              return 0;
+          }
+      }
+      if ((utf32_char & 0xFFFFFF00) == 0) {
+          *latin1_output++ = char(utf32_char);
+      } else {
+          // output can not be represented in latin1
+          return 0;
+      }
+      pos++;
   }
   return latin1_output - start;
 }
-
 
 } // utf32_to_latin1 namespace
 } // unnamed namespace
@@ -14265,213 +14278,6 @@ simdutf_really_inline uint16x8_t convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in
   return composed;
 }
 
-/* begin file src/arm64/arm_detect_encodings.cpp */
-template<class checker>
-// len is known to be a multiple of 2 when this is called
-int arm_detect_encodings(const char * buf, size_t len) {
-    const char* start = buf;
-    const char* end = buf + len;
-
-    bool is_utf8 = true;
-    bool is_utf16 = true;
-    bool is_utf32 = true;
-
-    int out = 0;
-
-    const auto v_d8 = simd8<uint8_t>::splat(0xd8);
-    const auto v_f8 = simd8<uint8_t>::splat(0xf8);
-
-    uint32x4_t currentmax = vmovq_n_u32(0x0);
-
-    checker check{};
-
-    while(end - buf >= 64) {
-        uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t*>(buf));
-        uint16x8_t secondin = vld1q_u16(reinterpret_cast<const uint16_t*>(buf) + simd16<uint16_t>::SIZE / sizeof(char16_t));
-        uint16x8_t thirdin = vld1q_u16(reinterpret_cast<const uint16_t*>(buf) + 2*simd16<uint16_t>::SIZE / sizeof(char16_t));
-        uint16x8_t fourthin = vld1q_u16(reinterpret_cast<const uint16_t*>(buf) + 3*simd16<uint16_t>::SIZE / sizeof(char16_t));
-
-        const auto u0 = simd16<uint16_t>(in);
-        const auto u1 = simd16<uint16_t>(secondin);
-        const auto u2 = simd16<uint16_t>(thirdin);
-        const auto u3 = simd16<uint16_t>(fourthin);
-
-        const auto v0 = u0.shr<8>();
-        const auto v1 = u1.shr<8>();
-        const auto v2 = u2.shr<8>();
-        const auto v3 = u3.shr<8>();
-
-        const auto in16 = simd16<uint16_t>::pack(v0, v1);
-        const auto nextin16 = simd16<uint16_t>::pack(v2, v3);
-
-        const uint64_t surrogates_wordmask0 = ((in16 & v_f8) == v_d8).to_bitmask64();
-        const uint64_t surrogates_wordmask1 = ((nextin16 & v_f8) == v_d8).to_bitmask64();
-
-        // Check for surrogates
-        if (surrogates_wordmask0 != 0 || surrogates_wordmask1 != 0) {
-            // Cannot be UTF8
-            is_utf8 = false;
-            // Can still be either UTF-16LE or UTF-32 depending on the positions of the surrogates
-            // To be valid UTF-32, a surrogate cannot be in the two most significant bytes of any 32-bit word.
-            // On the other hand, to be valid UTF-16LE, at least one surrogate must be in the two most significant
-            // bytes of a 32-bit word since they always come in pairs in UTF-16LE.
-            // Note that we always proceed in multiple of 4 before this point so there is no offset in 32-bit code units.
-
-            if (((surrogates_wordmask0 | surrogates_wordmask1) & 0xf0f0f0f0f0f0f0f0) != 0) {
-                is_utf32 = false;
-                // Code from arm_validate_utf16le.cpp
-                // Not efficient, we do not process surrogates_wordmask1
-                const char16_t * input = reinterpret_cast<const char16_t*>(buf);
-                const char16_t* end16 = reinterpret_cast<const char16_t*>(start) + len/2;
-
-                const auto v_fc = simd8<uint8_t>::splat(0xfc);
-                const auto v_dc = simd8<uint8_t>::splat(0xdc);
-
-                const uint64_t V0 = ~surrogates_wordmask0;
-
-                const auto vH0 = ((in16 & v_fc) ==  v_dc);
-                const uint64_t H0 = vH0.to_bitmask64();
-
-                const uint64_t L0 = ~H0 & surrogates_wordmask0;
-
-                const uint64_t a0 = L0 & (H0 >> 4);
-
-                const uint64_t b0 = a0 << 4;
-
-                const uint64_t c0 = V0 | a0 | b0;
-                if (c0 == ~0ull) {
-                    input += 16;
-                } else if (c0 == 0xfffffffffffffffull) {
-                    input += 15;
-                } else {
-                    is_utf16 = false;
-                    break;
-                }
-
-                while (input + 16 < end16) {
-                    const auto in0 = simd16<uint16_t>(input);
-                    const auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
-                    const auto t0 = in0.shr<8>();
-                    const auto t1 = in1.shr<8>();
-                    const simd8<uint8_t> in_16 = simd16<uint16_t>::pack(t0, t1);
-
-                    const uint64_t surrogates_wordmask = ((in_16 & v_f8) == v_d8).to_bitmask64();
-                    if(surrogates_wordmask == 0) {
-                        input += 16;
-                    } else {
-                        const uint64_t V = ~surrogates_wordmask;
-
-                        const auto vH = ((in_16 & v_fc) ==  v_dc);
-                        const uint64_t H = vH.to_bitmask64();
-
-                        const uint64_t L = ~H & surrogates_wordmask;
-
-                        const uint64_t a = L & (H >> 4);
-
-                        const uint64_t b = a << 4;
-
-                        const uint64_t c = V | a | b;
-                        if (c == ~0ull) {
-                            input += 16;
-                        } else if (c == 0xfffffffffffffffull) {
-                            input += 15;
-                        } else {
-                            is_utf16 = false;
-                            break;
-                        }
-                    }
-                }
-            } else {
-                is_utf16 = false;
-                // Check for UTF-32
-                if (len % 4 == 0) {
-                    const char32_t * input = reinterpret_cast<const char32_t*>(buf);
-                    const char32_t* end32 = reinterpret_cast<const char32_t*>(start) + len/4;
-
-                    // Must start checking for surrogates
-                    uint32x4_t currentoffsetmax = vmovq_n_u32(0x0);
-                    const uint32x4_t offset = vmovq_n_u32(0xffff2000);
-                    const uint32x4_t standardoffsetmax = vmovq_n_u32(0xfffff7ff);
-
-                    const uint32x4_t in32 =  vreinterpretq_u32_u16(in);
-                    const uint32x4_t secondin32 =  vreinterpretq_u32_u16(secondin);
-                    const uint32x4_t thirdin32 =  vreinterpretq_u32_u16(thirdin);
-                    const uint32x4_t fourthin32 =  vreinterpretq_u32_u16(fourthin);
-
-                    currentmax = vmaxq_u32(in32,currentmax);
-                    currentmax = vmaxq_u32(secondin32,currentmax);
-                    currentmax = vmaxq_u32(thirdin32,currentmax);
-                    currentmax = vmaxq_u32(fourthin32,currentmax);
-
-                    currentoffsetmax = vmaxq_u32(vaddq_u32(in32, offset), currentoffsetmax);
-                    currentoffsetmax = vmaxq_u32(vaddq_u32(secondin32, offset), currentoffsetmax);
-                    currentoffsetmax = vmaxq_u32(vaddq_u32(thirdin32, offset), currentoffsetmax);
-                    currentoffsetmax = vmaxq_u32(vaddq_u32(fourthin32, offset), currentoffsetmax);
-
-                    while (input + 4 < end32) {
-                        const uint32x4_t in_32 = vld1q_u32(reinterpret_cast<const uint32_t*>(input));
-                        currentmax = vmaxq_u32(in_32,currentmax);
-                        currentoffsetmax = vmaxq_u32(vaddq_u32(in_32, offset), currentoffsetmax);
-                        input += 4;
-                    }
-
-                    uint32x4_t forbidden_words = veorq_u32(vmaxq_u32(currentoffsetmax, standardoffsetmax), standardoffsetmax);
-                    if(vmaxvq_u32(forbidden_words) != 0) {
-                        is_utf32 = false;
-                    }
-                } else {
-                    is_utf32 = false;
-                }
-            }
-            break;
-        }
-        // If no surrogate, validate under other encodings as well
-
-        // UTF-32 validation
-        currentmax = vmaxq_u32(vreinterpretq_u32_u16(in),currentmax);
-        currentmax = vmaxq_u32(vreinterpretq_u32_u16(secondin),currentmax);
-        currentmax = vmaxq_u32(vreinterpretq_u32_u16(thirdin),currentmax);
-        currentmax = vmaxq_u32(vreinterpretq_u32_u16(fourthin),currentmax);
-
-        // UTF-8 validation
-        // Relies on ../generic/utf8_validation/utf8_lookup4_algorithm.h
-        simd::simd8x64<uint8_t> in8(vreinterpretq_u8_u16(in), vreinterpretq_u8_u16(secondin), vreinterpretq_u8_u16(thirdin), vreinterpretq_u8_u16(fourthin));
-        check.check_next_input(in8);
-
-        buf += 64;
-    }
-
-    // Check which encodings are possible
-
-    if (is_utf8) {
-        if (static_cast<size_t>(buf - start) != len) {
-            uint8_t block[64]{};
-            std::memset(block, 0x20, 64);
-            std::memcpy(block, buf, len - (buf - start));
-            simd::simd8x64<uint8_t> in(block);
-            check.check_next_input(in);
-        }
-        if (!check.errors()) {
-            out |= simdutf::encoding_type::UTF8;
-        }
-    }
-
-    if (is_utf16 && scalar::utf16::validate<endianness::LITTLE>(reinterpret_cast<const char16_t*>(buf), (len - (buf - start))/2)) {
-        out |= simdutf::encoding_type::UTF16_LE;
-    }
-
-    if (is_utf32 && (len % 4 == 0)) {
-        const uint32x4_t standardmax = vmovq_n_u32(0x10ffff);
-        uint32x4_t is_zero = veorq_u32(vmaxq_u32(currentmax, standardmax), standardmax);
-        if (vmaxvq_u32(is_zero) == 0 && scalar::utf32::validate(reinterpret_cast<const char32_t*>(buf), (len - (buf - start))/4)) {
-            out |= simdutf::encoding_type::UTF32_LE;
-        }
-    }
-
-    return out;
-}
-/* end file src/arm64/arm_detect_encodings.cpp */
-
 /* begin file src/arm64/arm_validate_utf16.cpp */
 template <endianness big_endian>
 const char16_t* arm_validate_utf16(const char16_t* input, size_t size) {
@@ -14480,7 +14286,7 @@ const char16_t* arm_validate_utf16(const char16_t* input, size_t size) {
     const auto v_f8 = simd8<uint8_t>::splat(0xf8);
     const auto v_fc = simd8<uint8_t>::splat(0xfc);
     const auto v_dc = simd8<uint8_t>::splat(0xdc);
-    while (input + 16 < end) {
+    while (end - input >= 16) {
         // 0. Load data: since the validation takes into account only higher
         //    byte of each word, we compress the two vectors into one which
         //    consists only the higher bytes.
@@ -14622,7 +14428,7 @@ const char32_t* arm_validate_utf32le(const char32_t* input, size_t size) {
     uint32x4_t currentmax = vmovq_n_u32(0x0);
     uint32x4_t currentoffsetmax = vmovq_n_u32(0x0);
 
-    while (input + 4 < end) {
+    while (end - input >= 4) {
         const uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t*>(input));
         currentmax = vmaxq_u32(in,currentmax);
         currentoffsetmax = vmaxq_u32(vaddq_u32(in, offset), currentoffsetmax);
@@ -14653,7 +14459,7 @@ const result arm_validate_utf32le_with_errors(const char32_t* input, size_t size
     uint32x4_t currentmax = vmovq_n_u32(0x0);
     uint32x4_t currentoffsetmax = vmovq_n_u32(0x0);
 
-    while (input + 4 < end) {
+    while (end - input >= 4) {
         const uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t*>(input));
         currentmax = vmaxq_u32(in,currentmax);
         currentoffsetmax = vmaxq_u32(vaddq_u32(in, offset), currentoffsetmax);
@@ -14688,7 +14494,7 @@ arm_convert_latin1_to_utf8(const char *latin1_input, size_t len,
   const uint16x8_t v_c080 = vmovq_n_u16((uint16_t)0xc080);
   // We always write 16 bytes, of which more than the first 8 bytes
   // are valid. A safety margin of 8 is more than sufficient.
-  while (latin1_input + 16 + 8 <= end) {
+  while (end - latin1_input >= 16 + 8) {
     uint8x16_t in8 = vld1q_u8(reinterpret_cast<const uint8_t *>(latin1_input));
     if (vmaxvq_u8(in8) <= 0x7F) { // ASCII fast path!!!!
       vst1q_u8(utf8_output, in8);
@@ -14771,7 +14577,7 @@ std::pair<const char*, char16_t*> arm_convert_latin1_to_utf16(const char* buf, s
 std::pair<const char*, char32_t*> arm_convert_latin1_to_utf32(const char* buf, size_t len, char32_t* utf32_output) {
     const char* end = buf + len;
 
-    while (end- buf >= 16) {
+    while (end - buf >= 16) {
         uint8x16_t in8 = vld1q_u8(reinterpret_cast<const uint8_t *>(buf));
         uint16x8_t in8low = vmovl_u8(vget_low_u8(in8));
         uint32x4_t in16lowlow = vmovl_u16(vget_low_u16(in8low));
@@ -14978,6 +14784,12 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // 3 byte: 00000000 1110bbbb 10cccccc 10dddddd
     // 4 byte: 11110aaa 10bbbbbb 10cccccc 10dddddd
     uint32x4_t perm = vreinterpretq_u32_u8(vqtbl1q_u8(in, sh));
+    // added to fix issue https://github.com/simdutf/simdutf/issues/514
+    // We only want to write 2 * 16-bit code units when that is actually what we have.
+    // Unfortunately, we cannot trust the input. So it is possible to get 0xff as an input byte
+    // and it should not result in a surrogate pair. We need to check for that.
+    uint32_t permbuffer[4];
+    vst1q_u32(permbuffer, perm);
     // Mask the low and middle bytes
     // 00000000 00000000 00000000 0ddddddd
     uint32x4_t ascii = vandq_u32(perm, vmovq_n_u32(0x7f));
@@ -15033,11 +14845,14 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // Attempting to shuffle and store would be complex, just scalarize.
     uint32_t buffer[4];
     vst1q_u32(buffer, selected);
-    // Test for the top bit of the surrogate mask.
-    const uint32_t SURROGATE_MASK = match_system(big_endian) ? 0x80000000 : 0x00800000;
+    // Test for the top bit of the surrogate mask. Remove due to issue 514
+    // const uint32_t SURROGATE_MASK = match_system(big_endian) ? 0x80000000 : 0x00800000;
     for (size_t i = 0; i < 3; i++) {
       // Surrogate
-      if (buffer[i] & SURROGATE_MASK) {
+      // Used to be if (buffer[i] & SURROGATE_MASK) {
+      // See discussion above.
+      // patch for issue https://github.com/simdutf/simdutf/issues/514
+      if((permbuffer[i] & 0xf8000000) == 0xf0000000) {
         utf16_output[0] = uint16_t(buffer[i] >> 16);
         utf16_output[1] = uint16_t(buffer[i] & 0xFFFF);
         utf16_output += 2;
@@ -16825,6 +16640,7 @@ static inline void compress(uint8x16_t data, uint16_t mask, char *output) {
 struct block64 {
   uint8x16_t chunks[4];
 };
+
 static_assert(sizeof(block64) == 64, "block64 is not 64 bytes");
 template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
   uint8x16_t v0f = vdupq_n_u8(0xf);
@@ -16846,6 +16662,7 @@ template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
   uint8x16_t lo_nibbles1 = vandq_u8(b->chunks[1], v0f);
   uint8x16_t lo_nibbles2 = vandq_u8(b->chunks[2], v0f);
   uint8x16_t lo_nibbles3 = vandq_u8(b->chunks[3], v0f);
+
   // Needed by the decoding step.
   uint8x16_t hi_nibbles0 = vshrq_n_u8(b->chunks[0], 4);
   uint8x16_t hi_nibbles1 = vshrq_n_u8(b->chunks[1], 4);
@@ -16855,20 +16672,16 @@ template <bool base64_url> uint64_t to_base64_mask(block64 *b, bool *error) {
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   if (base64_url) {
     lut_lo =
-        simdutf_make_uint8x16_t(0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-                                0x70, 0x61, 0xe1, 0xf4, 0xf5, 0xa5, 0xf4, 0xf4);
+        simdutf_make_uint8x16_t(0x3a,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x61,0xe1,0xf4,0xe5,0xa5,0xf4,0xf4);
   } else {
     lut_lo =
-        simdutf_make_uint8x16_t(0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-                                0x70, 0x61, 0xe1, 0xb4, 0xf5, 0xe5, 0xf4, 0xb4);
+        simdutf_make_uint8x16_t(0x3a,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x61,0xe1,0xb4,0xe5,0xe5,0xf4,0xb4);
   }
 #else
   if (base64_url) {
-    lut_lo = uint8x16_t{0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-              0x70, 0x61, 0xe1, 0xf4, 0xf5, 0xa5, 0xf4, 0xf4};
+    lut_lo = uint8x16_t{0x3a,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x61,0xe1,0xf4,0xe5,0xa5,0xf4,0xf4};
   } else {
-    lut_lo = uint8x16_t{0x3a, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
-              0x70, 0x61, 0xe1, 0xb4, 0xf5, 0xe5, 0xf4, 0xb4};
+    lut_lo = uint8x16_t{0x3a,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x70,0x61,0xe1,0xb4,0xe5,0xe5,0xf4,0xb4};
   }
 #endif
   uint8x16_t lo0 = vqtbl1q_u8(lut_lo, lo_nibbles0);
@@ -17040,19 +16853,22 @@ result compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                               base64_options options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  size_t equallocation = srclen; // location of the first padding character if any
   // skip trailing spaces
-  while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
     srclen--;
   }
   size_t equalsigns = 0;
   if (srclen > 0 && src[srclen - 1] == '=') {
+    equallocation = srclen - 1;
     srclen--;
     equalsigns = 1;
     // skip trailing spaces
-    while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
       srclen--;
     }
     if (srclen > 0 && src[srclen - 1] == '=') {
+      equallocation = srclen - 1;
       srclen--;
       equalsigns = 2;
     }
@@ -17072,21 +16888,23 @@ result compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       src += 64;
       bool error = false;
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
-      if(badcharmask)
-      if (error) {
-        src -= 64;
-
-        while (src < srcend && to_base64[uint8_t(*src)] <= 64) {
-          src++;
+      if(badcharmask){
+        if (error) {
+          src -= 64;
+          while (src < srcend && scalar::base64::is_eight_byte(*src) && to_base64[uint8_t(*src)] <= 64) {
+            src++;
+          }
+          if(src < srcend){
+            // should never happen
+          }
+          return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
         }
-        return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       }
 
       if (badcharmask != 0) {
         // optimization opportunity: check for simple masks like those made of
         // continuous 1s followed by continuous 0s. And masks containing a
         // single bad character.
-
         bufferptr += compress_block(&b, badcharmask, bufferptr);
       } else {
         // optimization opportunity: if bufferptr == buffer and mask == 0, we
@@ -17113,7 +16931,7 @@ result compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (val > 64) {
+      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       }
       bufferptr += (val <= 63);
@@ -17156,7 +16974,7 @@ result compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     if (leftover > 0) {
       while (leftover < 4 && src < srcend) {
         uint8_t val = to_base64[uint8_t(*src)];
-        if (val > 64) {
+        if (!scalar::base64::is_eight_byte(*src) || val > 64) {
           return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
         }
         buffer_start[leftover] = char(val);
@@ -17208,13 +17026,14 @@ result compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       // additional checks
       if((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
         r.error = error_code::INVALID_BASE64_CHARACTER;
+        r.count = equallocation;
       }
     }
     return r;
   }
   if(equalsigns > 0) {
     if((size_t(dst - dstinit) % 3 == 0) || ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, size_t(dst - dstinit)};
+      return {INVALID_BASE64_CHARACTER, equallocation};
     }
   }
   return {SUCCESS, size_t(dst - dstinit)};
@@ -18851,15 +18670,16 @@ simdutf_warn_unused int implementation::detect_encodings(const char * input, siz
   // If there is a BOM, then we trust it.
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
   if(bom_encoding != encoding_type::unspecified) { return bom_encoding; }
-  if (length % 2 == 0) {
-    return arm_detect_encodings<utf8_validation::utf8_checker>(input, length);
-  } else {
-    if (implementation::validate_utf8(input, length)) {
-      return simdutf::encoding_type::UTF8;
-    } else {
-      return simdutf::encoding_type::unspecified;
-    }
+  // todo: reimplement as a one-pass algorithm.
+  int out = 0;
+  if(validate_utf8(input, length)) { out |= encoding_type::UTF8; }
+  if((length % 2) == 0) {
+    if(validate_utf16le(reinterpret_cast<const char16_t*>(input), length/2)) { out |= encoding_type::UTF16_LE; }
   }
+  if((length % 4) == 0) {
+    if(validate_utf32(reinterpret_cast<const char32_t*>(input), length/4)) { out |= encoding_type::UTF32_LE; }
+  }
+  return out;
 }
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
@@ -18879,6 +18699,10 @@ simdutf_warn_unused result implementation::validate_ascii_with_errors(const char
 }
 
 simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid. protected the implementation from nullptr.
+    return true;
+  }
   const char16_t* tail = arm_validate_utf16<endianness::LITTLE>(buf, len);
   if (tail) {
     return scalar::utf16::validate<endianness::LITTLE>(tail, len - (tail - buf));
@@ -18888,7 +18712,11 @@ simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, s
 }
 
 simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, size_t len) const noexcept {
-  const char16_t* tail = arm_validate_utf16<endianness::BIG>(buf, len);
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid. protected the implementation from nullptr.
+    return true;
+  }
+  const char16_t *tail = arm_validate_utf16<endianness::BIG>(buf, len);
   if (tail) {
     return scalar::utf16::validate<endianness::BIG>(tail, len - (tail - buf));
   } else {
@@ -18897,6 +18725,9 @@ simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, s
 }
 
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return result(error_code::SUCCESS, 0);
+  }
   result res = arm_validate_utf16_with_errors<endianness::LITTLE>(buf, len);
   if (res.count != len) {
     result scalar_res = scalar::utf16::validate_with_errors<endianness::LITTLE>(buf + res.count, len - res.count);
@@ -18907,6 +18738,9 @@ simdutf_warn_unused result implementation::validate_utf16le_with_errors(const ch
 }
 
 simdutf_warn_unused result implementation::validate_utf16be_with_errors(const char16_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return result(error_code::SUCCESS, 0);
+  }
   result res = arm_validate_utf16_with_errors<endianness::BIG>(buf, len);
   if (res.count != len) {
     result scalar_res = scalar::utf16::validate_with_errors<endianness::BIG>(buf + res.count, len - res.count);
@@ -18917,6 +18751,10 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(const ch
 }
 
 simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid. protected the implementation from nullptr.
+    return true;
+  }
   const char32_t* tail = arm_validate_utf32le(buf, len);
   if (tail) {
     return scalar::utf32::validate(tail, len - (tail - buf));
@@ -18926,6 +18764,9 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return result(error_code::SUCCESS, 0);
+  }
   result res = arm_validate_utf32le_with_errors(buf, len);
   if (res.count != len) {
     result scalar_res = scalar::utf32::validate_with_errors(buf + res.count, len - res.count);
@@ -19182,6 +19023,9 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_utf8(const c
 }
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(const char32_t* buf, size_t len, char* utf8_output) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return 0;
+  }
   std::pair<const char32_t*, char*> ret = arm_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) { return 0; }
   size_t saved_bytes = ret.second - utf8_output;
@@ -19195,6 +19039,9 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(const char32_t*
 }
 
 simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(const char32_t* buf, size_t len, char* utf8_output) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return result(error_code::SUCCESS, 0);
+  }
   // ret.first.count is always the position in the buffer, not the number of code units written even if finished
   std::pair<result, char*> ret = arm_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
@@ -19574,6 +19421,8 @@ size_t implementation::binary_to_base64(const char * input, size_t length, char*
 
 
 
+#include <cstdint>
+#include <cstring>
 
 namespace simdutf {
 namespace fallback {
@@ -19582,6 +19431,7 @@ simdutf_warn_unused int implementation::detect_encodings(const char * input, siz
   // If there is a BOM, then we trust it.
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
   if(bom_encoding != encoding_type::unspecified) { return bom_encoding; }
+  // todo: reimplement as a one-pass algorithm.
   int out = 0;
   if(validate_utf8(input, length)) { out |= encoding_type::UTF8; }
   if((length % 2) == 0) {
@@ -19590,7 +19440,6 @@ simdutf_warn_unused int implementation::detect_encodings(const char * input, siz
   if((length % 4) == 0) {
     if(validate_utf32(reinterpret_cast<const char32_t*>(input), length/4)) { out |= encoding_type::UTF32_LE; }
   }
-
   return out;
 }
 
@@ -19848,7 +19697,31 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t lengt
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * input, size_t length) const noexcept {
-  return scalar::latin1::utf8_length_from_latin1(input,length);
+  size_t answer = length;
+  size_t i = 0;
+  auto pop = [](uint64_t v) {
+    return (size_t)(((v>>7) & UINT64_C(0x0101010101010101)) * UINT64_C(0x0101010101010101) >> 56);
+  };
+  for(; i + 32 <= length; i += 32) {
+    uint64_t v;
+    memcpy(&v, input + i, 8);
+    answer += pop(v);
+    memcpy(&v, input + i + 8, sizeof(v));
+    answer += pop(v);
+    memcpy(&v, input + i + 16, sizeof(v));
+    answer += pop(v);
+    memcpy(&v, input + i + 24, sizeof(v));
+    answer += pop(v);
+  }
+  for(; i + 8 <= length; i += 8) {
+    uint64_t v;
+    memcpy(&v, input + i, sizeof(v));
+    answer += pop(v);
+  }
+  for(; i + 1 <= length; i += 1) {
+      answer += static_cast<uint8_t>(input[i]) >> 7;
+  }
+  return answer;
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(const char16_t * input, size_t length) const noexcept {
@@ -19902,12 +19775,14 @@ simdutf_warn_unused result implementation::base64_to_binary(const char * input, 
   size_t equallocation = length; // location of the first padding character if any
   size_t equalsigns = 0;
   if(length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
     length -= 1;
     equalsigns++;
     while(length > 0 && scalar::base64::is_ascii_white_space(input[length - 1])) {
       length--;
     }
     if(length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
       equalsigns++;
       length -= 1;
     }
@@ -19939,12 +19814,14 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   size_t equallocation = length; // location of the first padding character if any
   size_t equalsigns = 0;
   if(length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
     length -= 1;
     equalsigns++;
     while(length > 0 && scalar::base64::is_ascii_white_space(input[length - 1])) {
       length--;
     }
     if(length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
       equalsigns++;
       length -= 1;
     }
@@ -21157,7 +21034,7 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
      * but we access 64 + 4 bytes.
      * We use masked writes to avoid overruns, see https://github.com/simdutf/simdutf/issues/471
      */
-    while (ptr + 64 + 4 <= end) {
+    while (end - ptr >= 64 + 4) {
         const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
         if(checker.check_next_input(utf8)) {
             SIMDUTF_ICELAKE_STORE_ASCII(UTF32, utf8, output)
@@ -21208,7 +21085,7 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
 
     // For the final pass, we validate 64 bytes, but we only transcode
     // 3*16 bytes, so we may end up double-validating 16 bytes.
-    if (ptr + 64 <= end) {
+    if (end - ptr >= 64) {
         const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
         if(checker.check_next_input(utf8)) {
             SIMDUTF_ICELAKE_STORE_ASCII(UTF32, utf8, output)
@@ -21334,7 +21211,7 @@ std::tuple<const char*, OUTPUT*, bool> validating_utf8_to_fixed_length_with_cons
 
     // For the final pass, we validate 64 bytes, but we only transcode
     // 3*16 bytes, so we may end up double-validating 16 bytes.
-    if (ptr + 64 <= end) {
+    if (end - ptr >= 64) {
         const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
         bool ascii = checker.check_next_input(utf8);
         if(checker.errors()) {        
@@ -23056,19 +22933,22 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                               base64_options options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  size_t equallocation = srclen; // location of the first padding character if any
   size_t equalsigns = 0;
   // skip trailing spaces
-  while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
     srclen--;
   }
   if (srclen > 0 && src[srclen - 1] == '=') {
+    equallocation = srclen - 1;
     srclen--;
     equalsigns = 1;
     // skip trailing spaces
-    while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
       srclen--;
     }
     if (srclen > 0 && src[srclen - 1] == '=') {
+      equallocation = srclen - 1;
       srclen--;
       equalsigns = 2;
     }
@@ -23091,7 +22971,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
       if (error) {
         src -= 64;
-        while (src < srcend && to_base64[uint8_t(*src)] <= 64) {
+        while (src < srcend && scalar::base64::is_eight_byte(*src) && to_base64[uint8_t(*src)] <= 64) {
           src++;
         }
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
@@ -23129,7 +23009,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (val > 64) {
+      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       }
       bufferptr += (val <= 63);
@@ -23170,7 +23050,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     if (leftover > 0) {
       while (leftover < 4 && src < srcend) {
         uint8_t val = to_base64[uint8_t(*src)];
-        if (val > 64) {
+        if (!scalar::base64::is_eight_byte(*src) || val > 64) {
           return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
         }
         buffer_start[leftover] = char(val);
@@ -23222,13 +23102,14 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       // additional checks
       if((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
         r.error = error_code::INVALID_BASE64_CHARACTER;
+        r.count = equallocation;
       }
     }
     return r;
   }
   if(equalsigns > 0) {
     if((size_t(dst - dstinit) % 3 == 0) || ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, size_t(dst - dstinit)};
+      return {INVALID_BASE64_CHARACTER, equallocation};
     }
   }
   return {SUCCESS, size_t(dst - dstinit)};
@@ -23250,143 +23131,27 @@ implementation::detect_encodings(const char *input,
                                  size_t length) const noexcept {
   // If there is a BOM, then we trust it.
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
+  // todo: convert to a one-pass algorithm
   if(bom_encoding != encoding_type::unspecified) { return bom_encoding; }
-  if (length % 2 == 0) {
-    const char *buf = input;
-
-    const char *start = buf;
-    const char *end = input + length;
-
-    bool is_utf8 = true;
-    bool is_utf16 = true;
-    bool is_utf32 = true;
-
-    int out = 0;
-
-    avx512_utf8_checker checker{};
-    __m512i currentmax = _mm512_setzero_si512();
-    while (end - buf >= 64) {
-      __m512i in = _mm512_loadu_si512((__m512i *)buf);
-      __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
-      __mmask32 surrogates =
-          _mm512_cmplt_epu16_mask(diff, _mm512_set1_epi16(uint16_t(0x0800)));
-      if (surrogates) {
-        is_utf8 = false;
-
-        // Can still be either UTF-16LE or UTF-32 depending on the positions
-        // of the surrogates To be valid UTF-32, a surrogate cannot be in the
-        // two most significant bytes of any 32-bit word. On the other hand, to
-        // be valid UTF-16LE, at least one surrogate must be in the two most
-        // significant bytes of a 32-bit word since they always come in pairs in
-        // UTF-16LE. Note that we always proceed in multiple of 4 before this
-        // point so there is no offset in 32-bit code units.
-
-        if ((surrogates & 0xaaaaaaaa) != 0) {
-          is_utf32 = false;
-          __mmask32 highsurrogates = _mm512_cmplt_epu16_mask(
-              diff, _mm512_set1_epi16(uint16_t(0x0400)));
-          __mmask32 lowsurrogates = surrogates ^ highsurrogates;
-          // high must be followed by low
-          if ((highsurrogates << 1) != lowsurrogates) {
-            return simdutf::encoding_type::unspecified;
-          }
-
-          bool ends_with_high = ((highsurrogates & 0x80000000) != 0);
-          if (ends_with_high) {
-            buf +=
-                31 *
-                sizeof(char16_t); // advance only by 31 code units so that we start
-                                  // with the high surrogate on the next round.
-          } else {
-            buf += 32 * sizeof(char16_t);
-          }
-          is_utf16 = validate_utf16le(reinterpret_cast<const char16_t *>(buf),
-                                      (end - buf) / sizeof(char16_t));
-          if (!is_utf16) {
-            return simdutf::encoding_type::unspecified;
-
-          } else {
-            return simdutf::encoding_type::UTF16_LE;
-          }
-
-        } else {
-          is_utf16 = false;
-          // Check for UTF-32
-          if (length % 4 == 0) {
-            const char32_t *input32 = reinterpret_cast<const char32_t *>(buf);
-            const char32_t *end32 =
-                reinterpret_cast<const char32_t *>(start) + length / 4;
-            if (validate_utf32(input32, end32 - input32)) {
-              return simdutf::encoding_type::UTF32_LE;
-            }
-          }
-          return simdutf::encoding_type::unspecified;
-        }
-      }
-      // If no surrogate, validate under other encodings as well
-
-      // UTF-32 validation
-      currentmax = _mm512_max_epu32(in, currentmax);
-
-      // UTF-8 validation
-      checker.check_next_input(in);
-
-      buf += 64;
-    }
-
-    // Check which encodings are possible
-
-    if (is_utf8) {
-      size_t current_length = static_cast<size_t>(buf - start);
-      if (current_length != length) {
-                const __m512i utf8 = _mm512_maskz_loadu_epi8(
-            (UINT64_C(1) << (length - current_length)) - 1, (const __m512i *)buf);
-        checker.check_next_input(utf8);
-      }
-      checker.check_eof();
-      if (!checker.errors()) {
-        out |= simdutf::encoding_type::UTF8;
-      }
-    }
-
-    if (is_utf16 && scalar::utf16::validate<endianness::LITTLE>(
-                        reinterpret_cast<const char16_t *>(buf),
-                        (length - (buf - start)) / 2)) {
-      out |= simdutf::encoding_type::UTF16_LE;
-    }
-
-    if (is_utf32 && (length % 4 == 0)) {
-      size_t leftover = length - static_cast<size_t>(buf - start);
-      currentmax = _mm512_max_epu32(
-          _mm512_maskz_loadu_epi8(
-              (UINT64_C(1) << leftover) - 1,
-              (const __m512i *)buf),
-          currentmax);
-      __mmask16 outside_range = _mm512_cmp_epu32_mask(currentmax, _mm512_set1_epi32(0x10ffff),
-                                _MM_CMPINT_GT);
-      if (outside_range == 0) {
-          out |= simdutf::encoding_type::UTF32_LE;
-        } else {
-        }
-        //}
-      /*} else {
-        out |= simdutf::encoding_type::UTF32_LE;
-      }*/
-    }
-
-    return out;
-  } else if (implementation::validate_utf8(input, length)) {
-    return simdutf::encoding_type::UTF8;
-  } else {
-    return simdutf::encoding_type::unspecified;
+  int out = 0;
+  if(validate_utf8(input, length)) { out |= encoding_type::UTF8; }
+  if((length % 2) == 0) {
+    if(validate_utf16le(reinterpret_cast<const char16_t*>(input), length/2)) { out |= encoding_type::UTF16_LE; }
   }
+  if((length % 4) == 0) {
+    if(validate_utf32(reinterpret_cast<const char32_t*>(input), length/4)) { out |= encoding_type::UTF32_LE; }
+  }
+  return out;
 }
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return true;
+  }
     avx512_utf8_checker checker{};
     const char* ptr = buf;
     const char* end = ptr + len;
-    for (; ptr + 64 <= end; ptr += 64) {
+    for (; end - ptr >= 64 ; ptr += 64) {
         const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
         checker.check_next_input(utf8);
     }
@@ -23399,11 +23164,14 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
 }
 
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
+    if (simdutf_unlikely(len == 0)) {
+       return result(error_code::SUCCESS, len);
+    }
     avx512_utf8_checker checker{};
     const char* ptr = buf;
     const char* end = ptr + len;
     size_t count{0};
-    for (; ptr + 64 <= end; ptr += 64) {
+    for (; end - ptr >= 64 ; ptr += 64) {
       const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
       checker.check_next_input(utf8);
       if(checker.errors()) {
@@ -23645,7 +23413,8 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
   if (tail) {
     return scalar::utf32::validate(tail, len - (tail - buf));
   } else {
-    return false;
+    // we come here if there was an error, or buf was nullptr which may happen for empty input.
+    return len == 0;
   }
 }
 
@@ -23741,7 +23510,7 @@ simdutf_warn_unused result implementation::convert_utf8_to_latin1_with_errors(co
     return {simdutf::SUCCESS, written};
   }
   size_t pos = obuf - buf;
-  result res = scalar::utf8_to_latin1::rewind_and_convert_with_errors(pos, buf + pos, len - pos, olatin1_output);
+  result res = scalar::utf8_to_latin1::rewind_and_convert_with_errors(pos, buf + pos, len - pos, latin1_output);
   res.count += pos;
   return res;
 }
@@ -23861,6 +23630,9 @@ simdutf_warn_unused size_t implementation::convert_utf8_to_utf32(const char* buf
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(const char* buf, size_t len, char32_t* utf32) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return {error_code::SUCCESS, 0};
+  }
   uint32_t * utf32_output = reinterpret_cast<uint32_t *>(utf32);
   auto ret = icelake::validating_utf8_to_fixed_length_with_constant_checks<endianness::LITTLE, uint32_t>(buf, len, utf32_output);
 
@@ -24475,60 +24247,68 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
   const uint8_t *str = reinterpret_cast<const uint8_t *>(input);
   size_t answer = length / sizeof(__m512i) * sizeof(__m512i);
   size_t i = 0;
-  unsigned char v_0xFF = 0xff;
-  __m512i eight_64bits = _mm512_setzero_si512();
-  while (i + sizeof(__m512i) <= length) {
-    __m512i runner = _mm512_setzero_si512();
-    size_t iterations = (length - i) / sizeof(__m512i);
-    if (iterations > 255) {
-      iterations = 255;
+  if(answer >= 2048) { // long strings optimization
+    unsigned char v_0xFF = 0xff;
+    __m512i eight_64bits = _mm512_setzero_si512();
+    while (i + sizeof(__m512i) <= length) {
+      __m512i runner = _mm512_setzero_si512();
+      size_t iterations = (length - i) / sizeof(__m512i);
+      if (iterations > 255) {
+        iterations = 255;
+      }
+      size_t max_i = i + iterations * sizeof(__m512i) - sizeof(__m512i);
+      for (; i + 4*sizeof(__m512i) <= max_i; i += 4*sizeof(__m512i)) {
+              // Load four __m512i vectors
+              __m512i input1 = _mm512_loadu_si512((const __m512i *)(str + i));
+              __m512i input2 = _mm512_loadu_si512((const __m512i *)(str + i + sizeof(__m512i)));
+              __m512i input3 = _mm512_loadu_si512((const __m512i *)(str + i + 2*sizeof(__m512i)));
+              __m512i input4 = _mm512_loadu_si512((const __m512i *)(str + i + 3*sizeof(__m512i)));
+
+              // Generate four masks
+              __mmask64 mask1 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input1);
+              __mmask64 mask2 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input2);
+              __mmask64 mask3 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input3);
+              __mmask64 mask4 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input4);
+              // Apply the masks and subtract from the runner
+              __m512i not_ascii1 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask1, v_0xFF);
+              __m512i not_ascii2 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask2, v_0xFF);
+              __m512i not_ascii3 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask3, v_0xFF);
+              __m512i not_ascii4 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask4, v_0xFF);
+
+              runner = _mm512_sub_epi8(runner, not_ascii1);
+              runner = _mm512_sub_epi8(runner, not_ascii2);
+              runner = _mm512_sub_epi8(runner, not_ascii3);
+              runner = _mm512_sub_epi8(runner, not_ascii4);
+      }
+
+      for (; i <= max_i; i += sizeof(__m512i)) {
+        __m512i more_input = _mm512_loadu_si512((const __m512i *)(str + i));
+
+        __mmask64 mask = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), more_input);
+        __m512i not_ascii = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask, v_0xFF);
+        runner = _mm512_sub_epi8(runner, not_ascii);
+      }
+
+      eight_64bits = _mm512_add_epi64(eight_64bits, _mm512_sad_epu8(runner, _mm512_setzero_si512()));
     }
-    size_t max_i = i + iterations * sizeof(__m512i) - sizeof(__m512i);
-    for (; i + 4*sizeof(__m512i) <= max_i; i += 4*sizeof(__m512i)) {
-            // Load four __m512i vectors
-            __m512i input1 = _mm512_loadu_si512((const __m512i *)(str + i));
-            __m512i input2 = _mm512_loadu_si512((const __m512i *)(str + i + sizeof(__m512i)));
-            __m512i input3 = _mm512_loadu_si512((const __m512i *)(str + i + 2*sizeof(__m512i)));
-            __m512i input4 = _mm512_loadu_si512((const __m512i *)(str + i + 3*sizeof(__m512i)));
 
-            // Generate four masks
-            __mmask64 mask1 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input1);
-            __mmask64 mask2 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input2);
-            __mmask64 mask3 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input3);
-            __mmask64 mask4 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input4);
-            // Apply the masks and subtract from the runner
-            __m512i not_ascii1 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask1, v_0xFF);
-            __m512i not_ascii2 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask2, v_0xFF);
-            __m512i not_ascii3 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask3, v_0xFF);
-            __m512i not_ascii4 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask4, v_0xFF);
-
-            runner = _mm512_sub_epi8(runner, not_ascii1);
-            runner = _mm512_sub_epi8(runner, not_ascii2);
-            runner = _mm512_sub_epi8(runner, not_ascii3);
-            runner = _mm512_sub_epi8(runner, not_ascii4);
+    __m256i first_half = _mm512_extracti64x4_epi64(eight_64bits, 0);
+    __m256i second_half = _mm512_extracti64x4_epi64(eight_64bits, 1);
+    answer += (size_t)_mm256_extract_epi64(first_half, 0) +
+              (size_t)_mm256_extract_epi64(first_half, 1) +
+              (size_t)_mm256_extract_epi64(first_half, 2) +
+              (size_t)_mm256_extract_epi64(first_half, 3) +
+              (size_t)_mm256_extract_epi64(second_half, 0) +
+              (size_t)_mm256_extract_epi64(second_half, 1) +
+              (size_t)_mm256_extract_epi64(second_half, 2) +
+              (size_t)_mm256_extract_epi64(second_half, 3);
+  } else if (answer > 0) {
+    for(; i + sizeof(__m512i) <= length; i += sizeof(__m512i)) {
+      __m512i latin = _mm512_loadu_si512((const __m512i*)(str + i));
+      uint64_t non_ascii = _mm512_movepi8_mask(latin);
+      answer += count_ones(non_ascii);
     }
-
-    for (; i <= max_i; i += sizeof(__m512i)) {
-      __m512i more_input = _mm512_loadu_si512((const __m512i *)(str + i));
-
-      __mmask64 mask = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), more_input);
-      __m512i not_ascii = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask, v_0xFF);
-      runner = _mm512_sub_epi8(runner, not_ascii);
-    }
-
-    eight_64bits = _mm512_add_epi64(eight_64bits, _mm512_sad_epu8(runner, _mm512_setzero_si512()));
   }
-
-  __m256i first_half = _mm512_extracti64x4_epi64(eight_64bits, 0);
-  __m256i second_half = _mm512_extracti64x4_epi64(eight_64bits, 1);
-  answer += (size_t)_mm256_extract_epi64(first_half, 0) +
-            (size_t)_mm256_extract_epi64(first_half, 1) +
-            (size_t)_mm256_extract_epi64(first_half, 2) +
-            (size_t)_mm256_extract_epi64(first_half, 3) +
-            (size_t)_mm256_extract_epi64(second_half, 0) +
-            (size_t)_mm256_extract_epi64(second_half, 1) +
-            (size_t)_mm256_extract_epi64(second_half, 2) +
-            (size_t)_mm256_extract_epi64(second_half, 3);
   return answer + scalar::latin1::utf8_length_from_latin1(reinterpret_cast<const char *>(str + i), length - i);
 }
 
@@ -24694,195 +24474,6 @@ simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> 
   return simd8<bool>(is_third_byte | is_fourth_byte);
 }
 
-/* begin file src/haswell/avx2_detect_encodings.cpp */
-template<class checker>
-// len is known to be a multiple of 2 when this is called
-int avx2_detect_encodings(const char * buf, size_t len) {
-    const char* start = buf;
-    const char* end = buf + len;
-
-    bool is_utf8 = true;
-    bool is_utf16 = true;
-    bool is_utf32 = true;
-
-    int out = 0;
-
-    const auto v_d8 = simd8<uint8_t>::splat(0xd8);
-    const auto v_f8 = simd8<uint8_t>::splat(0xf8);
-
-    __m256i currentmax = _mm256_setzero_si256();
-
-    checker check{};
-
-    while(end - buf >= 64) {
-        __m256i in = _mm256_loadu_si256((__m256i*)buf);
-        __m256i nextin = _mm256_loadu_si256((__m256i*)buf+1);
-
-        const auto u0 = simd16<uint16_t>(in);
-        const auto u1 = simd16<uint16_t>(nextin);
-
-        const auto v0 = u0.shr<8>();
-        const auto v1 = u1.shr<8>();
-
-        const auto in16 = simd16<uint16_t>::pack(v0, v1);
-
-        const auto surrogates_wordmask0 = (in16 & v_f8) == v_d8;
-        uint32_t surrogates_bitmask0 = surrogates_wordmask0.to_bitmask();
-
-        // Check for surrogates
-        if (surrogates_bitmask0 != 0x0) {
-            // Cannot be UTF8
-            is_utf8 = false;
-            // Can still be either UTF-16LE or UTF-32 depending on the positions of the surrogates
-            // To be valid UTF-32, a surrogate cannot be in the two most significant bytes of any 32-bit word.
-            // On the other hand, to be valid UTF-16LE, at least one surrogate must be in the two most significant
-            // bytes of a 32-bit word since they always come in pairs in UTF-16LE.
-            // Note that we always proceed in multiple of 4 before this point so there is no offset in 32-bit code units.
-
-            if ((surrogates_bitmask0 & 0xaaaaaaaa) != 0) {
-                is_utf32 = false;
-                // Code from avx2_validate_utf16le.cpp
-                const char16_t * input = reinterpret_cast<const char16_t*>(buf);
-                const char16_t* end16 = reinterpret_cast<const char16_t*>(start) + len/2;
-
-                const auto v_fc = simd8<uint8_t>::splat(0xfc);
-                const auto v_dc = simd8<uint8_t>::splat(0xdc);
-
-                const uint32_t V0 = ~surrogates_bitmask0;
-
-                const auto    vH0 = (in16 & v_fc) == v_dc;
-                const uint32_t H0 = vH0.to_bitmask();
-
-                const uint32_t L0 = ~H0 & surrogates_bitmask0;
-
-                const uint32_t a0 = L0 & (H0 >> 1);
-                const uint32_t b0 = a0 << 1;
-                const uint32_t c0 = V0 | a0 | b0;
-
-                if (c0 == 0xffffffff) {
-                    input += simd16<uint16_t>::ELEMENTS * 2;
-                } else if (c0 == 0x7fffffff) {
-                    input += simd16<uint16_t>::ELEMENTS * 2 - 1;
-                } else {
-                    return simdutf::encoding_type::unspecified;
-                }
-
-                while (input + simd16<uint16_t>::ELEMENTS * 2 < end16) {
-                    const auto in0 = simd16<uint16_t>(input);
-                    const auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::ELEMENTS);
-
-                    const auto t0 = in0.shr<8>();
-                    const auto t1 = in1.shr<8>();
-
-                    const auto in_16 = simd16<uint16_t>::pack(t0, t1);
-
-                    const auto surrogates_wordmask = (in_16 & v_f8) == v_d8;
-                    const uint32_t surrogates_bitmask = surrogates_wordmask.to_bitmask();
-                    if (surrogates_bitmask == 0x0) {
-                        input += simd16<uint16_t>::ELEMENTS * 2;
-                    } else {
-                        const uint32_t V = ~surrogates_bitmask;
-
-                        const auto    vH = (in_16 & v_fc) == v_dc;
-                        const uint32_t H = vH.to_bitmask();
-
-                        const uint32_t L = ~H & surrogates_bitmask;
-
-                        const uint32_t a = L & (H >> 1);
-
-                        const uint32_t b = a << 1;
-
-                        const uint32_t c = V | a | b;
-
-                        if (c == 0xffffffff) {
-                            input += simd16<uint16_t>::ELEMENTS * 2;
-                        } else if (c == 0x7fffffff) {
-                            input += simd16<uint16_t>::ELEMENTS * 2 - 1;
-                        } else {
-                            return simdutf::encoding_type::unspecified;
-                        }
-                    }
-                }
-            } else {
-                is_utf16 = false;
-                // Check for UTF-32
-                if (len % 4 == 0) {
-                    const char32_t * input = reinterpret_cast<const char32_t*>(buf);
-                    const char32_t* end32 = reinterpret_cast<const char32_t*>(start) + len/4;
-
-                    // Must start checking for surrogates
-                    __m256i currentoffsetmax = _mm256_setzero_si256();
-                    const __m256i offset = _mm256_set1_epi32(0xffff2000);
-                    const __m256i standardoffsetmax = _mm256_set1_epi32(0xfffff7ff);
-
-                    currentmax = _mm256_max_epu32(in, currentmax);
-                    currentmax = _mm256_max_epu32(nextin, currentmax);
-
-                    currentoffsetmax = _mm256_max_epu32(_mm256_add_epi32(in, offset), currentoffsetmax);
-                    currentoffsetmax = _mm256_max_epu32(_mm256_add_epi32(nextin, offset), currentoffsetmax);
-
-                    while (input + 8 < end32) {
-                        const __m256i in32 = _mm256_loadu_si256((__m256i *)input);
-                        currentmax = _mm256_max_epu32(in32,currentmax);
-                        currentoffsetmax = _mm256_max_epu32(_mm256_add_epi32(in32, offset), currentoffsetmax);
-                        input += 8;
-                    }
-
-                    __m256i forbidden_words = _mm256_xor_si256(_mm256_max_epu32(currentoffsetmax, standardoffsetmax), standardoffsetmax);
-                    if(_mm256_testz_si256(forbidden_words, forbidden_words) == 0) {
-                        return simdutf::encoding_type::unspecified;
-                    }
-                } else {
-                    return simdutf::encoding_type::unspecified;
-                }
-            }
-            break;
-        }
-        // If no surrogate, validate under other encodings as well
-
-        // UTF-32 validation
-        currentmax = _mm256_max_epu32(in, currentmax);
-        currentmax = _mm256_max_epu32(nextin, currentmax);
-
-        // UTF-8 validation
-        // Relies on ../generic/utf8_validation/utf8_lookup4_algorithm.h
-        simd::simd8x64<uint8_t> in8(in, nextin);
-        check.check_next_input(in8);
-
-        buf += 64;
-    }
-
-    // Check which encodings are possible
-
-    if (is_utf8) {
-        if (static_cast<size_t>(buf - start) != len) {
-            uint8_t block[64]{};
-            std::memset(block, 0x20, 64);
-            std::memcpy(block, buf, len - (buf - start));
-            simd::simd8x64<uint8_t> in(block);
-            check.check_next_input(in);
-        }
-        if (!check.errors()) {
-            out |= simdutf::encoding_type::UTF8;
-        }
-    }
-
-    if (is_utf16 && scalar::utf16::validate<endianness::LITTLE>(reinterpret_cast<const char16_t*>(buf), (len - (buf - start))/2)) {
-        out |= simdutf::encoding_type::UTF16_LE;
-    }
-
-    if (is_utf32 && (len % 4 == 0)) {
-        const __m256i standardmax = _mm256_set1_epi32(0x10ffff);
-        __m256i is_zero = _mm256_xor_si256(_mm256_max_epu32(currentmax, standardmax), standardmax);
-        if (_mm256_testz_si256(is_zero, is_zero) == 1 && scalar::utf32::validate(reinterpret_cast<const char32_t*>(buf), (len - (buf - start))/4)) {
-            out |= simdutf::encoding_type::UTF32_LE;
-        }
-    }
-
-    return out;
-}
-/* end file src/haswell/avx2_detect_encodings.cpp */
-
 /* begin file src/haswell/avx2_validate_utf16.cpp */
 /*
     In UTF-16 code units in range 0xD800 to 0xDFFF have special meaning.
@@ -25008,7 +24599,10 @@ const char16_t* avx2_validate_utf16(const char16_t* input, size_t size) {
 
 template <endianness big_endian>
 const result avx2_validate_utf16_with_errors(const char16_t* input, size_t size) {
-    const char16_t* start = input;
+    if (simdutf_unlikely(size == 0)) {
+        return result(error_code::SUCCESS, 0);
+    }
+    const char16_t *start = input;
     const char16_t* end = input + size;
 
     const auto v_d8 = simd8<uint8_t>::splat(0xd8);
@@ -25157,7 +24751,7 @@ std::pair<const char *, char *> avx2_convert_latin1_to_utf8(const char *latin1_i
   const __m256i v_ff80 = _mm256_set1_epi16((int16_t)0xff80);
   const size_t safety_margin = 12;
 
-  while (latin1_input + 16 + safety_margin <= end) {
+  while (end - latin1_input >= std::ptrdiff_t(16 + safety_margin)) {
     __m128i in8 = _mm_loadu_si128((__m128i *)latin1_input);
     // a single 16-bit UTF-16 word can yield 1, 2 or 3 UTF-8 bytes
     const __m128i v_80 = _mm_set1_epi8((char)0x80);
@@ -25313,8 +24907,8 @@ size_t convert_masked_utf8_to_utf16(const char *input,
   const __m128i in = _mm_loadu_si128((__m128i *)input);
   const uint16_t input_utf8_end_of_code_point_mask =
       utf8_end_of_code_point_mask & 0xfff;
-  if(((utf8_end_of_code_point_mask & 0xffff) == 0xffff)) {
-    // We process the data in chunks of 16 bytes.
+  if(utf8_end_of_code_point_mask  == 0xfff) {
+    // We process the data in chunks of 12 bytes.
     __m256i ascii = _mm256_cvtepu8_epi16(in);
     if (big_endian) {
       const __m256i swap256 = _mm256_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
@@ -25322,8 +24916,8 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       ascii = _mm256_shuffle_epi8(ascii, swap256);
     }
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(utf16_output), ascii);
-    utf16_output += 16; // We wrote 16 16-bit characters.
-    return 16; // We consumed 16 bytes.
+    utf16_output += 12; // We wrote 12 16-bit characters.
+    return 12; // We consumed 12 bytes.
   }
   if(((utf8_end_of_code_point_mask & 0xffff) == 0xaaaa)) {
     // We want to take 8 2-byte UTF-8 code units and turn them into 8 2-byte UTF-16 code units.
@@ -27423,9 +27017,8 @@ static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
 
   if (base64_url) {
     check_asso =
-        _mm256_setr_epi8(0xD, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x3,
-                         0x7, 0xB, 0x6, 0xB, 0x12, 0xD, 0x1, 0x1, 0x1, 0x1, 0x1,
-                         0x1, 0x1, 0x1, 0x1, 0x3, 0x7, 0xB, 0x6, 0xB, 0x12);
+        _mm256_setr_epi8(0xD,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x3,0x7,0xB,0xE,0xB,0x6,
+        0xD,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x3,0x7,0xB,0xE,0xB,0x6);
   } else {
 
     check_asso = _mm256_setr_epi8(
@@ -27436,13 +27029,8 @@ static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
   __m256i check_values;
   if (base64_url) {
     check_values = _mm256_setr_epi8(
-        0x0, uint8_t(0x80), uint8_t(0x80), uint8_t(0x80), uint8_t(0xCF),
-        uint8_t(0xBF), uint8_t(0xD3), uint8_t(0xA6), uint8_t(0xB5),
-        uint8_t(0x86), uint8_t(0xD0), uint8_t(0x80), uint8_t(0xB0),
-        uint8_t(0x80), 0x0, 0x0, 0x0, uint8_t(0x80), uint8_t(0x80),
-        uint8_t(0x80), uint8_t(0xCF), uint8_t(0xBF), uint8_t(0xD3),
-        uint8_t(0xA6), uint8_t(0xB5), uint8_t(0x86), uint8_t(0xD0),
-        uint8_t(0x80), uint8_t(0xB0), uint8_t(0x80), 0x0, 0x0);
+        uint8_t(0x80),uint8_t(0x80),uint8_t(0x80),uint8_t(0x80),uint8_t(0xCF),uint8_t(0xBF),uint8_t(0xB6),uint8_t(0xA6),uint8_t(0xB5),uint8_t(0xA1),0x0,uint8_t(0x80),0x0,uint8_t(0x80),0x0,uint8_t(0x80),
+        uint8_t(0x80),uint8_t(0x80),uint8_t(0x80),uint8_t(0x80),uint8_t(0xCF),uint8_t(0xBF),uint8_t(0xB6),uint8_t(0xA6),uint8_t(0xB5),uint8_t(0xA1),0x0,uint8_t(0x80),0x0,uint8_t(0x80),0x0,uint8_t(0x80));
   } else {
     check_values = _mm256_setr_epi8(
         int8_t(0x80), int8_t(0x80), int8_t(0x80), int8_t(0x80), int8_t(0xCF),
@@ -27453,7 +27041,7 @@ static inline uint32_t to_base64_mask(__m256i *src, bool *error) {
         int8_t(0x86), int8_t(0xD1), int8_t(0x80), int8_t(0xB1), int8_t(0x80),
         int8_t(0x91), int8_t(0x80));
   }
-  const __m256i shifted = _mm256_srli_epi32(*src, 3);
+  const __m256i shifted =_mm256_srli_epi32(*src, 3);
   const __m256i delta_hash =
       _mm256_avg_epu8(_mm256_shuffle_epi8(delta_asso, *src), shifted);
   const __m256i check_hash =
@@ -27560,22 +27148,22 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                               base64_options options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  size_t equallocation = srclen; // location of the first padding character if any
   // skip trailing spaces
-  while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
     srclen--;
   }
   size_t equalsigns = 0;
   if (srclen > 0 && src[srclen - 1] == '=') {
+    equallocation = srclen - 1;
     srclen--;
     equalsigns = 1;
     // skip trailing spaces
-    while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
-      srclen--;
-    }
-    while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
       srclen--;
     }
     if (srclen > 0 && src[srclen - 1] == '=') {
+      equallocation = srclen - 1;
       srclen--;
       equalsigns = 2;
     }
@@ -27601,7 +27189,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
       if (error) {
         src -= 64;
-        while (src < srcend && to_base64[uint8_t(*src)] <= 64) {
+        while (src < srcend && scalar::base64::is_eight_byte(*src) && to_base64[uint8_t(*src)] <= 64) {
           src++;
         }
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
@@ -27649,7 +27237,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (val > 64) {
+      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       }
       bufferptr += (val <= 63);
@@ -27696,7 +27284,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     if (leftover > 0) {
       while (leftover < 4 && src < srcend) {
         uint8_t val = to_base64[uint8_t(*src)];
-        if (val > 64) {
+        if (!scalar::base64::is_eight_byte(*src) || val > 64) {
           return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
         }
         buffer_start[leftover] = char(val);
@@ -27747,13 +27335,14 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       // additional checks
       if((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
         r.error = error_code::INVALID_BASE64_CHARACTER;
+        r.count = equallocation;
       }
     }
     return r;
   }
   if(equalsigns > 0) {
     if((size_t(dst - dstinit) % 3 == 0) || ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, size_t(dst - dstinit)};
+      return {INVALID_BASE64_CHARACTER, equallocation};
     }
   }
   return {SUCCESS, size_t(dst - dstinit)};
@@ -29388,15 +28977,15 @@ simdutf_warn_unused int implementation::detect_encodings(const char * input, siz
   // If there is a BOM, then we trust it.
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
   if(bom_encoding != encoding_type::unspecified) { return bom_encoding; }
-  if (length % 2 == 0) {
-    return avx2_detect_encodings<utf8_validation::utf8_checker>(input, length);
-  } else {
-    if (implementation::validate_utf8(input, length)) {
-      return simdutf::encoding_type::UTF8;
-    } else {
-      return simdutf::encoding_type::unspecified;
-    }
+  int out = 0;
+  if(validate_utf8(input, length)) { out |= encoding_type::UTF8; }
+  if((length % 2) == 0) {
+    if(validate_utf16le(reinterpret_cast<const char16_t*>(input), length/2)) { out |= encoding_type::UTF16_LE; }
   }
+  if((length % 4) == 0) {
+    if(validate_utf32(reinterpret_cast<const char32_t*>(input), length/4)) { out |= encoding_type::UTF32_LE; }
+  }
+  return out;
 }
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
@@ -29416,7 +29005,12 @@ simdutf_warn_unused result implementation::validate_ascii_with_errors(const char
 }
 
 simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, size_t len) const noexcept {
-  const char16_t* tail = avx2_validate_utf16<endianness::LITTLE>(buf, len);
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-16. protect the implementation from
+    // handling nullptr
+    return true;
+  }
+  const char16_t *tail = avx2_validate_utf16<endianness::LITTLE>(buf, len);
   if (tail) {
     return scalar::utf16::validate<endianness::LITTLE>(tail, len - (tail - buf));
   } else {
@@ -29425,6 +29019,11 @@ simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, s
 }
 
 simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-16. protect the implementation from
+    // handling nullptr
+    return true;
+  }
   const char16_t* tail = avx2_validate_utf16<endianness::BIG>(buf, len);
   if (tail) {
     return scalar::utf16::validate<endianness::BIG>(tail, len - (tail - buf));
@@ -29454,6 +29053,11 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(const ch
 }
 
 simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-32. protect the implementation from
+    // handling nullptr
+    return true;
+  }
   const char32_t* tail = avx2_validate_utf32le(buf, len);
   if (tail) {
     return scalar::utf32::validate(tail, len - (tail - buf));
@@ -29463,6 +29067,11 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-32. protect the implementation from
+    // handling nullptr
+    return result(error_code::SUCCESS, 0);
+  }
   result res = avx2_validate_utf32le_with_errors(buf, len);
   if (res.count != len) {
     result scalar_res = scalar::utf32::validate_with_errors(buf + res.count, len - res.count);
@@ -29993,40 +29602,48 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char *i
   const uint8_t *data = reinterpret_cast<const uint8_t *>(input);
   size_t answer = len / sizeof(__m256i) * sizeof(__m256i);
   size_t i = 0;
-  __m256i four_64bits = _mm256_setzero_si256();
-  while (i + sizeof(__m256i) <= len) {
-    __m256i runner = _mm256_setzero_si256();
-    // We can do up to 255 loops without overflow.
-    size_t iterations = (len - i) / sizeof(__m256i);
-    if (iterations > 255) {
-      iterations = 255;
+  if(answer >= 2048) { // long strings optimization
+    __m256i four_64bits = _mm256_setzero_si256();
+    while (i + sizeof(__m256i) <= len) {
+      __m256i runner = _mm256_setzero_si256();
+      // We can do up to 255 loops without overflow.
+      size_t iterations = (len - i) / sizeof(__m256i);
+      if (iterations > 255) {
+        iterations = 255;
+      }
+      size_t max_i = i + iterations * sizeof(__m256i) - sizeof(__m256i);
+      for (; i + 4*sizeof(__m256i) <= max_i; i += 4*sizeof(__m256i)) {
+        __m256i input1 = _mm256_loadu_si256((const __m256i *)(data + i));
+        __m256i input2 = _mm256_loadu_si256((const __m256i *)(data + i + sizeof(__m256i)));
+        __m256i input3 = _mm256_loadu_si256((const __m256i *)(data + i + 2*sizeof(__m256i)));
+        __m256i input4 = _mm256_loadu_si256((const __m256i *)(data + i + 3*sizeof(__m256i)));
+        __m256i input12 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input1),
+                _mm256_cmpgt_epi8(_mm256_setzero_si256(), input2));
+        __m256i input23 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input3),
+                _mm256_cmpgt_epi8(_mm256_setzero_si256(), input4));
+        __m256i input1234 = _mm256_add_epi8(input12, input23);
+        runner = _mm256_sub_epi8(
+            runner, input1234);
+      }
+      for (; i <= max_i; i += sizeof(__m256i)) {
+        __m256i input_256_chunk = _mm256_loadu_si256((const __m256i *)(data + i));
+        runner = _mm256_sub_epi8(
+            runner, _mm256_cmpgt_epi8(_mm256_setzero_si256(), input_256_chunk));
+      }
+      four_64bits = _mm256_add_epi64(
+          four_64bits, _mm256_sad_epu8(runner, _mm256_setzero_si256()));
     }
-    size_t max_i = i + iterations * sizeof(__m256i) - sizeof(__m256i);
-    for (; i + 4*sizeof(__m256i) <= max_i; i += 4*sizeof(__m256i)) {
-      __m256i input1 = _mm256_loadu_si256((const __m256i *)(data + i));
-      __m256i input2 = _mm256_loadu_si256((const __m256i *)(data + i + sizeof(__m256i)));
-      __m256i input3 = _mm256_loadu_si256((const __m256i *)(data + i + 2*sizeof(__m256i)));
-      __m256i input4 = _mm256_loadu_si256((const __m256i *)(data + i + 3*sizeof(__m256i)));
-      __m256i input12 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input1),
-              _mm256_cmpgt_epi8(_mm256_setzero_si256(), input2));
-      __m256i input23 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input3),
-              _mm256_cmpgt_epi8(_mm256_setzero_si256(), input4));
-      __m256i input1234 = _mm256_add_epi8(input12, input23);
-      runner = _mm256_sub_epi8(
-          runner, input1234);
+    answer += _mm256_extract_epi64(four_64bits, 0) +
+              _mm256_extract_epi64(four_64bits, 1) +
+              _mm256_extract_epi64(four_64bits, 2) +
+              _mm256_extract_epi64(four_64bits, 3);
+  } else if (answer > 0) {
+    for(; i + sizeof(__m256i) <= len; i += sizeof(__m256i)) {
+      __m256i latin = _mm256_loadu_si256((const __m256i*)(data + i));
+      uint32_t non_ascii = _mm256_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
     }
-    for (; i <= max_i; i += sizeof(__m256i)) {
-      __m256i input_256_chunk = _mm256_loadu_si256((const __m256i *)(data + i));
-      runner = _mm256_sub_epi8(
-          runner, _mm256_cmpgt_epi8(_mm256_setzero_si256(), input_256_chunk));
-    }
-    four_64bits = _mm256_add_epi64(
-        four_64bits, _mm256_sad_epu8(runner, _mm256_setzero_si256()));
   }
-  answer += _mm256_extract_epi64(four_64bits, 0) +
-            _mm256_extract_epi64(four_64bits, 1) +
-            _mm256_extract_epi64(four_64bits, 2) +
-            _mm256_extract_epi64(four_64bits, 3);
   return answer + scalar::latin1::utf8_length_from_latin1(reinterpret_cast<const char *>(data + i), len - i);
 }
 
@@ -31413,6 +31030,7 @@ simdutf_warn_unused int implementation::detect_encodings(const char * input, siz
   // If there is a BOM, then we trust it.
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
   if(bom_encoding != encoding_type::unspecified) { return bom_encoding; }
+  // todo: reimplement as a one-pass algorithm.
   int out = 0;
   if(validate_utf8(input, length)) { out |= encoding_type::UTF8; }
   if((length % 2) == 0) {
@@ -31646,12 +31264,14 @@ simdutf_warn_unused result implementation::base64_to_binary(const char * input, 
   size_t equallocation = length; // location of the first padding character if any
   size_t equalsigns = 0;
   if(length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
     length -= 1;
     equalsigns++;
     while(length > 0 && scalar::base64::is_ascii_white_space(input[length - 1])) {
       length--;
     }
     if(length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
       equalsigns++;
       length -= 1;
     }
@@ -31684,12 +31304,14 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   size_t equallocation = length; // location of the first padding character if any
   size_t equalsigns = 0;
   if(length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
     length -= 1;
     equalsigns++;
     while(length > 0 && scalar::base64::is_ascii_white_space(input[length - 1])) {
       length--;
     }
     if(length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
       equalsigns++;
       length -= 1;
     }
@@ -32300,6 +31922,25 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src, size_t l
     vuint8m2_t b3 = __riscv_vcompress_vm_u8m2(v2, m, vl);
     vuint8m2_t b4 = __riscv_vcompress_vm_u8m2(v3, m, vl);
 
+     /* remove prefix from leading bytes
+      *
+      * We could also use vrgather here, but it increases register pressure,
+      * and its performance varies widely on current platforms. It might be
+      * worth reconsidering, though, once there is more hardware available.
+      * Same goes for the __riscv_vsrl_vv_u32m4 correction step.
+      *
+      * We shift left and then right by the number of bytes in the prefix,
+      * which can be calculated as follows:
+      *         x                                max(x-10, 0)
+      * 0xxx -> 0000-0111 -> sift by 0 or 1   -> 0
+      * 10xx -> 1000-1011 -> don't care
+      * 110x -> 1100,1101 -> sift by 3        -> 2,3
+      * 1110 -> 1110      -> sift by 4        -> 4
+      * 1111 -> 1111      -> sift by 5        -> 5
+      *
+      * vssubu.vx v, 10, (max(x-10, 0)) almost gives us what we want, we
+      * just need to manually detect and handle the one special case:
+      */
     #define SIMDUTF_RVV_UTF8_TO_COMMON_M1(idx) \
       vuint8m1_t c1 = __riscv_vget_v_u8m2_u8m1(b1, idx); \
       vuint8m1_t c2 = __riscv_vget_v_u8m2_u8m1(b2, idx); \
@@ -32308,26 +31949,7 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src, size_t l
       /* remove prefix from trailing bytes */ \
       c2 = __riscv_vand_vx_u8m1(c2, 0b00111111, vlOut); \
       c3 = __riscv_vand_vx_u8m1(c3, 0b00111111, vlOut); \
-      c4 = __riscv_vand_vx_u8m1(c4, 0b00111111, vlOut); \
-      /* remove prefix from leading bytes
-       *
-       * We could also use vrgather here, but it increases register pressure,
-       * and its performance varies widely on current platforms. It might be
-       * worth reconsidering, though, once there is more hardware available.
-       * Same goes for the __riscv_vsrl_vv_u32m4 correction step.
-       *
-       * We shift left and then right by the number of bytes in the prefix,
-       * which can be calculated as follows:
-       *         x                                max(x-10, 0)
-       * 0xxx -> 0000-0111 -> sift by 0 or 1   -> 0
-       * 10xx -> 1000-1011 -> don't care
-       * 110x -> 1100,1101 -> sift by 3        -> 2,3
-       * 1110 -> 1110      -> sift by 4        -> 4
-       * 1111 -> 1111      -> sift by 5        -> 5
-       *
-       * vssubu.vx v, 10, (max(x-10, 0)) almost gives us what we want, we
-       * just need to manually detect and handle the one special case:
-       */ \
+      c4 = __riscv_vand_vx_u8m1(c4, 0b00111111, vlOut);  \
       vuint8m1_t shift = __riscv_vsrl_vx_u8m1(c1, 4, vlOut); \
       shift = __riscv_vmerge_vxm_u8m1(__riscv_vssubu_vx_u8m1(shift, 10, vlOut), 3, __riscv_vmseq_vx_u8m1_b8(shift, 12, vlOut), vlOut); \
       c1 = __riscv_vsll_vv_u8m1(c1, shift, vlOut); \
@@ -32387,23 +32009,41 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src, size_t l
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_latin1(const char *src, size_t len, char *dst) const noexcept {
   const char *beg = dst;
-  uint8_t last = 0b10000000;
+  uint8_t last = 0;
   for (size_t vl, vlOut; len > 0; len -= vl, src += vl, dst += vlOut, last = src[-1]) {
     vl = __riscv_vsetvl_e8m2(len);
     vuint8m2_t v1 = __riscv_vle8_v_u8m2((uint8_t*)src, vl);
-    vbool4_t m = __riscv_vmsltu_vx_u8m2_b4(v1, 0b11000000, vl);
-    vlOut = __riscv_vcpop_m_b4(m, vl);
-    if (vlOut != vl || last > 0b01111111) {
+    // check which bytes are ASCII
+    vbool4_t ascii = __riscv_vmsltu_vx_u8m2_b4(v1, 0b10000000, vl);
+    // count ASCII bytes
+    vlOut = __riscv_vcpop_m_b4(ascii, vl);
+    // The original code would only enter the next block after this check:
+    //   vbool4_t m = __riscv_vmsltu_vx_u8m2_b4(v1, 0b11000000, vl);
+    //   vlOut = __riscv_vcpop_m_b4(m, vl);
+    //   if (vlOut != vl || last > 0b01111111) {...}q
+    // So that everything is ASCII or continuation bytes, we just proceeded
+    // without any processing, going straight to __riscv_vse8_v_u8m2.
+    // But you need the __riscv_vslide1up_vx_u8m2 whenever there is a non-ASCII byte.
+    if (vlOut != vl) { // If not pure ASCII
+      // Non-ASCII characters
+      // We now want to mark the ascii and continuation bytes
+      vbool4_t m = __riscv_vmsltu_vx_u8m2_b4(v1, 0b11000000, vl);
+      // We count them, that's our new vlOut (output vector length)
+      vlOut = __riscv_vcpop_m_b4(m, vl);
+
       vuint8m2_t v0 = __riscv_vslide1up_vx_u8m2(v1, last, vl);
 
       vbool4_t leading0  = __riscv_vmsgtu_vx_u8m2_b4(v0, 0b10111111, vl);
       vbool4_t trailing1 = __riscv_vmslt_vx_i8m2_b4(__riscv_vreinterpret_v_u8m2_i8m2(v1), (uint8_t)0b11000000, vl);
+      // -62 i 0b11000010, so we check whether any of v0 is too big
       vbool4_t tobig = __riscv_vmand_mm_b4(leading0, __riscv_vmsgtu_vx_u8m2_b4(__riscv_vxor_vx_u8m2(v0, (uint8_t)-62, vl), 1, vl), vl);
       if (__riscv_vfirst_m_b4(__riscv_vmor_mm_b4(tobig, __riscv_vmxor_mm_b4(leading0, trailing1, vl), vl), vl) >= 0)
         return 0;
 
       v1 = __riscv_vor_vx_u8m2_mu(__riscv_vmseq_vx_u8m2_b4(v0, 0b11000011, vl), v1, v1, 0b01000000, vl);
       v1 = __riscv_vcompress_vm_u8m2(v1, m, vl);
+    } else if (last >= 0b11000000) { // If last byte is a leading  byte and we got only ASCII, error!
+      return 0;
     }
     __riscv_vse8_v_u8m2((uint8_t*)dst, v1, vlOut);
   }
@@ -32420,13 +32060,15 @@ simdutf_warn_unused result implementation::convert_utf8_to_latin1_with_errors(co
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_latin1(const char *src, size_t len, char *dst) const noexcept {
   const char *beg = dst;
-  uint8_t last = 0b11000000;
+  uint8_t last = 0;
   for (size_t vl, vlOut; len > 0; len -= vl, src += vl, dst += vlOut, last = src[-1]) {
     vl = __riscv_vsetvl_e8m2(len);
     vuint8m2_t v1 = __riscv_vle8_v_u8m2((uint8_t*)src, vl);
-    vbool4_t m = __riscv_vmsltu_vx_u8m2_b4(v1, 0b11000000, vl);
-    vlOut = __riscv_vcpop_m_b4(m, vl);
-    if (vlOut != vl || last > 0b01111111) {
+    vbool4_t ascii = __riscv_vmsltu_vx_u8m2_b4(v1, 0b10000000, vl);
+    vlOut = __riscv_vcpop_m_b4(ascii, vl);
+    if (vlOut != vl) { // If not pure ASCII
+      vbool4_t m = __riscv_vmsltu_vx_u8m2_b4(v1, 0b11000000, vl);
+      vlOut = __riscv_vcpop_m_b4(m, vl);
       vuint8m2_t v0 = __riscv_vslide1up_vx_u8m2(v1, last, vl);
       v1 = __riscv_vor_vx_u8m2_mu(__riscv_vmseq_vx_u8m2_b4(v0, 0b11000011, vl), v1, v1, 0b01000000, vl);
       v1 = __riscv_vcompress_vm_u8m2(v1, m, vl);
@@ -33051,6 +32693,7 @@ simdutf_warn_unused int implementation::detect_encodings(const char *input, size
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
   if (bom_encoding != encoding_type::unspecified)
     return bom_encoding;
+  // todo: reimplement as a one-pass algorithm.
   int out = 0;
   if (validate_utf8(input, length))
     out |= encoding_type::UTF8;
@@ -33093,12 +32736,14 @@ simdutf_warn_unused result implementation::base64_to_binary(const char * input, 
   size_t equallocation = length; // location of the first padding character if any
   size_t equalsigns = 0;
   if(length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
     length -= 1;
     equalsigns++;
     while(length > 0 && scalar::base64::is_ascii_white_space(input[length - 1])) {
       length--;
     }
     if(length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
       equalsigns++;
       length -= 1;
     }
@@ -33131,12 +32776,14 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   size_t equallocation = length; // location of the first padding character if any
   auto equalsigns = 0;
   if(length > 0 && input[length - 1] == '=') {
+    equallocation = length - 1;
     length -= 1;
     equalsigns++;
     while(length > 0 && scalar::base64::is_ascii_white_space(input[length - 1])) {
       length--;
     }
     if(length > 0 && input[length - 1] == '=') {
+      equallocation = length - 1;
       equalsigns++;
       length -= 1;
     }
@@ -33293,214 +32940,6 @@ inline void write_v_u16_11bits_to_utf8(
 } // namespace westmere
 } // namespace internal
 /* end file src/westmere/internal/loader.cpp */
-/* begin file src/westmere/sse_detect_encodings.cpp */
-template<class checker>
-// len is known to be a multiple of 2 when this is called
-int sse_detect_encodings(const char * buf, size_t len) {
-    const char* start = buf;
-    const char* end = buf + len;
-
-    bool is_utf8 = true;
-    bool is_utf16 = true;
-    bool is_utf32 = true;
-
-    int out = 0;
-
-    const auto v_d8 = simd8<uint8_t>::splat(0xd8);
-    const auto v_f8 = simd8<uint8_t>::splat(0xf8);
-
-    __m128i currentmax = _mm_setzero_si128();
-
-    checker check{};
-
-    while(end - buf >= 64) {
-        __m128i in = _mm_loadu_si128((__m128i*)buf);
-        __m128i secondin = _mm_loadu_si128((__m128i*)buf+1);
-        __m128i thirdin = _mm_loadu_si128((__m128i*)buf+2);
-        __m128i fourthin = _mm_loadu_si128((__m128i*)buf+3);
-
-        const auto u0 = simd16<uint16_t>(in);
-        const auto u1 = simd16<uint16_t>(secondin);
-        const auto u2 = simd16<uint16_t>(thirdin);
-        const auto u3 = simd16<uint16_t>(fourthin);
-
-        const auto v0 = u0.shr<8>();
-        const auto v1 = u1.shr<8>();
-        const auto v2 = u2.shr<8>();
-        const auto v3 = u3.shr<8>();
-
-        const auto in16 = simd16<uint16_t>::pack(v0, v1);
-        const auto nextin16 = simd16<uint16_t>::pack(v2, v3);
-
-        const auto surrogates_wordmask0 = (in16 & v_f8) == v_d8;
-        const auto surrogates_wordmask1 = (nextin16 & v_f8) == v_d8;
-        uint16_t surrogates_bitmask0 = static_cast<uint16_t>(surrogates_wordmask0.to_bitmask());
-        uint16_t surrogates_bitmask1 = static_cast<uint16_t>(surrogates_wordmask1.to_bitmask());
-
-        // Check for surrogates
-        if (surrogates_bitmask0 != 0x0 || surrogates_bitmask1 != 0x0) {
-            // Cannot be UTF8
-            is_utf8 = false;
-            // Can still be either UTF-16LE or UTF-32 depending on the positions of the surrogates
-            // To be valid UTF-32, a surrogate cannot be in the two most significant bytes of any 32-bit word.
-            // On the other hand, to be valid UTF-16LE, at least one surrogate must be in the two most significant
-            // bytes of a 32-bit word since they always come in pairs in UTF-16LE.
-            // Note that we always proceed in multiple of 4 before this point so there is no offset in 32-bit code units.
-
-            if (((surrogates_bitmask0 | surrogates_bitmask1) & 0xaaaa) != 0) {
-                is_utf32 = false;
-                // Code from sse_validate_utf16le.cpp
-                // Not efficient, we do not process surrogates_bitmask1
-                const char16_t * input = reinterpret_cast<const char16_t*>(buf);
-                const char16_t* end16 = reinterpret_cast<const char16_t*>(start) + len/2;
-
-                const auto v_fc = simd8<uint8_t>::splat(0xfc);
-                const auto v_dc = simd8<uint8_t>::splat(0xdc);
-
-                const uint16_t V0 = static_cast<uint16_t>(~surrogates_bitmask0);
-
-                const auto    vH0 = (in16 & v_fc) == v_dc;
-                const uint16_t H0 = static_cast<uint16_t>(vH0.to_bitmask());
-
-                const uint16_t L0 = static_cast<uint16_t>(~H0 & surrogates_bitmask0);
-
-                const uint16_t a0 = static_cast<uint16_t>(L0 & (H0 >> 1));
-
-                const uint16_t b0 = static_cast<uint16_t>(a0 << 1);
-
-                const uint16_t c0 = static_cast<uint16_t>(V0 | a0 | b0);
-
-                if (c0 == 0xffff) {
-                    input += 16;
-                } else if (c0 == 0x7fff) {
-                    input += 15;
-                } else {
-                    is_utf16 = false;
-                    break;
-                }
-
-                while (input + simd16<uint16_t>::SIZE * 2 < end16) {
-                    const auto in0 = simd16<uint16_t>(input);
-                    const auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
-
-                    const auto t0 = in0.shr<8>();
-                    const auto t1 = in1.shr<8>();
-
-                    const auto in_16 = simd16<uint16_t>::pack(t0, t1);
-
-                    const auto surrogates_wordmask = (in_16 & v_f8) == v_d8;
-                    const uint16_t surrogates_bitmask = static_cast<uint16_t>(surrogates_wordmask.to_bitmask());
-                    if (surrogates_bitmask == 0x0) {
-                        input += 16;
-                    } else {
-                        const uint16_t V = static_cast<uint16_t>(~surrogates_bitmask);
-
-                        const auto    vH = (in_16 & v_fc) == v_dc;
-                        const uint16_t H = static_cast<uint16_t>(vH.to_bitmask());
-
-                        const uint16_t L = static_cast<uint16_t>(~H & surrogates_bitmask);
-
-                        const uint16_t a = static_cast<uint16_t>(L & (H >> 1));
-
-                        const uint16_t b = static_cast<uint16_t>(a << 1);
-
-                        const uint16_t c = static_cast<uint16_t>(V | a | b);
-
-                        if (c == 0xffff) {
-                            input += 16;
-                        } else if (c == 0x7fff) {
-                            input += 15;
-                        } else {
-                            is_utf16 = false;
-                            break;
-                        }
-                    }
-                }
-            } else {
-                is_utf16 = false;
-                // Check for UTF-32
-                if (len % 4 == 0) {
-                    const char32_t * input = reinterpret_cast<const char32_t*>(buf);
-                    const char32_t* end32 = reinterpret_cast<const char32_t*>(start) + len/4;
-
-                    // Must start checking for surrogates
-                    __m128i currentoffsetmax = _mm_setzero_si128();
-                    const __m128i offset = _mm_set1_epi32(0xffff2000);
-                    const __m128i standardoffsetmax = _mm_set1_epi32(0xfffff7ff);
-
-                    currentmax = _mm_max_epu32(in, currentmax);
-                    currentmax = _mm_max_epu32(secondin, currentmax);
-                    currentmax = _mm_max_epu32(thirdin, currentmax);
-                    currentmax = _mm_max_epu32(fourthin, currentmax);
-
-                    currentoffsetmax = _mm_max_epu32(_mm_add_epi32(in, offset), currentoffsetmax);
-                    currentoffsetmax = _mm_max_epu32(_mm_add_epi32(secondin, offset), currentoffsetmax);
-                    currentoffsetmax = _mm_max_epu32(_mm_add_epi32(thirdin, offset), currentoffsetmax);
-                    currentoffsetmax = _mm_max_epu32(_mm_add_epi32(fourthin, offset), currentoffsetmax);
-
-                    while (input + 4 < end32) {
-                        const __m128i in32 = _mm_loadu_si128((__m128i *)input);
-                        currentmax = _mm_max_epu32(in32,currentmax);
-                        currentoffsetmax = _mm_max_epu32(_mm_add_epi32(in32, offset), currentoffsetmax);
-                        input += 4;
-                    }
-
-                    __m128i forbidden_words = _mm_xor_si128(_mm_max_epu32(currentoffsetmax, standardoffsetmax), standardoffsetmax);
-                    if(_mm_testz_si128(forbidden_words, forbidden_words) == 0) {
-                        is_utf32 = false;
-                    }
-                } else {
-                    is_utf32 = false;
-                }
-            }
-            break;
-        }
-        // If no surrogate, validate under other encodings as well
-
-        // UTF-32 validation
-        currentmax = _mm_max_epu32(in, currentmax);
-        currentmax = _mm_max_epu32(secondin, currentmax);
-        currentmax = _mm_max_epu32(thirdin, currentmax);
-        currentmax = _mm_max_epu32(fourthin, currentmax);
-
-        // UTF-8 validation
-        // Relies on ../generic/utf8_validation/utf8_lookup4_algorithm.h
-        simd::simd8x64<uint8_t> in8(in, secondin, thirdin, fourthin);
-        check.check_next_input(in8);
-
-        buf += 64;
-    }
-
-    // Check which encodings are possible
-
-    if (is_utf8) {
-        if (static_cast<size_t>(buf - start) != len) {
-            uint8_t block[64]{};
-            std::memset(block, 0x20, 64);
-            std::memcpy(block, buf, len - (buf - start));
-            simd::simd8x64<uint8_t> in(block);
-            check.check_next_input(in);
-        }
-        if (!check.errors()) {
-            out |= simdutf::encoding_type::UTF8;
-        }
-    }
-
-    if (is_utf16 && scalar::utf16::validate<endianness::LITTLE>(reinterpret_cast<const char16_t*>(buf), (len - (buf - start))/2)) {
-        out |= simdutf::encoding_type::UTF16_LE;
-    }
-
-    if (is_utf32 && (len % 4 == 0)) {
-        const __m128i standardmax = _mm_set1_epi32(0x10ffff);
-        __m128i is_zero = _mm_xor_si128(_mm_max_epu32(currentmax, standardmax), standardmax);
-        if (_mm_testz_si128(is_zero, is_zero) == 1 && scalar::utf32::validate(reinterpret_cast<const char32_t*>(buf), (len - (buf - start))/4)) {
-            out |= simdutf::encoding_type::UTF32_LE;
-        }
-    }
-
-    return out;
-}
-/* end file src/westmere/sse_detect_encodings.cpp */
 
 /* begin file src/westmere/sse_validate_utf16.cpp */
 /*
@@ -33626,6 +33065,9 @@ const char16_t* sse_validate_utf16(const char16_t* input, size_t size) {
 
 template <endianness big_endian>
 const result sse_validate_utf16_with_errors(const char16_t* input, size_t size) {
+    if (simdutf_unlikely(size == 0)) {
+        return result(error_code::SUCCESS, 0);
+    }
     const char16_t* start = input;
     const char16_t* end = input + size;
 
@@ -33805,7 +33247,7 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   // slow path writes useful 8-15 bytes twice (eagerly writes 16 bytes and then adjust the pointer)
   // so the last write can exceed the utf8_output size by 8-1 bytes
   // by reserving 8 extra input bytes, we expect the output to have 8-16 bytes free
-  while (latin_input + 16 + 8 <= end) {
+  while (end - latin_input >= 16 + 8) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
     __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
 
@@ -33830,7 +33272,7 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
     latin_input += 16;
   }
 
-  if (latin_input + 16 <= end) {
+  if (end - latin_input >= 16) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
     __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
 
@@ -33930,8 +33372,9 @@ size_t convert_masked_utf8_to_utf16(const char *input,
   const __m128i in = _mm_loadu_si128((__m128i *)input);
   const uint16_t input_utf8_end_of_code_point_mask =
       utf8_end_of_code_point_mask & 0xfff;
-  if(((utf8_end_of_code_point_mask & 0xffff) == 0xffff)) {
-    // We process the data in chunks of 16 bytes.
+  if(utf8_end_of_code_point_mask == 0xfff) {
+    // We process the data in chunks of 12 bytes.
+    // Note: using 16 bytes is unsafe, see issue_ossfuzz_71218
     __m128i ascii_first = _mm_cvtepu8_epi16(in);
     __m128i ascii_second = _mm_cvtepu8_epi16(_mm_srli_si128(in,8));
     if (big_endian) {
@@ -33940,8 +33383,8 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     }
     _mm_storeu_si128(reinterpret_cast<__m128i *>(utf16_output), ascii_first);
     _mm_storeu_si128(reinterpret_cast<__m128i *>(utf16_output + 8), ascii_second);
-    utf16_output += 16; // We wrote 16 16-bit characters.
-    return 16; // We consumed 16 bytes.
+    utf16_output += 12; // We wrote 12 16-bit characters.
+    return 12; // We consumed 12 bytes.
   }
   if(((utf8_end_of_code_point_mask & 0xFFFF) == 0xaaaa)) {
     // We want to take 8 2-byte UTF-8 code units and turn them into 8 2-byte UTF-16 code units.
@@ -35911,8 +35354,7 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   }
   __m128i check_asso;
   if (base64_url) {
-    check_asso = _mm_setr_epi8(0xD, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
-                               0x3, 0x7, 0xB, 0x6, 0xB, 0x12);
+    check_asso = _mm_setr_epi8(0xD,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x3,0x7,0xB,0xE,0xB,0x6);
   } else {
 
     check_asso = _mm_setr_epi8(0x0D, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
@@ -35920,11 +35362,9 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
   }
   __m128i check_values;
   if (base64_url) {
-    check_values = _mm_setr_epi8(0x0, uint8_t(0x80), uint8_t(0x80),
-                                 uint8_t(0x80), uint8_t(0xCF), uint8_t(0xBF),
-                                 uint8_t(0xD3), uint8_t(0xA6), uint8_t(0xB5),
-                                 uint8_t(0x86), uint8_t(0xD0), uint8_t(0x80),
-                                 uint8_t(0xB0), uint8_t(0x80), 0x0, 0x0);
+    check_values = _mm_setr_epi8(uint8_t(0x80),uint8_t(0x80),uint8_t(0x80),uint8_t(0x80),uint8_t(0xCF),
+                   uint8_t(0xBF),uint8_t(0xB6),uint8_t(0xA6),uint8_t(0xB5),uint8_t(0xA1),0x0,uint8_t(0x80),
+                   0x0,uint8_t(0x80),0x0,uint8_t(0x80));
   } else {
 
     check_values =
@@ -35933,7 +35373,7 @@ static inline uint16_t to_base64_mask(__m128i *src, bool *error) {
                       int8_t(0xB5), int8_t(0x86), int8_t(0xD1), int8_t(0x80),
                       int8_t(0xB1), int8_t(0x80), int8_t(0x91), int8_t(0x80));
   }
-  const __m128i shifted = _mm_srli_epi32(*src, 3);
+  const __m128i shifted =_mm_srli_epi32(*src, 3);
 
   const __m128i delta_hash =
       _mm_avg_epu8(_mm_shuffle_epi8(delta_asso, *src), shifted);
@@ -36063,19 +35503,22 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                               base64_options options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  size_t equallocation = srclen; // location of the first padding character if any
   // skip trailing spaces
-  while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+  while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
     srclen--;
   }
   size_t equalsigns = 0;
   if (srclen > 0 && src[srclen - 1] == '=') {
+    equallocation = srclen - 1;
     srclen--;
     equalsigns = 1;
     // skip trailing spaces
-    while (srclen > 0 && to_base64[uint8_t(src[srclen - 1])] == 64) {
+    while (srclen > 0 && scalar::base64::is_eight_byte(src[srclen - 1]) && to_base64[uint8_t(src[srclen - 1])] == 64) {
       srclen--;
     }
     if (srclen > 0 && src[srclen - 1] == '=') {
+      equallocation = srclen - 1;
       srclen--;
       equalsigns = 2;
     }
@@ -36101,7 +35544,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
       if (error) {
         src -= 64;
-        while (src < srcend && to_base64[uint8_t(*src)] <= 64) {
+        while (src < srcend && scalar::base64::is_eight_byte(*src) && to_base64[uint8_t(*src)] <= 64) {
           src++;
         }
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
@@ -36148,7 +35591,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (val > 64) {
+      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
       }
       bufferptr += (val <= 63);
@@ -36195,7 +35638,7 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     if (leftover > 0) {
       while (leftover < 4 && src < srcend) {
         uint8_t val = to_base64[uint8_t(*src)];
-        if (val > 64) {
+        if (!scalar::base64::is_eight_byte(*src) || val > 64) {
           return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit)};
         }
         buffer_start[leftover] = char(val);
@@ -36248,13 +35691,14 @@ result compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       // additional checks
       if((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
         r.error = error_code::INVALID_BASE64_CHARACTER;
+        r.count = equallocation;
       }
     }
     return r;
   }
   if(equalsigns > 0) {
     if((size_t(dst - dstinit) % 3 == 0) || ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
-      return {INVALID_BASE64_CHARACTER, size_t(dst - dstinit)};
+      return {INVALID_BASE64_CHARACTER, equallocation};
     }
   }
   return {SUCCESS, size_t(dst - dstinit)};
@@ -37891,16 +37335,17 @@ namespace westmere {
 simdutf_warn_unused int implementation::detect_encodings(const char * input, size_t length) const noexcept {
   // If there is a BOM, then we trust it.
   auto bom_encoding = simdutf::BOM::check_bom(input, length);
+  // todo: reimplement as a one-pass algorithm.
   if(bom_encoding != encoding_type::unspecified) { return bom_encoding; }
-  if (length % 2 == 0) {
-    return sse_detect_encodings<utf8_validation::utf8_checker>(input, length);
-  } else {
-    if (implementation::validate_utf8(input, length)) {
-      return simdutf::encoding_type::UTF8;
-    } else {
-      return simdutf::encoding_type::unspecified;
-    }
+  int out = 0;
+  if(validate_utf8(input, length)) { out |= encoding_type::UTF8; }
+  if((length % 2) == 0) {
+    if(validate_utf16le(reinterpret_cast<const char16_t*>(input), length/2)) { out |= encoding_type::UTF16_LE; }
   }
+  if((length % 4) == 0) {
+    if(validate_utf32(reinterpret_cast<const char32_t*>(input), length/4)) { out |= encoding_type::UTF32_LE; }
+  }
+  return out;
 }
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
@@ -37920,7 +37365,12 @@ simdutf_warn_unused result implementation::validate_ascii_with_errors(const char
 }
 
 simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, size_t len) const noexcept {
-  const char16_t* tail = sse_validate_utf16<endianness::LITTLE>(buf, len);
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-16. protect the implementation from
+    // handling nullptr
+    return true;
+  }
+  const char16_t *tail = sse_validate_utf16<endianness::LITTLE>(buf, len);
   if (tail) {
     return scalar::utf16::validate<endianness::LITTLE>(tail, len - (tail - buf));
   } else {
@@ -37929,7 +37379,12 @@ simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, s
 }
 
 simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, size_t len) const noexcept {
-  const char16_t* tail = sse_validate_utf16<endianness::BIG>(buf, len);
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-16. protect the implementation from
+    // handling nullptr
+    return true;
+  }
+  const char16_t *tail = sse_validate_utf16<endianness::BIG>(buf, len);
   if (tail) {
     return scalar::utf16::validate<endianness::BIG>(tail, len - (tail - buf));
   } else {
@@ -37958,7 +37413,12 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(const ch
 }
 
 simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, size_t len) const noexcept {
-  const char32_t* tail = sse_validate_utf32le(buf, len);
+  if (simdutf_unlikely(len == 0)) {
+    // empty input is valid UTF-32. protect the implementation from
+    // handling nullptr
+    return true;
+  }
+  const char32_t *tail = sse_validate_utf32le(buf, len);
   if (tail) {
     return scalar::utf32::validate(tail, len - (tail - buf));
   } else {
@@ -37967,6 +37427,11 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {
+  if (len == 0) {
+    // empty input is valid UTF-32. protect the implementation from
+    // handling nullptr
+    return result(error_code::SUCCESS, 0);
+  }
   result res = sse_validate_utf32le_with_errors(buf, len);
   if (res.count != len) {
     result scalar_res = scalar::utf32::validate_with_errors(buf + res.count, len - res.count);
@@ -38490,46 +37955,62 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
   const uint8_t *str = reinterpret_cast<const uint8_t *>(input);
   size_t answer = len / sizeof(__m128i) * sizeof(__m128i);
   size_t i = 0;
-  __m128i two_64bits = _mm_setzero_si128();
-  while (i + sizeof(__m128i) <= len) {
-    __m128i runner = _mm_setzero_si128();
-    size_t iterations = (len - i) / sizeof(__m128i);
-    if (iterations > 255) {
-      iterations = 255;
+  if(answer >= 2048) { // long strings optimization
+    __m128i two_64bits = _mm_setzero_si128();
+    while (i + sizeof(__m128i) <= len) {
+      __m128i runner = _mm_setzero_si128();
+      size_t iterations = (len - i) / sizeof(__m128i);
+      if (iterations > 255) {
+        iterations = 255;
+      }
+      size_t max_i = i + iterations * sizeof(__m128i) - sizeof(__m128i);
+      for (; i + 4*sizeof(__m128i) <= max_i; i += 4*sizeof(__m128i)) {
+        __m128i input1 = _mm_loadu_si128((const __m128i *)(str + i));
+        __m128i input2 = _mm_loadu_si128((const __m128i *)(str + i + sizeof(__m128i)));
+        __m128i input3 = _mm_loadu_si128((const __m128i *)(str + i + 2*sizeof(__m128i)));
+        __m128i input4 = _mm_loadu_si128((const __m128i *)(str + i + 3*sizeof(__m128i)));
+        __m128i input12 = _mm_add_epi8(
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input1),
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input2));
+        __m128i input34 = _mm_add_epi8(
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input3),
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input4));
+        __m128i input1234 = _mm_add_epi8(input12, input34);
+        runner = _mm_sub_epi8(runner, input1234);
+      }
+      for (; i <= max_i; i += sizeof(__m128i)) {
+        __m128i more_input = _mm_loadu_si128((const __m128i *)(str + i));
+        runner = _mm_sub_epi8(
+            runner, _mm_cmpgt_epi8(_mm_setzero_si128(), more_input));
+      }
+      two_64bits = _mm_add_epi64(
+          two_64bits, _mm_sad_epu8(runner, _mm_setzero_si128()));
     }
-    size_t max_i = i + iterations * sizeof(__m128i) - sizeof(__m128i);
-    for (; i + 4*sizeof(__m128i) <= max_i; i += 4*sizeof(__m128i)) {
-      __m128i input1 = _mm_loadu_si128((const __m128i *)(str + i));
-      __m128i input2 = _mm_loadu_si128((const __m128i *)(str + i + sizeof(__m128i)));
-      __m128i input3 = _mm_loadu_si128((const __m128i *)(str + i + 2*sizeof(__m128i)));
-      __m128i input4 = _mm_loadu_si128((const __m128i *)(str + i + 3*sizeof(__m128i)));
-      __m128i input12 = _mm_add_epi8(
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input1),
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input2));
-      __m128i input34 = _mm_add_epi8(
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input3),
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input4));
-      __m128i input1234 = _mm_add_epi8(input12, input34);
-      runner = _mm_sub_epi8(runner, input1234);
+    answer += _mm_extract_epi64(two_64bits, 0) +
+              _mm_extract_epi64(two_64bits, 1);
+  } else if (answer > 0) { // short string optimization
+    for(; i + 2*sizeof(__m128i) <= len; i += 2*sizeof(__m128i)) {
+      __m128i latin = _mm_loadu_si128((const __m128i*)(input + i));
+      uint16_t non_ascii = (uint16_t)_mm_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
+      latin = _mm_loadu_si128((const __m128i*)(input + i)+1);
+      non_ascii = (uint16_t)_mm_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
     }
-    for (; i <= max_i; i += sizeof(__m128i)) {
-      __m128i more_input = _mm_loadu_si128((const __m128i *)(str + i));
-      runner = _mm_sub_epi8(
-          runner, _mm_cmpgt_epi8(_mm_setzero_si128(), more_input));
+    for(; i + sizeof(__m128i) <= len; i += sizeof(__m128i)) {
+      __m128i latin = _mm_loadu_si128((const __m128i*)(input + i));
+      uint16_t non_ascii = (uint16_t)_mm_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
     }
-    two_64bits = _mm_add_epi64(
-        two_64bits, _mm_sad_epu8(runner, _mm_setzero_si128()));
   }
-  answer += _mm_extract_epi64(two_64bits, 0) +
-            _mm_extract_epi64(two_64bits, 1);
   return answer + scalar::latin1::utf8_length_from_latin1(reinterpret_cast<const char *>(str + i), len - i);
 }
 
@@ -38632,11 +38113,4 @@ SIMDUTF_UNTARGET_REGION
 #endif
 
 SIMDUTF_POP_DISABLE_WARNINGS
-
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
-IGNORE_WARNINGS_END
 /* end file src/simdutf.cpp */

--- a/Source/WTF/wtf/simdutf/simdutf_impl.h
+++ b/Source/WTF/wtf/simdutf/simdutf_impl.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2024-08-06 09:11:19 -0400. Do not edit! */
+/* auto-generated on 2024-08-17 15:52:42 -0400. Do not edit! */
 /* begin file include/simdutf.h */
 #ifndef SIMDUTF_H
 #define SIMDUTF_H
@@ -398,6 +398,8 @@
 #define SIMDUTF_ISALIGNED_N(ptr, n) (((uintptr_t)(ptr) & ((n)-1)) == 0)
 
 #if defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+  #define SIMDUTF_DEPRECATED __declspec(deprecated)
+
 
   #define simdutf_really_inline __forceinline
   #define simdutf_never_inline __declspec(noinline)
@@ -438,6 +440,8 @@
 #else
   #define simdutf_really_inline inline
 #endif
+
+  #define SIMDUTF_DEPRECATED __attribute__((deprecated))
   #define simdutf_never_inline inline __attribute__((noinline))
 
   #define simdutf_unused __attribute__((unused))
@@ -597,7 +601,7 @@ SIMDUTF_DISABLE_UNDESIRED_WARNINGS
 #define SIMDUTF_SIMDUTF_VERSION_H
 
 /** The version of simdutf being used (major.minor.revision) */
-#define SIMDUTF_VERSION "5.3.2"
+#define SIMDUTF_VERSION "5.3.8"
 
 namespace simdutf {
 enum {
@@ -612,7 +616,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdutf being used.
    */
-  SIMDUTF_VERSION_REVISION = 2
+  SIMDUTF_VERSION_REVISION = 8
 };
 } // namespace simdutf
 
@@ -1314,19 +1318,23 @@ simdutf_warn_unused size_t convert_utf8_to_utf32(const char * input, size_t leng
  */
 simdutf_warn_unused result convert_utf8_to_utf32_with_errors(const char * input, size_t length, char32_t* utf32_output) noexcept;
 
-    /**
-   * Convert valid UTF-8 string into latin1 string.
-   *
-   * This function assumes that the input string is valid UTF-8 and that it can be represented as Latin1.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-8 string to convert
-   * @param length        the length of the string in bytes
-   * @param latin1_output  the pointer to buffer that can hold conversion result
-   * @return the number of written char; 0 if the input was not valid UTF-8 string
-   */
-  simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
+/**
+ * Convert valid UTF-8 string into latin1 string.
+ *
+ * This function assumes that the input string is valid UTF-8 and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf8_to_latin1 instead.
+ * The function may be removed from the library in the future.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param input         the UTF-8 string to convert
+ * @param length        the length of the string in bytes
+ * @param latin1_output  the pointer to buffer that can hold conversion result
+ * @return the number of written char; 0 if the input was not valid UTF-8 string
+ */
+simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
 
 
 /**
@@ -1635,6 +1643,10 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf8(const char16_t * input, s
  * Using native endianness, convert UTF-16 string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-16 and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf16_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -1649,6 +1661,10 @@ simdutf_warn_unused size_t convert_valid_utf16_to_latin1(const char16_t * input,
  * Convert valid UTF-16LE string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-16LE and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf16le_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -1663,6 +1679,10 @@ simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(const char16_t * inpu
  * Convert valid UTF-16BE string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-16BE and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf16be_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -1997,6 +2017,10 @@ simdutf_warn_unused result convert_utf32_to_latin1_with_errors(const char32_t * 
  * Convert valid UTF-32 string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-32 and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf32_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -2323,7 +2347,6 @@ simdutf_warn_unused size_t trim_partial_utf16(const char16_t* input, size_t leng
 
 // base64_options are used to specify the base64 encoding options.
 using base64_options = uint64_t;
-using base64_options = uint64_t;
 enum : base64_options {
   base64_default = 0, /* standard base64 format (with padding) */
   base64_url = 1, /* base64url format (no padding) */
@@ -2355,7 +2378,7 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(const char * input,
 simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) noexcept;
 
 /**
- * Convert a base64 input to a binary ouput.
+ * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it will
  * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -2398,7 +2421,7 @@ simdutf_warn_unused result base64_to_binary(const char * input, size_t length, c
 simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options = base64_default) noexcept;
 
 /**
- * Convert a binary input to a base64 ouput.
+ * Convert a binary input to a base64 output.
  *
  * The default option (simdutf::base64_default) uses the characters `+` and `/` as part of its alphabet.
  * Further, it adds padding (`=`) at the end of the output to ensure that the output length is a multiple of four.
@@ -2417,7 +2440,7 @@ simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_optio
 size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options = base64_default) noexcept;
 
 /**
- * Convert a base64 input to a binary ouput.
+ * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it will
  * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -2452,7 +2475,7 @@ size_t binary_to_base64(const char * input, size_t length, char* output, base64_
 simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options = base64_default)  noexcept;
 
 /**
- * Convert a base64 input to a binary ouput.
+ * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it will
  * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -2766,6 +2789,9 @@ public:
    * Convert valid UTF-8 string into latin1 string.
    *
    * This function assumes that the input string is valid UTF-8 and that it can be represented as Latin1.
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf8_to_latin1 instead.
    *
    * This function is not BOM-aware.
    *
@@ -2983,7 +3009,10 @@ public:
    * Convert valid UTF-16LE string into Latin1 string.
    *
    * This function assumes that the input string is valid UTF-L16LE and that it can be represented as Latin1.
-
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf16le_to_latin1 instead.
+   *
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16LE string to convert
@@ -2997,6 +3026,9 @@ public:
    * Convert valid UTF-16BE string into Latin1 string.
    *
    * This function assumes that the input string is valid UTF16-BE and that it can be represented as Latin1.
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf16be_to_latin1 instead.
    *
    * This function is not BOM-aware.
    *
@@ -3246,7 +3278,10 @@ public:
   /**
    * Convert valid UTF-32 string into Latin1 string.
    *
-   * This function assumes that the input string is valid UTF-32.
+   * This function assumes that the input string is valid UTF-32 and can be represented as Latin1.
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf32_to_latin1 instead.
    *
    * This function is not BOM-aware.
    *
@@ -3598,7 +3633,7 @@ public:
   simdutf_warn_unused virtual size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept = 0;
 
   /**
-   * Convert a base64 input to a binary ouput.
+   * Convert a base64 input to a binary output.
    *
    * This function follows the WHATWG forgiving-base64 format, which means that it will
    * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -3623,7 +3658,7 @@ public:
   simdutf_warn_unused virtual result base64_to_binary(const char * input, size_t length, char* output, base64_options options = base64_default) const noexcept = 0;
 
   /**
-   * Convert a base64 input to a binary ouput.
+   * Convert a base64 input to a binary output.
    *
    * This function follows the WHATWG forgiving-base64 format, which means that it will
    * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -3657,7 +3692,7 @@ public:
   simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length, base64_options options = base64_default) const noexcept = 0;
 
   /**
-   * Convert a binary input to a base64 ouput.
+   * Convert a binary input to a base64 output.
    *
    * The default option (simdutf::base64_default) uses the characters `+` and `/` as part of its alphabet.
    * Further, it adds padding (`=`) at the end of the output to ensure that the output length is a multiple of four.


### PR DESCRIPTION
#### 2f8be88e5ae9556471df840a03d66a778afb3aef
<pre>
[WTF] Update simdutf
<a href="https://bugs.webkit.org/show_bug.cgi?id=278287">https://bugs.webkit.org/show_bug.cgi?id=278287</a>
<a href="https://rdar.apple.com/134164986">rdar://134164986</a>

Reviewed by Yijia Huang.

Update simdutf to 5.3.8.
It also introduces SIMDUTF.cpp wrapper C++, and including simdutf&apos;s cpp from that so that WebKit side&apos;s modification in simdutf is minimized.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/SIMDUTF.cpp: Added.
* Source/WTF/wtf/simdutf/simdutf_impl.cpp.h: Renamed from Source/WTF/wtf/simdutf/simdutf_impl.cpp.
(_mm512_set_epi8):
(simdutf_byteflip):
(simdutf::implementation::supported_by_runtime_system const):
(simdutf::internal::get_icelake_singleton):
(simdutf::internal::get_haswell_singleton):
(simdutf::internal::get_westmere_singleton):
(simdutf::internal::get_arm64_singleton):
(simdutf::internal::get_ppc64_singleton):
(simdutf::internal::get_rvv_singleton):
(simdutf::internal::get_fallback_singleton):
(simdutf::internal::get_single_implementation):
(simdutf::internal::get_unsupported_singleton):
(simdutf::get_available_implementations):
(simdutf::get_active_implementation):
(simdutf::get_default_implementation):
(simdutf::builtin_implementation):
(simdutf::trim_partial_utf8):
(simdutf::trim_partial_utf16be):
(simdutf::trim_partial_utf16le):
(simdutf::trim_partial_utf16):
(simdutf::match_system):
(simdutf::to_string):
(simdutf::BOM::check_bom):
(simdutf::BOM::bom_byte_size):
(simdutf::rvv::rvv_utf32_length_from_utf16):
(simdutf::rvv::rvv_utf8_length_from_utf16):
(simdutf::rvv::rvv_count_valid_utf8):
(simdutf::rvv::rvv_validate_utf16_with_errors):
(simdutf::rvv::rvv_utf32_store_utf16_m4):
(simdutf::rvv::rvv_utf8_to_common):
(simdutf::rvv::rvv_utf16_to_latin1_with_errors):
(simdutf::rvv::rvv_utf16_to_utf8_with_errors):
(simdutf::rvv::rvv_utf16_to_utf32_with_errors):
(simdutf::rvv::rvv_convert_utf32_to_utf16_with_errors):
(simdutf::rvv::rvv_convert_valid_utf32_to_utf16):
(simdutf::rvv::rvv_change_endianness_utf16):
* Source/WTF/wtf/simdutf/simdutf_impl.h:

Canonical link: <a href="https://commits.webkit.org/282395@main">https://commits.webkit.org/282395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/044572bd60abff6119ab1bf75580ec99634d1f0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63074 "43416 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67095 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50824 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9435 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11961 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12554 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68790 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62317 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58137 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58348 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5853 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84080 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38250 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14809 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->