### PR TITLE
[macOS] Block camera access in the WebContent process

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1318,64 +1318,6 @@
         ,@rules
         (set! deny orig-deny)
         (set! allow orig-allow))))
-
-;; Media capture, camera access
-(with-filter (extension "com.apple.webkit.camera")
-    (shared-preferences-read "com.apple.cmio")
-    (shared-preferences-read "com.apple.coremedia")
-    (allow file-read* (subpath "/Library/CoreMediaIO/Plug-Ins/DAL"))
-    (allow mach-lookup
-        (global-name "com.apple.cmio.AppleCameraAssistant")
-        (global-name "com.apple.cmio.registerassistantservice")
-        (global-name "com.apple.cmio.registerassistantservice.system-extensions")
-        ;; Apple DAL assistants
-        (global-name "com.apple.cmio.VDCAssistant")
-        (global-name "com.apple.cmio.AVCAssistant")
-        (global-name "com.apple.cmio.IIDCVideoAssistant")
-        ;; QuickTimeIIDCDigitizer assistant
-        (global-name "com.apple.IIDCAssistant")
-        ;; applecamerad
-        (require-all
-            (extension "com.apple.webkit.extension.mach")
-            (global-name "com.apple.applecamerad")
-        ))
-    (when (not (webcontent_gpu_sandbox_extensions_blocking))
-    ;; QuickTimeUSBVDCDigitizer
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (iokit-usb-interface-class kUSBVideoInterfaceClass)
-                (iokit-user-client-class "IOUSBDeviceUserClientV2"))
-            (apply-message-filter
-                (allow
-                    iokit-external-method)
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (iokit-usb-interface-class kUSBVideoInterfaceClass)
-                (iokit-user-client-class "IOUSBDeviceUserClientV2"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (iokit-usb-interface-class kUSBVideoInterfaceClass)
-                (iokit-user-client-class "IOUSBInterfaceUserClientV2"))
-            (apply-message-filter
-                (allow
-                    iokit-external-method)
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (iokit-usb-interface-class kUSBVideoInterfaceClass)
-                (iokit-user-client-class "IOUSBInterfaceUserClientV2")))))
-
-    (allow device-camera))
 #endif // PLATFORM(MAC)
 
 ;; <rdar://problem/60983812>
@@ -1698,16 +1640,6 @@
     (deny syscall-unix (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode))
     (when (equal? (param "CPU") "arm64")
         (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon))))
-#endif
-
-#if HAVE(ADDITIONAL_APPLE_CAMERA_SERVICE)
-(if (equal? (param "CPU") "arm64")
-    (with-filter (extension "com.apple.webkit.camera")
-        (allow mach-lookup
-            (require-all
-                (extension "com.apple.webkit.extension.mach")
-                (global-name "com.apple.appleh13camerad")
-            ))))
 #endif
 
 #if HAVE(SANDBOX_MESSAGE_FILTERING)


### PR DESCRIPTION
#### 87fe700dbd44d5ea4313407e8054e8b41cae5063
<pre>
[macOS] Block camera access in the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=278314">https://bugs.webkit.org/show_bug.cgi?id=278314</a>
<a href="https://rdar.apple.com/problem/134254233">rdar://problem/134254233</a>

Reviewed by Brent Fulgham.

Block camera access in the WebContent process on macOS. We should only support camera access in the GPU
process and UI process, so we can block this in the WebContent process.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/283715@main">https://commits.webkit.org/283715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b64af71d61563666396125adf2e853b6453cd1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13768 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50899 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36167 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12640 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58213 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5928 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38336 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->