### PR TITLE
[IFC][Ruby] Perform nested ruby layouts from IFC

### DIFF
--- a/LayoutTests/fast/ruby/floating-ruby-text-expected.txt
+++ b/LayoutTests/fast/ruby/floating-ruby-text-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 1428x585
 layer at (0,0) size 800x31
   RenderBlock {HTML} at (0,0) size 800x31 [color=#FFFFFF]
     RenderBody {BODY} at (8,8) size 784x15
-      RenderInline {RUBY} at (0,5) size 1420x10
+      RenderInline {RUBY} at (0,5) size 1420x12
         RenderInline (generated) at (0,5) size 1420x10
           RenderText {#text} at (0,5) size 1420x10
             text run at (0,5) width 1420: "Attempt to create a floating ruby text element. Float is not supported for ruby text, which should be apparent from the resulting render tree."

--- a/LayoutTests/fast/ruby/positioned-ruby-text-expected.txt
+++ b/LayoutTests/fast/ruby/positioned-ruby-text-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 1588x585
 layer at (0,0) size 800x31
   RenderBlock {HTML} at (0,0) size 800x31
     RenderBody {BODY} at (8,8) size 784x15
-      RenderInline {RUBY} at (0,5) size 1580x10
+      RenderInline {RUBY} at (0,5) size 1580x12
         RenderInline (generated) at (0,5) size 1580x10
           RenderText {#text} at (0,5) size 1580x10
             text run at (0,5) width 1580: "Attempt to create a positioned ruby text element. Non-static position is not supported for ruby text, which should be apparent from the resulting render tree."

--- a/Source/WebCore/layout/LayoutState.cpp
+++ b/Source/WebCore/layout/LayoutState.cpp
@@ -42,7 +42,7 @@ namespace Layout {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(LayoutState);
 
-LayoutState::LayoutState(const Document& document, const ElementBox& rootContainer, Type type, Function<void(const ElementBox&, LayoutState&)>&& formattingContextLayoutFunction)
+LayoutState::LayoutState(const Document& document, const ElementBox& rootContainer, Type type, FormattingContextLayoutFunction&& formattingContextLayoutFunction)
     : m_type(type)
     , m_rootContainer(rootContainer)
     , m_securityOrigin(document.securityOrigin())
@@ -151,9 +151,9 @@ void LayoutState::destroyInlineContentCache(const ElementBox& formattingContextR
     m_inlineContentCaches.remove(&formattingContextRoot);
 }
 
-void LayoutState::layoutWithFormattingContextForBox(const ElementBox& box)
+void LayoutState::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> widthConstraint)
 {
-    return m_formattingContextLayoutFunction(box, *this);
+    return m_formattingContextLayoutFunction(box, widthConstraint, *this);
 }
 
 }

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -62,7 +62,9 @@ public:
     // Primary layout state has a direct geometry cache in layout boxes.
     enum class Type { Primary, Secondary };
 
-    LayoutState(const Document&, const ElementBox& rootContainer, Type, Function<void(const ElementBox&, LayoutState&)>&& formattingContextLayoutFunction);
+    using FormattingContextLayoutFunction = Function<void(const ElementBox&, std::optional<LayoutUnit>, LayoutState&)>;
+
+    LayoutState(const Document&, const ElementBox& rootContainer, Type, FormattingContextLayoutFunction&&);
     ~LayoutState();
 
     Type type() const { return m_type; }
@@ -103,7 +105,7 @@ public:
 
     const ElementBox& root() const { return m_rootContainer; }
 
-    void layoutWithFormattingContextForBox(const ElementBox&);
+    void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> widthConstraint);
 
 private:
     void setQuirksMode(QuirksMode quirksMode) { m_quirksMode = quirksMode; }
@@ -125,7 +127,7 @@ private:
     CheckedRef<const ElementBox> m_rootContainer;
     Ref<SecurityOrigin> m_securityOrigin;
 
-    Function<void(const ElementBox&, LayoutState&)> m_formattingContextLayoutFunction;
+    FormattingContextLayoutFunction m_formattingContextLayoutFunction;
 };
 
 inline bool LayoutState::hasBoxGeometry(const Box& layoutBox) const

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -547,9 +547,9 @@ void InlineFormattingContext::rebuildInlineItemListIfNeeded(InlineDamage* lineDa
     inlineContentCache.clearMaximumIntrinsicWidthLineContent();
 }
 
-void InlineFormattingContext::layoutWithFormattingContextForBox(const ElementBox& box)
+void InlineFormattingContext::layoutWithFormattingContextForBox(const ElementBox& box, std::optional<LayoutUnit> widthConstraint)
 {
-    m_globalLayoutState.layoutWithFormattingContextForBox(box);
+    m_globalLayoutState.layoutWithFormattingContextForBox(box, widthConstraint);
 }
 
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -71,7 +71,7 @@ public:
     InlineLayoutState& layoutState() { return m_inlineLayoutState; }
     const InlineLayoutState& layoutState() const { return m_inlineLayoutState; }
 
-    void layoutWithFormattingContextForBox(const ElementBox&);
+    void layoutWithFormattingContextForBox(const ElementBox&, std::optional<LayoutUnit> widthConstraint = { });
 
     enum class EscapeReason {
         InkOverflowNeedsInitialContiningBlockForStrokeWidth

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -866,7 +866,7 @@ void InlineItemsBuilder::handleInlineBoxEnd(const Box& inlineBox, InlineItemList
 void InlineItemsBuilder::handleInlineLevelBox(const Box& layoutBox, InlineItemList& inlineItemList)
 {
     if (layoutBox.isRubyAnnotationBox())
-        return;
+        return inlineItemList.append({ layoutBox, InlineItem::Type::Opaque });
 
     if (layoutBox.isAtomicInlineLevelBox()) {
         m_isTextAndForcedLineBreakOnlyContent = false;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -658,7 +658,7 @@ void LineBuilder::candidateContentForLine(LineCandidate& lineCandidate, size_t c
         auto& inlineItem = m_inlineItemList[index];
         auto& style = isFirstFormattedLine() ? inlineItem.firstLineStyle() : inlineItem.style();
 
-        if (inlineItem.isFloat() || inlineItem.isBox())
+        if (inlineItem.isFloat() || inlineItem.isBox() || (inlineItem.isOpaque() && inlineItem.layoutBox().isRubyAnnotationBox()))
             formattingContext().layoutWithFormattingContextForBox(downcast<ElementBox>(inlineItem.layoutBox()));
 
         if (inlineItem.isFloat()) {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1096,6 +1096,7 @@ size_t InlineDisplayContentBuilder::processRubyBase(size_t rubyBaseStart, Inline
                 baseBorderBoxLogicalRect.setWidth(std::max(0_lu, baseBorderBoxLogicalRect.width() - letterSpacing));
             }
 
+            // FIXME: There is a confusion here. The functions expect margin box.
             auto borderBoxLogicalTopLeft = RubyFormattingContext::placeAnnotationBox(rubyBaseLayoutBox, baseBorderBoxLogicalRect, formattingContext);
             auto contentBoxLogicalSize = RubyFormattingContext::sizeAnnotationBox(rubyBaseLayoutBox, baseBorderBoxLogicalRect, formattingContext);
             auto& annotationBoxGeometry = formattingContext.geometryForBox(*annotationBox);

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
@@ -42,21 +42,21 @@ class RubyFormattingContext {
 public:
     // Line building
     static bool isAtSoftWrapOpportunity(const InlineItem& previous, const InlineItem& current);
-    static InlineLayoutUnit annotationBoxLogicalWidth(const Box& rubyBaseLayoutBox, const InlineFormattingContext&);
-    static InlineLayoutUnit baseEndAdditionalLogicalWidth(const Box& rubyBaseLayoutBox, const Line::RunList&, const InlineContentBreaker::ContinuousContent::RunList&, const InlineFormattingContext&);
-    static HashMap<const Box*, InlineLayoutUnit> applyRubyAlign(Line&, const InlineFormattingContext&);
-    static InlineLayoutUnit applyRubyAlignOnAnnotationBox(Line&, InlineLayoutUnit spaceToDistribute, const InlineFormattingContext&);
+    static InlineLayoutUnit annotationBoxLogicalWidth(const Box& rubyBaseLayoutBox, InlineFormattingContext&);
+    static InlineLayoutUnit baseEndAdditionalLogicalWidth(const Box& rubyBaseLayoutBox, const Line::RunList&, const InlineContentBreaker::ContinuousContent::RunList&, InlineFormattingContext&);
+    static HashMap<const Box*, InlineLayoutUnit> applyRubyAlign(Line&, InlineFormattingContext&);
+    static InlineLayoutUnit applyRubyAlignOnAnnotationBox(Line&, InlineLayoutUnit spaceToDistribute, InlineFormattingContext&);
 
     // Line box building
     static void applyAnnotationContributionToLayoutBounds(LineBox&, const InlineFormattingContext&);
 
     // Display content building
-    static InlineLayoutUnit baseEndAdditionalLogicalWidth(const Box& rubyBaseLayoutBox, const InlineDisplay::Box& baseDisplayBox, InlineLayoutUnit baseContentWidth, const InlineFormattingContext&);
-    static InlineLayoutPoint placeAnnotationBox(const Box& rubyBaseLayoutBox, const Rect& rubyBaseMarginBoxLogicalRect, const InlineFormattingContext&);
-    static InlineLayoutSize sizeAnnotationBox(const Box& rubyBaseLayoutBox, const Rect& rubyBaseMarginBoxLogicalRect, const InlineFormattingContext&);
+    static InlineLayoutUnit baseEndAdditionalLogicalWidth(const Box& rubyBaseLayoutBox, const InlineDisplay::Box& baseDisplayBox, InlineLayoutUnit baseContentWidth, InlineFormattingContext&);
+    static InlineLayoutPoint placeAnnotationBox(const Box& rubyBaseLayoutBox, const Rect& rubyBaseMarginBoxLogicalRect, InlineFormattingContext&);
+    static InlineLayoutSize sizeAnnotationBox(const Box& rubyBaseLayoutBox, const Rect& rubyBaseMarginBoxLogicalRect, InlineFormattingContext&);
 
-    static InlineLayoutUnit overhangForAnnotationBefore(const Box& rubyBaseLayoutBox, size_t rubyBaseStart, const InlineDisplay::Boxes&, InlineLayoutUnit lineLogicalHeight, const InlineFormattingContext&);
-    static InlineLayoutUnit overhangForAnnotationAfter(const Box& rubyBaseLayoutBox, WTF::Range<size_t> rubyBaseRange, const InlineDisplay::Boxes&, InlineLayoutUnit lineLogicalHeight, const InlineFormattingContext&);
+    static InlineLayoutUnit overhangForAnnotationBefore(const Box& rubyBaseLayoutBox, size_t rubyBaseStart, const InlineDisplay::Boxes&, InlineLayoutUnit lineLogicalHeight, InlineFormattingContext&);
+    static InlineLayoutUnit overhangForAnnotationAfter(const Box& rubyBaseLayoutBox, WTF::Range<size_t> rubyBaseRange, const InlineDisplay::Boxes&, InlineLayoutUnit lineLogicalHeight, InlineFormattingContext&);
 
     enum class RubyBasesMayNeedResizing : bool { No, Yes };
     static void applyAlignmentOffsetList(InlineDisplay::Boxes&, const HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, RubyBasesMayNeedResizing, InlineFormattingContext&);
@@ -69,7 +69,7 @@ public:
 private:
     using MaximumLayoutBoundsStretchMap = HashMap<const InlineLevelBox*, InlineLevelBox::AscentAndDescent>;
     static void adjustLayoutBoundsAndStretchAncestorRubyBase(LineBox&, InlineLevelBox& rubyBaseInlineBox, MaximumLayoutBoundsStretchMap&, const InlineFormattingContext&);
-    static size_t applyRubyAlignOnBaseContent(size_t rubyBaseStart, Line&, HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, const InlineFormattingContext&);
+    static size_t applyRubyAlignOnBaseContent(size_t rubyBaseStart, Line&, HashMap<const Box*, InlineLayoutUnit>& alignmentOffsetList, InlineFormattingContext&);
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -27,15 +27,24 @@
 #include "LayoutIntegrationFormattingContextLayout.h"
 
 #include "LayoutIntegrationBoxGeometryUpdater.h"
-#include "RenderElement.h"
+#include "RenderBox.h"
 
 namespace WebCore {
 namespace LayoutIntegration {
 
-void layoutWithFormattingContextForBox(const Layout::ElementBox& box, Layout::LayoutState& layoutState)
+void layoutWithFormattingContextForBox(const Layout::ElementBox& box, std::optional<LayoutUnit> widthConstraint, Layout::LayoutState& layoutState)
 {
-    auto& renderer = *box.rendererForIntegration();
+    auto& renderer = downcast<RenderBox>(*box.rendererForIntegration());
+
+    if (widthConstraint) {
+        renderer.setOverridingLogicalWidthLength({ *widthConstraint, LengthType::Fixed });
+        renderer.setNeedsLayout(MarkOnlyThis);
+    }
+
     renderer.layoutIfNeeded();
+
+    if (widthConstraint)
+        renderer.clearOverridingLogicalWidthLength();
 
     auto updater = BoxGeometryUpdater { layoutState };
     updater.updateGeometryAfterLayout(box);

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "LayoutUnit.h"
+
 namespace WebCore {
 
 namespace Layout {
@@ -35,7 +37,7 @@ class LayoutState;
 
 namespace LayoutIntegration {
 
-void layoutWithFormattingContextForBox(const Layout::ElementBox&, Layout::LayoutState&);
+void layoutWithFormattingContextForBox(const Layout::ElementBox&, std::optional<LayoutUnit> widthConstraint, Layout::LayoutState&);
 
 }
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -476,24 +476,6 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
             layer->setIsHiddenByOverflowTruncation(box.isFullyTruncated());
 
         renderer.setLocation(Layout::toLayoutPoint(box.visualRectIgnoringBlockDirection().location()));
-        auto relayoutRubyAnnotationIfNeeded = [&] {
-            if (!layoutBox.isRubyAnnotationBox())
-                return;
-            // Annotation inline-block may get resized during inline layout (when base is wider) and
-            // we need to apply this new size on the annotation content by running layout.
-            auto needsResizing = layoutBox.isInterlinearRubyAnnotationBox() || !isHorizontalWritingMode;
-            if (!needsResizing)
-                return;
-            auto logicalMarginBoxSize = Layout::BoxGeometry::marginBoxRect(layoutState().geometryForBox(layoutBox)).size();
-            if (logicalMarginBoxSize == renderer.size())
-                return;
-            renderer.setSize(logicalMarginBoxSize);
-            renderer.setOverridingLogicalWidthLength({ logicalMarginBoxSize.width(), LengthType::Fixed });
-            renderer.setNeedsLayout(MarkOnlyThis);
-            renderer.layoutIfNeeded();
-            renderer.clearOverridingLogicalWidthLength();
-        };
-        relayoutRubyAnnotationIfNeeded();
     }
 
     HashMap<CheckedRef<const Layout::Box>, LayoutSize> floatPaginationOffsetMap;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3850,9 +3850,6 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
                 modernLineLayout()->boxContentWillChange(*inlineLevelBox);
         }
 
-        if (box && box->style().display() == DisplayType::RubyAnnotation)
-            box->layoutIfNeeded();
-
         if (is<RenderLineBreak>(renderer) || is<RenderInline>(renderer) || is<RenderText>(renderer))
             renderer.clearNeedsLayout();
 


### PR DESCRIPTION
#### c25019a482079a9eebb41a9f0e312d487828dc32
<pre>
[IFC][Ruby] Perform nested ruby layouts from IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=278307">https://bugs.webkit.org/show_bug.cgi?id=278307</a>
<a href="https://rdar.apple.com/134239864">rdar://134239864</a>

Reviewed by Alan Baradlay.

Move nested ruby layouts to IFC. Handle also the case where we relayout because of
a constraints change.

* Source/WebCore/layout/LayoutState.cpp:
(WebCore::Layout::LayoutState::LayoutState):
(WebCore::Layout::LayoutState::layoutWithFormattingContextForBox):

Add optional width constraint argument.

* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::layoutWithFormattingContextForBox):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
(WebCore::Layout::InlineFormattingContext::layoutWithFormattingContextForBox):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::handleInlineLevelBox):

Include an opaque inline item for annotation boxes.

* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::candidateContentForLine):

Ensure opaque box has a layout.

Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::processRubyBase):
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
(WebCore::Layout::annotationMarginBoxVisualRect):
(WebCore::Layout::annotationOverlapCheck):
(WebCore::Layout::RubyFormattingContext::annotationBoxLogicalWidth):
(WebCore::Layout::RubyFormattingContext::baseEndAdditionalLogicalWidth):
(WebCore::Layout::RubyFormattingContext::applyRubyAlignOnBaseContent):
(WebCore::Layout::RubyFormattingContext::applyRubyAlign):
(WebCore::Layout::RubyFormattingContext::applyRubyAlignOnAnnotationBox):
(WebCore::Layout::RubyFormattingContext::placeAnnotationBox):
(WebCore::Layout::RubyFormattingContext::sizeAnnotationBox):

Layout again if the annotation box size changed.

(WebCore::Layout::RubyFormattingContext::overhangForAnnotationBefore):
(WebCore::Layout::RubyFormattingContext::overhangForAnnotationAfter):
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h:
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
(WebCore::LayoutIntegration::layoutWithFormattingContextForBox):
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):

Canonical link: <a href="https://commits.webkit.org/282495@main">https://commits.webkit.org/282495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29b4f64820d8fa03cc66991d369f72134e004f7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50997 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9614 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12499 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69025 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12101 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/69025 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54892 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/69025 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6042 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38485 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->