### PR TITLE
Make sure Markable is set when dereferencing it and getting its value

### DIFF
--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -131,15 +131,19 @@ public:
 
     void reset() { m_value = Traits::emptyValue(); }
 
-    constexpr const T& value() const& { return m_value; }
-    constexpr T& value() & { return m_value; }
-    constexpr T&& value() && { return WTFMove(m_value); }
+    constexpr const T& value() const& { RELEASE_ASSERT(bool(*this)); return m_value; }
+    constexpr T& value() & { RELEASE_ASSERT(bool(*this)); return m_value; }
+    constexpr T&& value() && { RELEASE_ASSERT(bool(*this)); return WTFMove(m_value); }
 
-    constexpr const T* operator->() const { return std::addressof(m_value); }
-    constexpr T* operator->() { return std::addressof(m_value); }
+    constexpr const T& unsafeValue() const& { return m_value; }
+    constexpr T& unsafeValue() & { return m_value; }
+    constexpr T&& unsafeValue() && { return WTFMove(m_value); }
 
-    constexpr const T& operator*() const& { return m_value; }
-    constexpr T& operator*() & { return m_value; }
+    constexpr const T* operator->() const { RELEASE_ASSERT(bool(*this)); return std::addressof(m_value); }
+    constexpr T* operator->() { RELEASE_ASSERT(bool(*this)); return std::addressof(m_value); }
+
+    constexpr const T& operator*() const& { RELEASE_ASSERT(bool(*this)); return m_value; }
+    constexpr T& operator*() & { RELEASE_ASSERT(bool(*this)); return m_value; }
 
     template <class U> constexpr T value_or(U&& fallback) const
     {

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -80,7 +80,7 @@ struct FontSizeAdjust {
 
 inline void add(Hasher& hasher, const FontSizeAdjust& fontSizeAdjust)
 {
-    add(hasher, fontSizeAdjust.metric, fontSizeAdjust.type, *fontSizeAdjust.value);
+    add(hasher, fontSizeAdjust.metric, fontSizeAdjust.type, fontSizeAdjust.value.unsafeValue());
 }
 
 inline TextStream& operator<<(TextStream& ts, const FontSizeAdjust& fontSizeAdjust)

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -403,8 +403,8 @@ bool OverloadResolver::unify(const TypeVariable* variable, const Type* argumentT
     // 2) unify(Var(T), Type(u32); Failed! Can't unify AbstractFloat and u32
     auto variablePromotionRank = conversionRank(resolvedType, argumentType);
     auto argumentConversionRank = conversionRank(argumentType, resolvedType);
-    logLn("variablePromotionRank: ", variablePromotionRank.value(), ", argumentConversionRank: ", argumentConversionRank.value());
-    if (variablePromotionRank.value() < argumentConversionRank.value())
+    logLn("variablePromotionRank: ", variablePromotionRank.unsafeValue(), ", argumentConversionRank: ", argumentConversionRank.unsafeValue());
+    if (variablePromotionRank.unsafeValue() < argumentConversionRank.unsafeValue())
         return assign(*variable, argumentType);
 
     return !!argumentConversionRank;
@@ -554,7 +554,7 @@ std::optional<unsigned> OverloadResolver::resolve(ValueVariable variable) const
 ConversionRank OverloadResolver::conversionRank(const Type* from, const Type* to) const
 {
     auto rank = ::WGSL::conversionRank(from, to);
-    logLn("conversionRank(from: ", *from, ", to: ", *to, ") = ", rank.value());
+    logLn("conversionRank(from: ", *from, ", to: ", *to, ") = ", rank.unsafeValue());
     return rank;
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -181,10 +181,10 @@ public:
     void setScaleWasSetByUIProcess(bool scaleWasSetByUIProcess) { m_scaleWasSetByUIProcess = scaleWasSetByUIProcess; }
 
 #if PLATFORM(MAC)
-    WebCore::PlatformLayerIdentifier pageScalingLayerID() const { return m_pageScalingLayerID.value(); }
+    WebCore::PlatformLayerIdentifier pageScalingLayerID() const { return m_pageScalingLayerID.unsafeValue(); }
     void setPageScalingLayerID(WebCore::PlatformLayerIdentifier layerID) { m_pageScalingLayerID = layerID; }
 
-    WebCore::PlatformLayerIdentifier scrolledContentsLayerID() const { return m_scrolledContentsLayerID.value(); }
+    WebCore::PlatformLayerIdentifier scrolledContentsLayerID() const { return m_scrolledContentsLayerID.unsafeValue(); }
     void setScrolledContentsLayerID(WebCore::PlatformLayerIdentifier layerID) { m_scrolledContentsLayerID = layerID; }
 #endif
 


### PR DESCRIPTION
#### 1b44f3a2465f6e00b2edf81879dd953241673700
<pre>
Make sure Markable is set when dereferencing it and getting its value
<a href="https://bugs.webkit.org/show_bug.cgi?id=278296">https://bugs.webkit.org/show_bug.cgi?id=278296</a>

Reviewed by Dan Glastonbury.

Make sure WTF::Markable is set when dereferencing it and getting its value,
similarly to what is done with std::optional. We currently have no check so
you can dereference an unset Markable and get an unexpected value. This
matters a lot when using Markable with ObjectIdentifier for example.
ObjectIdentifier is expected to be a valid identifier, however, you can
easily get can invalid ObjectIdentifier if it was stored in a Markable.

This tested as performance neutral on the benchmarks we track.

* Source/WTF/wtf/Markable.h:
(WTF::Markable::value const):
(WTF::Markable::value):
(WTF::Markable::unsafeValue const):
(WTF::Markable::unsafeValue):
(WTF::Markable::operator-&gt; const):
(WTF::Markable::operator-&gt;):
(WTF::Markable::operator* const):
(WTF::Markable::operator*):
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::add):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::conversionRank const):

Canonical link: <a href="https://commits.webkit.org/282412@main">https://commits.webkit.org/282412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e886ac9e93ec9ddd5f44a5bceca4a84eb9bb7753

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50862 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9473 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12599 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56229 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68835 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62362 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58176 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5891 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84125 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9515 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38295 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14821 "Found 3 new JSC stress test failures: wasm.yaml/wasm/fuzz/memory.js.wasm-bbq, wasm.yaml/wasm/fuzz/memory.js.wasm-collect-continuously, wasm.yaml/wasm/gc/bug250613.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->