### PR TITLE
REGRESSION (iOS 15): accessibility/misspelling-range.html is constantly failing

### DIFF
--- a/LayoutTests/accessibility/misspelling-range-expected.txt
+++ b/LayoutTests/accessibility/misspelling-range-expected.txt
@@ -1,8 +1,4 @@
-wrods is misspelled aab lotsi nowadays. euep.
 This tests that misspelling ranges are properly retrieved in the fashion that a spell checker would.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 textMarkerRange start: 0
 textMarkerRange end: 45
@@ -10,20 +6,21 @@ startRange start: 0
 startRange end: 0
 misspelling start: 0
 misspelling end: 5
-PASS text.stringForTextMarkerRange(misspellingRange) is 'wrods'
+PASS: text.stringForTextMarkerRange(misspellingRange) === 'wrods'
 misspelling start: 20
 misspelling end: 23
-PASS text.stringForTextMarkerRange(misspellingRange) is 'aab'
+PASS: text.stringForTextMarkerRange(misspellingRange) === 'aab'
 misspelling start: 24
 misspelling end: 29
-PASS text.stringForTextMarkerRange(misspellingRange) is 'lotsi'
+PASS: text.stringForTextMarkerRange(misspellingRange) === 'lotsi'
 misspelling start: 40
 misspelling end: 44
-PASS text.stringForTextMarkerRange(misspellingRange) is 'euep'
+PASS: text.stringForTextMarkerRange(misspellingRange) === 'euep'
 misspelling start: 24
 misspelling end: 29
-PASS text.stringForTextMarkerRange(misspellingRange) is 'lotsi'
+PASS: text.stringForTextMarkerRange(misspellingRange) === 'lotsi'
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+wrods is misspelled aab lotsi nowadays. euep.

--- a/LayoutTests/accessibility/misspelling-range.html
+++ b/LayoutTests/accessibility/misspelling-range.html
@@ -1,11 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
-<script>
-if (window.testRunner)
-   testRunner.dumpAsText();
-</script>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 
@@ -13,77 +10,81 @@ if (window.testRunner)
 wrods is misspelled aab lotsi nowadays. euep.
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This tests that misspelling ranges are properly retrieved in the fashion that a spell checker would.");
+let output = "This tests that misspelling ranges are properly retrieved in the fashion that a spell checker would.\n\n";
+jsTestIsAsync = true;
 
-    if (window.accessibilityController) {
-        var content = document.getElementById("content");
-        content.focus();
+if (window.accessibilityController && window.internals) {
+    var content = document.getElementById("content");
+    content.focus();
+    var text = accessibilityController.focusedElement;
 
-        var text = accessibilityController.focusedElement;
+    var textMarkerRange = text.textMarkerRangeForElement(text);
+    var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    output += `textMarkerRange start: ${text.indexForTextMarker(startMarker)}\n`;
+    var endMarker = text.endTextMarkerForTextMarkerRange(textMarkerRange);
+    output += `textMarkerRange end: ${text.indexForTextMarker(endMarker)}\n`;
 
-        var textMarkerRange = text.textMarkerRangeForElement(text);
-        var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        debug("textMarkerRange start: " + text.indexForTextMarker(startMarker));
-        var endMarker = text.endTextMarkerForTextMarkerRange(textMarkerRange);
-        debug("textMarkerRange end: " + text.indexForTextMarker(endMarker));
+    // Find the first misspelling, "wrods".
+    var startRange = text.textMarkerRangeForMarkers(startMarker, startMarker);
+    startMarker = text.startTextMarkerForTextMarkerRange(startRange);
+    output += `startRange start: ${text.indexForTextMarker(startMarker)}\n`;
+    endMarker = text.endTextMarkerForTextMarkerRange(startRange);
+    output += `startRange end: ${text.indexForTextMarker(endMarker)}\n`;
 
-        // Find the first misspelling, "wrods".
-        var startRange = text.textMarkerRangeForMarkers(startMarker, startMarker);
-        startMarker = text.startTextMarkerForTextMarkerRange(startRange);
-        debug("startRange start: " + text.indexForTextMarker(startMarker));
-        endMarker = text.endTextMarkerForTextMarkerRange(startRange);
-        debug("startRange end: " + text.indexForTextMarker(endMarker));
-
-        var misspellingRange = text.misspellingTextMarkerRange(startRange, true);
-        startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling start: " + text.indexForTextMarker(startMarker));
+    setTimeout(async () => {
+        misspellingRange = null;
+        startMarker = null;
+        await waitFor(() => {
+            misspellingRange = text.misspellingTextMarkerRange(startRange, true);
+            startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
+            return text.indexForTextMarker(startMarker) >= 0;
+        });
+        output += `misspelling start: ${text.indexForTextMarker(startMarker)}\n`;
         endMarker = text.endTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling end: " + text.indexForTextMarker(endMarker));
-        shouldBe("text.stringForTextMarkerRange(misspellingRange)", "'wrods'");
+        output += `misspelling end: ${text.indexForTextMarker(endMarker)}\n`;
+        output += expect("text.stringForTextMarkerRange(misspellingRange)", "'wrods'");
 
         // Find the next one, "aab".
         startRange = misspellingRange;
         misspellingRange = text.misspellingTextMarkerRange(startRange, true);
         startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling start: " + text.indexForTextMarker(startMarker));
+        output += `misspelling start: ${text.indexForTextMarker(startMarker)}\n`;
         endMarker = text.endTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling end: " + text.indexForTextMarker(endMarker));
-        shouldBe("text.stringForTextMarkerRange(misspellingRange)", "'aab'");
+        output += `misspelling end: ${text.indexForTextMarker(endMarker)}\n`;
+        output += expect("text.stringForTextMarkerRange(misspellingRange)", "'aab'");
 
         // Find the next one, "lotsi".
         startRange = misspellingRange;
         misspellingRange = text.misspellingTextMarkerRange(startRange, true);
         startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling start: " + text.indexForTextMarker(startMarker));
+        output += `misspelling start: ${text.indexForTextMarker(startMarker)}\n`;
         endMarker = text.endTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling end: " + text.indexForTextMarker(endMarker));
-        shouldBe("text.stringForTextMarkerRange(misspellingRange)", "'lotsi'");
+        output += `misspelling end: ${text.indexForTextMarker(endMarker)}\n`;
+        output += expect("text.stringForTextMarkerRange(misspellingRange)", "'lotsi'");
 
         // Find the next one, "euep".
         startRange = misspellingRange;
         misspellingRange = text.misspellingTextMarkerRange(startRange, true);
         startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling start: " + text.indexForTextMarker(startMarker));
+        output += `misspelling start: ${text.indexForTextMarker(startMarker)}\n`;
         endMarker = text.endTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling end: " + text.indexForTextMarker(endMarker));
-        shouldBe("text.stringForTextMarkerRange(misspellingRange)", "'euep'");
+        output += `misspelling end: ${text.indexForTextMarker(endMarker)}\n`;
+        output += expect("text.stringForTextMarkerRange(misspellingRange)", "'euep'");
 
         // Find the previous one, "lotsi".
         startRange = misspellingRange;
         misspellingRange = text.misspellingTextMarkerRange(startRange, false);
         startMarker = text.startTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling start: " + text.indexForTextMarker(startMarker));
+        output += `misspelling start: ${text.indexForTextMarker(startMarker)}\n`;
         endMarker = text.endTextMarkerForTextMarkerRange(misspellingRange);
-        debug("misspelling end: " + text.indexForTextMarker(endMarker));
-        shouldBe("text.stringForTextMarkerRange(misspellingRange)", "'lotsi'");
-    }
-</script>
+        output += `misspelling end: ${text.indexForTextMarker(endMarker)}\n`;
+        output += expect("text.stringForTextMarkerRange(misspellingRange)", "'lotsi'");
 
-<script src="../resources/js-test-post.js"></script>
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
 </body>
 </html>
-

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3456,8 +3456,7 @@ http/wpt/mediarecorder/mute-tracks.html [ Pass Failure ]
 # rdar://80396502 ([ iOS15 ] http/wpt/mediarecorder/pause-recording.html is a flaky crash)
 http/wpt/mediarecorder/pause-recording.html [ Pass Crash ]
 
-# rdar://80383672 ([ iOS15 ] accessibility/misspelling-range.html is failing)
-webkit.org/b/231261 accessibility/misspelling-range.html [ Failure ]
+accessibility/misspelling-range.html [ Pass ]
 
 # Behavior of navigator-language-ru changed in iOS 15.
 fast/text/international/system-language/navigator-language/navigator-language-ru.html [ Failure ]


### PR DESCRIPTION
#### a7cbc19642ca8032fcec544d951b328cdc910eaa
<pre>
REGRESSION (iOS 15): accessibility/misspelling-range.html is constantly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=231261">https://bugs.webkit.org/show_bug.cgi?id=231261</a>
<a href="https://rdar.apple.com/80383672">rdar://80383672</a>

Reviewed by Tyler Wilcock.

This test was failing because it needs to be async for the unified checker to work.
Re-wrote the test to match LayoutTests/accessibility standards.

* LayoutTests/accessibility/misspelling-range-expected.txt:
* LayoutTests/accessibility/misspelling-range.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/282537@main">https://commits.webkit.org/282537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2a6fec50ccf07d22e1a66fee3edae5f35fb0c5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13938 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51021 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9639 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12810 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58580 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6067 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38507 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->