### PR TITLE
Strengthen configuration check in UIClient::createNewPage

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -351,10 +351,8 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
                 [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
             ALLOW_DEPRECATED_DECLARATIONS_END
 
-            // FIXME: Remove this site isolation check when rdar://133991604 is resolved.
-            // Move it to WebPageProxy once rdar://134317255 and rdar://134317400 are resolved.
-            if (webView->_configuration->_pageConfiguration->preferences().siteIsolationEnabled()
-                && openerInfo != webView->_configuration->_pageConfiguration->openerInfo())
+            // FIXME: Move this to WebPageProxy once rdar://134317255 and rdar://134317400 are resolved.
+            if (openerInfo != webView->_configuration->_pageConfiguration->openerInfo())
                 [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
 
             completionHandler(webView->_page.get());
@@ -373,10 +371,8 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
         [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
-    // FIXME: Remove this site isolation check when rdar://133991604 is resolved.
-    // Move it to WebPageProxy once rdar://134317255 is resolved.
-    if (webView->_configuration->_pageConfiguration->preferences().siteIsolationEnabled()
-        && openerInfo != webView.get()->_configuration->_pageConfiguration->openerInfo())
+    // FIXME: Move this to WebPageProxy once rdar://134317255 and rdar://134317400 are resolved.
+    if (openerInfo != webView.get()->_configuration->_pageConfiguration->openerInfo())
         [NSException raise:NSInternalInconsistencyException format:@"Returned WKWebView was not created with the given configuration."];
     completionHandler(webView->_page.get());
 }

--- a/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h
@@ -39,7 +39,6 @@
 @property (readonly) BOOL wasPrompted;
 @property int numberOfPrompts;
 @property WKPermissionDecision decision;
-@property (readonly) BOOL shouldCreateNewWebView;
 
 -(void)waitUntilPrompted;
 -(void)resetWasPrompted;
@@ -47,14 +46,8 @@
 -(void)setAudioDecision:(WKPermissionDecision)decision;
 -(void)setVideoDecision:(WKPermissionDecision)decision;
 -(void)setGetDisplayMediaDecision:(WKDisplayCapturePermissionDecision)decision;
--(void)setWebViewForPopup:(WKWebView*)webView;
 
-// WKUIDelegate
-- (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler;
-- (void)_webView:(WKWebView *)webView checkUserMediaPermissionForURL:(NSURL *)url mainFrameURL:(NSURL *)mainFrameURL frameIdentifier:(NSUInteger)frameIdentifier decisionHandler:(void (^)(NSString *salt, BOOL authorized))decisionHandler;
-- (void)_webView:(WKWebView *)webView requestDisplayCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame withSystemAudio:(BOOL)withSystemAudio decisionHandler:(void (^)(WKDisplayCapturePermissionDecision decision))decisionHandler;
-- (void)_webView:(WKWebView *)webView queryPermission:(NSString*) name forOrigin:(WKSecurityOrigin *)origin completionHandler:(void (^)(WKPermissionDecision state))completionHandler;
-- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures;
+@property (nonatomic, copy) WKWebView* (^createWebViewWithConfiguration)(WKWebViewConfiguration *, WKNavigationAction *, WKWindowFeatures *);
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm
@@ -32,11 +32,11 @@
 #import <WebKit/WKWebpagePreferencesPrivate.h>
 
 @implementation UserMediaCaptureUIDelegate {
-    WKWebView* _webViewForPopup;
+    Vector<RetainPtr<WKWebView>> _createdWebViews;
 }
+@synthesize createWebViewWithConfiguration = _createWebViewWithConfiguration;
 @synthesize numberOfPrompts = _numberOfPrompts;
 @synthesize decision = _decision;
-@synthesize shouldCreateNewWebView = _shouldCreateNewWebView;
 
 -(id)init {
     self = [super init];
@@ -49,10 +49,6 @@
     }
 
     return self;
-}
-
--(void)setWebViewForPopup:(WKWebView*)webView {
-    _webViewForPopup = webView;
 }
 
 -(BOOL)wasPrompted {
@@ -132,10 +128,10 @@
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    if (_shouldCreateNewWebView)
-        return [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
-
-    return _webViewForPopup;
+    if (_createWebViewWithConfiguration)
+        return _createWebViewWithConfiguration(configuration, navigationAction, windowFeatures);
+    _createdWebViews.append(adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]));
+    return _createdWebViews.last().get();
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
@@ -40,21 +40,7 @@ void PlatformWebView::initialize(WKPageConfigurationRef pageConfiguration)
 {
     NSRect rect = NSMakeRect(0, 0, 800, 600);
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    if (auto* context = WKPageConfigurationGetContext(pageConfiguration))
-        configuration.get().processPool = (WKProcessPool *)context;
-    if (auto* controller = WKPageConfigurationGetUserContentController(pageConfiguration))
-        configuration.get().userContentController = (WKUserContentController *)controller;
-    if (auto* dataStore = WKPageConfigurationGetWebsiteDataStore(pageConfiguration))
-        configuration.get().websiteDataStore = (WKWebsiteDataStore *)dataStore;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (auto* relatedPage = WKPageConfigurationGetRelatedPage(pageConfiguration))
-        configuration.get()._relatedWebView = WKPageGetWebView(relatedPage);
-    ALLOW_DEPRECATED_DECLARATIONS_END
-    if (auto* preferences = WKPageConfigurationGetPreferences(pageConfiguration))
-        configuration.get().preferences = (WKPreferences *)preferences;
-
-    m_view = [[WKWebView alloc] initWithFrame:rect configuration:configuration.get()];
+    m_view = [[WKWebView alloc] initWithFrame:rect configuration:(__bridge WKWebViewConfiguration *)pageConfiguration];
     [m_view _setWindowOcclusionDetectionEnabled:NO];
 
     m_window = [[OffscreenWindow alloc] initWithSize:NSSizeToCGSize(rect.size)];


### PR DESCRIPTION
#### 15cf18453a96df5ef307c4f27f9edf03a8b3a0cb
<pre>
Strengthen configuration check in UIClient::createNewPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=278385">https://bugs.webkit.org/show_bug.cgi?id=278385</a>
<a href="https://rdar.apple.com/134346771">rdar://134346771</a>

Reviewed by Charlie Wolfe.

When WKUIDelegate.createWebViewWithConfiguration is called, we need that configuration
to actually be used.  It used to be possible to use WKWebViewConfiguration._relatedWebView
to take another WKWebViewConfiguration and make it look similar enough that WebKit didn&apos;t
care it wasn&apos;t the same, but with site isolation we need to store more information than
the _relatedWebView on the configuration (the API::PageConfiguration::OpenerInfo) so
it is no longer possible to use _relatedWebView to retrofit another configuration and have
the opener be set up correctly.  I went through the users of _relatedWebView, and I think
the only client that still does this is WebKitTestRunner, so I strengthen the check
and fix WebKitTestRunner, and one test in TestWebKitAPI, which I replace by using the
correct configuration.

* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::createNewPage):
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::TransferTrackBetweenSameProcessPages)):
* Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm:
(-[UserMediaCaptureUIDelegate webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:]):
(-[UserMediaCaptureUIDelegate setWebViewForPopup:]): Deleted.
* Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm:
(TestWebKitAPI::PlatformWebView::initialize):

Canonical link: <a href="https://commits.webkit.org/282760@main">https://commits.webkit.org/282760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/100e9e5cb2e60f30f113994ee19d0b8c58f4534c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51274 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9837 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31903 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13095 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55176 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58756 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6304 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9718 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38791 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->