### PR TITLE
Re-import content-security-policy/script-src WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html
@@ -5,7 +5,7 @@
 <script nonce="abc">
     var t = async_test("Unnonced scripts generate reports.");
     var events = 0;
-    var firstLine = 38;
+    var firstLine = 43;
     var expectations = {}
     expectations[firstLine] = true;
     expectations[firstLine + 3] = true;
@@ -14,11 +14,16 @@
     expectations[firstLine + 12] = true;
     expectations[firstLine + 15] = true;
     expectations[firstLine + 18] = true;
+    expectations[firstLine + 21] = true;
+    expectations[firstLine + 24] = true;
+    expectations[firstLine + 28] = true;
     expectations["/content-security-policy/support/nonce-should-be-blocked.js?1"] = true;
     expectations["/content-security-policy/support/nonce-should-be-blocked.js?2"] = true;
     expectations["/content-security-policy/support/nonce-should-be-blocked.js?3"] = true;
     expectations["/content-security-policy/support/nonce-should-be-blocked.js?4"] = true;
     expectations["/content-security-policy/support/nonce-should-be-blocked.js?5"] = true;
+    expectations["/content-security-policy/support/nonce-should-be-blocked.js?6"] = true;
+    expectations["/content-security-policy/support/nonce-should-be-blocked.js?7"] = true;
 
     document.addEventListener('securitypolicyviolation', t.step_func(e => {
         if (e.lineNumber) {
@@ -31,7 +36,7 @@
             assert_true(expectations[url.pathname + url.search], "URL: " + e.blockedURI);
         }
         events++;
-        if (events == 12)
+        if (events == Object.keys(expectations).length)
           t.done();
     }));
 </script>
@@ -47,17 +52,30 @@
 <script attribute<script nonce="abc">
     t.unreached_func("'attribute<script', no execution.")();
 </script>
+<script attribute<style="value" nonce="abc">
+    t.unreached_func("'attribute<style' attribute, no execution.")();
+</script>
 <script attribute=<script nonce="abc">
     t.unreached_func("'<script' value, no execution.")();
 </script>
 <script attribute=value<script nonce="abc">
     t.unreached_func("'value<script', no execution.")();
 </script>
-<script attribute="" attribute=<style nonce="abc">
+<script attribute attribute nonce="abc">
     t.unreached_func("Duplicate attribute, no execution.")();
 </script>
+<script attribute attribute=<style nonce="abc">
+    t.unreached_func("2# Duplicate attribute, no execution.")();
+</script>
+<svg xmlns="http://www.w3.org/2000/svg">
+<script attribute attribute nonce="abc">
+    t.unreached_func("Duplicate attribute in SVG, no execution.")();
+</script>
+</svg>
 <script src="../support/nonce-should-be-blocked.js?1" <script nonce="abc"></script>
 <script src="../support/nonce-should-be-blocked.js?2" attribute=<script nonce="abc"></script>
 <script src="../support/nonce-should-be-blocked.js?3" <style nonce="abc"></script>
 <script src="../support/nonce-should-be-blocked.js?4" attribute=<style nonce="abc"></script>
-<script src="../support/nonce-should-be-blocked.js?5" attribute=<style nonce="abc"></script>
+<script src="../support/nonce-should-be-blocked.js?5" attribute attribute nonce="abc"></script>
+<script src="../support/nonce-should-be-blocked.js?6" attribute<script nonce="abc"></script>
+<script src="../support/nonce-should-be-blocked.js?7" attribute=value<script nonce="abc"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt
@@ -3,6 +3,7 @@ External scripts with matching SRI hash should be allowed.
 
 PASS Load all the tests.
 PASS matching integrity
+PASS matching integrity (case-insensitive algorithm)
 PASS multiple matching integrity
 PASS no integrity
 PASS matching plus unsupported integrity

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html
@@ -6,7 +6,8 @@
     <script src='/resources/testharness.js' nonce='dummy'></script>
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
-    <!-- CSP served: script-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'sha256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA=' -->
+    <!-- CSP served: script-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'ShA256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA==' -->
+    <!-- ShA256 is intentionally mixed case -->
 </head>
 
 <body>
@@ -25,9 +26,13 @@
             './simpleSourcedScript.js',
             'sha256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=',
             true ],
+          [ 'matching integrity (case-insensitive algorithm)',
+            './simpleSourcedScript.js',
+            'sha256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=',
+            true ],
           [ 'multiple matching integrity',
             './simpleSourcedScript.js',
-            'sha256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c= sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA=',
+            'sha256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c= sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA==',
             true ],
           [ 'no integrity',
             './simpleSourcedScript.js',

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html.sub.headers
@@ -2,4 +2,4 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Content-Security-Policy: script-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'sha256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA='
+Content-Security-Policy: script-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'ShA256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA=='

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes-expected.txt
@@ -1,6 +1,9 @@
 `strict-dynamic` allows scripts matching hashes present in the policy.
 
 
+Harness Error (FAIL), message = Error: assert_unreached: CSP violation reports should not fire. Reached unreachable code
+
 PASS Script matching SHA256 hash is allowed with `strict-dynamic`.
 PASS Script injected via `appendChild` from a script matching SHA256 hash is allowed with `strict-dynamic`.
+FAIL External script in a script tag with matching SRI hash is allowed with `strict-dynamic`. assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
@@ -6,7 +6,7 @@
     <script src='/resources/testharness.js' nonce='dummy'></script>
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
-    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' -->
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' -->
 </head>
 
 <body>
@@ -46,6 +46,17 @@
             e.onerror = t.unreached_func('Error should not be triggered.');
             document.body.appendChild(e);
         }, 'Script injected via `appendChild` from a script matching SHA256 hash is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        var externalRan = false;
+    </script>
+    <script src='./externalScript.js'
+        integrity="sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0="></script>
+    <script nonce='dummy'>
+        test(function(t) {
+            assert_true(externalRan);
+        }, "External script in a script tag with matching SRI hash is allowed with `strict-dynamic`.");
     </script>
 </body>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
@@ -2,4 +2,4 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA='
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0='

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/support/worker-with-script-src-none-set-timeout.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/support/worker-with-script-src-none-set-timeout.js
@@ -8,7 +8,7 @@ if (typeof SharedWorkerGlobalScope === "function") {
   onconnect = function (e) {
     var port = e.ports[0];
 
-    port.onmessage = function () { port.postMessage(message); }
+    port.onmessage = function () { port.postMessage(message); };
     port.postMessage(message);
   };
 } else if (typeof DedicatedWorkerGlobalScope === "function") {

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Shared worker with data: url inherits CSP assert_unreached: The 'error' event should not have fired. Reached unreachable code
+FAIL Shared worker with data: url inherits CSP assert_equals: expected "setTimeout blocked" but got "setTimeout allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub.html
@@ -5,7 +5,7 @@
     <!-- We add two CSP entries on purpose. The first one does nothing
     for the purpose of this test, but we want to check that both are
     inherited -->
-    <meta http-equiv="Content-Security-Policy" content="object-src: 'none'">
+    <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
     <meta http-equiv="Content-Security-Policy" content="script-src data: 'self' 'unsafe-inline'; connect-src 'self';">
     <title>worker-data-set-timeout</title>
     <script src="/resources/testharness.js"></script>
@@ -19,7 +19,7 @@
        .then(data => data.text())
        .then(
            text => assert_shared_worker_is_loaded(
-               `data:text/javascript,${text}`,
+               `data:text/javascript;base64,${btoa(text)}`,
                "Shared worker with data: url inherits CSP",
                "setTimeout blocked"));
     </script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt
@@ -5,6 +5,7 @@ External scripts with matching SRI hash should be allowed.
 
 PASS Load all the tests.
 PASS matching integrity
+PASS matching integrity (case-insensitive algorithm)
 PASS multiple matching integrity
 PASS no integrity
 PASS matching plus unsupported integrity

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt
@@ -5,6 +5,7 @@ External scripts with matching SRI hash should be allowed.
 
 PASS Load all the tests.
 PASS matching integrity
+PASS matching integrity (case-insensitive algorithm)
 PASS multiple matching integrity
 PASS no integrity
 PASS matching plus unsupported integrity


### PR DESCRIPTION
#### 83cc6f24d7b679183916aa73fe604c70d7978bc4
<pre>
Re-import content-security-policy/script-src WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=278376">https://bugs.webkit.org/show_bug.cgi?id=278376</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/2eb5c22fba7e20f805a7bd5decebe1e404d7a810">https://github.com/web-platform-tests/wpt/commit/2eb5c22fba7e20f805a7bd5decebe1e404d7a810</a>

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-enforce-blocked.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub.html.sub.headers:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/support/worker-with-script-src-none-set-timeout.js:
(typeof.SharedWorkerGlobalScope.string_appeared_here.port.onmessage):
(typeof.SharedWorkerGlobalScope.string_appeared_here.onconnect):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub.html:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-sri_hash.sub-expected.txt:

Canonical link: <a href="https://commits.webkit.org/282509@main">https://commits.webkit.org/282509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe98a58e1853530cb93ed3a1df6e414fd60d0cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51004 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9617 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12791 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58541 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14033 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6046 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38488 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39567 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->