### PR TITLE
Object.keys(global) includes non-enumerable properties unless delete'd first

### DIFF
--- a/JSTests/stress/static-property-table-reconfigure-non-enumerable.js
+++ b/JSTests/stress/static-property-table-reconfigure-non-enumerable.js
@@ -1,0 +1,12 @@
+let object = $vm.createStaticCustomAccessor();
+
+object = $vm.toCacheableDictionary(object);
+if (!Object.keys(object).includes("testStaticAccessor"))
+    throw new Error();
+const d = Object.getOwnPropertyDescriptor(object, "testStaticAccessor");
+d.enumerable = false;
+Object.defineProperty(object, "testStaticAccessor", d);
+
+if (Object.keys(object).includes("testStaticAccessor"))
+    throw new Error();
+


### PR DESCRIPTION
#### eed6352f9b2365ff23dac63c6969040d14d72a68
<pre>
Object.keys(global) includes non-enumerable properties unless delete&apos;d first
<a href="https://bugs.webkit.org/show_bug.cgi?id=277899">https://bugs.webkit.org/show_bug.cgi?id=277899</a>
<a href="https://rdar.apple.com/134121649">rdar://134121649</a>

Reviewed by Yusuke Suzuki.

Right now when we reconfigure a static property we simply shadow it on the structure
without reifying the static table. This works for normal property access but
getNonReifiedStaticPropertyNames wasn&apos;t checking if the property had been shadowed.
So it was still adding the static property to the list. With this change
getNonReifiedStaticPropertyNames now checks if there&apos;s a shadowing property and
skips it when necessary.

I think there&apos;s still an issue with reconfigured properties being incorrectly
ordered when reified e.g.

```
print(Object.keys(objectWithStaticProperties)); // bar,baz,foo
makeNotEnum(objectWithStaticProperties, &quot;foo&quot;);
delete objectWithStaticProperties.bar;
print(Object.keys(objectWithStaticProperties)); // foo,baz
```

But it seems like reifying static properties reorders all names anyway so it&apos;s
not clear how big of an issue this is.

* JSTests/stress/static-property-table-reconfigure-non-enumerable.js: Added.
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getNonReifiedStaticPropertyNames):

Canonical link: <a href="https://commits.webkit.org/282554@main">https://commits.webkit.org/282554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85a083b206a206bf39277ffc4850443c173acc25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51034 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9651 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36332 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12212 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12830 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56462 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69067 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62594 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54933 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58596 "Found 3 new API test failures: /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6089 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38527 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14860 "Found 1466 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->