### PR TITLE
Use HashMap::ensure in SVGTextLayoutAttributesBuilder

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -141,25 +141,17 @@ void SVGTextLayoutAttributesBuilder::buildCharacterDataMap(RenderSVGText& textRo
     TextPosition wholeTextPosition(outermostTextElement.get(), 0, m_textLength);
     fillCharacterDataMap(wholeTextPosition);
 
-    // Handle x/y default attributes.
-    SVGCharacterDataMap::iterator it = m_characterDataMap.find(1);
-    if (it == m_characterDataMap.end()) {
-        SVGCharacterData data;
-        data.x = 0;
-        data.y = 0;
-        m_characterDataMap.set(1, data);
-    } else {
-        SVGCharacterData& data = it->value;
-        if (SVGTextLayoutAttributes::isEmptyValue(data.x))
-            data.x = 0;
-        if (SVGTextLayoutAttributes::isEmptyValue(data.y))
-            data.y = 0;
-    }
-
     // Fill character data map using child text positioning elements in top-down order. 
     unsigned size = m_textPositions.size();
     for (unsigned i = 0; i < size; ++i)
         fillCharacterDataMap(m_textPositions[i]);
+
+    // Handle x/y default attributes.
+    auto& data = m_characterDataMap.ensure((1), [] { return SVGCharacterData(); }).iterator->value;
+    if (data.x == SVGTextLayoutAttributes::emptyValue())
+        data.x = 0;
+    if (data.y == SVGTextLayoutAttributes::emptyValue())
+        data.y = 0;
 }
 
 static inline void updateCharacterData(unsigned i, float& lastRotation, SVGCharacterData& data, const SVGLengthContext& lengthContext, const SVGLengthList* xList, const SVGLengthList* yList, const SVGLengthList* dxList, const SVGLengthList* dyList, const SVGNumberList* rotateList)
@@ -206,15 +198,8 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         if (!xListPtr && !yListPtr && !dxListPtr && !dyListPtr && !rotateListPtr)
             break;
 
-        SVGCharacterDataMap::iterator it = m_characterDataMap.find(position.start + i + 1);
-        if (it == m_characterDataMap.end()) {
-            SVGCharacterData data;
-            updateCharacterData(i, lastRotation, data, lengthContext, xListPtr, yListPtr, dxListPtr, dyListPtr, rotateListPtr);
-            m_characterDataMap.set(position.start + i + 1, data);
-            continue;
-        }
-
-        updateCharacterData(i, lastRotation, it->value, lengthContext, xListPtr, yListPtr, dxListPtr, dyListPtr, rotateListPtr);
+        auto& data = m_characterDataMap.ensure((position.start + i + 1), [] { return SVGCharacterData(); }).iterator->value;
+        updateCharacterData(i, lastRotation, data, lengthContext, xListPtr, yListPtr, dxListPtr, dyListPtr, rotateListPtr);
     }
 
     // The last rotation value always spans the whole scope.
@@ -222,15 +207,8 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         return;
 
     for (unsigned i = rotateList.items().size(); i < position.length; ++i) {
-        SVGCharacterDataMap::iterator it = m_characterDataMap.find(position.start + i + 1);
-        if (it == m_characterDataMap.end()) {
-            SVGCharacterData data;
-            data.rotate = lastRotation;
-            m_characterDataMap.set(position.start + i + 1, data);
-            continue;
-        }
-
-        it->value.rotate = lastRotation;
+        auto& data = m_characterDataMap.ensure((position.start + i + 1), [] { return SVGCharacterData(); }).iterator->value;
+        data.rotate = lastRotation;
     }
 }
 


### PR DESCRIPTION
#### 1336f9d083267a704bd89169a879960c27a8f5b0
<pre>
Use HashMap::ensure in SVGTextLayoutAttributesBuilder

<a href="https://bugs.webkit.org/show_bug.cgi?id=278292">https://bugs.webkit.org/show_bug.cgi?id=278292</a>
<a href="https://rdar.apple.com/134186468">rdar://134186468</a>

Reviewed by NOBODY (OOPS!).

Inspired by: <a href="https://chromium.googlesource.com/chromium/src.git/+/0f6c84977fee3a56a328e9baa1134b668a316569">https://chromium.googlesource.com/chromium/src.git/+/0f6c84977fee3a56a328e9baa1134b668a316569</a>

Removes some redundancies and eliminates double-hashing.
Do the update of default values last.

* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::SVGTextLayoutAttributesBuilder::buildCharacterDataMap):
(WebCore::SVGTextLayoutAttributesBuilder::fillCharacterDataMap):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1336f9d083267a704bd89169a879960c27a8f5b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91437 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27726 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94438 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8647 "Found 25 new test failures: svg/W3C-SVG-1.1/animate-elem-36-t.svg svg/W3C-SVG-1.1/animate-elem-39-t.svg svg/W3C-SVG-1.1/animate-elem-41-t.svg svg/W3C-SVG-1.1/animate-elem-60-t.svg svg/W3C-SVG-1.1/animate-elem-61-t.svg svg/W3C-SVG-1.1/animate-elem-62-t.svg svg/W3C-SVG-1.1/animate-elem-63-t.svg svg/W3C-SVG-1.1/animate-elem-64-t.svg svg/W3C-SVG-1.1/animate-elem-65-t.svg svg/W3C-SVG-1.1/animate-elem-66-t.svg ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8413 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/410 "Found 60 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/multicol-inside-container.html imported/w3c/web-platform-tests/css/css-grid/animation/grid-template-columns-composition.html imported/w3c/web-platform-tests/css/css-grid/animation/grid-template-columns-interpolation.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78733 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/416 "Found 60 new test failures: compositing/geometry/layer-position-after-removing-perspective.html compositing/scrolling/touch-scrolling-repaint.html fast/canvas/image-buffer-resource-limits.html fast/css/aspect-ratio-min-height-replaced.html gamepad/gamepad-event-handlers.html http/tests/navigation/page-cache-shared-worker.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html imported/w3c/web-platform-tests/editing/other/delete-in-child-of-head.tentative.html?designMode=on&method=backspace imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=forwarddelete imported/w3c/web-platform-tests/editing/other/insertparagraph-in-child-of-head.tentative.html?designMode=on&white-space=normal ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18599 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13673 "Found 60 new test failures: fast/text/glyph-display-lists/glyph-display-list-color.html fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html http/tests/security/referrer-policy-header-multipart.html http/tests/xmlhttprequest/state-after-network-error.html http/wpt/service-workers/basic-fetch-with-contentfilter.https.html http/wpt/webauthn/public-key-credential-get-success-u2f.https.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79231 "Found 49 new test failures: imported/w3c/web-platform-tests/svg/import/animate-elem-36-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-39-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-60-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-61-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-62-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-63-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-64-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-65-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-66-t-manual.svg ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78435 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22953 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/311 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant.html css3/flexbox/image-percent-max-height.html fast/dynamic/content-visibility-crash-with-continuation-and-table.html fast/hidpi/image-srcset-svg-canvas-2x.html fast/multicol/client-rects.html fast/shadow-dom/media-query-in-shadow-style.html fast/text/canvas-color-fonts/stroke-gradient-COLR.html imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-mouseup.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23873 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->