### PR TITLE
[css-masonry] Update masonry-intrinsic-sizing-cols-003-ref/expected to align with base test case

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1699,7 +1699,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-0
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-001.html [ ImageOnlyFailure ]
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-005.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-expected.html
@@ -97,7 +97,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
+  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
   <item style="width:5ch; grid-area: 2/1/3/4">6</item>
 
   <item class="hidden">0</item>
@@ -193,7 +193,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
+  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
   <item style="width:5ch; grid-area: 2/1/3/4">6</item>
 
   <item class="hidden">0</item>
@@ -291,7 +291,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
+  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
   <item style="width:5ch; grid-area: 2/1/3/4">6</item>
 
   <item class="hidden">0</item>
@@ -351,7 +351,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="grid-row: span 2">5 5</item>
+  <item style="grid-row: span 2; width: 2ch;">5 5</item>
   <item class="hidden" style="grid-area: 2/4/4">0 0</item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-ref.html
@@ -97,7 +97,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
+  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
   <item style="width:5ch; grid-area: 2/1/3/4">6</item>
 
   <item class="hidden">0</item>
@@ -193,7 +193,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
+  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
   <item style="width:5ch; grid-area: 2/1/3/4">6</item>
 
   <item class="hidden">0</item>
@@ -291,7 +291,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="width:3ch; grid-area: 1/2/2/4">5 5</item>
+  <item style="width:3ch; grid-area: 1/2/2/4">5</item>
   <item style="width:5ch; grid-area: 2/1/3/4">6</item>
 
   <item class="hidden">0</item>
@@ -351,7 +351,7 @@ item {
   <item style="grid-row: span 2">2 2</item>
   <item style="grid-row: span 2">3 3</item>
   <item>4</item>
-  <item style="grid-row: span 2">5 5</item>
+  <item style="grid-row: span 2; width: 2ch;">5 5</item>
   <item class="hidden" style="grid-area: 2/4/4">0 0</item>
 </grid>
 


### PR DESCRIPTION
#### 6a622c21a8f68ab89beb3291db8af8360912c089
<pre>
[css-masonry] Update masonry-intrinsic-sizing-cols-003-ref/expected to align with base test case
<a href="https://bugs.webkit.org/show_bug.cgi?id=278379">https://bugs.webkit.org/show_bug.cgi?id=278379</a>
<a href="https://rdar.apple.com/problem/134341983">rdar://problem/134341983</a>

Reviewed by Sammy Gill.

There were two issues with this ref/expected test cases.

1. In test case two of mixed sizing: fixed + auto + fr the 5 needs to be a width of 2ch, because the width is set to 2ch in the base test case.

2. The number of 5s present in the other test cases were miscounted.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-003-ref.html:

Canonical link: <a href="https://commits.webkit.org/282501@main">https://commits.webkit.org/282501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08e44ded2a70dc35b54387ceac7be9bc0da9c4e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51013 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9627 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58322 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14030 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6058 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38499 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->