### PR TITLE
[Media] Fix -Wmissing-designated-field-initializers warnings for CoreMediaWrapped objects

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/WebKit/CMBaseObjectSPI.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/WebKit/CMBaseObjectSPI.h
@@ -47,6 +47,10 @@ enum {
     kCMBaseObjectError_ValueNotAvailable = -12783,
 };
 
+enum {
+    kCMBaseObjectDescriptionOffset_NotPresent = 0,
+};
+
 typedef struct OpaqueCMBaseObject *CMBaseObjectRef;
 typedef struct OpaqueCMBaseClass *CMBaseClassID;
 typedef struct OpaqueCMBaseProtocol *CMBaseProtocolID;
@@ -95,6 +99,8 @@ typedef struct {
    CMBaseObjectSetPropertyFunction setProperty;
    OSStatus (*notificationBarrier)(CMBaseObjectRef);
    const CMBaseProtocolTable *protocolTable;
+   size_t offsetToDescriptionStringWithinStorage;
+   OSStatus (*isDefunct)(CMBaseObjectRef, Boolean*);
 } CMBaseClass;
 #pragma pack(pop)
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
@@ -103,6 +103,7 @@ typedef struct OpaqueMTPluginTrackReader *MTPluginTrackReaderRef;
 
 typedef OSStatus (*MTPluginFormatReaderFunction_CopyTrackArray)(MTPluginFormatReaderRef, CFArrayRef*);
 typedef OSStatus (*MTPluginFormatReaderFunction_ParseAdditionalFragments)(MTPluginFormatReaderRef, uint32_t, uint32_t*);
+typedef OSStatus (*MTPluginFormatReaderFunction_EstablishCombinedDataRateProfileForTracks)(MTPluginFormatReaderRef, CFArrayRef, int64_t*, uint32_t, CMTime*);
 typedef OSStatus (*MTPluginSampleCursorFunction_Copy)(MTPluginSampleCursorRef, MTPluginSampleCursorRef*);
 typedef OSStatus (*MTPluginSampleCursorFunction_StepInDecodeOrderAndReportStepsTaken)(MTPluginSampleCursorRef, int64_t, int64_t*);
 typedef OSStatus (*MTPluginSampleCursorFunction_StepInPresentationOrderAndReportStepsTaken)(MTPluginSampleCursorRef, int64_t, int64_t*);
@@ -121,6 +122,10 @@ typedef OSStatus (*MTPluginSampleCursorFunction_CopyUnrefinedSampleLocation)(MTP
 typedef OSStatus (*MTPluginSampleCursorFunction_RefineSampleLocation)(MTPluginSampleCursorRef, MTPluginSampleCursorStorageRange, const uint8_t*, size_t, MTPluginSampleCursorStorageRange*);
 typedef OSStatus (*MTPluginSampleCursorFunction_CopyExtendedSampleDependencyAttributes)(MTPluginSampleCursorRef, CFDictionaryRef*);
 typedef OSStatus (*MTPluginSampleCursorFunction_GetPlayableHorizon)(MTPluginSampleCursorRef, CMTime*);
+#if !USE(APPLE_INTERNAL_SDK) || (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 150000)
+// Defined in <MediaToolbox/MTPluginFormatReader.h> in Sequoia and later.
+typedef OSStatus (*MTPluginSampleCursorFunction_CopyPostDecodeProcessingMetadata)(MTPluginSampleCursorRef, CFDictionaryRef);
+#endif
 typedef OSStatus (*MTPluginTrackReaderFunction_GetTrackInfo)(MTPluginTrackReaderRef, MTPersistentTrackID*, CMMediaType*);
 typedef CMItemCount (*MTPluginTrackReaderFunction_GetTrackEditCount)(MTPluginTrackReaderRef);
 typedef OSStatus (*MTPluginTrackReaderFunction_GetTrackEditWithIndex)(MTPluginTrackReaderRef, CMItemCount, CMTimeMapping*);
@@ -155,6 +160,7 @@ typedef struct {
     unsigned long version;
     MTPluginFormatReaderFunction_CopyTrackArray copyTrackArray;
     MTPluginFormatReaderFunction_ParseAdditionalFragments parseAdditionalFragments;
+    MTPluginFormatReaderFunction_EstablishCombinedDataRateProfileForTracks establishCombinedDataRateProfileForTracks;
 } MTPluginFormatReaderClass;
 
 typedef struct {
@@ -182,6 +188,7 @@ typedef struct {
     MTPluginSampleCursorFunction_RefineSampleLocation refineSampleLocation;
     MTPluginSampleCursorFunction_CopyExtendedSampleDependencyAttributes copyExtendedSampleDependencyAttributes;
     MTPluginSampleCursorFunction_GetPlayableHorizon getPlayableHorizon;
+    MTPluginSampleCursorFunction_CopyPostDecodeProcessingMetadata copyPostDecodeProcessingMetadata;
 } MTPluginSampleCursorClass;
 
 typedef struct {

--- a/Source/WebKit/Shared/mac/MediaFormatReader/CoreMediaWrapped.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/CoreMediaWrapped.h
@@ -129,6 +129,8 @@ constexpr CMBaseClass CoreMediaWrapped<Wrapped>::wrapperClass()
     return {
         .version = kCMBaseObject_ClassVersion_1,
         .derivedStorageSize = size,
+        .equal = nullptr,
+        .invalidate = nullptr,
         .finalize = [](CMBaseObjectRef object) {
             Wrapped::unwrap(object)->finalize();
         },
@@ -138,6 +140,11 @@ constexpr CMBaseClass CoreMediaWrapped<Wrapped>::wrapperClass()
         .copyProperty = [](CMBaseObjectRef object, CFStringRef key, CFAllocatorRef allocator, void* copiedValue) {
             return Wrapped::unwrap(object)->copyProperty(key, allocator, copiedValue);
         },
+        .setProperty = nullptr,
+        .notificationBarrier = nullptr,
+        .protocolTable = nullptr,
+        .offsetToDescriptionStringWithinStorage = kCMBaseObjectDescriptionOffset_NotPresent,
+        .isDefunct = nullptr,
     };
 };
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
@@ -106,6 +106,8 @@ constexpr MediaFormatReader::WrapperClass MediaFormatReader::wrapperClass()
         .copyTrackArray = [](WrapperRef reader, CFArrayRef* trackArrayCopy) {
             return unwrap(reader)->copyTrackArray(trackArrayCopy);
         },
+        .parseAdditionalFragments = nullptr,
+        .establishCombinedDataRateProfileForTracks = nullptr,
     };
 }
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.cpp
@@ -396,7 +396,9 @@ OSStatus MediaSampleCursor::getSyncInfo(MTPluginSampleCursorSyncInfo* syncInfo) 
 {
     return getMediaSample([&](auto& sample) {
         *syncInfo = {
-            .fullSync = (sample.second->flags & MediaSample::IsSync) != 0
+            .fullSync = (sample.second->flags & MediaSample::IsSync) != 0,
+            .partialSync = false,
+            .droppable = false,
         };
     });
 }

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
@@ -151,17 +151,25 @@ constexpr MediaSampleCursor::WrapperClass MediaSampleCursor::wrapperClass()
         .getSyncInfo = [](MTPluginSampleCursorRef sampleCursor, MTPluginSampleCursorSyncInfo* syncInfo) -> OSStatus {
             return unwrap(sampleCursor)->getSyncInfo(syncInfo);
         },
+        .getDependencyInfo = nullptr,
+        .testReorderingBoundary = nullptr,
         .copySampleLocation = [](MTPluginSampleCursorRef sampleCursor, MTPluginSampleCursorStorageRange* storageRange, MTPluginByteSourceRef* byteSource) {
             return unwrap(sampleCursor)->copySampleLocation(storageRange, byteSource);
         },
+        .copyChunkDetails = nullptr,
         .copyFormatDescription = [](MTPluginSampleCursorRef sampleCursor, CMFormatDescriptionRef* formatDescription) {
             return unwrap(sampleCursor)->copyFormatDescription(formatDescription);
         },
+        .createSampleBuffer = nullptr,
+        .copyUnrefinedSampleLocation = nullptr,
+        .refineSampleLocation = nullptr,
+        .copyExtendedSampleDependencyAttributes = nullptr,
 #if HAVE(MT_PLUGIN_SAMPLE_CURSOR_PLAYABLE_HORIZON)
         .getPlayableHorizon = [](MTPluginSampleCursorRef sampleCursor, CMTime* playableHorizon) {
             return unwrap(sampleCursor)->getPlayableHorizon(playableHorizon);
         },
 #endif
+        .copyPostDecodeProcessingMetadata = nullptr,
     };
 }
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
@@ -126,6 +126,8 @@ constexpr MediaTrackReader::WrapperClass MediaTrackReader::wrapperClass()
         .getTrackInfo = [](MTPluginTrackReaderRef trackReader, MTPersistentTrackID* trackID, CMMediaType* mediaType) {
             return unwrap(trackReader)->getTrackInfo(trackID, mediaType);
         },
+        .getTrackEditCount = nullptr,
+        .getTrackEditWithIndex = nullptr,
         .createCursorAtPresentationTimeStamp = [](MTPluginTrackReaderRef trackReader, CMTime timestamp, MTPluginSampleCursorRef* cursor) {
             return unwrap(trackReader)->createCursorAtPresentationTimeStamp(timestamp, cursor);
         },


### PR DESCRIPTION
#### 7831acc403ac055f451f13966de91e4afa4e8435
<pre>
[Media] Fix -Wmissing-designated-field-initializers warnings for CoreMediaWrapped objects
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278295">https://bugs.webkit.org/show_bug.cgi?id=278295</a>&gt;
&lt;<a href="https://rdar.apple.com/134205424">rdar://134205424</a>&gt;

Reviewed by NOBODY (OOPS!).

* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/WebKit/CMBaseObjectSPI.h:
- Define an enum and missing struct fields for public SDK builds.

* Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h:
- Add missing struct fields (and function pointer definitions) for
  public SDK builds.

* Source/WebKit/Shared/mac/MediaFormatReader/CoreMediaWrapped.h:
(WebKit::CoreMediaWrapped&lt;Wrapped&gt;::wrapperClass):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h:
(WebKit::MediaFormatReader::wrapperClass):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.cpp:
(WebKit::MediaSampleCursor::getSyncInfo const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h:
(WebKit::MediaSampleCursor::wrapperClass):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h:
(WebKit::MediaTrackReader::wrapperClass):
- Add missing field initializers to various inline constructors.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7831acc403ac055f451f13966de91e4afa4e8435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63921 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51492 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10044 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55436 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58962 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6541 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39098 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->