### PR TITLE
Add propper waiting to the backdrop-filter-page-scale

### DIFF
--- a/LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html
+++ b/LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html
@@ -3,9 +3,13 @@
 <head>
 <meta charset="utf-8">
     <script>
-        window.onload = async function() {
-            if (window.testRunner)
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+        async function test() {
+            if (window.testRunner) {
                 await window.testRunner.setPageScaleFactor(2, 0, 0);
+                window.testRunner.notifyDone();
+            }
         }
     </script>
 <style>
@@ -17,7 +21,7 @@ div {
 
 </style>
 </head>
-<body>
+<body onload="test()">
   Hello
   <div></div>
 </body>

--- a/LayoutTests/css3/filters/backdrop-filter-page-scale.html
+++ b/LayoutTests/css3/filters/backdrop-filter-page-scale.html
@@ -3,9 +3,13 @@
 <head>
 <meta charset="utf-8">
     <script>
-        window.onload = async function() {
-            if (window.testRunner)
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+        async function test() {
+            if (window.testRunner) {
                 await window.testRunner.setPageScaleFactor(2, 0, 0);
+                window.testRunner.notifyDone();
+            }
         }
     </script>
 <style>
@@ -17,7 +21,7 @@ div {
 
 </style>
 </head>
-<body>
+<body onload="test()">
   Hello
   <div></div>
 </body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7522,9 +7522,6 @@ fast/forms/ios/focus-checkbox.html [ Pass Timeout ]
 fast/forms/ios/focus-checked-checkbox.html [ Pass Timeout ]
 fast/forms/ios/focus-checked-radio.html [ Pass Timeout ]
 
-# webkit.org/b/278323 REGRESSION(282170@main): [ iOS ] css3/filters/backdrop-filter-page-scale.html is a flaky image failure
-css3/filters/backdrop-filter-page-scale.html [ Pass ImageOnlyFailure ]
-
 # webkit.org/b/278329 [ iOS ] imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe.html is a flaky failure
 imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe.html [ Pass Failure ]
 


### PR DESCRIPTION
#### a3e1039effdbe4ff75832fc8f55356528b866de2
<pre>
Add propper waiting to the backdrop-filter-page-scale
<a href="https://bugs.webkit.org/show_bug.cgi?id=278323">https://bugs.webkit.org/show_bug.cgi?id=278323</a>
<a href="https://rdar.apple.com/134269886">rdar://134269886</a>

Reviewed by Alex Christensen.

I cannot reproduce this failure but I suspect propper waiting for the test
to finish was missing so adding that.
Also reverting the gardening commit for this test.

* LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html:
* LayoutTests/css3/filters/backdrop-filter-page-scale.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/282480@main">https://commits.webkit.org/282480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d913ac584f3d0fc37da1d39b194ff159d1b412e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50954 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9570 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12110 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/68961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58263 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14014 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5986 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->