### PR TITLE
Use an enum class for CSSValue Type

### DIFF
--- a/Source/WebCore/css/CSSAnchorValue.h
+++ b/Source/WebCore/css/CSSAnchorValue.h
@@ -48,7 +48,7 @@ public:
 
 private:
     CSSAnchorValue(RefPtr<CSSPrimitiveValue>&& anchorElement, Ref<CSSValue>&& anchorSide, RefPtr<CSSPrimitiveValue>&& fallback)
-        : CSSValue(AnchorClass)
+        : CSSValue(ClassType::Anchor)
         , m_anchorElement(WTFMove(anchorElement))
         , m_anchorSide(WTFMove(anchorSide))
         , m_fallback(WTFMove(fallback))

--- a/Source/WebCore/css/CSSAspectRatioValue.h
+++ b/Source/WebCore/css/CSSAspectRatioValue.h
@@ -48,7 +48,7 @@ public:
 
 private:
     CSSAspectRatioValue(float numeratorValue, float denominatorValue)
-        : CSSValue(AspectRatioClass)
+        : CSSValue(ClassType::AspectRatio)
         , m_numeratorValue(numeratorValue)
         , m_denominatorValue(denominatorValue)
     {

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 CSSBackgroundRepeatValue::CSSBackgroundRepeatValue(CSSValueID xValue, CSSValueID yValue)
-    : CSSValue(BackgroundRepeatClass)
+    : CSSValue(ClassType::BackgroundRepeat)
     , m_xValue(xValue)
     , m_yValue(yValue)
 {

--- a/Source/WebCore/css/CSSBasicShapes.cpp
+++ b/Source/WebCore/css/CSSBasicShapes.cpp
@@ -42,7 +42,7 @@
 namespace WebCore {
 
 CSSCircleValue::CSSCircleValue(RefPtr<CSSValue>&& radius, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY)
-    : CSSValue(CircleClass)
+    : CSSValue(ClassType::Circle)
     , m_radius(WTFMove(radius))
     , m_centerX(WTFMove(centerX))
     , m_centerY(WTFMove(centerY))
@@ -78,7 +78,7 @@ bool CSSCircleValue::equals(const CSSCircleValue& other) const
 // MARK: -
 
 CSSEllipseValue::CSSEllipseValue(RefPtr<CSSValue>&& radiusX, RefPtr<CSSValue>&& radiusY, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY)
-    : CSSValue(EllipseClass)
+    : CSSValue(ClassType::Ellipse)
     , m_radiusX(WTFMove(radiusX))
     , m_radiusY(WTFMove(radiusY))
     , m_centerX(WTFMove(centerX))
@@ -149,7 +149,7 @@ bool CSSEllipseValue::equals(const CSSEllipseValue& other) const
 // MARK: -
 
 CSSXywhValue::CSSXywhValue(Ref<CSSValue>&& insetX, Ref<CSSValue>&& insetY, Ref<CSSValue>&& width, Ref<CSSValue>&& height, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius)
-    : CSSValue(XywhShapeClass)
+    : CSSValue(ClassType::XywhShape)
     , m_insetX(WTFMove(insetX))
     , m_insetY(WTFMove(insetY))
     , m_width(WTFMove(width))
@@ -269,7 +269,7 @@ String CSSXywhValue::customCSSText() const
 // MARK: -
 
 CSSRectShapeValue::CSSRectShapeValue(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius)
-    : CSSValue(RectShapeClass)
+    : CSSValue(ClassType::RectShape)
     , m_top(WTFMove(top))
     , m_right(WTFMove(right))
     , m_bottom(WTFMove(bottom))
@@ -337,7 +337,7 @@ String CSSRectShapeValue::customCSSText() const
 // MARK: -
 
 CSSPathValue::CSSPathValue(SVGPathByteStream data, WindRule rule)
-    : CSSValue(PathClass)
+    : CSSValue(ClassType::Path)
     , m_pathData(WTFMove(data))
     , m_windRule(rule)
 {
@@ -370,7 +370,7 @@ bool CSSPathValue::equals(const CSSPathValue& other) const
 // MARK: -
 
 CSSPolygonValue::CSSPolygonValue(CSSValueListBuilder&& values, WindRule rule)
-    : CSSValueContainingVector(PolygonClass, SpaceSeparator, WTFMove(values))
+    : CSSValueContainingVector(ClassType::Polygon, SpaceSeparator, WTFMove(values))
     , m_windRule(rule)
 {
 }
@@ -402,7 +402,7 @@ bool CSSPolygonValue::equals(const CSSPolygonValue& other) const
 // MARK: -
 
 CSSInsetShapeValue::CSSInsetShapeValue(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius)
-    : CSSValue(InsetShapeClass)
+    : CSSValue(ClassType::InsetShape)
     , m_top(WTFMove(top))
     , m_right(WTFMove(right))
     , m_bottom(WTFMove(bottom))
@@ -487,7 +487,7 @@ Ref<CSSShapeValue> CSSShapeValue::create(WindRule windRule, Ref<CSSValuePair>&& 
 }
 
 CSSShapeValue::CSSShapeValue(WindRule windRule, Ref<CSSValuePair>&& fromCoordinates, CSSValueListBuilder&& shapeSegments)
-    : CSSValueContainingVector(ShapeClass, CommaSeparator, WTFMove(shapeSegments))
+    : CSSValueContainingVector(ClassType::Shape, CommaSeparator, WTFMove(shapeSegments))
     , m_fromCoordinates(WTFMove(fromCoordinates))
     , m_windRule(windRule)
 {

--- a/Source/WebCore/css/CSSBorderImageSliceValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 CSSBorderImageSliceValue::CSSBorderImageSliceValue(Quad slices, bool fill)
-    : CSSValue(BorderImageSliceClass)
+    : CSSValue(ClassType::BorderImageSlice)
     , m_slices(WTFMove(slices))
     , m_fill(fill)
 {

--- a/Source/WebCore/css/CSSBorderImageWidthValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 CSSBorderImageWidthValue::CSSBorderImageWidthValue(Quad widths, bool overridesBorderWidths)
-    : CSSValue(BorderImageWidthClass)
+    : CSSValue(ClassType::BorderImageWidth)
     , m_widths(WTFMove(widths))
     , m_overridesBorderWidths(overridesBorderWidths)
 {

--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 CSSCanvasValue::CSSCanvasValue(String&& name)
-    : CSSValue { CanvasClass }
+    : CSSValue { ClassType::Canvas }
     , m_name { WTFMove(name) }
 {
 }

--- a/Source/WebCore/css/CSSContentDistributionValue.cpp
+++ b/Source/WebCore/css/CSSContentDistributionValue.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 CSSContentDistributionValue::CSSContentDistributionValue(CSSValueID distribution, CSSValueID position, CSSValueID overflow)
-    : CSSValue(ContentDistributionClass)
+    : CSSValue(ClassType::ContentDistribution)
     , m_distribution(distribution)
     , m_position(position)
     , m_overflow(overflow)

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 CSSCounterValue::CSSCounterValue(AtomString identifier, AtomString separator, RefPtr<CSSValue> counterStyle)
-    : CSSValue(CounterClass)
+    : CSSValue(ClassType::Counter)
     , m_identifier(WTFMove(identifier))
     , m_separator(WTFMove(separator))
     , m_counterStyle(WTFMove(counterStyle))

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 inline CSSCrossfadeValue::CSSCrossfadeValue(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Ref<CSSPrimitiveValue>&& percentageValue, bool isPrefixed)
-    : CSSValue { CrossfadeClass }
+    : CSSValue { ClassType::Crossfade }
     , m_fromValueOrNone { WTFMove(fromValueOrNone) }
     , m_toValueOrNone { WTFMove(toValueOrNone) }
     , m_percentageValue { WTFMove(percentageValue) }

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -50,7 +50,7 @@ Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue,
 }
 
 CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, URL originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)
-    : CSSValue(CursorImageClass)
+    : CSSValue(ClassType::CursorImage)
     , m_originalURL(WTFMove(originalURL))
     , m_imageValue(WTFMove(imageValue))
     , m_hotSpot(WTFMove(hotSpot))

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -120,7 +120,7 @@ public:
 
 private:
     CSSCustomPropertyValue(const AtomString& name, VariantValue&& value)
-        : CSSValue(CustomPropertyClass)
+        : CSSValue(ClassType::CustomProperty)
         , m_name(name)
         , m_value(WTFMove(value))
     {

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 CSSFilterImageValue::CSSFilterImageValue(Ref<CSSValue>&& imageValueOrNone, Ref<CSSValue>&& filterValue)
-    : CSSValue { FilterImageClass }
+    : CSSValue { ClassType::FilterImage }
     , m_imageValueOrNone { WTFMove(imageValueOrNone) }
     , m_filterValue { WTFMove(filterValue) }
 {

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -41,7 +41,7 @@
 namespace WebCore {
 
 CSSFontFaceSrcLocalValue::CSSFontFaceSrcLocalValue(AtomString&& fontFaceName)
-    : CSSValue(FontFaceSrcLocalClass)
+    : CSSValue(ClassType::FontFaceSrcLocal)
     , m_fontFaceName(WTFMove(fontFaceName))
 {
 }
@@ -74,7 +74,7 @@ bool CSSFontFaceSrcLocalValue::equals(const CSSFontFaceSrcLocalValue& other) con
 }
 
 CSSFontFaceSrcResourceValue::CSSFontFaceSrcResourceValue(ResolvedURL&& location, String&& format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource source)
-    : CSSValue(FontFaceSrcResourceClass)
+    : CSSValue(ClassType::FontFaceSrcResource)
     , m_location(WTFMove(location))
     , m_format(WTFMove(format))
     , m_technologies(WTFMove(technologies))

--- a/Source/WebCore/css/CSSFontFeatureValue.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValue.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 CSSFontFeatureValue::CSSFontFeatureValue(FontTag&& tag, Ref<CSSPrimitiveValue>&& value)
-    : CSSValue(FontFeatureClass)
+    : CSSValue(ClassType::FontFeature)
     , m_tag(WTFMove(tag))
     , m_value(WTFMove(value))
 {

--- a/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
@@ -71,7 +71,7 @@ public:
 
 private:
     CSSFontPaletteValuesOverrideColorsValue(Ref<CSSPrimitiveValue>&& key, Ref<CSSPrimitiveValue>&& color)
-        : CSSValue(FontPaletteValuesOverrideColorsClass)
+        : CSSValue(ClassType::FontPaletteValuesOverrideColors)
         , m_key(WTFMove(key))
         , m_color(WTFMove(color))
     {

--- a/Source/WebCore/css/CSSFontStyleRangeValue.h
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.h
@@ -62,7 +62,7 @@ public:
 
 private:
     CSSFontStyleRangeValue(Ref<CSSPrimitiveValue>&& fontStyleValue, RefPtr<CSSValueList>&& obliqueValues)
-        : CSSValue(FontStyleRangeClass)
+        : CSSValue(ClassType::FontStyleRange)
         , fontStyleValue(WTFMove(fontStyleValue))
         , obliqueValues(WTFMove(obliqueValues))
     {

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 CSSFontStyleWithAngleValue::CSSFontStyleWithAngleValue(Ref<CSSPrimitiveValue>&& obliqueAngle)
-    : CSSValue(FontStyleWithAngleClass)
+    : CSSValue(ClassType::FontStyleWithAngle)
     , m_obliqueAngle(WTFMove(obliqueAngle))
 {
 }

--- a/Source/WebCore/css/CSSFontValue.h
+++ b/Source/WebCore/css/CSSFontValue.h
@@ -51,7 +51,7 @@ public:
 
 private:
     CSSFontValue()
-        : CSSValue(FontClass)
+        : CSSValue(ClassType::Font)
     {
     }
 };

--- a/Source/WebCore/css/CSSFontVariantAlternatesValue.cpp
+++ b/Source/WebCore/css/CSSFontVariantAlternatesValue.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 CSSFontVariantAlternatesValue::CSSFontVariantAlternatesValue(FontVariantAlternates&& alternates)
-    : CSSValue(FontVariantAlternatesClass)
+    : CSSValue(ClassType::FontVariantAlternates)
     , m_value(alternates)
 {
 }

--- a/Source/WebCore/css/CSSFontVariationValue.cpp
+++ b/Source/WebCore/css/CSSFontVariationValue.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 CSSFontVariationValue::CSSFontVariationValue(FontTag tag, float value)
-    : CSSValue(FontVariationClass)
+    : CSSValue(ClassType::FontVariation)
     , m_tag(tag)
     , m_value(value)
 {

--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -34,37 +34,37 @@
 namespace WebCore {
     
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, CSSValueListBuilder arguments)
-    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(arguments))
+    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTFMove(arguments))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name)
-    : CSSValueContainingVector(FunctionClass, CommaSeparator)
+    : CSSValueContainingVector(ClassType::Function, CommaSeparator)
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument)
-    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument))
+    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTFMove(argument))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2)
-    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument1), WTFMove(argument2))
+    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTFMove(argument1), WTFMove(argument2))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2, Ref<CSSValue> argument3)
-    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3))
+    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3))
     , m_name(name)
 {
 }
 
 CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2, Ref<CSSValue> argument3, Ref<CSSValue> argument4)
-    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3), WTFMove(argument4))
+    : CSSValueContainingVector(ClassType::Function, CommaSeparator, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3), WTFMove(argument4))
     , m_name(name)
 {
 }

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -149,7 +149,7 @@ public:
 
 private:
     CSSLinearGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(LinearGradientClass)
+        : CSSValue(ClassType::LinearGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_repeating(repeating)
@@ -158,7 +158,7 @@ private:
     }
 
     CSSLinearGradientValue(const CSSLinearGradientValue& other)
-        : CSSValue(LinearGradientClass)
+        : CSSValue(ClassType::LinearGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
@@ -226,7 +226,7 @@ public:
 
 private:
     CSSPrefixedLinearGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(PrefixedLinearGradientClass)
+        : CSSValue(ClassType::PrefixedLinearGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_repeating(repeating)
@@ -235,7 +235,7 @@ private:
     }
 
     CSSPrefixedLinearGradientValue(const CSSPrefixedLinearGradientValue& other)
-        : CSSValue(PrefixedLinearGradientClass)
+        : CSSValue(ClassType::PrefixedLinearGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
@@ -295,7 +295,7 @@ public:
 
 private:
     CSSDeprecatedLinearGradientValue(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(DeprecatedLinearGradientClass)
+        : CSSValue(ClassType::DeprecatedLinearGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_colorInterpolationMethod(colorInterpolationMethod)
@@ -303,7 +303,7 @@ private:
     }
 
     CSSDeprecatedLinearGradientValue(const CSSDeprecatedLinearGradientValue& other)
-        : CSSValue(DeprecatedLinearGradientClass)
+        : CSSValue(ClassType::DeprecatedLinearGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
@@ -497,7 +497,7 @@ public:
 
 private:
     CSSRadialGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(RadialGradientClass)
+        : CSSValue(ClassType::RadialGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_repeating(repeating)
@@ -506,7 +506,7 @@ private:
     }
 
     CSSRadialGradientValue(const CSSRadialGradientValue& other)
-        : CSSValue(RadialGradientClass)
+        : CSSValue(ClassType::RadialGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
@@ -593,7 +593,7 @@ public:
 
 private:
     CSSPrefixedRadialGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(PrefixedRadialGradientClass)
+        : CSSValue(ClassType::PrefixedRadialGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_repeating(repeating)
@@ -602,7 +602,7 @@ private:
     }
 
     CSSPrefixedRadialGradientValue(const CSSPrefixedRadialGradientValue& other)
-        : CSSValue(PrefixedRadialGradientClass)
+        : CSSValue(ClassType::PrefixedRadialGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
@@ -693,7 +693,7 @@ public:
 
 private:
     CSSDeprecatedRadialGradientValue(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(DeprecatedRadialGradientClass)
+        : CSSValue(ClassType::DeprecatedRadialGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_colorInterpolationMethod(colorInterpolationMethod)
@@ -701,7 +701,7 @@ private:
     }
 
     CSSDeprecatedRadialGradientValue(const CSSDeprecatedRadialGradientValue& other)
-        : CSSValue(DeprecatedRadialGradientClass)
+        : CSSValue(ClassType::DeprecatedRadialGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
@@ -774,7 +774,7 @@ public:
 
 private:
     explicit CSSConicGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
-        : CSSValue(ConicGradientClass)
+        : CSSValue(ClassType::ConicGradient)
         , m_data(WTFMove(data))
         , m_stops(WTFMove(stops))
         , m_repeating(repeating)
@@ -783,7 +783,7 @@ private:
     }
 
     CSSConicGradientValue(const CSSConicGradientValue& other)
-        : CSSValue(ConicGradientClass)
+        : CSSValue(ClassType::ConicGradient)
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
@@ -37,7 +37,7 @@
 namespace WebCore {
 
 CSSGridAutoRepeatValue::CSSGridAutoRepeatValue(bool isAutoFit, CSSValueListBuilder builder)
-    : CSSValueContainingVector(GridAutoRepeatClass, SpaceSeparator, WTFMove(builder))
+    : CSSValueContainingVector(ClassType::GridAutoRepeat, SpaceSeparator, WTFMove(builder))
     , m_isAutoFit(isAutoFit)
 {
 }

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue(Ref<CSSPrimitiveValue>&& repetitions, CSSValueListBuilder builder)
-    : CSSValueContainingVector(GridIntegerRepeatClass, SpaceSeparator, WTFMove(builder))
+    : CSSValueContainingVector(ClassType::GridIntegerRepeat, SpaceSeparator, WTFMove(builder))
     , m_repetitions(WTFMove(repetitions))
 {
 }

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -51,7 +51,7 @@ String CSSGridLineNamesValue::customCSSText() const
 }
 
 CSSGridLineNamesValue::CSSGridLineNamesValue(std::span<const String> names)
-    : CSSValue(GridLineNamesClass)
+    : CSSValue(ClassType::GridLineNames)
     , m_names(names.begin(), names.end())
 {
 }

--- a/Source/WebCore/css/CSSGridLineValue.cpp
+++ b/Source/WebCore/css/CSSGridLineValue.cpp
@@ -49,7 +49,7 @@ String CSSGridLineValue::customCSSText() const
 }
 
 CSSGridLineValue::CSSGridLineValue(RefPtr<CSSPrimitiveValue>&& spanValue, RefPtr<CSSPrimitiveValue>&& numericValue, RefPtr<CSSPrimitiveValue>&& gridLineName)
-    : CSSValue(GridLineValueClass)
+    : CSSValue(ClassType::GridLineValue)
     , m_spanValue(WTFMove(spanValue))
     , m_numericValue(WTFMove(numericValue))
     , m_gridLineName(WTFMove(gridLineName))

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
@@ -41,7 +41,7 @@
 namespace WebCore {
 
 CSSGridTemplateAreasValue::CSSGridTemplateAreasValue(NamedGridAreaMap map, size_t rowCount, size_t columnCount)
-    : CSSValue(GridTemplateAreasClass)
+    : CSSValue(ClassType::GridTemplateAreas)
     , m_map(WTFMove(map))
     , m_rowCount(rowCount)
     , m_columnCount(columnCount)

--- a/Source/WebCore/css/CSSImageSetOptionValue.cpp
+++ b/Source/WebCore/css/CSSImageSetOptionValue.cpp
@@ -31,14 +31,14 @@
 namespace WebCore {
 
 CSSImageSetOptionValue::CSSImageSetOptionValue(Ref<CSSValue>&& image, Ref<CSSPrimitiveValue>&& resolution)
-    : CSSValue(ImageSetOptionClass)
+    : CSSValue(ClassType::ImageSetOption)
     , m_image(WTFMove(image))
     , m_resolution(WTFMove(resolution))
 {
 }
 
 CSSImageSetOptionValue::CSSImageSetOptionValue(Ref<CSSValue>&& image, Ref<CSSPrimitiveValue>&& resolution, String&& type)
-    : CSSValue(ImageSetOptionClass)
+    : CSSValue(ClassType::ImageSetOption)
     , m_image(WTFMove(image))
     , m_resolution(WTFMove(resolution))
     , m_mimeType(WTFMove(type))

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -42,7 +42,7 @@ Ref<CSSImageSetValue> CSSImageSetValue::create(CSSValueListBuilder builder)
 }
 
 CSSImageSetValue::CSSImageSetValue(CSSValueListBuilder builder)
-    : CSSValueContainingVector(ImageSetClass, CommaSeparator, WTFMove(builder))
+    : CSSValueContainingVector(ClassType::ImageSet, CommaSeparator, WTFMove(builder))
 {
 }
 

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -37,13 +37,13 @@
 namespace WebCore {
 
 CSSImageValue::CSSImageValue()
-    : CSSValue(ImageClass)
+    : CSSValue(ClassType::Image)
     , m_isInvalid(true)
 {
 }
 
 CSSImageValue::CSSImageValue(ResolvedURL&& location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString&& initiatorType)
-    : CSSValue(ImageClass)
+    : CSSValue(ClassType::Image)
     , m_location(WTFMove(location))
     , m_initiatorType(WTFMove(initiatorType))
     , m_loadedFromOpaqueSource(loadedFromOpaqueSource)

--- a/Source/WebCore/css/CSSLineBoxContainValue.cpp
+++ b/Source/WebCore/css/CSSLineBoxContainValue.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 CSSLineBoxContainValue::CSSLineBoxContainValue(OptionSet<LineBoxContain> value)
-    : CSSValue(LineBoxContainClass)
+    : CSSValue(ClassType::LineBoxContain)
     , m_value(value)
 {
 }

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 CSSNamedImageValue::CSSNamedImageValue(String&& name)
-    : CSSValue { NamedImageClass }
+    : CSSValue { ClassType::NamedImage }
     , m_name { WTFMove(name) }
 {
 }

--- a/Source/WebCore/css/CSSOffsetRotateValue.h
+++ b/Source/WebCore/css/CSSOffsetRotateValue.h
@@ -61,7 +61,7 @@ public:
 
 private:
     CSSOffsetRotateValue(RefPtr<CSSPrimitiveValue>&& modifier, RefPtr<CSSPrimitiveValue>&& angle)
-        : CSSValue(OffsetRotateClass)
+        : CSSValue(ClassType::OffsetRotate)
         , m_modifier(WTFMove(modifier))
         , m_angle(WTFMove(angle))
     {

--- a/Source/WebCore/css/CSSPaintImageValue.cpp
+++ b/Source/WebCore/css/CSSPaintImageValue.cpp
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 CSSPaintImageValue::CSSPaintImageValue(String&& name, Ref<CSSVariableData>&& arguments)
-    : CSSValue { PaintImageClass }
+    : CSSValue { ClassType::PaintImage }
     , m_name { WTFMove(name) }
     , m_arguments { WTFMove(arguments) }
 {

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -60,7 +60,7 @@ public:
 
 private:
     CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
-        : CSSValue(PendingSubstitutionValueClass)
+        : CSSValue(ClassType::PendingSubstitutionValue)
         , m_shorthandPropertyId(shorthandPropertyId)
         , m_shorthandValue(WTFMove(shorthandValue))
     {

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -267,21 +267,21 @@ CSSUnitType CSSPrimitiveValue::primitiveType() const
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(CSSPropertyID propertyID)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_PROPERTY_ID);
     m_value.propertyID = propertyID;
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(double number, CSSUnitType type)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(type);
     m_value.number = number;
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(const String& string, CSSUnitType type)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     ASSERT(isStringType(type));
     setPrimitiveUnitType(type);
@@ -290,7 +290,7 @@ CSSPrimitiveValue::CSSPrimitiveValue(const String& string, CSSUnitType type)
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(Color color)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_RGBCOLOR);
     static_assert(sizeof(m_value.colorAsInteger) == sizeof(color));
@@ -313,7 +313,7 @@ Color CSSPrimitiveValue::absoluteColor() const
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(StaticCSSValueTag, CSSValueID valueID)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_VALUE_ID);
     m_value.valueID = valueID;
@@ -339,21 +339,21 @@ CSSPrimitiveValue::CSSPrimitiveValue(StaticCSSValueTag, ImplicitInitialValueTag)
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSCalcValue> value)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_CALC);
     m_value.calc = &value.leakRef();
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(CSSUnresolvedColor unresolvedColor)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_UNRESOLVED_COLOR);
     m_value.unresolvedColor = new CSSUnresolvedColor(WTFMove(unresolvedColor));
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSAnchorValue> value)
-    : CSSValue(PrimitiveClass)
+    : CSSValue(ClassType::Primitive)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_ANCHOR);
     m_value.anchor = &value.leakRef();

--- a/Source/WebCore/css/CSSQuadValue.cpp
+++ b/Source/WebCore/css/CSSQuadValue.cpp
@@ -29,7 +29,7 @@
 namespace WebCore {
 
 CSSQuadValue::CSSQuadValue(Quad quad)
-    : CSSValue(QuadClass)
+    : CSSValue(ClassType::Quad)
     , m_quad(WTFMove(quad))
 {
 }

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -71,7 +71,7 @@ public:
 
 private:
     CSSRayValue(Ref<CSSPrimitiveValue>&& angle, CSSValueID size, bool isContaining, RefPtr<CSSValuePair>&& position)
-        : CSSValue(RayClass)
+        : CSSValue(ClassType::Ray)
         , m_angle(WTFMove(angle))
         , m_size(size)
         , m_isContaining(isContaining)
@@ -82,7 +82,7 @@ private:
     }
 
     CSSRayValue(Ref<CSSPrimitiveValue>&& angle, CSSValueID size, bool isContaining, RefPtr<CSSValuePair>&& position, CSSBoxType coordinateBox)
-        : CSSValue(RayClass)
+        : CSSValue(ClassType::Ray)
         , m_angle(WTFMove(angle))
         , m_size(size)
         , m_isContaining(isContaining)

--- a/Source/WebCore/css/CSSRectValue.cpp
+++ b/Source/WebCore/css/CSSRectValue.cpp
@@ -29,7 +29,7 @@
 namespace WebCore {
 
 CSSRectValue::CSSRectValue(Rect rect)
-    : CSSValue(RectClass)
+    : CSSValue(ClassType::Rect)
     , m_rect(WTFMove(rect))
 {
 }

--- a/Source/WebCore/css/CSSReflectValue.cpp
+++ b/Source/WebCore/css/CSSReflectValue.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 CSSReflectValue::CSSReflectValue(CSSValueID direction, Ref<CSSPrimitiveValue> offset, RefPtr<CSSValue> mask)
-    : CSSValue(ReflectClass)
+    : CSSValue(ClassType::Reflect)
     , m_direction(direction)
     , m_offset(WTFMove(offset))
     , m_mask(WTFMove(mask))

--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -69,7 +69,7 @@ public:
 
 private:
     CSSScrollValue(RefPtr<CSSValue>&& scroller, RefPtr<CSSValue>&& axis)
-        : CSSValue(ScrollClass)
+        : CSSValue(ClassType::Scroll)
         , m_scroller(WTFMove(scroller))
         , m_axis(WTFMove(axis))
     {

--- a/Source/WebCore/css/CSSShadowValue.cpp
+++ b/Source/WebCore/css/CSSShadowValue.cpp
@@ -27,7 +27,7 @@ namespace WebCore {
 
 // Used for text-shadow and box-shadow
 CSSShadowValue::CSSShadowValue(RefPtr<CSSPrimitiveValue>&& x, RefPtr<CSSPrimitiveValue>&& y, RefPtr<CSSPrimitiveValue>&& blur, RefPtr<CSSPrimitiveValue>&& spread, RefPtr<CSSPrimitiveValue>&& style, RefPtr<CSSPrimitiveValue>&& color, bool isWebkitBoxShadow)
-    : CSSValue(ShadowClass)
+    : CSSValue(ClassType::Shadow)
     , x(WTFMove(x))
     , y(WTFMove(y))
     , blur(WTFMove(blur))

--- a/Source/WebCore/css/CSSShapeSegmentValue.h
+++ b/Source/WebCore/css/CSSShapeSegmentValue.h
@@ -179,7 +179,7 @@ private:
     }
 
     CSSShapeSegmentValue(SegmentType type, std::unique_ptr<ShapeSegmentData>&& data)
-        : CSSValue(ShapeSegmentClass)
+        : CSSValue(ClassType::ShapeSegment)
         , m_type(type)
         , m_data(WTFMove(data))
     {

--- a/Source/WebCore/css/CSSSubgridValue.cpp
+++ b/Source/WebCore/css/CSSSubgridValue.cpp
@@ -46,7 +46,7 @@ String CSSSubgridValue::customCSSText() const
 }
 
 CSSSubgridValue::CSSSubgridValue(CSSValueListBuilder builder)
-    : CSSValueContainingVector(SubgridClass, SpaceSeparator, WTFMove(builder))
+    : CSSValueContainingVector(ClassType::Subgrid, SpaceSeparator, WTFMove(builder))
 {
 }
 

--- a/Source/WebCore/css/CSSTimingFunctionValue.h
+++ b/Source/WebCore/css/CSSTimingFunctionValue.h
@@ -64,7 +64,7 @@ public:
 
 private:
     CSSLinearTimingFunctionValue(Vector<LinearStop>&& stops)
-        : CSSValue(LinearTimingFunctionClass)
+        : CSSValue(ClassType::LinearTimingFunction)
         , m_stops(WTFMove(stops))
     {
         ASSERT(m_stops.size() >= 2);
@@ -88,7 +88,7 @@ public:
 
 private:
     CSSCubicBezierTimingFunctionValue(Ref<CSSPrimitiveValue>&& x1, Ref<CSSPrimitiveValue>&& y1, Ref<CSSPrimitiveValue>&& x2, Ref<CSSPrimitiveValue>&& y2)
-        : CSSValue(CubicBezierTimingFunctionClass)
+        : CSSValue(ClassType::CubicBezierTimingFunction)
         , m_x1(WTFMove(x1))
         , m_y1(WTFMove(y1))
         , m_x2(WTFMove(x2))
@@ -121,7 +121,7 @@ public:
 
 private:
     CSSStepsTimingFunctionValue(Ref<CSSPrimitiveValue>&& steps, std::optional<StepsTimingFunction::StepPosition> stepPosition)
-        : CSSValue(StepsTimingFunctionClass)
+        : CSSValue(ClassType::StepsTimingFunction)
         , m_steps(WTFMove(steps))
         , m_stepPosition(stepPosition)
     {
@@ -147,7 +147,7 @@ public:
 
 private:
     CSSSpringTimingFunctionValue(Ref<CSSPrimitiveValue>&& mass, Ref<CSSPrimitiveValue>&& stiffness, Ref<CSSPrimitiveValue>&& damping, Ref<CSSPrimitiveValue>&& initialVelocity)
-        : CSSValue(SpringTimingFunctionClass)
+        : CSSValue(ClassType::SpringTimingFunction)
         , m_mass(WTFMove(mass))
         , m_stiffness(WTFMove(stiffness))
         , m_damping(WTFMove(damping))

--- a/Source/WebCore/css/CSSTransformListValue.cpp
+++ b/Source/WebCore/css/CSSTransformListValue.cpp
@@ -34,12 +34,12 @@
 namespace WebCore {
 
 CSSTransformListValue::CSSTransformListValue(CSSValueListBuilder builder)
-    : CSSValueContainingVector(TransformListClass, SpaceSeparator, WTFMove(builder))
+    : CSSValueContainingVector(ClassType::TransformList, SpaceSeparator, WTFMove(builder))
 {
 }
 
 CSSTransformListValue::CSSTransformListValue(Ref<CSSValue> value)
-    : CSSValueContainingVector(TransformListClass, SpaceSeparator, WTFMove(value))
+    : CSSValueContainingVector(ClassType::TransformList, SpaceSeparator, WTFMove(value))
 {
 }
 

--- a/Source/WebCore/css/CSSUnicodeRangeValue.h
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.h
@@ -46,7 +46,7 @@ public:
 
 private:
     CSSUnicodeRangeValue(char32_t from, char32_t to)
-        : CSSValue(UnicodeRangeClass)
+        : CSSValue(ClassType::UnicodeRange)
         , m_from(from)
         , m_to(to)
     {

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -101,146 +101,147 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);
 
 template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visitor&& visitor)
 {
-    switch (classType()) {
-    case AnchorClass:
+    using enum CSSValue::ClassType;
+    switch (m_classType) {
+    case Anchor:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAnchorValue>(*this));
-    case AspectRatioClass:
+    case AspectRatio:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAspectRatioValue>(*this));
-    case BackgroundRepeatClass:
+    case BackgroundRepeat:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBackgroundRepeatValue>(*this));
-    case BorderImageSliceClass:
+    case BorderImageSlice:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBorderImageSliceValue>(*this));
-    case BorderImageWidthClass:
+    case BorderImageWidth:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBorderImageWidthValue>(*this));
-    case CalculationClass:
+    case Calculation:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCalcValue>(*this));
-    case CanvasClass:
+    case Canvas:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCanvasValue>(*this));
-    case CircleClass:
+    case Circle:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCircleValue>(*this));
-    case ConicGradientClass:
+    case ConicGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSConicGradientValue>(*this));
-    case ContentDistributionClass:
+    case ContentDistribution:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSContentDistributionValue>(*this));
-    case CounterClass:
+    case Counter:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCounterValue>(*this));
-    case CrossfadeClass:
+    case Crossfade:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCrossfadeValue>(*this));
-    case CubicBezierTimingFunctionClass:
+    case CubicBezierTimingFunction:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCubicBezierTimingFunctionValue>(*this));
-    case CursorImageClass:
+    case CursorImage:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCursorImageValue>(*this));
-    case CustomPropertyClass:
+    case CustomProperty:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCustomPropertyValue>(*this));
-    case DeprecatedLinearGradientClass:
+    case DeprecatedLinearGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSDeprecatedLinearGradientValue>(*this));
-    case DeprecatedRadialGradientClass:
+    case DeprecatedRadialGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSDeprecatedRadialGradientValue>(*this));
-    case EllipseClass:
+    case Ellipse:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSEllipseValue>(*this));
-    case FilterImageClass:
+    case FilterImage:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFilterImageValue>(*this));
-    case FontClass:
+    case Font:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontValue>(*this));
-    case FontFaceSrcLocalClass:
+    case FontFaceSrcLocal:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFaceSrcLocalValue>(*this));
-    case FontFaceSrcResourceClass:
+    case FontFaceSrcResource:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFaceSrcResourceValue>(*this));
-    case FontFeatureClass:
+    case FontFeature:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFeatureValue>(*this));
-    case FontPaletteValuesOverrideColorsClass:
+    case FontPaletteValuesOverrideColors:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontPaletteValuesOverrideColorsValue>(*this));
-    case FontStyleWithAngleClass:
+    case FontStyleWithAngle:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontStyleWithAngleValue>(*this));
-    case FontStyleRangeClass:
+    case FontStyleRange:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontStyleRangeValue>(*this));
-    case FontVariantAlternatesClass:
+    case FontVariantAlternates:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontVariantAlternatesValue>(*this));
-    case FontVariationClass:
+    case FontVariation:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontVariationValue>(*this));
-    case FunctionClass:
+    case Function:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFunctionValue>(*this));
-    case GridAutoRepeatClass:
+    case GridAutoRepeat:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridAutoRepeatValue>(*this));
-    case GridIntegerRepeatClass:
+    case GridIntegerRepeat:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridIntegerRepeatValue>(*this));
-    case GridLineNamesClass:
+    case GridLineNames:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridLineNamesValue>(*this));
-    case GridLineValueClass:
+    case GridLineValue:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridLineValue>(*this));
-    case GridTemplateAreasClass:
+    case GridTemplateAreas:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridTemplateAreasValue>(*this));
-    case ImageClass:
+    case Image:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSImageValue>(*this));
-    case ImageSetOptionClass:
+    case ImageSetOption:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSImageSetOptionValue>(*this));
-    case ImageSetClass:
+    case ImageSet:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSImageSetValue>(*this));
-    case InsetShapeClass:
+    case InsetShape:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSInsetShapeValue>(*this));
-    case LineBoxContainClass:
+    case LineBoxContain:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSLineBoxContainValue>(*this));
-    case LinearGradientClass:
+    case LinearGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSLinearGradientValue>(*this));
-    case LinearTimingFunctionClass:
+    case LinearTimingFunction:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSLinearTimingFunctionValue>(*this));
-    case NamedImageClass:
+    case NamedImage:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSNamedImageValue>(*this));
-    case PrefixedLinearGradientClass:
+    case PrefixedLinearGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrefixedLinearGradientValue>(*this));
-    case PrefixedRadialGradientClass:
+    case PrefixedRadialGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrefixedRadialGradientValue>(*this));
-    case RadialGradientClass:
+    case RadialGradient:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRadialGradientValue>(*this));
-    case OffsetRotateClass:
+    case OffsetRotate:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSOffsetRotateValue>(*this));
-    case PathClass:
+    case Path:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPathValue>(*this));
-    case PendingSubstitutionValueClass:
+    case PendingSubstitutionValue:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPendingSubstitutionValue>(*this));
-    case PolygonClass:
+    case Polygon:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPolygonValue>(*this));
-    case PrimitiveClass:
+    case Primitive:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrimitiveValue>(*this));
-    case QuadClass:
+    case Quad:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSQuadValue>(*this));
-    case RayClass:
+    case Ray:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRayValue>(*this));
-    case RectClass:
+    case Rect:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRectValue>(*this));
-    case RectShapeClass:
+    case RectShape:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRectShapeValue>(*this));
-    case ReflectClass:
+    case Reflect:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSReflectValue>(*this));
-    case ScrollClass:
+    case Scroll:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSScrollValue>(*this));
-    case ShadowClass:
+    case Shadow:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShadowValue>(*this));
-    case ShapeClass:
+    case Shape:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShapeValue>(*this));
-    case ShapeSegmentClass:
+    case ShapeSegment:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShapeSegmentValue>(*this));
-    case SubgridClass:
+    case Subgrid:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSubgridValue>(*this));
-    case StepsTimingFunctionClass:
+    case StepsTimingFunction:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSStepsTimingFunctionValue>(*this));
-    case SpringTimingFunctionClass:
+    case SpringTimingFunction:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSpringTimingFunctionValue>(*this));
-    case TransformListClass:
+    case TransformList:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSTransformListValue>(*this));
-    case UnicodeRangeClass:
+    case UnicodeRange:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSUnicodeRangeValue>(*this));
-    case ValueListClass:
+    case ValueList:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSValueList>(*this));
-    case ValuePairClass:
+    case ValuePair:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSValuePair>(*this));
-    case VariableReferenceClass:
+    case VariableReference:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSVariableReferenceValue>(*this));
-    case ViewClass:
+    case View:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSViewValue>(*this));
-    case XywhShapeClass:
+    case XywhShape:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSXywhValue>(*this));
-    case PaintImageClass:
+    case PaintImage:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPaintImageValue>(*this));
     }
 
@@ -407,21 +408,22 @@ void CSSValue::operator delete(CSSValue* value, std::destroying_delete_t)
 // FIXME: Consider renaming to DeprecatedCSSOMValue::create and moving it out of the CSSValue class.
 Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclaration& styleDeclaration) const
 {
-    switch (classType()) {
-    case ImageClass:
+    using enum CSSValue::ClassType;
+    switch (m_classType) {
+    case Image:
         return uncheckedDowncast<CSSImageValue>(*this).createDeprecatedCSSOMWrapper(styleDeclaration);
-    case PrimitiveClass:
-    case CounterClass:
-    case QuadClass:
-    case RectClass:
-    case ValuePairClass:
+    case Primitive:
+    case Counter:
+    case Quad:
+    case Rect:
+    case ValuePair:
         return DeprecatedCSSOMPrimitiveValue::create(*this, styleDeclaration);
-    case ValueListClass:
-    case GridAutoRepeatClass: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
-    case GridIntegerRepeatClass: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
-    case ImageSetClass: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
-    case SubgridClass: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
-    case TransformListClass:
+    case ValueList:
+    case GridAutoRepeat: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
+    case GridIntegerRepeat: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
+    case ImageSet: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
+    case Subgrid: // FIXME: Likely this class should not be exposed and serialized as a CSSValueList. Confirm and remove this case.
+    case TransformList:
         return DeprecatedCSSOMValueList::create(downcast<CSSValueContainingVector>(*this), styleDeclaration);
     default:
         return DeprecatedCSSOMComplexValue::create(*this, styleDeclaration);

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -72,82 +72,82 @@ public:
 
     WEBCORE_EXPORT String cssText() const;
 
-    bool isAnchorValue() const { return m_classType == AnchorClass; }
-    bool isAspectRatioValue() const { return m_classType == AspectRatioClass; }
-    bool isBackgroundRepeatValue() const { return m_classType == BackgroundRepeatClass; }
-    bool isBorderImageSliceValue() const { return m_classType == BorderImageSliceClass; }
-    bool isBorderImageWidthValue() const { return m_classType == BorderImageWidthClass; }
-    bool isCalcValue() const { return m_classType == CalculationClass; }
-    bool isCanvasValue() const { return m_classType == CanvasClass; }
-    bool isCircle() const { return m_classType == CircleClass; }
-    bool isConicGradientValue() const { return m_classType == ConicGradientClass; }
-    bool isContentDistributionValue() const { return m_classType == ContentDistributionClass; }
-    bool isCounter() const { return m_classType == CounterClass; }
-    bool isCrossfadeValue() const { return m_classType == CrossfadeClass; }
-    bool isCubicBezierTimingFunctionValue() const { return m_classType == CubicBezierTimingFunctionClass; }
-    bool isCursorImageValue() const { return m_classType == CursorImageClass; }
-    bool isCustomPropertyValue() const { return m_classType == CustomPropertyClass; }
-    bool isDeprecatedLinearGradientValue() const { return m_classType == DeprecatedLinearGradientClass; }
-    bool isDeprecatedRadialGradientValue() const { return m_classType == DeprecatedRadialGradientClass; }
-    bool isEllipse() const { return m_classType == EllipseClass; }
-    bool isFilterImageValue() const { return m_classType == FilterImageClass; }
-    bool isFontFaceSrcLocalValue() const { return m_classType == FontFaceSrcLocalClass; }
-    bool isFontFaceSrcResourceValue() const { return m_classType == FontFaceSrcResourceClass; }
-    bool isFontFeatureValue() const { return m_classType == FontFeatureClass; }
-    bool isFontPaletteValuesOverrideColorsValue() const { return m_classType == FontPaletteValuesOverrideColorsClass; }
-    bool isFontStyleRangeValue() const { return m_classType == FontStyleRangeClass; }
-    bool isFontStyleWithAngleValue() const { return m_classType == FontStyleWithAngleClass; }
-    bool isFontValue() const { return m_classType == FontClass; }
-    bool isFontVariantAlternatesValue() const { return m_classType == FontVariantAlternatesClass; }
-    bool isFontVariationValue() const { return m_classType == FontVariationClass; }
-    bool isFunctionValue() const { return m_classType == FunctionClass; }
-    bool isGridAutoRepeatValue() const { return m_classType == GridAutoRepeatClass; }
-    bool isGridIntegerRepeatValue() const { return m_classType == GridIntegerRepeatClass; }
-    bool isGridLineNamesValue() const { return m_classType == GridLineNamesClass; }
-    bool isGridLineValue() const { return m_classType == GridLineValueClass; }
-    bool isGridTemplateAreasValue() const { return m_classType == GridTemplateAreasClass; }
-    bool isImageSetOptionValue() const { return m_classType == ImageSetOptionClass; }
-    bool isImageSetValue() const { return m_classType == ImageSetClass; }
-    bool isImageValue() const { return m_classType == ImageClass; }
-    bool isInsetShape() const { return m_classType == InsetShapeClass; }
-    bool isLineBoxContainValue() const { return m_classType == LineBoxContainClass; }
-    bool isLinearGradientValue() const { return m_classType == LinearGradientClass; }
-    bool isLinearTimingFunctionValue() const { return m_classType == LinearTimingFunctionClass; }
-    bool isNamedImageValue() const { return m_classType == NamedImageClass; }
-    bool isOffsetRotateValue() const { return m_classType == OffsetRotateClass; }
-    bool isPair() const { return m_classType == ValuePairClass; }
-    bool isPath() const { return m_classType == PathClass; }
-    bool isPendingSubstitutionValue() const { return m_classType == PendingSubstitutionValueClass; }
-    bool isPolygon() const { return m_classType == PolygonClass; }
-    bool isPrefixedLinearGradientValue() const { return m_classType == PrefixedLinearGradientClass; }
-    bool isPrefixedRadialGradientValue() const { return m_classType == PrefixedRadialGradientClass; }
-    bool isPrimitiveValue() const { return m_classType == PrimitiveClass; }
-    bool isQuad() const { return m_classType == QuadClass; }
-    bool isRadialGradientValue() const { return m_classType == RadialGradientClass; }
-    bool isRayValue() const { return m_classType == RayClass; }
-    bool isRect() const { return m_classType == RectClass; }
-    bool isRectShape() const { return m_classType == RectShapeClass; }
-    bool isReflectValue() const { return m_classType == ReflectClass; }
-    bool isScrollValue() const { return m_classType == ScrollClass; }
-    bool isShadowValue() const { return m_classType == ShadowClass; }
-    bool isShape() const { return m_classType == ShapeClass; }
-    bool isShapeSegment() const { return m_classType == ShapeSegmentClass; }
-    bool isSpringTimingFunctionValue() const { return m_classType == SpringTimingFunctionClass; }
-    bool isStepsTimingFunctionValue() const { return m_classType == StepsTimingFunctionClass; }
-    bool isSubgridValue() const { return m_classType == SubgridClass; }
-    bool isTransformListValue() const { return m_classType == TransformListClass; }
-    bool isUnicodeRangeValue() const { return m_classType == UnicodeRangeClass; }
-    bool isValueList() const { return m_classType == ValueListClass; }
-    bool isVariableReferenceValue() const { return m_classType == VariableReferenceClass; }
-    bool isViewValue() const { return m_classType == ViewClass; }
-    bool isXywhShape() const { return m_classType == XywhShapeClass; }
-    bool isPaintImageValue() const { return m_classType == PaintImageClass; }
+    bool isAnchorValue() const { return m_classType == ClassType::Anchor; }
+    bool isAspectRatioValue() const { return m_classType == ClassType::AspectRatio; }
+    bool isBackgroundRepeatValue() const { return m_classType == ClassType::BackgroundRepeat; }
+    bool isBorderImageSliceValue() const { return m_classType == ClassType::BorderImageSlice; }
+    bool isBorderImageWidthValue() const { return m_classType == ClassType::BorderImageWidth; }
+    bool isCalcValue() const { return m_classType == ClassType::Calculation; }
+    bool isCanvasValue() const { return m_classType == ClassType::Canvas; }
+    bool isCircle() const { return m_classType == ClassType::Circle; }
+    bool isConicGradientValue() const { return m_classType == ClassType::ConicGradient; }
+    bool isContentDistributionValue() const { return m_classType == ClassType::ContentDistribution; }
+    bool isCounter() const { return m_classType == ClassType::Counter; }
+    bool isCrossfadeValue() const { return m_classType == ClassType::Crossfade; }
+    bool isCubicBezierTimingFunctionValue() const { return m_classType == ClassType::CubicBezierTimingFunction; }
+    bool isCursorImageValue() const { return m_classType == ClassType::CursorImage; }
+    bool isCustomPropertyValue() const { return m_classType == ClassType::CustomProperty; }
+    bool isDeprecatedLinearGradientValue() const { return m_classType == ClassType::DeprecatedLinearGradient; }
+    bool isDeprecatedRadialGradientValue() const { return m_classType == ClassType::DeprecatedRadialGradient; }
+    bool isEllipse() const { return m_classType == ClassType::Ellipse; }
+    bool isFilterImageValue() const { return m_classType == ClassType::FilterImage; }
+    bool isFontFaceSrcLocalValue() const { return m_classType == ClassType::FontFaceSrcLocal; }
+    bool isFontFaceSrcResourceValue() const { return m_classType == ClassType::FontFaceSrcResource; }
+    bool isFontFeatureValue() const { return m_classType == ClassType::FontFeature; }
+    bool isFontPaletteValuesOverrideColorsValue() const { return m_classType == ClassType::FontPaletteValuesOverrideColors; }
+    bool isFontStyleRangeValue() const { return m_classType == ClassType::FontStyleRange; }
+    bool isFontStyleWithAngleValue() const { return m_classType == ClassType::FontStyleWithAngle; }
+    bool isFontValue() const { return m_classType == ClassType::Font; }
+    bool isFontVariantAlternatesValue() const { return m_classType == ClassType::FontVariantAlternates; }
+    bool isFontVariationValue() const { return m_classType == ClassType::FontVariation; }
+    bool isFunctionValue() const { return m_classType == ClassType::Function; }
+    bool isGridAutoRepeatValue() const { return m_classType == ClassType::GridAutoRepeat; }
+    bool isGridIntegerRepeatValue() const { return m_classType == ClassType::GridIntegerRepeat; }
+    bool isGridLineNamesValue() const { return m_classType == ClassType::GridLineNames; }
+    bool isGridLineValue() const { return m_classType == ClassType::GridLineValue; }
+    bool isGridTemplateAreasValue() const { return m_classType == ClassType::GridTemplateAreas; }
+    bool isImageSetOptionValue() const { return m_classType == ClassType::ImageSetOption; }
+    bool isImageSetValue() const { return m_classType == ClassType::ImageSet; }
+    bool isImageValue() const { return m_classType == ClassType::Image; }
+    bool isInsetShape() const { return m_classType == ClassType::InsetShape; }
+    bool isLineBoxContainValue() const { return m_classType == ClassType::LineBoxContain; }
+    bool isLinearGradientValue() const { return m_classType == ClassType::LinearGradient; }
+    bool isLinearTimingFunctionValue() const { return m_classType == ClassType::LinearTimingFunction; }
+    bool isNamedImageValue() const { return m_classType == ClassType::NamedImage; }
+    bool isOffsetRotateValue() const { return m_classType == ClassType::OffsetRotate; }
+    bool isPair() const { return m_classType == ClassType::ValuePair; }
+    bool isPath() const { return m_classType == ClassType::Path; }
+    bool isPendingSubstitutionValue() const { return m_classType == ClassType::PendingSubstitutionValue; }
+    bool isPolygon() const { return m_classType == ClassType::Polygon; }
+    bool isPrefixedLinearGradientValue() const { return m_classType == ClassType::PrefixedLinearGradient; }
+    bool isPrefixedRadialGradientValue() const { return m_classType == ClassType::PrefixedRadialGradient; }
+    bool isPrimitiveValue() const { return m_classType == ClassType::Primitive; }
+    bool isQuad() const { return m_classType == ClassType::Quad; }
+    bool isRadialGradientValue() const { return m_classType == ClassType::RadialGradient; }
+    bool isRayValue() const { return m_classType == ClassType::Ray; }
+    bool isRect() const { return m_classType == ClassType::Rect; }
+    bool isRectShape() const { return m_classType == ClassType::RectShape; }
+    bool isReflectValue() const { return m_classType == ClassType::Reflect; }
+    bool isScrollValue() const { return m_classType == ClassType::Scroll; }
+    bool isShadowValue() const { return m_classType == ClassType::Shadow; }
+    bool isShape() const { return m_classType == ClassType::Shape; }
+    bool isShapeSegment() const { return m_classType == ClassType::ShapeSegment; }
+    bool isSpringTimingFunctionValue() const { return m_classType == ClassType::SpringTimingFunction; }
+    bool isStepsTimingFunctionValue() const { return m_classType == ClassType::StepsTimingFunction; }
+    bool isSubgridValue() const { return m_classType == ClassType::Subgrid; }
+    bool isTransformListValue() const { return m_classType == ClassType::TransformList; }
+    bool isUnicodeRangeValue() const { return m_classType == ClassType::UnicodeRange; }
+    bool isValueList() const { return m_classType == ClassType::ValueList; }
+    bool isVariableReferenceValue() const { return m_classType == ClassType::VariableReference; }
+    bool isViewValue() const { return m_classType == ClassType::View; }
+    bool isXywhShape() const { return m_classType == ClassType::XywhShape; }
+    bool isPaintImageValue() const { return m_classType == ClassType::PaintImage; }
 
     bool hasVariableReferences() const { return isVariableReferenceValue() || isPendingSubstitutionValue(); }
-    bool isGradientValue() const { return m_classType >= LinearGradientClass && m_classType <= PrefixedRadialGradientClass; }
-    bool isImageGeneratorValue() const { return m_classType >= CanvasClass && m_classType <= PrefixedRadialGradientClass; }
+    bool isGradientValue() const { return m_classType >= ClassType::LinearGradient && m_classType <= ClassType::PrefixedRadialGradient; }
+    bool isImageGeneratorValue() const { return m_classType >= ClassType::Canvas && m_classType <= ClassType::PrefixedRadialGradient; }
     bool isImplicitInitialValue() const { return m_isImplicitInitialValue; }
-    bool containsVector() const { return m_classType >= ValueListClass; }
+    bool containsVector() const { return m_classType >= ClassType::ValueList; }
 
     // NOTE: This returns true for all image-like values except CSSCursorImageValues; these are the values that correspond to the CSS <image> production.
     bool isImage() const { return isImageValue() || isImageSetValue() || isImageGeneratorValue(); }
@@ -218,92 +218,90 @@ public:
 protected:
     static const size_t ClassTypeBits = 7;
 
-    // FIXME: Use an enum class here so we don't have to repeat "Class" in every name.
-    enum ClassType {
-        PrimitiveClass,
+    enum class ClassType : uint8_t {
+        Primitive,
 
         // Image classes.
-        ImageClass,
-        ImageSetOptionClass,
-        CursorImageClass,
-
+        Image,
+        ImageSetOption,
+        CursorImage,
         // Image generator classes.
-        CanvasClass,
-        PaintImageClass,
-        NamedImageClass,
-        CrossfadeClass,
-        FilterImageClass,
-        LinearGradientClass,
-        RadialGradientClass,
-        ConicGradientClass,
-        DeprecatedLinearGradientClass,
-        DeprecatedRadialGradientClass,
-        PrefixedLinearGradientClass,
-        PrefixedRadialGradientClass,
+        Canvas,
+        PaintImage,
+        NamedImage,
+        Crossfade,
+        FilterImage,
+        LinearGradient,
+        RadialGradient,
+        ConicGradient,
+        DeprecatedLinearGradient,
+        DeprecatedRadialGradient,
+        PrefixedLinearGradient,
+        PrefixedRadialGradient,
 
         // Timing function classes.
-        LinearTimingFunctionClass,
-        CubicBezierTimingFunctionClass,
-        SpringTimingFunctionClass,
-        StepsTimingFunctionClass,
+        LinearTimingFunction,
+        CubicBezierTimingFunction,
+        SpringTimingFunction,
+        StepsTimingFunction,
 
         // Other non-list classes.
-        AnchorClass,
-        AspectRatioClass,
-        BackgroundRepeatClass,
-        BorderImageSliceClass,
-        BorderImageWidthClass,
-        CalculationClass,
-        CircleClass,
-        ContentDistributionClass,
-        CounterClass,
-        CustomPropertyClass,
-        EllipseClass,
-        FontClass,
-        FontFaceSrcLocalClass,
-        FontFaceSrcResourceClass,
-        FontFeatureClass,
-        FontPaletteValuesOverrideColorsClass,
-        FontStyleRangeClass,
-        FontStyleWithAngleClass,
-        FontVariantAlternatesClass,
-        FontVariationClass,
-        GridLineNamesClass,
-        GridLineValueClass,
-        GridTemplateAreasClass,
-        InsetShapeClass,
-        LineBoxContainClass,
-        OffsetRotateClass,
-        PathClass,
-        PendingSubstitutionValueClass,
-        QuadClass,
-        RayClass,
-        RectClass,
-        RectShapeClass,
-        ReflectClass,
-        ScrollClass,
-        ShadowClass,
-        ShapeSegmentClass,
-        UnicodeRangeClass,
-        ValuePairClass,
-        VariableReferenceClass,
-        ViewClass,
-        XywhShapeClass,
+        Anchor,
+        AspectRatio,
+        BackgroundRepeat,
+        BorderImageSlice,
+        BorderImageWidth,
+        Calculation,
+        Circle,
+        ContentDistribution,
+        Counter,
+        CustomProperty,
+        Ellipse,
+        Font,
+        FontFaceSrcLocal,
+        FontFaceSrcResource,
+        FontFeature,
+        FontPaletteValuesOverrideColors,
+        FontStyleRange,
+        FontStyleWithAngle,
+        FontVariantAlternates,
+        FontVariation,
+        GridLineNames,
+        GridLineValue,
+        GridTemplateAreas,
+        InsetShape,
+        LineBoxContain,
+        OffsetRotate,
+        Path,
+        PendingSubstitutionValue,
+        Quad,
+        Ray,
+        Rect,
+        RectShape,
+        Reflect,
+        Scroll,
+        Shadow,
+        ShapeSegment,
+        UnicodeRange,
+        ValuePair,
+        VariableReference,
+        View,
+        XywhShape,
 
         // Classes that contain vectors, which derive from CSSValueContainingVector.
-        ValueListClass,
-        FunctionClass,
-        GridAutoRepeatClass,
-        GridIntegerRepeatClass,
-        ImageSetClass,
-        PolygonClass,
-        ShapeClass,
-        SubgridClass,
-        TransformListClass,
+        ValueList,
+        Function,
+        GridAutoRepeat,
+        GridIntegerRepeat,
+        ImageSet,
+        Polygon,
+        Shape,
+        Subgrid,
+        TransformList,
         // Do not append classes here unless they derive from CSSValueContainingVector.
     };
 
-    constexpr ClassType classType() const { return static_cast<ClassType>(m_classType); }
+    constexpr ClassType classType() const { return m_classType; }
 
     explicit CSSValue(ClassType classType)
         : m_classType(classType)
@@ -337,15 +335,15 @@ protected:
     // These data members are used by derived classes but here to maximize struct packing.
 
     // CSSPrimitiveValue:
-    unsigned m_primitiveUnitType : 7 { 0 }; // CSSUnitType
-    mutable unsigned m_hasCachedCSSText : 1 { false };
-    unsigned m_isImplicitInitialValue : 1 { false };
+    uint8_t m_primitiveUnitType : 7 { 0 }; // CSSUnitType
+    mutable uint8_t m_hasCachedCSSText : 1 { false };
+    uint8_t m_isImplicitInitialValue : 1 { false };
 
     // CSSValueList and CSSValuePair:
-    unsigned m_valueSeparator : ValueSeparatorBits { 0 };
+    uint8_t m_valueSeparator : ValueSeparatorBits { 0 };
 
 private:
-    unsigned m_classType : ClassTypeBits; // ClassType
+    ClassType m_classType : ClassTypeBits;
 };
 
 inline void CSSValue::deref() const

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -92,32 +92,32 @@ CSSValueContainingVector::CSSValueContainingVector(ClassType type, ValueSeparato
 }
 
 CSSValueList::CSSValueList(ValueSeparator separator)
-    : CSSValueContainingVector(ValueListClass, separator)
+    : CSSValueContainingVector(ClassType::ValueList, separator)
 {
 }
 
 CSSValueList::CSSValueList(ValueSeparator separator, CSSValueListBuilder values)
-    : CSSValueContainingVector(ValueListClass, separator, WTFMove(values))
+    : CSSValueContainingVector(ClassType::ValueList, separator, WTFMove(values))
 {
 }
 
 CSSValueList::CSSValueList(ValueSeparator separator, Ref<CSSValue> value)
-    : CSSValueContainingVector(ValueListClass, separator, WTFMove(value))
+    : CSSValueContainingVector(ClassType::ValueList, separator, WTFMove(value))
 {
 }
 
 CSSValueList::CSSValueList(ValueSeparator separator, Ref<CSSValue> value1, Ref<CSSValue> value2)
-    : CSSValueContainingVector(ValueListClass, separator, WTFMove(value1), WTFMove(value2))
+    : CSSValueContainingVector(ClassType::ValueList, separator, WTFMove(value1), WTFMove(value2))
 {
 }
 
 CSSValueList::CSSValueList(ValueSeparator separator, Ref<CSSValue> value1, Ref<CSSValue> value2, Ref<CSSValue> value3)
-    : CSSValueContainingVector(ValueListClass, separator, WTFMove(value1), WTFMove(value2), WTFMove(value3))
+    : CSSValueContainingVector(ClassType::ValueList, separator, WTFMove(value1), WTFMove(value2), WTFMove(value3))
 {
 }
 
 CSSValueList::CSSValueList(ValueSeparator separator, Ref<CSSValue> value1, Ref<CSSValue> value2, Ref<CSSValue> value3, Ref<CSSValue> value4)
-    : CSSValueContainingVector(ValueListClass, separator, WTFMove(value1), WTFMove(value2), WTFMove(value3), WTFMove(value4))
+    : CSSValueContainingVector(ClassType::ValueList, separator, WTFMove(value1), WTFMove(value2), WTFMove(value3), WTFMove(value4))
 {
 }
 

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 CSSValuePair::CSSValuePair(ValueSeparator separator, Ref<CSSValue> first, Ref<CSSValue> second, IdenticalValueSerialization serialization)
-    : CSSValue(ValuePairClass)
+    : CSSValue(ClassType::ValuePair)
     , m_coalesceIdenticalValues(serialization != IdenticalValueSerialization::DoNotCoalesce)
     , m_first(WTFMove(first))
     , m_second(WTFMove(second))

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -45,7 +45,7 @@
 namespace WebCore {
 
 CSSVariableReferenceValue::CSSVariableReferenceValue(Ref<CSSVariableData>&& data)
-    : CSSValue(VariableReferenceClass)
+    : CSSValue(ClassType::VariableReference)
     , m_data(WTFMove(data))
 {
     cacheSimpleReference();

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -75,7 +75,7 @@ public:
 
 private:
     CSSViewValue(RefPtr<CSSValue>&& axis, RefPtr<CSSValue>&& startInset, RefPtr<CSSValue>&& endInset)
-        : CSSValue(ViewClass)
+        : CSSValue(ClassType::View)
         , m_axis(WTFMove(axis))
         , m_startInset(WTFMove(startInset))
         , m_endInset(WTFMove(endInset))

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -110,7 +110,7 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& 
 }
 
 CSSCalcValue::CSSCalcValue(CSSCalc::Tree&& tree)
-    : CSSValue(CalculationClass)
+    : CSSValue(ClassType::Calculation)
     , m_tree(WTFMove(tree))
 {
 }


### PR DESCRIPTION
#### 81dfdabf3b60c3d6ec78ad6c52c901731223d4da
<pre>
Use an enum class for CSSValue Type
<a href="https://bugs.webkit.org/show_bug.cgi?id=277660">https://bugs.webkit.org/show_bug.cgi?id=277660</a>
<a href="https://rdar.apple.com/133256102">rdar://133256102</a>

Reviewed by Tim Nguyen.

Convert the enum ClassType into an enum class.

* Source/WebCore/css/CSSAnchorValue.h:
* Source/WebCore/css/CSSAspectRatioValue.h:
* Source/WebCore/css/CSSBackgroundRepeatValue.cpp:
(WebCore::CSSBackgroundRepeatValue::CSSBackgroundRepeatValue):
* Source/WebCore/css/CSSBasicShapes.cpp:
(WebCore::CSSCircleValue::CSSCircleValue):
(WebCore::CSSEllipseValue::CSSEllipseValue):
(WebCore::CSSXywhValue::CSSXywhValue):
(WebCore::CSSRectShapeValue::CSSRectShapeValue):
(WebCore::CSSPathValue::CSSPathValue):
(WebCore::CSSPolygonValue::CSSPolygonValue):
(WebCore::CSSInsetShapeValue::CSSInsetShapeValue):
(WebCore::CSSShapeValue::CSSShapeValue):
* Source/WebCore/css/CSSBorderImageSliceValue.cpp:
(WebCore::CSSBorderImageSliceValue::CSSBorderImageSliceValue):
* Source/WebCore/css/CSSBorderImageWidthValue.cpp:
(WebCore::CSSBorderImageWidthValue::CSSBorderImageWidthValue):
* Source/WebCore/css/CSSCanvasValue.cpp:
(WebCore::CSSCanvasValue::CSSCanvasValue):
* Source/WebCore/css/CSSContentDistributionValue.cpp:
(WebCore::CSSContentDistributionValue::CSSContentDistributionValue):
* Source/WebCore/css/CSSCounterValue.cpp:
(WebCore::CSSCounterValue::CSSCounterValue):
* Source/WebCore/css/CSSCrossfadeValue.cpp:
(WebCore::CSSCrossfadeValue::CSSCrossfadeValue):
* Source/WebCore/css/CSSCursorImageValue.cpp:
(WebCore::CSSCursorImageValue::CSSCursorImageValue):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSFilterImageValue.cpp:
(WebCore::CSSFilterImageValue::CSSFilterImageValue):
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcLocalValue::CSSFontFaceSrcLocalValue):
(WebCore::CSSFontFaceSrcResourceValue::CSSFontFaceSrcResourceValue):
* Source/WebCore/css/CSSFontFeatureValue.cpp:
(WebCore::CSSFontFeatureValue::CSSFontFeatureValue):
* Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h:
* Source/WebCore/css/CSSFontStyleRangeValue.h:
* Source/WebCore/css/CSSFontStyleWithAngleValue.cpp:
(WebCore::CSSFontStyleWithAngleValue::CSSFontStyleWithAngleValue):
* Source/WebCore/css/CSSFontValue.h:
* Source/WebCore/css/CSSFontVariantAlternatesValue.cpp:
(WebCore::CSSFontVariantAlternatesValue::CSSFontVariantAlternatesValue):
* Source/WebCore/css/CSSFontVariationValue.cpp:
(WebCore::CSSFontVariationValue::CSSFontVariationValue):
* Source/WebCore/css/CSSFunctionValue.cpp:
(WebCore::CSSFunctionValue::CSSFunctionValue):
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSGridAutoRepeatValue.cpp:
(WebCore::CSSGridAutoRepeatValue::CSSGridAutoRepeatValue):
* Source/WebCore/css/CSSGridIntegerRepeatValue.cpp:
(WebCore::CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue):
* Source/WebCore/css/CSSGridLineNamesValue.cpp:
(WebCore::CSSGridLineNamesValue::CSSGridLineNamesValue):
* Source/WebCore/css/CSSGridTemplateAreasValue.cpp:
(WebCore::CSSGridTemplateAreasValue::CSSGridTemplateAreasValue):
* Source/WebCore/css/CSSImageSetOptionValue.cpp:
(WebCore::CSSImageSetOptionValue::CSSImageSetOptionValue):
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::CSSImageSetValue):
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::CSSImageValue):
* Source/WebCore/css/CSSLineBoxContainValue.cpp:
(WebCore::CSSLineBoxContainValue::CSSLineBoxContainValue):
* Source/WebCore/css/CSSNamedImageValue.cpp:
(WebCore::CSSNamedImageValue::CSSNamedImageValue):
* Source/WebCore/css/CSSOffsetRotateValue.h:
* Source/WebCore/css/CSSPaintImageValue.cpp:
(WebCore::CSSPaintImageValue::CSSPaintImageValue):
* Source/WebCore/css/CSSPendingSubstitutionValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::CSSPrimitiveValue):
* Source/WebCore/css/CSSQuadValue.cpp:
(WebCore::CSSQuadValue::CSSQuadValue):
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/CSSRectValue.cpp:
(WebCore::CSSRectValue::CSSRectValue):
* Source/WebCore/css/CSSReflectValue.cpp:
(WebCore::CSSReflectValue::CSSReflectValue):
* Source/WebCore/css/CSSScrollValue.h:
* Source/WebCore/css/CSSShadowValue.cpp:
(WebCore::CSSShadowValue::CSSShadowValue):
* Source/WebCore/css/CSSShapeSegmentValue.h:
(WebCore::CSSShapeSegmentValue::CSSShapeSegmentValue):
* Source/WebCore/css/CSSSubgridValue.cpp:
(WebCore::CSSSubgridValue::CSSSubgridValue):
* Source/WebCore/css/CSSTimingFunctionValue.h:
* Source/WebCore/css/CSSTransformListValue.cpp:
(WebCore::CSSTransformListValue::CSSTransformListValue):
* Source/WebCore/css/CSSUnicodeRangeValue.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
(WebCore::CSSValue::createDeprecatedCSSOMWrapper const):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isAnchorValue const):
(WebCore::CSSValue::isAspectRatioValue const):
(WebCore::CSSValue::isBackgroundRepeatValue const):
(WebCore::CSSValue::isBorderImageSliceValue const):
(WebCore::CSSValue::isBorderImageWidthValue const):
(WebCore::CSSValue::isCalcValue const):
(WebCore::CSSValue::isCanvasValue const):
(WebCore::CSSValue::isCircle const):
(WebCore::CSSValue::isConicGradientValue const):
(WebCore::CSSValue::isContentDistributionValue const):
(WebCore::CSSValue::isCounter const):
(WebCore::CSSValue::isCrossfadeValue const):
(WebCore::CSSValue::isCubicBezierTimingFunctionValue const):
(WebCore::CSSValue::isCursorImageValue const):
(WebCore::CSSValue::isCustomPropertyValue const):
(WebCore::CSSValue::isDeprecatedLinearGradientValue const):
(WebCore::CSSValue::isDeprecatedRadialGradientValue const):
(WebCore::CSSValue::isEllipse const):
(WebCore::CSSValue::isFilterImageValue const):
(WebCore::CSSValue::isFontFaceSrcLocalValue const):
(WebCore::CSSValue::isFontFaceSrcResourceValue const):
(WebCore::CSSValue::isFontFeatureValue const):
(WebCore::CSSValue::isFontPaletteValuesOverrideColorsValue const):
(WebCore::CSSValue::isFontStyleRangeValue const):
(WebCore::CSSValue::isFontStyleWithAngleValue const):
(WebCore::CSSValue::isFontValue const):
(WebCore::CSSValue::isFontVariantAlternatesValue const):
(WebCore::CSSValue::isFontVariationValue const):
(WebCore::CSSValue::isFunctionValue const):
(WebCore::CSSValue::isGridAutoRepeatValue const):
(WebCore::CSSValue::isGridIntegerRepeatValue const):
(WebCore::CSSValue::isGridLineNamesValue const):
(WebCore::CSSValue::isGridTemplateAreasValue const):
(WebCore::CSSValue::isImageSetOptionValue const):
(WebCore::CSSValue::isImageSetValue const):
(WebCore::CSSValue::isImageValue const):
(WebCore::CSSValue::isInsetShape const):
(WebCore::CSSValue::isLineBoxContainValue const):
(WebCore::CSSValue::isLinearGradientValue const):
(WebCore::CSSValue::isLinearTimingFunctionValue const):
(WebCore::CSSValue::isNamedImageValue const):
(WebCore::CSSValue::isOffsetRotateValue const):
(WebCore::CSSValue::isPair const):
(WebCore::CSSValue::isPath const):
(WebCore::CSSValue::isPendingSubstitutionValue const):
(WebCore::CSSValue::isPolygon const):
(WebCore::CSSValue::isPrefixedLinearGradientValue const):
(WebCore::CSSValue::isPrefixedRadialGradientValue const):
(WebCore::CSSValue::isPrimitiveValue const):
(WebCore::CSSValue::isQuad const):
(WebCore::CSSValue::isRadialGradientValue const):
(WebCore::CSSValue::isRayValue const):
(WebCore::CSSValue::isRect const):
(WebCore::CSSValue::isRectShape const):
(WebCore::CSSValue::isReflectValue const):
(WebCore::CSSValue::isScrollValue const):
(WebCore::CSSValue::isShadowValue const):
(WebCore::CSSValue::isShape const):
(WebCore::CSSValue::isShapeSegment const):
(WebCore::CSSValue::isSpringTimingFunctionValue const):
(WebCore::CSSValue::isStepsTimingFunctionValue const):
(WebCore::CSSValue::isSubgridValue const):
(WebCore::CSSValue::isTransformListValue const):
(WebCore::CSSValue::isUnicodeRangeValue const):
(WebCore::CSSValue::isValueList const):
(WebCore::CSSValue::isVariableReferenceValue const):
(WebCore::CSSValue::isViewValue const):
(WebCore::CSSValue::isXywhShape const):
(WebCore::CSSValue::isPaintImageValue const):
(WebCore::CSSValue::isGradientValue const):
(WebCore::CSSValue::isImageGeneratorValue const):
(WebCore::CSSValue::containsVector const):
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueList::CSSValueList):
* Source/WebCore/css/CSSValuePair.cpp:
(WebCore::CSSValuePair::CSSValuePair):
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::CSSVariableReferenceValue):
* Source/WebCore/css/CSSViewValue.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::CSSCalcValue):

Canonical link: <a href="https://commits.webkit.org/283564@main">https://commits.webkit.org/283564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9cb1ad50841b509c239e83281bc844f4a3b6fef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53043 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11623 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71819 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10040 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14352 "Found 1 new test failure: http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1934 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41266 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->