### PR TITLE
[JSC] `Temporal.Instant.prototype.epochMilliseconds` should return floored value

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -101,7 +101,7 @@ function shouldThrow(func, errorType, message) {
         Temporal.Instant.from('1677-09-21T00:12:43.145224192Z'),
     ];
     instants.forEach((instant) => {
-        shouldBe(instant.epochMilliseconds, -9223372036854);
+        shouldBe(instant.epochMilliseconds, -9223372036855);
         shouldBe(instant.epochNanoseconds, -9223372036854775808n);
         shouldBe(instant.toString(), '1677-09-21T00:12:43.145224192Z');
         shouldBe(instant.toJSON(), '1677-09-21T00:12:43.145224192Z');

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1186,9 +1186,6 @@ test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-invalid-
 test/built-ins/Temporal/Duration/prototype/total/total-of-each-unit-relativeto.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(63072000_000_000_000n /* = 1972-01-01T00Z */, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(63072000_000_000_000n /* = 1972-01-01T00Z */, \"UTC\")')"
-test/built-ins/Temporal/Instant/prototype/epochMilliseconds/basic.js:
-  default: 'Test262Error: epochMilliseconds pre epoch Expected SameValue(«-217175010876», «-217175010877») to be true'
-  strict mode: 'Test262Error: epochMilliseconds pre epoch Expected SameValue(«-217175010876», «-217175010877») to be true'
 test/built-ins/Temporal/Instant/prototype/since/largestunit.js:
   default: 'Test262Error: does not include higher units than necessary (largest unit unspecified): nanoseconds result Expected SameValue(«40», «101») to be true'
   strict mode: 'Test262Error: does not include higher units than necessary (largest unit unspecified): nanoseconds result Expected SameValue(«40», «101») to be true'

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -110,6 +110,14 @@ public:
     {
         return static_cast<int64_t>(m_epochNanoseconds / ExactTime::nsPerMillisecond);
     }
+    int64_t floorEpochMilliseconds() const
+    {
+        auto div = m_epochNanoseconds / ExactTime::nsPerMillisecond;
+        auto rem = m_epochNanoseconds % ExactTime::nsPerMillisecond;
+        if (rem && m_epochNanoseconds < 0)
+            div -= 1;
+        return static_cast<int64_t>(div);
+    }
     constexpr Int128 epochNanoseconds() const
     {
         return m_epochNanoseconds;

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -280,7 +280,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMilliseconds, (JSGlo
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochMilliseconds called on value that's not a Instant"_s);
 
-    return JSValue::encode(jsNumber(instant->exactTime().epochMilliseconds()));
+    return JSValue::encode(jsNumber(instant->exactTime().floorEpochMilliseconds()));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochNanoseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))


### PR DESCRIPTION
#### 845ee710b8ee7b4623e523bdb63ae7fb8aceed93
<pre>
[JSC] `Temporal.Instant.prototype.epochMilliseconds` should return floored value
<a href="https://bugs.webkit.org/show_bug.cgi?id=278300">https://bugs.webkit.org/show_bug.cgi?id=278300</a>

Reviewed by Yusuke Suzuki.

According to the latest Temporal spec [1], `Temporal.Instant.prototype.epochMilliseconds` should
return a floored value.

However, the current implementation in JSC returns a truncated value instead of a floored one.

This patch changes `Temporal.Instant.prototype.epochMilliseconds` to return a floored value.

[1]: <a href="https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmilliseconds">https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmilliseconds</a>

* JSTests/stress/temporal-instant.js:
(instants.forEach):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):

Canonical link: <a href="https://commits.webkit.org/282718@main">https://commits.webkit.org/282718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0ae0b8aea7831b3b01abcf005a93bf5835f90fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14661 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51585 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10122 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13534 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57165 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69774 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63298 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59053 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6633 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85059 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39230 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15001 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->