### PR TITLE
Web Manifest: parser should trim with isASCIIWhitespace

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -193,7 +193,7 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
     };
     static constexpr SortedArrayMap displayValues { displayValueMappings };
 
-    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).trim(isUnicodeCompatibleASCIIWhitespace<UChar>)))
+    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<UChar>)))
         return *displayValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid display mode."_s));
@@ -225,7 +225,7 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
 
     static SortedArrayMap orientationValues { orientationValueMappings };
 
-    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).trim(isUnicodeCompatibleASCIIWhitespace<UChar>)))
+    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<UChar>)))
         return *orientationValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid orientation."_s));
@@ -327,7 +327,7 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
                 purposes.add(ApplicationManifest::Icon::Purpose::Any);
                 currentIcon.purposes = purposes;
             } else {
-                for (auto keyword : StringView(purposeStringValue).trim(isUnicodeCompatibleASCIIWhitespace<UChar>).splitAllowingEmptyEntries(' ')) {
+                for (auto keyword : StringView(purposeStringValue).trim(isASCIIWhitespace<UChar>).splitAllowingEmptyEntries(' ')) {
                     if (equalLettersIgnoringASCIICase(keyword, "monochrome"_s))
                         purposes.add(ApplicationManifest::Icon::Purpose::Monochrome);
                     else if (equalLettersIgnoringASCIICase(keyword, "maskable"_s))

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -459,6 +459,7 @@ TEST_F(ApplicationManifestParserTest, Display)
     testDisplay("\"minimal-ui\""_s, ApplicationManifest::Display::MinimalUI);
     testDisplay("\"fullscreen\""_s, ApplicationManifest::Display::Fullscreen);
     testDisplay("\"\t\nMINIMAL-UI \""_s, ApplicationManifest::Display::MinimalUI);
+    testDisplay("\"\vbminimal-ui\""_s, ApplicationManifest::Display::Browser);
 }
 
 TEST_F(ApplicationManifestParserTest, Orientation)
@@ -471,6 +472,7 @@ TEST_F(ApplicationManifestParserTest, Orientation)
     testOrientation("[ ]"_s, std::nullopt);
     testOrientation("\"\""_s, std::nullopt);
     testOrientation("\"garbage string\""_s, std::nullopt);
+    testOrientation("\"\vbportrait-secondary\""_s, std::nullopt);
 
     testOrientation("\"any\""_s, WebCore::ScreenOrientationLockType::Any);
     testOrientation("\"natural\""_s, WebCore::ScreenOrientationLockType::Natural);


### PR DESCRIPTION
#### 98099931172e5708c4e5ed80f8f811f9a078fe80
<pre>
Web Manifest: parser should trim with isASCIIWhitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=278377">https://bugs.webkit.org/show_bug.cgi?id=278377</a>
<a href="https://rdar.apple.com/134336817">rdar://134336817</a>

Reviewed by Anne van Kesteren.

Now trims using isASCIIWhitespace instead of isUnicodeCompatibleASCIIWhitespace.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseDisplay):
(WebCore::ApplicationManifestParser::parseOrientation):
(WebCore::ApplicationManifestParser::parseIcons):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/282544@main">https://commits.webkit.org/282544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58d457c20c331866b716c060dd31b75ca03c761e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51006 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9621 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14051 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6051 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38492 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->