### PR TITLE
Fix enable flag around ReuseBetweenProcessPools test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -881,7 +881,7 @@ TEST(GPUProcess, ValidateWebAudioMediaProcessingAssertion)
     EXPECT_TRUE([configuration.get().processPool _hasAudibleMediaActivity]);
 }
 
-#if ENABLE(ENABLE_GPU_PROCESS_DOM_RENDERING_BY_DEFAULT)
+#if ENABLE(GPU_PROCESS_DOM_RENDERING_BY_DEFAULT)
 TEST(GPUProcess, ReuseBetweenProcessPools)
 {
     auto loadBlankViewAndWaitForGPUProcess = []() -> pid_t {
@@ -909,6 +909,6 @@ TEST(GPUProcess, ReuseBetweenProcessPools)
 
     EXPECT_EQ(firstGPUProcessPID, secondGPUProcessPID);
 }
-#endif // ENABLE(ENABLE_GPU_PROCESS_DOM_RENDERING_BY_DEFAULT)
+#endif // ENABLE(GPU_PROCESS_DOM_RENDERING_BY_DEFAULT)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fb43630e4ea666c39f00493e3b7a03864aeec27d
<pre>
Fix enable flag around ReuseBetweenProcessPools test
<a href="https://bugs.webkit.org/show_bug.cgi?id=278389">https://bugs.webkit.org/show_bug.cgi?id=278389</a>

Reviewed by Chris Dumez.

Used ENABLE(ENABLE_GPU_PROCESS_DOM_RENDERING_BY_DEFAULT) erroneously.
Identified with the `find-feature-flags` script.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:

Canonical link: <a href="https://commits.webkit.org/282582@main">https://commits.webkit.org/282582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b599d4d74a59f3c276970990732107bfea65e39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51038 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9648 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31719 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36329 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12209 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-error-events.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12827 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54930 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58585 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6083 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38524 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->