### PR TITLE
[WebAuthn] Fix -Wmissing-designated-field-initializers issues in CtapRequestTest.cpp

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -238,9 +238,14 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
     PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
     AuthenticationExtensionsClientInputs extensionInputs = {
+        .appid = WTF::nullString(),
+        .credProps = false,
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
-            .support = "required"_s
-        }
+            .support = "required"_s,
+            .read = std::nullopt,
+            .write = std::nullopt,
+        },
+        .prf = std::nullopt,
     };
 
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
@@ -267,9 +272,14 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
     PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
     AuthenticationExtensionsClientInputs extensionInputs = {
+        .appid = WTF::nullString(),
+        .credProps = false,
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
-            .support = "required"_s
-        }
+            .support = "required"_s,
+            .read = std::nullopt,
+            .write = std::nullopt,
+        },
+        .prf = std::nullopt,
     };
 
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
@@ -484,9 +494,14 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)
     descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
     options.extensions = AuthenticationExtensionsClientInputs {
+        .appid = WTF::nullString(),
+        .credProps = false,
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
+            .support = WTF::nullString(),
             .read = true,
-        }
+            .write = std::nullopt,
+        },
+        .prf = std::nullopt,
     };
 
     options.userVerification = UserVerificationRequirement::Required;
@@ -527,9 +542,14 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)
     descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
     options.extensions = AuthenticationExtensionsClientInputs {
+        .appid = WTF::nullString(),
+        .credProps = false,
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
+            .support = WTF::nullString(),
             .read = true,
-        }
+            .write = std::nullopt,
+        },
+        .prf = std::nullopt,
     };
 
     options.userVerification = UserVerificationRequirement::Required;
@@ -574,9 +594,14 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
         0xAB, 0xCD, 0xEF
     };
     options.extensions = AuthenticationExtensionsClientInputs {
+        .appid = WTF::nullString(),
+        .credProps = false,
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
+            .support = WTF::nullString(),
+            .read = std::nullopt,
             .write = WebCore::toBufferSource(blob),
-        }
+        },
+        .prf = std::nullopt,
     };
 
     options.userVerification = UserVerificationRequirement::Required;


### PR DESCRIPTION
#### bb53aa397cb66f68b137cfee0ae9ce1f74fc59ce
<pre>
[WebAuthn] Fix -Wmissing-designated-field-initializers issues in CtapRequestTest.cpp
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=278387">https://bugs.webkit.org/show_bug.cgi?id=278387</a>&gt;
&lt;<a href="https://rdar.apple.com/134349142">rdar://134349142</a>&gt;

Reviewed by Pascoe.

Add missing field initializers.

* Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp:
(TestWebKitAPI::TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)):
(TestWebKitAPI::TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob)):
(TestWebKitAPI::TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)):
(TestWebKitAPI::TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)):
(TestWebKitAPI::TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)):

Canonical link: <a href="https://commits.webkit.org/282519@main">https://commits.webkit.org/282519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95bdab6188c968a54f4bb7251366c82cc14adf7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51029 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9642 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12821 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58338 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58570 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6075 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39597 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->