### PR TITLE
[CSP] Allow loading external script with matching SRI when `'strict-dynamic'` is present in `script-src`.

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/external-script.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/external-script.js
@@ -1,0 +1,1 @@
+console.log("external script matching hash allowed");

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/non-parser-inserted-script.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/non-parser-inserted-script.js
@@ -1,0 +1,1 @@
+console.log("non-parser-inserted script allowed by strict-dynamic");

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-load-external-scripts-with-matching-sri-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-load-external-scripts-with-matching-sri-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: external script matching hash allowed
+CONSOLE MESSAGE: non-parser-inserted script allowed by strict-dynamic
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-load-external-scripts-with-matching-sri.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-load-external-scripts-with-matching-sri.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- This tests that we allow loading external scripts with matching SRI attributes when the CSP contains 'strict-dynamic'. -->
+    <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-dummy' 'strict-dynamic' 'sha256-rlj3VyA1NVoQyZJJUxOqJOzLFauqQjXDoMdgCtJgsuo='">
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <script nonce="dummy">
+      if (window.testRunner) {
+        testRunner.dumpAsText();
+      }
+    </script>
+  </head>
+  <body>
+    <script src="resources/external-script.js" integrity="sha256-rlj3VyA1NVoQyZJJUxOqJOzLFauqQjXDoMdgCtJgsuo="></script>
+    <script nonce="dummy">
+      function loadScriptDynamically() {
+        var script = document.createElement('script');
+        script.src = "resources/non-parser-inserted-script.js";
+        document.body.appendChild(script);
+      }
+      loadScriptDynamically();
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -271,7 +271,7 @@ void ContentSecurityPolicy::didReceiveHeader(const String& header, ContentSecuri
             begin = buffer.position();
         }
     });
-    
+
 
     if (m_scriptExecutionContext)
         applyPolicyToScriptExecutionContext();
@@ -479,7 +479,7 @@ bool ContentSecurityPolicy::shouldPerformEarlyCSPCheck() const
 
 bool ContentSecurityPolicy::allowNonParserInsertedScripts(const URL& sourceURL, const URL& contextURL, const OrdinalNumber& contextLine, const String& nonce, const StringView& scriptContent, ParserInserted parserInserted) const
 {
-    if (!shouldPerformEarlyCSPCheck() || m_policies.isEmpty())
+    if (shouldPerformEarlyCSPCheck() || m_policies.isEmpty())
         return true;
 
     auto handleViolatedDirective = [&] (const ContentSecurityPolicyDirective& violatedDirective) {
@@ -907,7 +907,7 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
 
     // FIXME: Is it policy to not use the status code for HTTPS, or is that a bug?
     unsigned short httpStatusCode = m_selfSourceProtocol == "http"_s ? m_httpStatusCode : 0;
-    
+
     // WPT indicate modern Reporting API expect valid status code, regardless of protocol:
     //     content-security-policy/reporting-api/report-to-directive-allowed-in-meta.https.sub.html
     //     content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html
@@ -1151,7 +1151,7 @@ void ContentSecurityPolicy::setUpgradeInsecureRequests(bool upgradeInsecureReque
         upgradeURL.setProtocol("http"_s);
     else if (upgradeURL.protocolIs("wss"_s))
         upgradeURL.setProtocol("ws"_s);
-    
+
     m_insecureNavigationRequestsToUpgrade.add(SecurityOriginData::fromURL(upgradeURL));
 }
 


### PR DESCRIPTION
#### 66bf2841f24e32e1294331814bab749bd1d387d3
<pre>
[CSP] Allow loading external script with matching SRI when `&apos;strict-dynamic&apos;` is present in `script-src`.

<a href="https://bugs.webkit.org/show_bug.cgi?id=270784">https://bugs.webkit.org/show_bug.cgi?id=270784</a>

Reviewed by NOBODY (OOPS!).

The `&apos;strict-dynamic&apos;` keyword source when used in a `script-src`
directive as part of a Content Security Policy is designed to propagate
trust from scripts explicitly allowlisted by the CSP using hashes or
nonces to their children (i.e., non-parser inserted scripts should be
loaded when `&apos;strict-dynamic&apos;` is enabled without having to explicitly
allowlist them).

See: <a href="https://www.w3.org/TR/CSP3/#strict-dynamic-usage">https://www.w3.org/TR/CSP3/#strict-dynamic-usage</a>

The current implementation of the `allowNonParserInsertedScripts()`
function incorrectly returns false when `&apos;strict-dynamic&apos;` is present.

The proposed fix involves inverting the condition in this function to
allow loading external scripts with matching SRI (Subresource integrity)
hashes while also maintaining the trust propagation using
`&apos;strict-dynamic&apos;`.

There is a known workaround to make Web applications work on
versions of Safari/WebKit prior to this fix involving the use of
browser-sniffing:

- [ ] Lower the CSP level so that it uses something like `&apos;unsafe-inline&apos; https:` as
      the source list for the `script-src` directive, but this makes the
      website susceptible to XSS. See:
      <a href="https://www.w3.org/TR/CSP3/#strict-dynamic-usage">https://www.w3.org/TR/CSP3/#strict-dynamic-usage</a>

* LayoutTests/http/tests/security/contentSecurityPolicy/resources/external-script.js: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-load-external-scripts-with-matching-sri-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-load-external-scripts-with-matching-sri.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::didReceiveHeader):
(WebCore::ContentSecurityPolicy::allowNonParserInsertedScripts const):
(WebCore::ContentSecurityPolicy::reportViolation const):
(WebCore::ContentSecurityPolicy::setUpgradeInsecureRequests):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3029250adf2425d32da245aeaded36d4de0cb22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67164 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14031 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50882 "Found 21 new test failures: imported/w3c/web-platform-tests/content-security-policy/default-src/default-src-strict_dynamic_and_unsafe_inline.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-report-only-policy-works-with-external-hash-policy.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_discard_source_expressions.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9493 "Found 2 new test failures: imported/w3c/web-platform-tests/import-maps/csp/hash-failure.html imported/w3c/web-platform-tests/import-maps/csp/nonce-failure.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66212 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39467 "Found 60 new test failures: editing/selection/ios/look-up-selected-text.html fast/forms/ios/focus-input-via-button.html fast/forms/ios/zoom-after-input-tap-wide-input.html fast/forms/ios/zoom-after-input-tap.html fast/forms/state-restore-per-form.html fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html http/tests/scroll-to-text-fragment/generation-does-not-emit-empty-prefix.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31568 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36152 "Found 20 new test failures: imported/w3c/web-platform-tests/content-security-policy/default-src/default-src-strict_dynamic_and_unsafe_inline.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_discard_source_expressions.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_double_policy_honor_source_expressions.sub.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12020 "Found 60 new test failures: fast/workers/dedicated-worker-lifecycle.html fonts/font-weight-invalid-crash.html fonts/ligature.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57692 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12349 "Found 60 new test failures: editing/input/scroll-viewport-page-up-down.html http/tests/media/fairplay/fps-mse-multi-key-renewal.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68859 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7089 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11961 "Found 60 new test failures: fast/css/aspect-ratio-min-height-replaced.html http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58195 "Found 77 new test failures: http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-and-scripthash.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-basic-blocked.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-ignore-unsafeinline.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-in-enforced-policy-and-not-in-report-only.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-multiple-policies.html http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58408 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5913 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->