### PR TITLE
[WGSL] Use templates for standard library calls

### DIFF
--- a/Source/WebGPU/WGSL/BoundsCheck.cpp
+++ b/Source/WebGPU/WGSL/BoundsCheck.cpp
@@ -91,7 +91,7 @@ void BoundsCheckVisitor::visit(AST::IndexAccessExpression& access)
 
         auto& minTarget = m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(
             SourceSpan::empty(),
-            AST::Identifier::make("min"_s)
+            AST::Identifier::make("__wgslMin"_s)
         );
         minTarget.m_inferredType = m_shaderModule.types().bottomType();
 
@@ -125,6 +125,7 @@ void BoundsCheckVisitor::visit(AST::IndexAccessExpression& access)
         newAccess.m_inferredType = access.inferredType();
 
         m_shaderModule.replace(access, newAccess);
+        m_shaderModule.setUsesMin();
     };
 
     auto* base = access.base().inferredType();

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -518,6 +518,19 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
+    if (m_shaderModule.usesMin()) {
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
+            m_indent, "static T __attribute((always_inline)) __wgslMin(T a, T b)\n"_s,
+            m_indent, "{\n"_s);
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "volatile T va = a;\n"_s,
+                m_indent, "volatile T vb = b;\n"_s,
+                m_indent, "return min(va, vb);\n"_s);
+        }
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
+    }
+
     m_shaderModule.clearUsesPackedVec3();
 }
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -143,6 +143,9 @@ public:
     void setUsesPackedVec3() { m_usesPackedVec3 = true; }
     void clearUsesPackedVec3() { m_usesPackedVec3 = false; }
 
+    bool usesMin() const { return m_usesMin; }
+    void setUsesMin() { m_usesMin = true; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -292,6 +295,7 @@ private:
     bool m_usesDot4U8Packed { false };
     bool m_usesExtractBits { false };
     bool m_usesPackedVec3 { false };
+    bool m_usesMin { false };
     OptionSet<Extension> m_enabledExtensions;
     OptionSet<LanguageFeature> m_requiredFeatures;
     Configuration m_configuration;


### PR DESCRIPTION
#### dadb67ce019e3ff492a7cb2750d1f9163d2fad03
<pre>
[WGSL] Use templates for standard library calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=278317">https://bugs.webkit.org/show_bug.cgi?id=278317</a>
<a href="https://rdar.apple.com/134260190">rdar://134260190</a>

Reviewed by Dan Glastonbury.

Ensure calls to min() are inlined.

* Source/WebGPU/WGSL/BoundsCheck.cpp:
(WGSL::BoundsCheckVisitor::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesMin const):
(WGSL::ShaderModule::setUsesMin):

Canonical link: <a href="https://commits.webkit.org/282591@main">https://commits.webkit.org/282591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0244be5f4296b40ecb8e51862b7bde20d3ecdbc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13896 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50981 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9596 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36275 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6026 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38465 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39544 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->