### PR TITLE
[JSC] Atomics.and returns incorrect number type in JIT compiler

### DIFF
--- a/JSTests/stress/atomics-ops-sign-extend-not-bit-mask.js
+++ b/JSTests/stress/atomics-ops-sign-extend-not-bit-mask.js
@@ -1,0 +1,48 @@
+//@ requireOptions("--jitPolicyScale=0.001")
+
+function opt16() {
+    const arr = new Int16Array([-1, 1]);
+    if (Atomics.and(arr, 0, 0) !== -1)
+        throw new Error();
+
+    if (Atomics.and(arr, 1, 0) !== 1)
+        throw new Error();
+}
+noInline(opt16);
+
+function optU16() {
+    const arr = new Uint16Array([-1, 1]);
+    if (Atomics.and(arr, 0, 0) !== 65535)
+        throw new Error();
+
+    if (Atomics.and(arr, 1, 0) !== 1)
+        throw new Error();
+}
+noInline(optU16);
+
+function opt8() {
+    const arr = new Int8Array([-1, 1]);
+    if (Atomics.and(arr, 0, 0) !== -1)
+        throw new Error();
+
+    if (Atomics.and(arr, 1, 0) !== 1)
+        throw new Error();
+}
+noInline(opt8);
+
+function optU8() {
+    const arr = new Uint8Array([-1, 1]);
+    if (Atomics.and(arr, 0, 0) !== 255)
+        throw new Error();
+
+    if (Atomics.and(arr, 1, 0) !== 1)
+        throw new Error();
+}
+noInline(optU8);
+
+for (let i = 0; i < 1e3; i++) {
+    opt16();
+    optU16();
+    opt8();
+    optU8();
+}

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -5002,7 +5002,7 @@ private:
         LValue result;
 
         auto sanitizeResult = [&] (LValue value) -> LValue {
-            if (isSigned(type)) {
+            if (!isSigned(type)) {
                 switch (elementSize(type)) {
                 case 1:
                     value = m_out.bitAnd(value, m_out.constInt32(0xff));


### PR DESCRIPTION
#### 67c8ea6bd1f03982d2ad7d4a4a621cc81d954072
<pre>
[JSC] Atomics.and returns incorrect number type in JIT compiler
<a href="https://bugs.webkit.org/show_bug.cgi?id=277895">https://bugs.webkit.org/show_bug.cgi?id=277895</a>
<a href="https://rdar.apple.com/134115829">rdar://134115829</a>

Reviewed by Yusuke Suzuki.

FTL was incorrectly masking signed non-canonical width Atomics operations rather than the unsigned
operations.

* JSTests/stress/atomics-ops-sign-extend-not-bit-mask.js: Added.
(opt16):
(optU16):
(opt8):
(optU8):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileAtomicsReadModifyWrite):

Canonical link: <a href="https://commits.webkit.org/282476@main">https://commits.webkit.org/282476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a19d7f9dfe492ae11f7879206a8039281ea7b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13854 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50953 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12726 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56358 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68963 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62489 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58262 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54834 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5994 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84252 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14843 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40614 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->