### PR TITLE
Reduce use of LegacyNullableObjectIdentifier

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -166,6 +166,7 @@ public:
 
     MappedTakeType take(const KeyType&); // efficient combination of get with remove
     MappedTakeType take(iterator);
+    std::optional<MappedTakeType> takeOptional(const KeyType&);
     MappedTakeType takeFirst();
 
     // Alternate versions of find() / contains() / get() / remove() that find the object
@@ -563,6 +564,15 @@ auto HashMap<T, U, V, W, MappedTraits, Y>::take(iterator it) -> MappedTakeType
     auto value = MappedTraits::take(WTFMove(it->value));
     remove(it);
     return value;
+}
+
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
+auto HashMap<T, U, V, W, MappedTraits, Y>::takeOptional(const KeyType& key) -> std::optional<MappedTakeType>
+{
+    auto it = find(key);
+    if (it == end())
+        return std::nullopt;
+    return take(it);
 }
 
 template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>

--- a/Source/WebCore/html/track/InbandGenericTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.cpp
@@ -61,8 +61,8 @@ void GenericTextTrackCueMap::remove(InbandGenericCueIdentifier inbandCueIdentifi
 
 void GenericTextTrackCueMap::remove(TextTrackCue& publicCue)
 {
-    if (auto cueIdentifier = m_cueToDataMap.take(&publicCue))
-        m_dataToCueMap.remove(cueIdentifier);
+    if (auto cueIdentifier = m_cueToDataMap.takeOptional(&publicCue))
+        m_dataToCueMap.remove(*cueIdentifier);
 }
 
 inline InbandGenericTextTrack::InbandGenericTextTrack(ScriptExecutionContext& context, InbandTextTrackPrivate& trackPrivate)

--- a/Source/WebCore/page/cocoa/ImageOverlayDataDetectionResultIdentifier.h
+++ b/Source/WebCore/page/cocoa/ImageOverlayDataDetectionResultIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 enum class ImageOverlayDataDetectionResultIdentifierType { };
-using ImageOverlayDataDetectionResultIdentifier = LegacyNullableObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>;
+using ImageOverlayDataDetectionResultIdentifier = ObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -150,12 +150,10 @@ bool ImageOverlayController::handleDataDetectorAction(const HTMLElement& element
         return false;
 
     auto identifierValue = parseInteger<uint64_t>(element.attributeWithoutSynchronization(HTMLNames::x_apple_data_detectors_resultAttr));
-    if (!identifierValue)
+    if (!identifierValue || !*identifierValue)
         return false;
 
-    auto identifier = LegacyNullableObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>(*identifierValue);
-    if (!identifier.isValid())
-        return false;
+    auto identifier = ObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>(*identifierValue);
 
     auto* dataDetectionResults = frame->dataDetectionResultsIfExists();
     if (!dataDetectionResults)

--- a/Source/WebCore/platform/graphics/ImageDecoderIdentifier.h
+++ b/Source/WebCore/platform/graphics/ImageDecoderIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum class ImageDecoderIdentifierType { };
-using ImageDecoderIdentifier = LegacyNullableObjectIdentifier<ImageDecoderIdentifierType>;
+using ImageDecoderIdentifier = ObjectIdentifier<ImageDecoderIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/InbandGenericCue.cpp
+++ b/Source/WebCore/platform/graphics/InbandGenericCue.cpp
@@ -44,7 +44,7 @@ String InbandGenericCue::toJSONString() const
     auto object = JSON::Object::create();
 
     object->setString("text"_s, m_cueData.m_content);
-    object->setInteger("identifier"_s, m_cueData.m_uniqueId.toUInt64());
+    object->setInteger("identifier"_s, m_cueData.m_uniqueId->toUInt64());
     object->setDouble("start"_s, m_cueData.m_startTime.toDouble());
     object->setDouble("end"_s, m_cueData.m_endTime.toDouble());
 

--- a/Source/WebCore/platform/graphics/InbandGenericCue.h
+++ b/Source/WebCore/platform/graphics/InbandGenericCue.h
@@ -39,7 +39,7 @@ struct GenericCueData {
     enum class Status : uint8_t { Uninitialized, Partial, Complete };
 
     GenericCueData() = default;
-    GenericCueData(InbandGenericCueIdentifier uniqueId, const MediaTime& startTime, const MediaTime& endTime, const AtomString& id, const String& content, const String& fontName, double line, double position, double size, double baseFontSize, double relativeFontSize, const Color& foregroundColor, const Color& backgroundColor, const Color& highlightColor, GenericCueData::Alignment positionAlign, GenericCueData::Alignment align, GenericCueData::Status status)
+    GenericCueData(Markable<InbandGenericCueIdentifier> uniqueId, const MediaTime& startTime, const MediaTime& endTime, const AtomString& id, const String& content, const String& fontName, double line, double position, double size, double baseFontSize, double relativeFontSize, const Color& foregroundColor, const Color& backgroundColor, const Color& highlightColor, GenericCueData::Alignment positionAlign, GenericCueData::Alignment align, GenericCueData::Status status)
         : m_uniqueId(uniqueId)
         , m_startTime(startTime)
         , m_endTime(endTime)
@@ -64,7 +64,7 @@ struct GenericCueData {
     bool isValid() const { return !!m_uniqueId; }
     bool equalNotConsideringTimesOrId(const GenericCueData&) const;
 
-    InbandGenericCueIdentifier m_uniqueId;
+    Markable<InbandGenericCueIdentifier> m_uniqueId;
     MediaTime m_startTime;
     MediaTime m_endTime;
     AtomString m_id;
@@ -88,7 +88,7 @@ public:
     static Ref<InbandGenericCue> create() { return adoptRef(*new InbandGenericCue); }
     static Ref<InbandGenericCue> create(GenericCueData&& cueData) { return adoptRef(*new InbandGenericCue(WTFMove(cueData))); }
 
-    InbandGenericCueIdentifier uniqueId() const { return m_cueData.m_uniqueId; }
+    InbandGenericCueIdentifier uniqueId() const { return *m_cueData.m_uniqueId; }
 
     MediaTime startTime() const { return m_cueData.m_startTime; }
     void setStartTime(const MediaTime& startTime) { m_cueData.m_startTime = startTime; }

--- a/Source/WebCore/platform/graphics/InbandGenericCueIdentifier.h
+++ b/Source/WebCore/platform/graphics/InbandGenericCueIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum class InbandGenericCueIdentifierType { };
-using InbandGenericCueIdentifier = LegacyNullableObjectIdentifier<InbandGenericCueIdentifierType>;
+using InbandGenericCueIdentifier = ObjectIdentifier<InbandGenericCueIdentifierType>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordIdentifier.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum class BackgroundFetchRecordIdentifierType { };
-using BackgroundFetchRecordIdentifier = LegacyNullableObjectIdentifier<BackgroundFetchRecordIdentifierType>;
+using BackgroundFetchRecordIdentifier = ObjectIdentifier<BackgroundFetchRecordIdentifierType>;
 
 } // namespace WebCore
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -60,13 +60,8 @@ header: <wtf/text/AtomString.h>
 }
 
 header: <wtf/ObjectIdentifier.h>
-template: class WebKit::WebURLSchemeHandler
 template: enum class WebCore::AXIDType
-template: enum class WebCore::BackgroundFetchRecordIdentifierType
 template: enum class WebCore::FetchIdentifierType
-template: enum class WebCore::ImageDecoderIdentifierType
-template: enum class WebCore::ImageOverlayDataDetectionResultIdentifierType
-template: enum class WebCore::InbandGenericCueIdentifierType
 template: enum class WebCore::LayerHostingContextIdentifierType
 template: enum class WebCore::MediaSessionGroupIdentifierType
 template: enum class WebCore::MediaUniqueIdentifierType
@@ -159,7 +154,12 @@ template: struct WebKit::WebTransportStreamIdentifierType
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
 
+template: class WebKit::WebURLSchemeHandler
+template: enum class WebCore::BackgroundFetchRecordIdentifierType
 template: enum class WebCore::ElementIdentifierType
+template: enum class WebCore::ImageDecoderIdentifierType
+template: enum class WebCore::ImageOverlayDataDetectionResultIdentifierType
+template: enum class WebCore::InbandGenericCueIdentifierType
 template: struct WebCore::NavigationIdentifierType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4886,7 +4886,7 @@ class WebCore::SocketStreamError {
 
 header: <WebCore/InbandGenericCue.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GenericCueData {
-    WebCore::InbandGenericCueIdentifier m_uniqueId;
+    Markable<WebCore::InbandGenericCueIdentifier> m_uniqueId;
     MediaTime m_startTime;
     MediaTime m_endTime;
     AtomString m_id;

--- a/Source/WebKit/Shared/WebURLSchemeHandlerIdentifier.h
+++ b/Source/WebKit/Shared/WebURLSchemeHandlerIdentifier.h
@@ -31,6 +31,6 @@ namespace WebKit {
 
 class WebURLSchemeHandler;
 
-using WebURLSchemeHandlerIdentifier = LegacyNullableObjectIdentifier<WebURLSchemeHandler>;
+using WebURLSchemeHandlerIdentifier = ObjectIdentifier<WebURLSchemeHandler>;
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -576,7 +576,7 @@ using TapIdentifier = LegacyNullableObjectIdentifier<TapIdentifierType>;
 using TextCheckerRequestID = LegacyNullableObjectIdentifier<TextCheckerRequestType>;
 using TransactionID = MonotonicObjectIdentifier<TransactionIDType>;
 using WebPageProxyIdentifier = LegacyNullableObjectIdentifier<WebPageProxyIdentifierType>;
-using WebURLSchemeHandlerIdentifier = LegacyNullableObjectIdentifier<WebURLSchemeHandler>;
+using WebURLSchemeHandlerIdentifier = ObjectIdentifier<WebURLSchemeHandler>;
 using WebUndoStepID = uint64_t;
 
 class WebPageProxy final : public API::ObjectImpl<API::Object::Type::Page>, public IPC::MessageReceiver {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3067,12 +3067,10 @@ static void dataDetectorImageOverlayPositionInformation(const HTMLElement& overl
 
     auto [foundElement, elementBounds] = *elementAndBounds;
     auto identifierValue = parseInteger<uint64_t>(foundElement->attributeWithoutSynchronization(HTMLNames::x_apple_data_detectors_resultAttr));
-    if (!identifierValue)
+    if (!identifierValue || !*identifierValue)
         return;
 
-    auto identifier = LegacyNullableObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>(*identifierValue);
-    if (!identifier.isValid())
-        return;
+    auto identifier = ObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>(*identifierValue);
 
     auto* dataDetectionResults = frame->dataDetectionResultsIfExists();
     if (!dataDetectionResults)


### PR DESCRIPTION
#### 584c5f30a3a23301b7464d7c77a03853460b4b92
<pre>
Reduce use of LegacyNullableObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=278298">https://bugs.webkit.org/show_bug.cgi?id=278298</a>

Reviewed by Per Arne Vollan.

Reduce use of LegacyNullableObjectIdentifier, and use ObjectIdentifier instead.

* Source/WTF/wtf/HashMap.h:
(WTF::Y&gt;::takeOptional):
* Source/WebCore/html/track/InbandGenericTextTrack.cpp:
(WebCore::GenericTextTrackCueMap::remove):
* Source/WebCore/page/cocoa/ImageOverlayDataDetectionResultIdentifier.h:
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::handleDataDetectorAction):
* Source/WebCore/platform/graphics/ImageDecoderIdentifier.h:
* Source/WebCore/platform/graphics/InbandGenericCue.cpp:
(WebCore::InbandGenericCue::toJSONString const):
* Source/WebCore/platform/graphics/InbandGenericCue.h:
(WebCore::GenericCueData::GenericCueData):
(WebCore::InbandGenericCue::uniqueId const):
* Source/WebCore/platform/graphics/InbandGenericCueIdentifier.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordIdentifier.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebURLSchemeHandlerIdentifier.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::dataDetectorImageOverlayPositionInformation):

Canonical link: <a href="https://commits.webkit.org/282414@main">https://commits.webkit.org/282414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efbb87292397c057cddf7e4c82f84f4fbc25d1be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67139 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50861 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11997 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12598 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56228 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68834 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62361 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58173 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58386 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5890 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84124 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9516 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38294 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14820 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39374 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->