### PR TITLE
REGRESSION (iOS 18): 9 layout tests need to be re-written to expect new behavior.

### DIFF
--- a/LayoutTests/http/tests/cookies/resources/testharness-helpers.js
+++ b/LayoutTests/http/tests/cookies/resources/testharness-helpers.js
@@ -5,7 +5,9 @@ var TEST_SUB  = "subdomain." + TEST_HOST;
 
 var STRICT_DOM = "strict_from_dom";
 var IMPLICIT_STRICT_DOM = "implicit_strict_from_dom";
+var IMPLICIT_LAX_DOM = "implicit_lax_from_dom";
 var STRICT_BECAUSE_INVALID_SAMESITE_VALUE = "strict_because_invalid_SameSite_value";
+var LAX_BECAUSE_INVALID_SAMESITE_VALUE = "lax_because_invalid_SameSite_value";
 var LAX_DOM = "lax_from_dom";
 var NORMAL_DOM = "normal_from_dom";
 

--- a/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page-expected.txt
@@ -10,14 +10,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Cookies sent with HTTP request:
 PASS Do not have cookie "strict".
-PASS Has cookie "implicit-strict" with value 6.
-PASS Has cookie "strict-because-invalid-SameSite-value" with value 6.
+PASS Do not have cookie "implicit-lax".
+PASS Do not have cookie "lax-because-invalid-SameSite-value".
 PASS Do not have cookie "lax".
 
 Cookies visible in DOM:
 PASS Do not have DOM cookie "strict".
-PASS Has DOM cookie "implicit-strict" with value 6.
-PASS Has DOM cookie "strict-because-invalid-SameSite-value" with value 6.
+PASS Do not have DOM cookie "implicit-lax".
+PASS Do not have DOM cookie "lax-because-invalid-SameSite-value".
 PASS Do not have DOM cookie "lax".
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html
@@ -8,8 +8,8 @@ async function runTest()
 {
     await resetCookies();
     await setCookie("strict", "6", {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
-    await setCookie("implicit-strict", "6", {"SameSite": null, "Max-Age": 100, "path": "/"});
-    await setCookie("strict-because-invalid-SameSite-value", "6", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
+    await setCookie("implicit-lax", "6", {"SameSite": null, "Max-Age": 100, "path": "/"});
+    await setCookie("lax-because-invalid-SameSite-value", "6", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
     await setCookie("lax", "6", {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
     window.location.href = "http://localhost:8000/resources/echo-iframe-src.py?src=http%3A//127.0.0.1%3A8000/cookies/same-site/resources/click-hyperlink.py%3Fhref%3Dfetch-after-navigating-iframe-in-cross-origin-page.py";
 }

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker-expected.txt
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker-expected.txt
@@ -10,14 +10,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Cookies sent with HTTP request:
 PASS Do not have cookie "strict".
-PASS Has cookie "implicit-strict" with value 10.
-PASS Has cookie "strict-because-invalid-SameSite-value" with value 10.
+PASS Do not have cookie "implicit-lax".
+PASS Do not have cookie "lax-because-invalid-SameSite-value".
 PASS Do not have cookie "lax".
 
 Cookies visible in DOM:
 PASS Do not have DOM cookie "strict".
-PASS Do not have DOM cookie "implicit-strict".
-PASS Do not have DOM cookie "strict-because-invalid-SameSite-value".
+PASS Do not have DOM cookie "implicit-lax".
+PASS Do not have DOM cookie "lax-because-invalid-SameSite-value".
 PASS Do not have DOM cookie "lax".
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html
+++ b/LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html
@@ -18,8 +18,8 @@ async function runTest()
     if (window.location.hostname === "127.0.0.1") {
         await resetCookies();
         await setCookie("strict", "10", {"SameSite": "Strict", "Max-Age": 100, "path": "/"});
-        await setCookie("implicit-strict", "10", {"SameSite": null, "Max-Age": 100, "path": "/"});
-        await setCookie("strict-because-invalid-SameSite-value", "10", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
+        await setCookie("implicit-lax", "10", {"SameSite": null, "Max-Age": 100, "path": "/"});
+        await setCookie("lax-because-invalid-SameSite-value", "10", {"SameSite": "invalid", "Max-Age": 100, "path": "/"});
         await setCookie("lax", "10", {"SameSite": "Lax", "Max-Age": 100, "path": "/"});
         window.location.hostname = "localhost";
     } else {

--- a/LayoutTests/http/tests/cookies/same-site/popup-cross-site-post.html
+++ b/LayoutTests/http/tests/cookies/same-site/popup-cross-site-post.html
@@ -7,8 +7,8 @@
 if (window.location.hostname == "127.0.0.1") {
     clearKnownCookies();
     document.cookie = STRICT_DOM + "=1; SameSite=Strict; Max-Age=100; path=/";
-    document.cookie = IMPLICIT_STRICT_DOM + "=1; SameSite; Max-Age=100; path=/";
-    document.cookie = STRICT_BECAUSE_INVALID_SAMESITE_VALUE + "=1; SameSite=invalid; Max-Age=100; path=/";
+    document.cookie = IMPLICIT_LAX_DOM + "=1; SameSite; Max-Age=100; path=/";
+    document.cookie = LAX_BECAUSE_INVALID_SAMESITE_VALUE + "=1; SameSite=invalid; Max-Age=100; path=/";
     document.cookie = LAX_DOM + "=1; SameSite=Lax; Max-Age=100; path=/";
     document.cookie = NORMAL_DOM + "=1; Max-Age=100; path=/";
     window.location.hostname = "localhost";
@@ -16,11 +16,11 @@ if (window.location.hostname == "127.0.0.1") {
     async_test(t => {
         window.addEventListener("message", t.step_func_done(e => {
             assert_equals(e.data.http[STRICT_DOM], undefined, "strict");
-            assert_equals(e.data.http[IMPLICIT_STRICT_DOM], "1", "implicit-strict");
-            assert_equals(e.data.http[STRICT_BECAUSE_INVALID_SAMESITE_VALUE], "1", "strict-because-invalid-SameSite-value");
+            assert_equals(e.data.http[IMPLICIT_LAX_DOM], undefined, "implicit-lax");
+            assert_equals(e.data.http[LAX_BECAUSE_INVALID_SAMESITE_VALUE], undefined, "lax-because-invalid-SameSite-value");
             assert_equals(e.data.http[LAX_DOM], undefined, "lax");
-            assert_equals(e.data.http[NORMAL_DOM], "1", "normal");
-            assert_equals(normalizeCookie(e.data.document), normalizeCookie(IMPLICIT_STRICT_DOM + "=1; " + LAX_DOM + "=1; " + NORMAL_DOM + "=1; " + STRICT_BECAUSE_INVALID_SAMESITE_VALUE + "=1; " + STRICT_DOM + "=1"));
+            assert_equals(e.data.http[NORMAL_DOM], undefined, "normal");
+            assert_equals(normalizeCookie(e.data.document), normalizeCookie(IMPLICIT_LAX_DOM + "=1; " + LAX_DOM + "=1; " + NORMAL_DOM + "=1; " + LAX_BECAUSE_INVALID_SAMESITE_VALUE + "=1; " + STRICT_DOM + "=1"));
             e.source.close();
         }));
 

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py
@@ -31,14 +31,14 @@ async function checkResult()
 {{
     debug("Cookies sent with HTTP request:");
     await shouldNotHaveCookie("strict");
-    await shouldHaveCookieWithValue("implicit-strict", "6");
-    await shouldHaveCookieWithValue("strict-because-invalid-SameSite-value", "6");
+    await shouldNotHaveCookie("implicit-lax", "6");
+    await shouldNotHaveCookie("lax-because-invalid-SameSite-value", "6");
     await shouldNotHaveCookie("lax");
 
     debug("<br>Cookies visible in DOM:");
     shouldNotHaveDOMCookie("strict");
-    shouldHaveDOMCookieWithValue("implicit-strict", "6");
-    shouldHaveDOMCookieWithValue("strict-because-invalid-SameSite-value", "6");
+    shouldNotHaveDOMCookie("implicit-lax", "6");
+    shouldNotHaveDOMCookie("lax-because-invalid-SameSite-value", "6");
     shouldNotHaveDOMCookie("lax");
 
     await resetCookies();

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-in-cross-origin-service-worker.html
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-in-cross-origin-service-worker.html
@@ -16,14 +16,14 @@ async function checkResult()
 
     debug("Cookies sent with HTTP request:");
     await shouldNotHaveCookie("strict");
-    await shouldHaveCookieWithValue("implicit-strict", "10"); // Behaves like a non-SameSite cookie
-    await shouldHaveCookieWithValue("strict-because-invalid-SameSite-value", "10"); // Behaves like a non-SameSite cookie
+    await shouldNotHaveCookie("implicit-lax", "10"); // Behaves like a non-SameSite cookie
+    await shouldNotHaveCookie("lax-because-invalid-SameSite-value", "10"); // Behaves like a non-SameSite cookie
     await shouldNotHaveCookie("lax");
 
     debug("<br>Cookies visible in DOM:");
     shouldNotHaveDOMCookie("strict");
-    shouldNotHaveDOMCookie("implicit-strict");
-    shouldNotHaveDOMCookie("strict-because-invalid-SameSite-value");
+    shouldNotHaveDOMCookie("implicit-lax");
+    shouldNotHaveDOMCookie("lax-because-invalid-SameSite-value");
     shouldNotHaveDOMCookie("lax");
 
     await resetCookies();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Setup
 FAIL Anonymous same-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL Anonymous cross-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+PASS Anonymous cross-origin iframe is loaded without credentials
 FAIL same_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
+PASS same_origin anonymous iframe can't send cross_origin credentials
+PASS cross_origin anonymous iframe can't send cross_origin credentials
+PASS cross_origin anonymous iframe can't send same_origin credentials
 FAIL same_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
+PASS same_origin anonymous iframe can't send cross_origin credentials on child iframe
+PASS cross_origin anonymous iframe can't send cross_origin credentials on child iframe
+PASS cross_origin anonymous iframe can't send same_origin credentials on child iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Setup
 FAIL Anonymous same-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL Anonymous cross-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+PASS Anonymous cross-origin iframe is loaded without credentials
 FAIL same_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
+PASS same_origin anonymous iframe can't send cross_origin credentials
+PASS cross_origin anonymous iframe can't send cross_origin credentials
+PASS cross_origin anonymous iframe can't send same_origin credentials
 FAIL same_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
+PASS same_origin anonymous iframe can't send cross_origin credentials on child iframe
+PASS cross_origin anonymous iframe can't send cross_origin credentials on child iframe
+PASS cross_origin anonymous iframe can't send same_origin credentials on child iframe
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4125,6 +4125,10 @@ webkit.org/b/124566 fast/dom/SelectorAPI/resig-SelectorsAPI-test.xhtml [ Skip ] 
 # Failures related with compositing tests.
 webkit.org/b/169918 compositing/fixed-with-fixed-layout.html [ Crash Pass ]
 
+# Fails when cookies are not SameSite=Lax by default
+imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
+imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/ios-17/TestExpectations
+++ b/LayoutTests/platform/ios-17/TestExpectations
@@ -84,22 +84,19 @@ webkit.org/b/277067 http/tests/misc/authentication-redirect-3/authentication-sen
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.any.html [ Pass ]
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.any.worker.html [ Pass ]
 
-# webkit.org/b/277460 (REGRESSION (iOS 18): 9 layout tests need to be re-written to expect new behavior.)
-http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Pass ]
-http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Pass ]
-http/tests/cookies/same-site/popup-cross-site-post.html [ Pass ]
-http/tests/privateClickMeasurement/send-attribution-conversion-request.html [ Pass ]
-imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Pass ]
-imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Pass ]
-imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Pass ]
-imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Pass ]
-
 # webkit.org/b/277933 (REGRESSION (iOS 18): 5 WPT CSS layout tests are constantly failing (ImageOnlyFailure). (277933))
 imported/w3c/web-platform-tests/css/css-content/quotes-025.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-content/quotes-026.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-content/quotes-027.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-004.xht [ Pass ]
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-005.xht [ Pass ]
+
+# Fails when cookies are not SameSite=Lax by default
+http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
+http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
+http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
+imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
+imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
 
 ###
 ### NOTICE: Unless you know that the issue for which you're setting expectations specifically only occurs on iOS 17, 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7487,15 +7487,7 @@ imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenera
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.any.worker.html [ Failure ]
 
-# webkit.org/b/277460 (REGRESSION (iOS 18): 9 layout tests need to be re-written to expect new behavior.)
-http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
-http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ] # uncomment expectation set for this test (above) when this is resolved
-http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
-http/tests/privateClickMeasurement/send-attribution-conversion-request.html [ Failure ]
-imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Failure ]
-imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
+webkit.org/b/278353 http/tests/privateClickMeasurement/send-attribution-conversion-request.html [ Failure ]
 
 # webkit.org/b/277933 (REGRESSION (iOS 18): 5 WPT CSS layout tests are constantly failing (ImageOnlyFailure). (277933))
 imported/w3c/web-platform-tests/css/css-content/quotes-025.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2896,5 +2896,9 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre.html
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html
 
+[ Ventura Sonoma ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
+[ Ventura Sonoma ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
+
 # webkit.org/b/278293 [MacOS WK1] imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-only-sends-reports-to-first-endpoint.https.sub.html is a flakey failure
 imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-only-sends-reports-to-first-endpoint.https.sub.html [ Pass Failure ]
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1788,17 +1788,19 @@ webkit.org/b/275913 [ Debug ] imported/w3c/web-platform-tests/media-source/dedic
 
 webkit.org/b/275873 storage/indexeddb/database-transaction-cycle.html [ Pass Failure ]
 
-# rdar://124363343 ([ Sequoia+ ] Multiple WebKit tests failing after explicit "SameSite" attribute change)
-# Some of these tests have expectations set elsewhere (marked with inline comment). Please uncomment those when this issue is resolved.
-[ Sequoia+ ] http/tests/resourceLoadStatistics/do-not-remove-blocking-in-redirect.html [ Failure ]
-[ Sequoia+ ] http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Failure Timeout ] # expectation exists above
-[ Sequoia+ ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
-[ Sequoia+ ] http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure Timeout ]
-[ Sequoia+ ] http/tests/privateClickMeasurement/send-attribution-conversion-request.html [ Failure Timeout ]
+webkit.org/b/278353 [ Sequoia+ ] http/tests/resourceLoadStatistics/do-not-remove-blocking-in-redirect.html [ Failure ]
+webkit.org/b/278353 [ Sequoia+ ] http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Failure Timeout ] # expectation exists above
+webkit.org/b/278353 [ Sequoia+ ] http/tests/privateClickMeasurement/send-attribution-conversion-request.html [ Failure Timeout ]
+
+# rdar://125587489
 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.html [ Failure ]
 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies-redirect.any.worker.html [ Failure ]
-[ Sequoia+ ] imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
-[ Sequoia+ ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
+
+[ Ventura Sonoma ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
+[ Ventura Sonoma ] http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
+[ Ventura Sonoma ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
+[ Ventura Sonoma ] imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
+[ Ventura Sonoma ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
 
 webkit.org/b/276389 media/video-transformed.html [ Pass Failure ] 
 


### PR DESCRIPTION
#### 11ca8f29c7c6154703bcfee946a4009c67e90151
<pre>
REGRESSION (iOS 18): 9 layout tests need to be re-written to expect new behavior.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277460">https://bugs.webkit.org/show_bug.cgi?id=277460</a>
<a href="https://rdar.apple.com/132946342">rdar://132946342</a>

Reviewed by Pascoe.

These tests should expect SameSite Lax cookies by default on iOS 18 and macOS Sequoia.

* LayoutTests/http/tests/cookies/resources/testharness-helpers.js:
* LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page-expected.txt:
* LayoutTests/http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html:
* LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker-expected.txt:
* LayoutTests/http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html:
* LayoutTests/http/tests/cookies/same-site/popup-cross-site-post.html:
* LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py:
* LayoutTests/http/tests/cookies/same-site/resources/fetch-in-cross-origin-service-worker.html:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios-17/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/282548@main">https://commits.webkit.org/282548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/953a63dcf350265ffb05c8568c5d3ceba5a4a558

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51052 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12237 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12860 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69097 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58361 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58601 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6109 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9593 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38557 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->