### PR TITLE
[JSC] Add DynamicBuffer version of JSON FastStringifier

### DIFF
--- a/JSTests/stress/self-reference-json-stringify-overflow.js
+++ b/JSTests/stress/self-reference-json-stringify-overflow.js
@@ -1,0 +1,21 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var object = { };
+object.object = object;
+
+shouldThrow(() => {
+    JSON.stringify(object);
+}, `TypeError: JSON.stringify cannot serialize cyclic structures.`);

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -42,6 +42,7 @@
 #include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringBuilderJSON.h>
 #include <wtf/text/StringCommon.h>
 
 // Turn this on to log information about fastStringify usage, with a focus on why it failed.
@@ -668,13 +669,27 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
 // since there is no side effect, the full general purpose Stringifier can be used
 // and the only cost of the fast stringifying attempt is the time wasted.
 
-template<typename CharType>
+enum class BufferMode : uint8_t {
+    StaticBuffer,
+    DynamicBuffer,
+};
+
+enum class FailureReason : uint8_t {
+    BufferFull,
+    Found16BitEarly,
+    Found16BitLate,
+    StackOverflow,
+    Unknown,
+};
+
+template<typename CharType, BufferMode bufferMode>
 class FastStringifier {
 public:
     // Returns null string if the fast case fails.
-    static String stringify(JSGlobalObject&, JSValue, JSValue replacer, JSValue space, bool& retryWith16Bit);
+    static String stringify(JSGlobalObject&, JSValue, JSValue replacer, JSValue space, std::optional<FailureReason>&);
 
-    static constexpr unsigned bufferSize = 8192;
+    static constexpr unsigned staticBufferSize = bufferMode == BufferMode::StaticBuffer ? 8192 : 8;
+    static constexpr unsigned dynamicBufferInlineCapacity = bufferMode == BufferMode::StaticBuffer ? 0 : 1024;
 
 private:
     explicit FastStringifier(JSGlobalObject&);
@@ -683,7 +698,11 @@ private:
 
     void append(char, char, char, char);
     void append(char, char, char, char, char);
-    template<typename T> void recordFailure(T&& reason);
+    template<typename T> void recordFailure(FailureReason, T&& reason);
+    template<typename T> void recordFailure(T&& reason)
+    {
+        recordFailure(FailureReason::Unknown, std::forward<T>(reason));
+    }
     void recordBufferFull();
     String firstGetterSetterPropertyName(JSObject&) const;
     void recordFastPropertyEnumerationFailure(JSObject&);
@@ -697,21 +716,26 @@ private:
 
     static unsigned usableBufferSize(unsigned availableBufferSize);
 
+    CharType* buffer();
+    const CharType* buffer() const;
+
     JSGlobalObject& m_globalObject;
     VM& m_vm;
     unsigned m_length { 0 }; // length of content already filled into m_buffer.
     unsigned m_capacity { 0 };
     bool m_checkedObjectPrototype { false };
     bool m_checkedArrayPrototype { false };
-    bool m_retryWith16BitFastStringifier { false };
+    std::optional<FailureReason> m_failureReason;
+    Vector<CharType, dynamicBufferInlineCapacity> m_dynamicBuffer;
+    uint8_t* m_stackLimit { nullptr };
 
-    CharType m_buffer[bufferSize];
+    CharType m_buffer[staticBufferSize];
 };
 
 #if !FAST_STRINGIFY_LOG_USAGE
 
-template<typename CharType>
-inline void FastStringifier<CharType>::logOutcome(ASCIILiteral)
+template<typename CharType, BufferMode bufferMode>
+inline void FastStringifier<CharType, bufferMode>::logOutcome(ASCIILiteral)
 {
 }
 
@@ -737,22 +761,40 @@ static void logOutcomeImpl(String&& outcome)
     }
 }
 
-template<typename CharType>
-void FastStringifier<CharType>::logOutcome(ASCIILiteral outcome)
+template<typename CharType, BufferMode bufferMode>
+void FastStringifier<CharType, bufferMode>::logOutcome(ASCIILiteral outcome)
 {
     logOutcomeImpl(String { outcome });
 }
 
-template<typename CharType>
-void FastStringifier<CharType>::logOutcome(String&& outcome)
+template<typename CharType, BufferMode bufferMode>
+void FastStringifier<CharType, bufferMode>::logOutcome(String&& outcome)
 {
     logOutcomeImpl(WTFMove(outcome));
 }
 
 #endif
 
-template<typename CharType>
-inline unsigned FastStringifier<CharType>::usableBufferSize(unsigned availableBufferSize)
+template<typename CharType, BufferMode bufferMode>
+ALWAYS_INLINE CharType* FastStringifier<CharType, bufferMode>::buffer()
+{
+    if constexpr (bufferMode == BufferMode::StaticBuffer)
+        return m_buffer;
+    else
+        return m_dynamicBuffer.data();
+}
+
+template<typename CharType, BufferMode bufferMode>
+ALWAYS_INLINE const CharType* FastStringifier<CharType, bufferMode>::buffer() const
+{
+    if constexpr (bufferMode == BufferMode::StaticBuffer)
+        return m_buffer;
+    else
+        return m_dynamicBuffer.data();
+}
+
+template<typename CharType, BufferMode bufferMode>
+inline unsigned FastStringifier<CharType, bufferMode>::usableBufferSize(unsigned availableBufferSize)
 {
     // FastStringifier relies on m_capacity (i.e. the remaining usable capacity) in m_buffer
     // to limit recursion. Hence, we need to compute an appropriate m_capacity value.
@@ -818,22 +860,28 @@ inline unsigned FastStringifier<CharType>::usableBufferSize(unsigned availableBu
     return usableBufferSize;
 }
 
-template<typename CharType>
-inline FastStringifier<CharType>::FastStringifier(JSGlobalObject& globalObject)
+template<typename CharType, BufferMode bufferMode>
+inline FastStringifier<CharType, bufferMode>::FastStringifier(JSGlobalObject& globalObject)
     : m_globalObject(globalObject)
     , m_vm(globalObject.vm())
 {
-    m_capacity = m_length + usableBufferSize(bufferSize);
+    if constexpr (bufferMode == BufferMode::StaticBuffer)
+        m_capacity = m_length + usableBufferSize(staticBufferSize);
+    else {
+        m_dynamicBuffer.grow(dynamicBufferInlineCapacity);
+        m_capacity = dynamicBufferInlineCapacity;
+        m_stackLimit = bitwise_cast<uint8_t*>(m_vm.softStackLimit());
+    }
 }
 
-template<typename CharType>
-inline bool FastStringifier<CharType>::haveFailure() const
+template<typename CharType, BufferMode bufferMode>
+inline bool FastStringifier<CharType, bufferMode>::haveFailure() const
 {
-    return m_length > bufferSize;
+    return !!m_failureReason;
 }
 
-template<typename CharType>
-inline String FastStringifier<CharType>::result() const
+template<typename CharType, BufferMode bufferMode>
+inline String FastStringifier<CharType, bufferMode>::result() const
 {
     if (haveFailure())
         return { };
@@ -845,25 +893,25 @@ inline String FastStringifier<CharType>::result() const
     }
     logOutcome("success"_s);
 #endif
-    return std::span { m_buffer, m_length };
+    return std::span { buffer(), m_length };
 }
 
-template<typename CharType>
-template<typename T> inline void FastStringifier<CharType>::recordFailure(T&& reason)
+template<typename CharType, BufferMode bufferMode>
+template<typename T> inline void FastStringifier<CharType, bufferMode>::recordFailure(FailureReason failureReason, T&& reason)
 {
     if (!haveFailure())
         logOutcome(std::forward<T>(reason));
-    m_length = bufferSize + 1;
+    m_failureReason = failureReason;
 }
 
-template<typename CharType>
-inline void FastStringifier<CharType>::recordBufferFull()
+template<typename CharType, BufferMode bufferMode>
+inline void FastStringifier<CharType, bufferMode>::recordBufferFull()
 {
-    recordFailure("buffer full"_s);
+    recordFailure(FailureReason::BufferFull, "buffer full"_s);
 }
 
-template<typename CharType>
-ALWAYS_INLINE bool FastStringifier<CharType>::hasRemainingCapacity(unsigned size)
+template<typename CharType, BufferMode bufferMode>
+ALWAYS_INLINE bool FastStringifier<CharType, bufferMode>::hasRemainingCapacity(unsigned size)
 {
     ASSERT(!haveFailure());
     ASSERT(size > 0);
@@ -873,33 +921,45 @@ ALWAYS_INLINE bool FastStringifier<CharType>::hasRemainingCapacity(unsigned size
     return hasRemainingCapacitySlow(size);
 }
 
-template<typename CharType>
-bool FastStringifier<CharType>::hasRemainingCapacitySlow(unsigned size)
+template<typename CharType, BufferMode bufferMode>
+bool FastStringifier<CharType, bufferMode>::hasRemainingCapacitySlow(unsigned size)
 {
     ASSERT(!haveFailure());
+    if constexpr (bufferMode == BufferMode::StaticBuffer) {
+        unsigned unusedBufferSize = staticBufferSize - m_length;
+        unsigned usableSize = usableBufferSize(unusedBufferSize);
+        if (usableSize < size)
+            return false;
 
-    unsigned unusedBufferSize = bufferSize - m_length;
-    unsigned usableSize = usableBufferSize(unusedBufferSize);
-    if (usableSize < size)
-        return false;
+        m_capacity = m_length + usableSize;
+        ASSERT(m_capacity - m_length >= size);
+        return true;
+    } else {
+        size_t newSize = std::max<size_t>(m_dynamicBuffer.size() * 2, m_dynamicBuffer.size() + size);
+        if (UNLIKELY(newSize > StringImpl::MaxLength))
+            return false;
 
-    m_capacity = m_length + usableSize;
-    ASSERT(m_capacity - m_length >= size);
-    return true;
+        if (UNLIKELY(!m_dynamicBuffer.tryGrow(newSize)))
+            return false;
+
+        m_capacity = m_dynamicBuffer.size();
+        ASSERT(m_capacity - m_length >= size);
+        return true;
+    }
 }
 
 #if !FAST_STRINGIFY_LOG_USAGE
 
-template<typename CharType>
-inline void FastStringifier<CharType>::recordFastPropertyEnumerationFailure(JSObject&)
+template<typename CharType, BufferMode bufferMode>
+inline void FastStringifier<CharType, bufferMode>::recordFastPropertyEnumerationFailure(JSObject&)
 {
     recordFailure("!canPerformFastPropertyEnumerationForJSONStringify"_s);
 }
 
 #else
 
-template<typename CharType>
-String FastStringifier<CharType>::firstGetterSetterPropertyName(JSObject& object) const
+template<typename CharType, BufferMode bufferMode>
+String FastStringifier<CharType, bufferMode>::firstGetterSetterPropertyName(JSObject& object) const
 {
     auto scope = DECLARE_THROW_SCOPE(m_vm);
     PropertyNameArray names(m_vm, PropertyNameMode::Strings, PrivateSymbolMode::Include);
@@ -915,8 +975,8 @@ String FastStringifier<CharType>::firstGetterSetterPropertyName(JSObject& object
     RELEASE_AND_RETURN(scope, "not found"_s);
 }
 
-template<typename CharType>
-void FastStringifier<CharType>::recordFastPropertyEnumerationFailure(JSObject& object)
+template<typename CharType, BufferMode bufferMode>
+void FastStringifier<CharType, bufferMode>::recordFastPropertyEnumerationFailure(JSObject& object)
 {
     auto& structure = *object.structure();
     if (structure.typeInfo().overridesGetOwnPropertySlot())
@@ -939,8 +999,8 @@ void FastStringifier<CharType>::recordFastPropertyEnumerationFailure(JSObject& o
 
 #endif
 
-template<typename CharType>
-inline bool FastStringifier<CharType>::mayHaveToJSON(JSObject& object) const
+template<typename CharType, BufferMode bufferMode>
+inline bool FastStringifier<CharType, bufferMode>::mayHaveToJSON(JSObject& object) const
 {
     if (auto function = object.structure()->cachedSpecialProperty(CachedSpecialPropertyKey::ToJSON))
         return !function.isUndefined();
@@ -954,38 +1014,45 @@ inline bool FastStringifier<CharType>::mayHaveToJSON(JSObject& object) const
     return false;
 }
 
-template<typename CharType>
-inline void FastStringifier<CharType>::append(char a, char b, char c, char d)
+template<typename CharType, BufferMode bufferMode>
+inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c, char d)
 {
     if (UNLIKELY(!hasRemainingCapacity(4))) {
         recordBufferFull();
         return;
     }
-    m_buffer[m_length] = a;
-    m_buffer[m_length + 1] = b;
-    m_buffer[m_length + 2] = c;
-    m_buffer[m_length + 3] = d;
+    buffer()[m_length] = a;
+    buffer()[m_length + 1] = b;
+    buffer()[m_length + 2] = c;
+    buffer()[m_length + 3] = d;
     m_length += 4;
 }
 
-template<typename CharType>
-inline void FastStringifier<CharType>::append(char a, char b, char c, char d, char e)
+template<typename CharType, BufferMode bufferMode>
+inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c, char d, char e)
 {
     if (UNLIKELY(!hasRemainingCapacity(5))) {
         recordBufferFull();
         return;
     }
-    m_buffer[m_length] = a;
-    m_buffer[m_length + 1] = b;
-    m_buffer[m_length + 2] = c;
-    m_buffer[m_length + 3] = d;
-    m_buffer[m_length + 4] = e;
+    buffer()[m_length] = a;
+    buffer()[m_length + 1] = b;
+    buffer()[m_length + 2] = c;
+    buffer()[m_length + 3] = d;
+    buffer()[m_length + 4] = e;
     m_length += 5;
 }
 
-template<typename CharType>
-void FastStringifier<CharType>::append(JSValue value)
+template<typename CharType, BufferMode bufferMode>
+void FastStringifier<CharType, bufferMode>::append(JSValue value)
 {
+    if constexpr (bufferMode == BufferMode::DynamicBuffer) {
+        if (UNLIKELY(bitwise_cast<uint8_t*>(currentStackPointer()) < m_stackLimit)) {
+            recordFailure(FailureReason::StackOverflow, "stack overflow"_s);
+            return;
+        }
+    }
+
     if (value.isNull()) {
         append('n', 'u', 'l', 'l');
         return;
@@ -1009,7 +1076,7 @@ void FastStringifier<CharType>::append(JSValue value)
             return;
         }
         if constexpr (sizeof(CharType) == 1) {
-            char* cursor = bitwise_cast<char*>(m_buffer) + m_length;
+            char* cursor = bitwise_cast<char*>(buffer()) + m_length;
             auto result = std::to_chars(cursor, cursor + maxInt32StringLength, number);
             ASSERT(result.ec != std::errc::value_too_large);
             m_length += result.ptr - cursor;
@@ -1018,7 +1085,7 @@ void FastStringifier<CharType>::append(JSValue value)
             auto result = std::to_chars(temporary.data(), temporary.data() + maxInt32StringLength, number);
             ASSERT(result.ec != std::errc::value_too_large);
             unsigned lengthToCopy = result.ptr - temporary.data();
-            WTF::copyElements(bitwise_cast<uint16_t*>(&m_buffer[m_length]), bitwise_cast<const uint8_t*>(temporary.data()), lengthToCopy);
+            WTF::copyElements(bitwise_cast<uint16_t*>(buffer() + m_length), bitwise_cast<const uint8_t*>(temporary.data()), lengthToCopy);
             m_length += lengthToCopy;
         }
         return;
@@ -1035,14 +1102,14 @@ void FastStringifier<CharType>::append(JSValue value)
             return;
         }
         if constexpr (sizeof(CharType) == 1) {
-            WTF::double_conversion::StringBuilder builder { reinterpret_cast<char*>(&m_buffer[m_length]), sizeof(NumberToStringBuffer) };
+            WTF::double_conversion::StringBuilder builder { reinterpret_cast<char*>(buffer() + m_length), sizeof(NumberToStringBuffer) };
             WTF::double_conversion::DoubleToStringConverter::EcmaScriptConverter().ToShortest(number, &builder);
             m_length += builder.position();
         } else {
             NumberToStringBuffer temporary;
             WTF::double_conversion::StringBuilder builder { temporary.data(), sizeof(NumberToStringBuffer) };
             WTF::double_conversion::DoubleToStringConverter::EcmaScriptConverter().ToShortest(number, &builder);
-            WTF::copyElements(bitwise_cast<uint16_t*>(&m_buffer[m_length]), bitwise_cast<const uint8_t*>(temporary.data()), builder.position());
+            WTF::copyElements(bitwise_cast<uint16_t*>(buffer() + m_length), bitwise_cast<const uint8_t*>(temporary.data()), builder.position());
             m_length += builder.position();
         }
         return;
@@ -1157,45 +1224,60 @@ void FastStringifier<CharType>::append(JSValue value)
             return false;
         };
 
+        auto stringLength = string.data.length();
         if constexpr (sizeof(CharType) == 1) {
             if (UNLIKELY(!string.data.is8Bit())) {
-                m_retryWith16BitFastStringifier = m_length < (m_capacity / 2);
-                recordFailure("16-bit string"_s);
+                if constexpr (bufferMode == BufferMode::DynamicBuffer)
+                    recordFailure(FailureReason::Unknown, "16-bit string"_s);
+                else
+                    recordFailure(m_length < (m_capacity / 2) ? FailureReason::Found16BitEarly : FailureReason::Found16BitLate, "16-bit string"_s);
                 return;
             }
-            auto stringLength = string.data.length();
             if (UNLIKELY(!hasRemainingCapacity(1 + stringLength + 1))) {
                 recordBufferFull();
                 return;
             }
-            m_buffer[m_length] = '"';
-            if (UNLIKELY(charactersCopySameType(string.data.span8(), m_buffer + m_length + 1))) {
-                recordFailure("string character needs escaping"_s);
+            buffer()[m_length] = '"';
+            if (LIKELY(!charactersCopySameType(string.data.span8(), buffer() + m_length + 1))) {
+                buffer()[m_length + 1 + stringLength] = '"';
+                m_length += 1 + stringLength + 1;
                 return;
             }
-            m_buffer[m_length + 1 + stringLength] = '"';
-            m_length += 1 + stringLength + 1;
         } else {
-            auto stringLength = string.data.length();
             if (UNLIKELY(!hasRemainingCapacity(1 + stringLength + 1))) {
                 recordBufferFull();
                 return;
             }
-            m_buffer[m_length] = '"';
+            buffer()[m_length] = '"';
             if (string.data.is8Bit()) {
-                if (UNLIKELY(charactersCopyUpconvert(string.data.span8(), m_buffer + m_length + 1))) {
-                    recordFailure("string character needs escaping"_s);
+                if (LIKELY(!charactersCopyUpconvert(string.data.span8(), buffer() + m_length + 1))) {
+                    buffer()[m_length + 1 + stringLength] = '"';
+                    m_length += 1 + stringLength + 1;
                     return;
                 }
             } else {
-                if (UNLIKELY(charactersCopySameType(string.data.span16(), m_buffer + m_length + 1))) {
-                    recordFailure("string character needs escaping or surrogate pair handling"_s);
+                if (LIKELY(!charactersCopySameType(string.data.span16(), buffer() + m_length + 1))) {
+                    buffer()[m_length + 1 + stringLength] = '"';
+                    m_length += 1 + stringLength + 1;
                     return;
                 }
             }
-            m_buffer[m_length + 1 + stringLength] = '"';
-            m_length += 1 + stringLength + 1;
         }
+
+        if (UNLIKELY(!hasRemainingCapacity(1 + static_cast<size_t>(stringLength) * 6 + 1))) {
+            recordBufferFull();
+            return;
+        }
+        auto* output = buffer() + m_length + 1;
+        if constexpr (sizeof(CharType) == 2) {
+            if (string.data.is8Bit())
+                WTF::appendEscapedJSONStringContent(output, string.data.span8());
+            else
+                WTF::appendEscapedJSONStringContent(output, string.data.span16());
+        } else
+            WTF::appendEscapedJSONStringContent(output, string.data.span8());
+        *output++ = '"';
+        m_length = output - buffer();
         return;
     }
 
@@ -1226,7 +1308,7 @@ void FastStringifier<CharType>::append(JSValue value)
             recordBufferFull();
             return;
         }
-        m_buffer[m_length++] = '{';
+        buffer()[m_length++] = '{';
         if (UNLIKELY(!structure.canPerformFastPropertyEnumeration())) {
             recordFastPropertyEnumerationFailure(object);
             return;
@@ -1255,15 +1337,15 @@ void FastStringifier<CharType>::append(JSValue value)
             if (value.isUndefined())
                 return true;
 
-            bool needComma = m_buffer[m_length - 1] != '{';
+            bool needComma = buffer()[m_length - 1] != '{';
             unsigned nameLength = name.length();
             if (UNLIKELY(!hasRemainingCapacity(needComma + 1 + nameLength + 2))) {
                 recordBufferFull();
                 return false;
             }
             if (needComma)
-                m_buffer[m_length++] = ',';
-            m_buffer[m_length] = '"';
+                buffer()[m_length++] = ',';
+            buffer()[m_length] = '"';
             auto characters = name.span8();
             for (unsigned i = 0; i < nameLength; ++i) {
                 auto character = characters[i];
@@ -1271,10 +1353,10 @@ void FastStringifier<CharType>::append(JSValue value)
                     recordFailure("property name character needs escaping"_s);
                     return false;
                 }
-                m_buffer[m_length + 1 + i] = character;
+                buffer()[m_length + 1 + i] = character;
             }
-            m_buffer[m_length + 1 + nameLength] = '"';
-            m_buffer[m_length + 1 + nameLength + 1] = ':';
+            buffer()[m_length + 1 + nameLength] = '"';
+            buffer()[m_length + 1 + nameLength + 1] = ':';
             m_length += 1 + nameLength + 2;
             append(value);
             return !haveFailure();
@@ -1285,7 +1367,7 @@ void FastStringifier<CharType>::append(JSValue value)
             recordBufferFull();
             return;
         }
-        m_buffer[m_length++] = '}';
+        buffer()[m_length++] = '}';
         return;
     }
 
@@ -1314,14 +1396,14 @@ void FastStringifier<CharType>::append(JSValue value)
             recordBufferFull();
             return;
         }
-        m_buffer[m_length++] = '[';
+        buffer()[m_length++] = '[';
         for (unsigned i = 0, length = array.length(); i < length; ++i) {
             if (i) {
                 if (UNLIKELY(!hasRemainingCapacity())) {
                     recordBufferFull();
                     return;
                 }
-                m_buffer[m_length++] = ',';
+                buffer()[m_length++] = ',';
             }
             if (UNLIKELY(!array.canGetIndexQuickly(i))) {
                 recordFailure("!canGetIndexQuickly"_s);
@@ -1335,7 +1417,7 @@ void FastStringifier<CharType>::append(JSValue value)
             recordBufferFull();
             return;
         }
-        m_buffer[m_length++] = ']';
+        buffer()[m_length++] = ']';
         return;
     }
 
@@ -1348,8 +1430,8 @@ void FastStringifier<CharType>::append(JSValue value)
     }
 }
 
-template<typename CharType>
-inline String FastStringifier<CharType>::stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space, bool& retryWith16Bit)
+template<typename CharType, BufferMode bufferMode>
+inline String FastStringifier<CharType, bufferMode>::stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space, std::optional<FailureReason>& failureReason)
 {
     if (replacer.isObject()) {
         logOutcome("replacer"_s);
@@ -1361,20 +1443,32 @@ inline String FastStringifier<CharType>::stringify(JSGlobalObject& globalObject,
     }
     FastStringifier stringifier(globalObject);
     stringifier.append(value);
-    retryWith16Bit = stringifier.m_retryWith16BitFastStringifier;
+    failureReason = stringifier.m_failureReason;
     return stringifier.result();
 }
 
-static inline String stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space)
+static NEVER_INLINE String stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space)
 {
     VM& vm = globalObject.vm();
     uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
     if (LIKELY(bitwise_cast<uint8_t*>(currentStackPointer()) >= stackLimit)) {
-        bool retryWith16Bit = false;
-        if (String result = FastStringifier<LChar>::stringify(globalObject, value, replacer, space, retryWith16Bit); !result.isNull())
+        std::optional<FailureReason> failureReason;
+        failureReason = std::nullopt;
+        if (String result = FastStringifier<LChar, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
             return result;
-        if (retryWith16Bit) {
-            if (String result = FastStringifier<UChar>::stringify(globalObject, value, replacer, space, retryWith16Bit); !result.isNull())
+        if (failureReason == FailureReason::Found16BitEarly) {
+            failureReason = std::nullopt;
+            if (String result = FastStringifier<UChar, BufferMode::StaticBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
+                return result;
+
+            if (failureReason == FailureReason::BufferFull) {
+                failureReason = std::nullopt;
+                if (String result = FastStringifier<UChar, BufferMode::DynamicBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
+                    return result;
+            }
+        } else if (failureReason == FailureReason::BufferFull) {
+            failureReason = std::nullopt;
+            if (String result = FastStringifier<LChar, BufferMode::DynamicBuffer>::stringify(globalObject, value, replacer, space, failureReason); !result.isNull())
                 return result;
         }
     }

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -847,6 +847,7 @@
 		E38C7CD82C366A1800BB9B18 /* SIMDUTF.h in Headers */ = {isa = PBXBuildFile; fileRef = E38C7CD72C366A1800BB9B18 /* SIMDUTF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38C82692BECAE9D0071EF52 /* SIMDHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38D6E271F5522E300A75CC4 /* StringBuilderJSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */; };
+		E391CB482C746E1F000C994C /* StringBuilderJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = E391CB472C746E1F000C994C /* StringBuilderJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E392FA2722E92BFF00ECDC73 /* ResourceUsageCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */; };
 		E39664762C7198AA00F91F3A /* SIMDUTF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39664752C7198AA00F91F3A /* SIMDUTF.cpp */; };
 		E396C11D2BE885D9000CBAE1 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = E396C1192BE885D9000CBAE1 /* neon.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1805,6 +1806,7 @@
 		E38C7CD72C366A1800BB9B18 /* SIMDUTF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIMDUTF.h; sourceTree = "<group>"; };
 		E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIMDHelpers.h; sourceTree = "<group>"; };
 		E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringBuilderJSON.cpp; sourceTree = "<group>"; };
+		E391CB472C746E1F000C994C /* StringBuilderJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringBuilderJSON.h; sourceTree = "<group>"; };
 		E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceUsageCocoa.cpp; sourceTree = "<group>"; };
 		E39664752C7198AA00F91F3A /* SIMDUTF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SIMDUTF.cpp; sourceTree = "<group>"; };
 		E396C1192BE885D9000CBAE1 /* neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = neon.h; sourceTree = "<group>"; };
@@ -2608,6 +2610,7 @@
 				A8A47325151A825B004123FF /* StringBuilder.h */,
 				A8A47325151A825B004123EE /* StringBuilderInternals.h */,
 				E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */,
+				E391CB472C746E1F000C994C /* StringBuilderJSON.h */,
 				E3DA37E6287AD1A10066808F /* StringCommon.cpp */,
 				430B47871AAAAC1A001223DA /* StringCommon.h */,
 				A8A47326151A825B004123FF /* StringConcatenate.h */,
@@ -3494,6 +3497,7 @@
 				DDF307D827C086DF006A526F /* StringBuffer.h in Headers */,
 				DDF307CC27C086DF006A526F /* StringBuilder.h in Headers */,
 				DDF307D927C086DF006A526F /* StringBuilderInternals.h in Headers */,
+				E391CB482C746E1F000C994C /* StringBuilderJSON.h in Headers */,
 				DDF307DE27C086DF006A526F /* StringCommon.h in Headers */,
 				DDF307EA27C086DF006A526F /* StringConcatenate.h in Headers */,
 				DDF307ED27C086DF006A526F /* StringConcatenateCF.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -430,6 +430,7 @@ set(WTF_PUBLIC_HEADERS
     text/StringBuffer.h
     text/StringBuilder.h
     text/StringBuilderInternals.h
+    text/StringBuilderJSON.h
     text/StringCommon.h
     text/StringConcatenate.h
     text/StringConcatenateNumbers.h

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -10,63 +10,12 @@
  */
 
 #include "config.h"
-#include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringBuilderJSON.h>
 
 #include <wtf/text/EscapedFormsForJSON.h>
-#include <wtf/text/StringBuilderInternals.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
-
-template<typename OutputCharacterType, typename InputCharacterType>
-ALWAYS_INLINE static void appendQuotedJSONStringInternal(OutputCharacterType*& output, std::span<const InputCharacterType> input)
-{
-    for (; !input.empty(); input = input.subspan(1)) {
-        auto character = input.front();
-        if (LIKELY(character <= 0xFF)) {
-            auto escaped = escapedFormsForJSON[character];
-            if (LIKELY(!escaped)) {
-                *output++ = character;
-                continue;
-            }
-
-            *output++ = '\\';
-            *output++ = escaped;
-            if (UNLIKELY(escaped == 'u')) {
-                *output++ = '0';
-                *output++ = '0';
-                *output++ = upperNibbleToLowercaseASCIIHexDigit(character);
-                *output++ = lowerNibbleToLowercaseASCIIHexDigit(character);
-            }
-            continue;
-        }
-
-        if (LIKELY(!U16_IS_SURROGATE(character))) {
-            *output++ = character;
-            continue;
-        }
-
-        if (input.size() > 1) {
-            auto next = input[1];
-            bool isValidSurrogatePair = U16_IS_SURROGATE_LEAD(character) && U16_IS_TRAIL(next);
-            if (isValidSurrogatePair) {
-                *output++ = character;
-                *output++ = next;
-                input = input.subspan(1);
-                continue;
-            }
-        }
-
-        uint8_t upper = static_cast<uint32_t>(character) >> 8;
-        uint8_t lower = static_cast<uint8_t>(character);
-        *output++ = '\\';
-        *output++ = 'u';
-        *output++ = upperNibbleToLowercaseASCIIHexDigit(upper);
-        *output++ = lowerNibbleToLowercaseASCIIHexDigit(upper);
-        *output++ = upperNibbleToLowercaseASCIIHexDigit(lower);
-        *output++ = lowerNibbleToLowercaseASCIIHexDigit(lower);
-    }
-}
 
 void StringBuilder::appendQuotedJSONString(const String& string)
 {
@@ -90,7 +39,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
         if (auto* output = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, stringLengthValue))) {
             auto* end = output + stringLengthValue;
             *output++ = '"';
-            appendQuotedJSONStringInternal(output, string.span8());
+            appendEscapedJSONStringContent(output, string.span8());
             *output++ = '"';
             if (output < end)
                 shrink(m_length - (end - output));
@@ -100,9 +49,9 @@ void StringBuilder::appendQuotedJSONString(const String& string)
             auto* end = output + stringLengthValue;
             *output++ = '"';
             if (string.is8Bit())
-                appendQuotedJSONStringInternal(output, string.span8());
+                appendEscapedJSONStringContent(output, string.span8());
             else
-                appendQuotedJSONStringInternal(output, string.span16());
+                appendEscapedJSONStringContent(output, string.span16());
             *output++ = '"';
             if (output < end)
                 shrink(m_length - (end - output));

--- a/Source/WTF/wtf/text/StringBuilderJSON.h
+++ b/Source/WTF/wtf/text/StringBuilderJSON.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>. All rights reserved.
+ * Copyright (C) 2017 Mozilla Foundation. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <wtf/text/EscapedFormsForJSON.h>
+#include <wtf/text/StringBuilderInternals.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+template<typename OutputCharacterType, typename InputCharacterType>
+ALWAYS_INLINE static void appendEscapedJSONStringContent(OutputCharacterType*& output, std::span<const InputCharacterType> input)
+{
+    for (; !input.empty(); input = input.subspan(1)) {
+        auto character = input.front();
+        if (LIKELY(character <= 0xFF)) {
+            auto escaped = escapedFormsForJSON[character];
+            if (LIKELY(!escaped)) {
+                *output++ = character;
+                continue;
+            }
+
+            *output++ = '\\';
+            *output++ = escaped;
+            if (UNLIKELY(escaped == 'u')) {
+                *output++ = '0';
+                *output++ = '0';
+                *output++ = upperNibbleToLowercaseASCIIHexDigit(character);
+                *output++ = lowerNibbleToLowercaseASCIIHexDigit(character);
+            }
+            continue;
+        }
+
+        if (LIKELY(!U16_IS_SURROGATE(character))) {
+            *output++ = character;
+            continue;
+        }
+
+        if (input.size() > 1) {
+            auto next = input[1];
+            bool isValidSurrogatePair = U16_IS_SURROGATE_LEAD(character) && U16_IS_TRAIL(next);
+            if (isValidSurrogatePair) {
+                *output++ = character;
+                *output++ = next;
+                input = input.subspan(1);
+                continue;
+            }
+        }
+
+        uint8_t upper = static_cast<uint32_t>(character) >> 8;
+        uint8_t lower = static_cast<uint8_t>(character);
+        *output++ = '\\';
+        *output++ = 'u';
+        *output++ = upperNibbleToLowercaseASCIIHexDigit(upper);
+        *output++ = lowerNibbleToLowercaseASCIIHexDigit(upper);
+        *output++ = upperNibbleToLowercaseASCIIHexDigit(lower);
+        *output++ = lowerNibbleToLowercaseASCIIHexDigit(lower);
+    }
+}
+
+} // namespace WTF


### PR DESCRIPTION
#### 8ac6cfb4089ac722887e4ffd50be735ef56363b5
<pre>
[JSC] Add DynamicBuffer version of JSON FastStringifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=278372">https://bugs.webkit.org/show_bug.cgi?id=278372</a>
<a href="https://rdar.apple.com/134322432">rdar://134322432</a>

Reviewed by Keith Miller.

This patch extends JSON FastStringifier.

1. We add DynamicBuffer mode. Previously we are only supporting StaticBuffer version so that if the generated string becomes too long, we fallback.
   But this patch adds Vector&lt;&gt; backing dynamic buffer version so that FastStringifier can work with very long output too.
2. Use currentStackPointer based stack overflow detection for DynamicBuffer mode in JSON stringifier. StaticBuffer mode relies on static buffer&apos;s
   fullfillment for stack overflow detection. For DynamicBuffer mode, we just check stack pointer to detect stack overflow and going to the slow
   path when it happens.
3. We support escaped strings generation in JSON FastStringifier. When the fast path detects that the output string can contain escaped strings,
   we go to the slow path code generating escaped strings.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier::recordFailure):
(JSC::bufferMode&gt;::logOutcome):
(JSC::bufferMode&gt;::buffer):
(JSC::bufferMode&gt;::buffer const):
(JSC::bufferMode&gt;::usableBufferSize):
(JSC::bufferMode&gt;::FastStringifier):
(JSC::bufferMode&gt;::haveFailure const):
(JSC::bufferMode&gt;::result const):
(JSC::bufferMode&gt;::recordFailure):
(JSC::bufferMode&gt;::recordBufferFull):
(JSC::bufferMode&gt;::hasRemainingCapacity):
(JSC::bufferMode&gt;::hasRemainingCapacitySlow):
(JSC::bufferMode&gt;::recordFastPropertyEnumerationFailure):
(JSC::bufferMode&gt;::firstGetterSetterPropertyName const):
(JSC::bufferMode&gt;::mayHaveToJSON const):
(JSC::bufferMode&gt;::append):
(JSC::bufferMode&gt;::stringify):
(JSC::stringify):
(JSC::FastStringifier&lt;CharType&gt;::logOutcome): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::usableBufferSize): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::FastStringifier): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::haveFailure const): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::result const): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::recordFailure): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::recordBufferFull): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::hasRemainingCapacity): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::hasRemainingCapacitySlow): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::recordFastPropertyEnumerationFailure): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::firstGetterSetterPropertyName const): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::mayHaveToJSON const): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::append): Deleted.
(JSC::FastStringifier&lt;CharType&gt;::stringify): Deleted.
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::appendQuotedJSONStringInternal): Deleted.
* Source/WTF/wtf/text/StringBuilderJSON.h: Copied from Source/WTF/wtf/text/StringBuilderJSON.cpp.
(WTF::appendQuotedJSONStringInternal):

Canonical link: <a href="https://commits.webkit.org/282502@main">https://commits.webkit.org/282502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5bce1bcf5eb258b0ffad081fdc4ef77cbf0d77e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42711 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/15952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/50399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14243 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66424 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/50399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/15952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/50399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/15952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/56467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/50399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/15952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62599 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/7302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/7333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/15952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84361 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9567 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/14861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->