### PR TITLE
[WebPush] Fix -Wmissing-designated-field-initializers warnings

### DIFF
--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -392,6 +392,7 @@ void SubscribeRequest::startImpl(IsRetry isRetry)
             }
 
             auto clientKeys = m_service.connection().generateClientKeys();
+            IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
             PushRecord record {
                 .subscriptionSetIdentifier = m_identifier,
                 .securityOrigin = SecurityOrigin::createFromString(m_scope)->data().toString(),
@@ -403,6 +404,7 @@ void SubscribeRequest::startImpl(IsRetry isRetry)
                 .clientPrivateKey = WTFMove(clientKeys.clientP256DHKeyPair.privateKey),
                 .sharedAuthSecret = WTFMove(clientKeys.sharedAuthSecret)
             };
+            IGNORE_CLANG_WARNINGS_END
 
             m_database.insertRecord(record, [this, weakThis = WeakPtr { *this }](auto&& result) mutable {
                 if (!weakThis)

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -208,6 +208,7 @@ class PushDatabaseTest : public testing::Test {
 public:
     std::unique_ptr<PushDatabase> db;
 
+    IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
     PushRecord record1 {
         .subscriptionSetIdentifier = { "com.apple.webapp"_s, emptyString(), std::nullopt },
         .securityOrigin = "https://www.apple.com"_s,
@@ -298,6 +299,7 @@ public:
         .clientPrivateKey = { 23 },
         .sharedAuthSecret = { 24 }
     };
+    IGNORE_CLANG_WARNINGS_END
 
     std::optional<PushRecord> insertResult1;
     std::optional<PushRecord> insertResult2;
@@ -844,6 +846,7 @@ TEST(PushDatabase, ManyInFlightOps)
         ASSERT_TRUE(createResult);
 
         auto& database = *createResult;
+        IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
         PushRecord record {
             .subscriptionSetIdentifier = PushSubscriptionSetIdentifier { "com.apple.Safari"_s, emptyString(), std::nullopt },
             .securityOrigin = "https://www.webkit.org"_s,
@@ -854,6 +857,7 @@ TEST(PushDatabase, ManyInFlightOps)
             .sharedAuthSecret = { 4, 5 },
             .expirationTime = convertSecondsToEpochTimeStamp(1643350000),
         };
+        IGNORE_CLANG_WARNINGS_END
 
         for (unsigned i = 0; i < recordCount; i++) {
             record.scope = makeString("http://www.webkit.org/test/"_s, i);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -306,7 +306,9 @@ static WebKit::WebPushD::WebPushDaemonConnectionConfiguration defaultWebPushDaem
     Vector<uint8_t> auditToken(sizeof(token));
     memcpy(auditToken.data(), &token, sizeof(token));
 
+    IGNORE_CLANG_WARNINGS_BEGIN("missing-designated-field-initializers")
     return { .hostAppAuditTokenData = WTFMove(auditToken) };
+    IGNORE_CLANG_WARNINGS_END
 }
 
 RetainPtr<xpc_connection_t> createAndConfigureConnectionToService(const char* serviceName, std::optional<WebKit::WebPushD::WebPushDaemonConnectionConfiguration> configuration = std::nullopt)


### PR DESCRIPTION
#### 2a4cf936370c9d32f4f3df96ea84047ed1575b3c
<pre>
[WebPush] Fix -Wmissing-designated-field-initializers warnings
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278301">https://bugs.webkit.org/show_bug.cgi?id=278301</a>&gt;
&lt;<a href="https://rdar.apple.com/134222548">rdar://134222548</a>&gt;

Reviewed by Ben Nham.

Ignore warnings for PushRecord and
WebPushD::WebPushDaemonConnectionConfiguration structs.

* Source/WebKit/webpushd/PushService.mm:
(WebPushD::SubscribeRequest::startImpl):
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::TEST(PushDatabase, ManyInFlightOps)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::defaultWebPushDaemonConfiguration):

Canonical link: <a href="https://commits.webkit.org/282584@main">https://commits.webkit.org/282584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c827523e37b2f38970f32d3365a4c2fd8fd4c105

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14473 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55061 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12436 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/13066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7532 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12333 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55148 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6284 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9616 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->