### PR TITLE
WorkerSWClientConnection should not invoke callback when it does not exist

### DIFF
--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -361,14 +361,14 @@ CookieStoreManager& ServiceWorkerRegistration::cookies()
 
 void ServiceWorkerRegistration::addCookieChangeSubscriptions(Vector<CookieStoreGetOptions>&& subscriptions, Ref<DeferredPromise>&& promise)
 {
+    if (isContextStopped()) {
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
+        return;
+    }
+
     Vector<CookieChangeSubscription> cookieChangeSubscriptions;
     cookieChangeSubscriptions.reserveInitialCapacity(subscriptions.size());
     for (auto& subscription : subscriptions) {
-        if (isContextStopped()) {
-            promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
-            return;
-        }
-
         // FIXME: Fall back to scope url since spec does not specify an alternative and WPT layout tests expect this behavior (https://github.com/WICG/cookie-store/issues/236).
         String url;
         if (subscription.url.isNull())
@@ -389,14 +389,14 @@ void ServiceWorkerRegistration::addCookieChangeSubscriptions(Vector<CookieStoreG
 
 void ServiceWorkerRegistration::removeCookieChangeSubscriptions(Vector<CookieStoreGetOptions>&& subscriptions, Ref<DeferredPromise>&& promise)
 {
+    if (isContextStopped()) {
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
+        return;
+    }
+
     Vector<CookieChangeSubscription> cookieChangeSubscriptions;
     cookieChangeSubscriptions.reserveInitialCapacity(subscriptions.size());
     for (auto& subscription : subscriptions) {
-        if (isContextStopped()) {
-            promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
-            return;
-        }
-
         // FIXME: Fall back to scope url since spec does not specify an alternative and WPT layout tests expect this behavior (https://github.com/WICG/cookie-store/issues/236).
         String url;
         if (subscription.url.isNull())
@@ -417,6 +417,11 @@ void ServiceWorkerRegistration::removeCookieChangeSubscriptions(Vector<CookieSto
 
 void ServiceWorkerRegistration::cookieChangeSubscriptions(Ref<DeferredPromise>&& promise)
 {
+    if (isContextStopped()) {
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The script execution context is not currently running"_s });
+        return;
+    }
+
     protectedContainer()->cookieChangeSubscriptions(identifier(), WTFMove(promise));
 }
 

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -566,12 +566,8 @@ void WorkerSWClientConnection::addCookieChangeSubscriptions(ServiceWorkerRegistr
         Ref connection = ServiceWorkerProvider::singleton().serviceWorkerConnection();
         connection->addCookieChangeSubscriptions(registrationIdentifier, WTFMove(subscriptions), [thread = WTFMove(thread), requestIdentifier](auto&& result) {
             thread->runLoop().postTaskForMode([requestIdentifier, result = crossThreadCopy(WTFMove(result))](auto& scope) mutable {
-                auto callback = downcast<WorkerGlobalScope>(scope).swClientConnection().m_voidCallbacks.take(requestIdentifier);
-                if (!callback) {
-                    callback(Exception { ExceptionCode::InvalidStateError, "Unable to add cookie change subscriptions"_s });
-                    return;
-                }
-                callback(WTFMove(result));
+                if (auto callback = downcast<WorkerGlobalScope>(scope).swClientConnection().m_voidCallbacks.take(requestIdentifier))
+                    callback(WTFMove(result));
             }, WorkerRunLoop::defaultMode());
         });
     });
@@ -586,12 +582,8 @@ void WorkerSWClientConnection::removeCookieChangeSubscriptions(ServiceWorkerRegi
         Ref connection = ServiceWorkerProvider::singleton().serviceWorkerConnection();
         connection->removeCookieChangeSubscriptions(registrationIdentifier, WTFMove(subscriptions), [thread = WTFMove(thread), requestIdentifier](auto&& result) {
             thread->runLoop().postTaskForMode([requestIdentifier, result = crossThreadCopy(WTFMove(result))](auto& scope) mutable {
-                auto callback = downcast<WorkerGlobalScope>(scope).swClientConnection().m_voidCallbacks.take(requestIdentifier);
-                if (!callback) {
-                    callback(Exception { ExceptionCode::InvalidStateError, "Unable to remove cookie change subscriptions"_s });
-                    return;
-                }
-                callback(WTFMove(result));
+                if (auto callback = downcast<WorkerGlobalScope>(scope).swClientConnection().m_voidCallbacks.take(requestIdentifier))
+                    callback(WTFMove(result));
             }, WorkerRunLoop::defaultMode());
         });
     });
@@ -606,12 +598,8 @@ void WorkerSWClientConnection::cookieChangeSubscriptions(ServiceWorkerRegistrati
         Ref connection = ServiceWorkerProvider::singleton().serviceWorkerConnection();
         connection->cookieChangeSubscriptions(registrationIdentifier, [thread = WTFMove(thread), requestIdentifier](auto&& result) {
             thread->runLoop().postTaskForMode([requestIdentifier, result = crossThreadCopy(WTFMove(result))](auto& scope) mutable {
-                auto callback = downcast<WorkerGlobalScope>(scope).swClientConnection().m_cookieChangeSubscriptionsCallback.take(requestIdentifier);
-                if (!callback) {
-                    callback(Exception { ExceptionCode::InvalidStateError, "Unable to retrieve cookie change subscriptions"_s });
-                    return;
-                }
-                callback(WTFMove(result));
+                if (auto callback = downcast<WorkerGlobalScope>(scope).swClientConnection().m_cookieChangeSubscriptionsCallback.take(requestIdentifier))
+                    callback(WTFMove(result));
             }, WorkerRunLoop::defaultMode());
         });
     });


### PR DESCRIPTION
#### 655f127964b691bd053177a07304d37a31b31c5d
<pre>
WorkerSWClientConnection should not invoke callback when it does not exist
<a href="https://bugs.webkit.org/show_bug.cgi?id=278334">https://bugs.webkit.org/show_bug.cgi?id=278334</a>
<a href="https://rdar.apple.com/134278561">rdar://134278561</a>

Reviewed by Chris Dumez.

This patch also contains a drive-by fix for ServiceWorkerRegistration to reject Promise early when script execution
context has stopped.

* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::addCookieChangeSubscriptions):
(WebCore::ServiceWorkerRegistration::removeCookieChangeSubscriptions):
(WebCore::ServiceWorkerRegistration::cookieChangeSubscriptions):
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
(WebCore::WorkerSWClientConnection::addCookieChangeSubscriptions):
(WebCore::WorkerSWClientConnection::removeCookieChangeSubscriptions):
(WebCore::WorkerSWClientConnection::cookieChangeSubscriptions):

Canonical link: <a href="https://commits.webkit.org/282456@main">https://commits.webkit.org/282456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bb06a23c724d11a9f16c02dca935b4199b7eec8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67215 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14082 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/50935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9543 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54719 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12065 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12674 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68911 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7141 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54787 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5959 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40562 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->