### PR TITLE
Adopt smart pointers in InternalObserver-related classes

### DIFF
--- a/Source/WebCore/dom/InternalObserver.cpp
+++ b/Source/WebCore/dom/InternalObserver.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 void InternalObserver::error(JSC::JSValue value)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -54,7 +54,7 @@ public:
 
         CallbackResult<void> handleEvent(Subscriber& subscriber) final
         {
-            auto context = scriptExecutionContext();
+            RefPtr context = scriptExecutionContext();
 
             if (!context) {
                 subscriber.complete();

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -55,7 +55,7 @@ public:
 
         CallbackResult<void> handleEvent(Subscriber& subscriber) final
         {
-            auto context = scriptExecutionContext();
+            RefPtr context = scriptExecutionContext();
 
             if (!context) {
                 subscriber.complete();
@@ -85,7 +85,7 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto context = scriptExecutionContext();
+        RefPtr context = scriptExecutionContext();
         if (!context)
             return;
 

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -55,7 +55,7 @@ public:
 
         CallbackResult<void> handleEvent(Subscriber& subscriber) final
         {
-            auto context = scriptExecutionContext();
+            RefPtr context = scriptExecutionContext();
 
             if (!context) {
                 subscriber.complete();
@@ -85,7 +85,7 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto context = scriptExecutionContext();
+        RefPtr context = scriptExecutionContext();
         if (!context)
             return;
 

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -54,7 +54,7 @@ public:
 
         CallbackResult<void> handleEvent(Subscriber& subscriber) final
         {
-            auto context = scriptExecutionContext();
+            RefPtr context = scriptExecutionContext();
 
             if (!context || !m_amount) {
                 subscriber.complete();


### PR DESCRIPTION
#### 2a1c5a8e2aa20b0e604ca87be93839b10a08a94b
<pre>
Adopt smart pointers in InternalObserver-related classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=278378">https://bugs.webkit.org/show_bug.cgi?id=278378</a>

Reviewed by Chris Dumez.

Addresses a couple of alpha.webkit.UncountedLocalVarsChecker warnings
for variables calling non-trivial methods.

* Source/WebCore/dom/InternalObserver.cpp:
(WebCore::InternalObserver::error):
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:

Canonical link: <a href="https://commits.webkit.org/282607@main">https://commits.webkit.org/282607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f05277844a1e48ecded55a5a7c734f3dd33d6287

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51009 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9625 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69035 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58549 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6052 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38495 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->