### PR TITLE
Let websites override system-default accessibility caption styling

### DIFF
--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -312,6 +312,14 @@ void CaptionUserPreferencesMediaAF::setCaptionPreferencesDelegate(std::unique_pt
     captionPreferencesDelegate() = WTFMove(delegate);
 }
 
+static bool behaviorShouldNotBeOverriden(MACaptionAppearanceBehavior behavior)
+{
+    if (!canLoad_MediaAccessibility_MACaptionAppearanceIsCustomized())
+        return behavior == kMACaptionAppearanceBehaviorUseValue;
+
+    return (behavior == kMACaptionAppearanceBehaviorUseValue) && MACaptionAppearanceIsCustomized(kMACaptionAppearanceDomainUser);
+}
+
 String CaptionUserPreferencesMediaAF::captionsWindowCSS() const
 {
     MACaptionAppearanceBehavior behavior;
@@ -321,10 +329,10 @@ String CaptionUserPreferencesMediaAF::captionsWindowCSS() const
     if (!windowColor.isValid())
         windowColor = Color::transparentBlack;
 
-    bool important = behavior == kMACaptionAppearanceBehaviorUseValue;
+    bool important = behaviorShouldNotBeOverriden(behavior);
     CGFloat opacity = MACaptionAppearanceGetWindowOpacity(kMACaptionAppearanceDomainUser, &behavior);
     if (!important)
-        important = behavior == kMACaptionAppearanceBehaviorUseValue;
+        important = behaviorShouldNotBeOverriden(behavior);
     String windowStyle = colorPropertyCSS(CSSPropertyBackgroundColor, windowColor.colorWithAlpha(opacity), important);
 
     if (!opacity)
@@ -346,10 +354,10 @@ String CaptionUserPreferencesMediaAF::captionsBackgroundCSS() const
     if (!backgroundColor.isValid())
         backgroundColor = defaultBackgroundColor;
 
-    bool important = behavior == kMACaptionAppearanceBehaviorUseValue;
+    bool important = behaviorShouldNotBeOverriden(behavior);
     CGFloat opacity = MACaptionAppearanceGetBackgroundOpacity(kMACaptionAppearanceDomainUser, &behavior);
     if (!important)
-        important = behavior == kMACaptionAppearanceBehaviorUseValue;
+        important = behaviorShouldNotBeOverriden(behavior);
     return colorPropertyCSS(CSSPropertyBackgroundColor, backgroundColor.colorWithAlpha(opacity), important);
 }
 
@@ -362,10 +370,10 @@ Color CaptionUserPreferencesMediaAF::captionsTextColor(bool& important) const
         // This default value must be the same as the one specified in mediaControls.css for -webkit-media-text-track-container.
         textColor = Color::white;
     }
-    important = behavior == kMACaptionAppearanceBehaviorUseValue;
+    important = behaviorShouldNotBeOverriden(behavior);
     CGFloat opacity = MACaptionAppearanceGetForegroundOpacity(kMACaptionAppearanceDomainUser, &behavior);
     if (!important)
-        important = behavior == kMACaptionAppearanceBehaviorUseValue;
+        important = behaviorShouldNotBeOverriden(behavior);
     return textColor.colorWithAlpha(opacity);
 }
 
@@ -391,7 +399,7 @@ String CaptionUserPreferencesMediaAF::windowRoundedCornerRadiusCSS() const
         return emptyString();
 
     StringBuilder builder;
-    appendCSS(builder, CSSPropertyBorderRadius, behavior == kMACaptionAppearanceBehaviorUseValue, radius, "px"_s);
+    appendCSS(builder, CSSPropertyBorderRadius, behaviorShouldNotBeOverriden(behavior), radius, "px"_s);
     return builder.toString();
 }
 
@@ -419,7 +427,7 @@ bool CaptionUserPreferencesMediaAF::captionStrokeWidthForFont(float fontSize, co
 
     // Since only half of the stroke is visible because the stroke is drawn before the fill, we double the stroke width here.
     strokeWidth = strokeWidthPt * 2;
-    important = behavior == kMACaptionAppearanceBehaviorUseValue;
+    important = behaviorShouldNotBeOverriden(behavior);
     return true;
 }
 
@@ -432,7 +440,7 @@ String CaptionUserPreferencesMediaAF::captionsTextEdgeCSS() const
         return emptyString();
 
     StringBuilder builder;
-    bool important = behavior == kMACaptionAppearanceBehaviorUseValue;
+    bool important = behaviorShouldNotBeOverriden(behavior);
     if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleRaised)
         appendCSS(builder, CSSPropertyTextShadow, important, "-.1em -.1em .16em black"_s);
     else if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDepressed)
@@ -487,7 +495,7 @@ String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
             builder.append(", \""_s, fontCascadeName.get(), '"');
         }
     }
-    builder.append(behavior == kMACaptionAppearanceBehaviorUseValue ? " !important;"_s : ";"_s);
+    builder.append(behaviorShouldNotBeOverriden(behavior) ? " !important;"_s : ";"_s);
     return builder.toString();
 }
 
@@ -503,7 +511,7 @@ float CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance(bool& imp
     if (!scaleAdjustment)
         return characterScale;
 
-    important = behavior == kMACaptionAppearanceBehaviorUseValue;
+    important = behaviorShouldNotBeOverriden(behavior);
 #if defined(__LP64__) && __LP64__
     return narrowPrecisionToFloat(scaleAdjustment * characterScale);
 #else

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
@@ -59,5 +59,5 @@ SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, kMAXCapti
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, kMAAudibleMediaSettingsChangedNotification, CFStringRef)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, MAImageCaptioningCopyCaptionWithSource, CFStringRef, (CGImageSourceRef imageSource, CFErrorRef *error), (imageSource, error))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, MediaAccessibility, MAAudibleMediaPrefCopyPreferDescriptiveVideo, CFBooleanRef, (), ())
-
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebCore, MediaAccessibility, MACaptionAppearanceIsCustomized, bool, (MACaptionAppearanceDomain domain), (domain));
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
@@ -81,7 +81,8 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MAImageCapti
 #define MAImageCaptioningCopyCaptionWithSource softLink_MediaAccessibility_MAImageCaptioningCopyCaptionWithSource
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, MediaAccessibility, MAAudibleMediaPrefCopyPreferDescriptiveVideo, CFBooleanRef, (), ())
 #define MAAudibleMediaPrefCopyPreferDescriptiveVideo softLink_MediaAccessibility_MAAudibleMediaPrefCopyPreferDescriptiveVideo
-
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceIsCustomized, bool, (MACaptionAppearanceDomain domain), (domain))
+#define MACaptionAppearanceIsCustomized softLink_MediaAccessibility_MACaptionAppearanceIsCustomized
 
 #if COMPILER(MSVC)
 #pragma warning(pop)


### PR DESCRIPTION
#### 526cd9597fafe37c83d5aab52b46f7ddc1e5a8f4
<pre>
Let websites override system-default accessibility caption styling
<a href="https://bugs.webkit.org/show_bug.cgi?id=278319">https://bugs.webkit.org/show_bug.cgi?id=278319</a>
<a href="https://rdar.apple.com/134265139">rdar://134265139</a>

Reviewed by Eric Carlson.

In the system accessibility settings, users can select a system-default caption style,
or create a custom style, which changes how webvtt captions appear on websites.
Currently, the system’s default styles override websites’ styling, even though
often the user did not select this styling and is just using the default.

This patch makes it so that if the accessibility caption style is a system-default
style, it is overridable by the website.

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::behaviorShouldNotBeOverriden):
(WebCore::CaptionUserPreferencesMediaAF::captionsWindowCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionsBackgroundCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionsTextColor const):
(WebCore::CaptionUserPreferencesMediaAF::windowRoundedCornerRadiusCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionStrokeWidthForFont const):
(WebCore::CaptionUserPreferencesMediaAF::captionsTextEdgeCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionsDefaultFontCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance const):
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h:

Canonical link: <a href="https://commits.webkit.org/282568@main">https://commits.webkit.org/282568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ea6ad14411a93cbf5eeb5bec88b3d2e2d4b430

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50916 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9523 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57725 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12377 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.serviceworker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68885 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58226 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54769 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58440 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5939 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9604 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38345 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39425 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->