### PR TITLE
Delete push subscriptions and terminate IPC connections associated with removed web clips

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -144,11 +144,18 @@
 #import <UIKit/UIView+SpatialComputing.h>
 #endif
 
+#if PLATFORM(IOS)
+@interface UIWebClip(Staging_134304426)
++ (NSString *)pathForWebClipWithIdentifier:(NSString *)identifier;
+@end
+#endif
+
 #else // USE(APPLE_INTERNAL_SDK)
 
 @interface UIWebClip : NSObject
 + (UIWebClip *)webClipWithIdentifier:(NSString *)identifier;
 + (NSArray *)webClips;
++ (NSString *)pathForWebClipWithIdentifier:(NSString *)identifier;
 @property (copy) NSString *identifier;
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, retain) NSURL *pageURL;

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -84,6 +84,10 @@ public:
     void didReceivePublicToken(Vector<uint8_t>&&);
     void didReceivePushMessage(NSString *topic, NSDictionary *userInfo, CompletionHandler<void()>&& = [] { });
 
+#if PLATFORM(IOS)
+    void updateSubscriptionSetState(const Vector<String>& allowedBundleIdentifiers, const HashSet<String>& webClipIdentifiers, CompletionHandler<void()>&&);
+#endif
+
 private:
     PushService(UniqueRef<PushServiceConnection>&&, UniqueRef<WebCore::PushDatabase>&&, IncomingPushMessageHandler&&);
 
@@ -93,15 +97,12 @@ private:
 
     void removeRecordsImpl(const WebCore::PushSubscriptionSetIdentifier&, const std::optional<String>& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
-    void updateSubscriptionSetState(CompletionHandler<void()>&&);
     void updateTopicLists(CompletionHandler<void()>&&);
 
     UniqueRef<PushServiceConnection> m_connection;
     UniqueRef<WebCore::PushDatabase> m_database;
 
     IncomingPushMessageHandler m_incomingPushMessageHandler;
-
-    int m_notifyToken;
 
     PushServiceRequestMap m_getSubscriptionRequests;
     PushServiceRequestMap m_subscribeRequests;

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -52,22 +52,6 @@
 #import "UIKitSPI.h"
 #endif
 
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/PushServiceAdditions.mm>)
-#import <WebKitAdditions/PushServiceAdditions.mm>
-#endif
-
-#if !defined(PUSH_SERVICE_CONSTRUCTOR_ADDITIONS)
-#define PUSH_SERVICE_CONSTRUCTOR_ADDITIONS
-#endif
-
-#if !defined(UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_1)
-#define UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_1
-#endif
-
-#if !defined(UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_2)
-#define UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_2
-#endif
-
 namespace WebPushD {
 using namespace WebKit;
 using namespace WebCore;
@@ -161,10 +145,7 @@ void PushService::create(const String& incomingPushServiceName, const String& da
             // date, which APSConnection cares about.
             auto& serviceRef = service.get();
             serviceRef.updateTopicLists([transaction, service = WTFMove(service), creationHandler = WTFMove(creationHandler)]() mutable {
-                auto& serviceRef = service.get();
-                serviceRef.updateSubscriptionSetState([transaction, service = WTFMove(service), creationHandler = WTFMove(creationHandler)]() mutable {
-                    creationHandler(service.moveToUniquePtr());
-                });
+                creationHandler(service.moveToUniquePtr());
             });
         });
     });
@@ -197,7 +178,6 @@ PushService::PushService(UniqueRef<PushServiceConnection>&& pushServiceConnectio
     : m_connection(WTFMove(pushServiceConnection))
     , m_database(WTFMove(pushDatabase))
     , m_incomingPushMessageHandler(WTFMove(incomingPushMessageHandler))
-    , m_notifyToken(NOTIFY_TOKEN_INVALID)
 {
     RELEASE_ASSERT(m_incomingPushMessageHandler);
 
@@ -212,15 +192,9 @@ PushService::PushService(UniqueRef<PushServiceConnection>&& pushServiceConnectio
             return;
         didReceivePushMessage(topic, userInfo);
     });
-
-    PUSH_SERVICE_CONSTRUCTOR_ADDITIONS;
 }
 
-PushService::~PushService()
-{
-    if (m_notifyToken != NOTIFY_TOKEN_INVALID)
-        notify_cancel(m_notifyToken);
-}
+PushService::~PushService() = default;
 
 static PushSubscriptionData makePushSubscriptionFromRecord(PushRecord&& record)
 {
@@ -705,41 +679,21 @@ void PushService::removeRecordsImpl(const PushSubscriptionSetIdentifier& identif
         m_database->removeRecordsBySubscriptionSet(identifier, WTFMove(removedRecordsHandler));
 }
 
-void PushService::updateSubscriptionSetState(CompletionHandler<void()>&& completionHandler)
+#if PLATFORM(IOS)
+
+void PushService::updateSubscriptionSetState(const Vector<String>& allowedBundleIdentifiers, const HashSet<String>& installedWebClipIdentifiers, CompletionHandler<void()>&& completionHandler)
 {
-#if !PLATFORM(IOS) && !PLATFORM(VISION)
-    completionHandler();
-#else
-    RetainPtr<NSMutableSet> installedWebClipIdentifiers;
-
-    @autoreleasepool {
-        NSArray *webClips = [UIWebClip webClips];
-        installedWebClipIdentifiers = adoptNS([[NSMutableSet alloc] initWithCapacity:webClips.count]);
-
-        for (UIWebClip *webClip in webClips) {
-            if (NSString *identifier = [webClip identifier])
-                [installedWebClipIdentifiers addObject:identifier];
-        }
-    }
-
-    RELEASE_LOG(Push, "Found %zu web clips", [installedWebClipIdentifiers count]);
-
-    m_database->getPushSubscriptionSetRecords([this, weakThis = WeakPtr { *this }, installedWebClipIdentifiers = WTFMove(installedWebClipIdentifiers), completionHandler = WTFMove(completionHandler)](auto&& records) mutable {
+    m_database->getPushSubscriptionSetRecords([this, weakThis = WeakPtr { *this }, allowedBundleIdentifiers, installedWebClipIdentifiers, completionHandler = WTFMove(completionHandler)](auto&& records) mutable {
         if (!weakThis)
             return completionHandler();
 
         HashSet<PushSubscriptionSetIdentifier> identifiersToRemove;
 
-        UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_1;
-
         for (const auto& record : records) {
-            NSString *webClipIdentifier = (NSString *)record.identifier.pushPartition;
-            if (![installedWebClipIdentifiers containsObject:webClipIdentifier]) {
+            auto bundleIdentifier = record.identifier.bundleIdentifier;
+            auto webClipIdentifier = record.identifier.pushPartition;
+            if (!allowedBundleIdentifiers.contains(bundleIdentifier) || !installedWebClipIdentifiers.contains(webClipIdentifier))
                 identifiersToRemove.add(record.identifier);
-                continue;
-            }
-
-            UPDATE_SUBSCRIPTION_SET_STATE_ADDITIONS_2;
         }
 
         if (identifiersToRemove.isEmpty()) {
@@ -769,8 +723,9 @@ void PushService::updateSubscriptionSetState(CompletionHandler<void()>&& complet
             });
         }
     });
-#endif
 }
+
+#endif
 
 void PushService::updateTopicLists(CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -120,6 +120,10 @@ private:
     void silentPushTimerFired();
     void didShowNotification(const WebCore::PushSubscriptionSetIdentifier&, const String& scope);
 
+#if PLATFORM(IOS)
+    void updateSubscriptionSetState();
+#endif
+
     PushClientConnection* toPushClientConnection(xpc_connection_t);
     HashSet<xpc_connection_t> m_pendingConnectionSet;
     HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;


### PR DESCRIPTION
#### dda465082921b0804144f7ef51f24193af44b20d
<pre>
Delete push subscriptions and terminate IPC connections associated with removed web clips
<a href="https://bugs.webkit.org/show_bug.cgi?id=278367">https://bugs.webkit.org/show_bug.cgi?id=278367</a>
<a href="https://rdar.apple.com/131367607">rdar://131367607</a>

Reviewed by Brady Eidson.

This moves the logic from 282260@main (which removed push subscriptions associated with uninstalled
web clips) up one level from PushService to WebPushDaemon. We now check for web clips that are
deleted or associated with obsolete bundle IDs on every IPC and also before firing push events. If
we detect a subscription in an invalid state, then we terminate any associated IPC connections and
also remove the subscriptions from the database. Previously, we were only doing the latter.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::create):
(WebPushD::PushService::PushService):
(WebPushD::PushService::updateSubscriptionSetState):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(getAllowedBundleIdentifiers):
(getInstalledWebClipIdentifiers):
(webClipExists):
(WebPushD::WebPushDaemon::startPushService):
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::updateSubscriptionSetState):
(WebPushD::WebPushDaemon::handleIncomingPush):

Canonical link: <a href="https://commits.webkit.org/282583@main">https://commits.webkit.org/282583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4ce220694844613af1f14b6cf7d655a5cc04017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51022 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36320 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69053 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58332 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14071 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6069 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38513 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->