### PR TITLE
[CSS] @supports(selector(..)) only accepts complex selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html
@@ -18,9 +18,12 @@
   }
 
   .test {
+    > .test-2 {
+      background-color: green;
+    }
     @supports (selector(> .test-2)) {
       > .test-2 {
-        background-color: green;
+        background-color: red;
       }
     }
   }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -209,19 +209,15 @@ MutableCSSSelectorList CSSSelectorParser::consumeNestedComplexForgivingSelectorL
     });
 }
 
-bool CSSSelectorParser::supportsComplexSelector(CSSParserTokenRange range, const CSSSelectorParserContext& context, CSSParserEnum::IsNestedContext isNestedContext)
+bool CSSSelectorParser::supportsComplexSelector(CSSParserTokenRange range, const CSSSelectorParserContext& context)
 {
     range.consumeWhitespace();
-    CSSSelectorParser parser(context, nullptr, isNestedContext);
+    CSSSelectorParser parser(context, nullptr);
 
     // @supports requires that all arguments parse.
     parser.m_disableForgivingParsing = true;
 
-    std::unique_ptr<MutableCSSSelector> mutableSelector;
-    if (isNestedContext == CSSParserEnum::IsNestedContext::Yes)
-        mutableSelector = parser.consumeNestedComplexSelector(range);
-    else
-        mutableSelector = parser.consumeComplexSelector(range);
+    auto mutableSelector = parser.consumeComplexSelector(range);
 
     if (parser.m_failedParsing || !range.atEnd() || !mutableSelector)
         return false;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -59,7 +59,7 @@ public:
     MutableCSSSelectorList consumeComplexForgivingSelectorList(CSSParserTokenRange&);
     MutableCSSSelectorList consumeNestedComplexForgivingSelectorList(CSSParserTokenRange&);
 
-    static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&, CSSParserEnum::IsNestedContext);
+    static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList);
     static std::pair<bool, std::optional<Style::PseudoElementIdentifier>> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -164,7 +164,7 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsSelectorFunc
     auto block = range.consumeBlock();
     block.consumeWhitespace();
 
-    return CSSSelectorParser::supportsComplexSelector(block, m_parser.context(), m_isNestedContext) ? Supported : Unsupported;
+    return CSSSelectorParser::supportsComplexSelector(block, m_parser.context()) ? Supported : Unsupported;
 }
 
 // <supports-font-format-fn>


### PR DESCRIPTION
#### 94719bb343acb2d914fa3e692e8f2d4c75bbcec2
<pre>
[CSS] @supports(selector(..)) only accepts complex selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=277869">https://bugs.webkit.org/show_bug.cgi?id=277869</a>
<a href="https://rdar.apple.com/133555106">rdar://133555106</a>

Reviewed by Tim Nguyen.

<a href="https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn">https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn</a>

Fix to make it not contextually aware, as defined by the spec.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::supportsComplexSelector):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsSelectorFunction):

Canonical link: <a href="https://commits.webkit.org/282515@main">https://commits.webkit.org/282515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d8483175aa91644077509352d00e42f3275451b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51028 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31709 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12203 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69057 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58337 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58567 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6076 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38517 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->