### PR TITLE
[WebDriver] Add BiDi webSocketUrl capability

### DIFF
--- a/Source/WebDriver/Capabilities.h
+++ b/Source/WebDriver/Capabilities.h
@@ -85,6 +85,8 @@ struct Capabilities {
 #if PLATFORM(GTK)
     std::optional<bool> useOverlayScrollbars;
 #endif
+    // https://w3c.github.io/webdriver-bidi/#websocket-url
+    std::optional<bool> webSocketURL;
 };
 
 } // namespace WebDriver

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -131,6 +131,7 @@ private:
     bool platformValidateCapability(const String&, const Ref<JSON::Value>&) const;
     bool platformMatchCapability(const String&, const Ref<JSON::Value>&) const;
     bool platformSupportProxyType(const String&) const;
+    bool platformSupportBidi() const;
     void parseCapabilities(const JSON::Object& desiredCapabilities, Capabilities&) const;
     void platformParseCapabilities(const JSON::Object& desiredCapabilities, Capabilities&) const;
     void connectToBrowser(Vector<Capabilities>&&, Function<void (CommandResult&&)>&&);

--- a/Source/WebDriver/glib/WebDriverServiceGLib.cpp
+++ b/Source/WebDriver/glib/WebDriverServiceGLib.cpp
@@ -85,4 +85,9 @@ bool WebDriverService::platformSupportProxyType(const String&) const
     return true;
 }
 
+bool WebDriverService::platformSupportBidi() const
+{
+    return false;
+}
+
 } // namespace WebDriver

--- a/Source/WebDriver/playstation/WebDriverServicePlayStation.cpp
+++ b/Source/WebDriver/playstation/WebDriverServicePlayStation.cpp
@@ -75,4 +75,9 @@ bool WebDriverService::platformSupportProxyType(const String&) const
     return false;
 }
 
+bool WebDriverService::platformSupportBidi() const
+{
+    return false;
+}
+
 } // namespace WebDriver

--- a/Source/WebDriver/win/WebDriverServiceWin.cpp
+++ b/Source/WebDriver/win/WebDriverServiceWin.cpp
@@ -68,4 +68,9 @@ bool WebDriverService::platformSupportProxyType(const String&) const
     return false;
 }
 
+bool WebDriverService::platformSupportBidi() const
+{
+    return false;
+}
+
 } // namespace WebDriver


### PR DESCRIPTION
#### 311f6ee395f786e3285e1502a0935c40551f2777
<pre>
[WebDriver] Add BiDi webSocketUrl capability
<a href="https://bugs.webkit.org/show_bug.cgi?id=278390">https://bugs.webkit.org/show_bug.cgi?id=278390</a>

Reviewed by Carlos Garcia Campos.

This is a new capability defined by the Webdriver Bidi spec[1]. When the
user sends `webSocketUrl==true`, it means the user requested a BiDi
session in parallel to the classic session being initiated.

This commit adds support for parsing and processing webSocketURL, failing
the capability negotiation explictly if the user requested it and we don&apos;t
support BiDi, which is the case for now, instead of failing as a unknown
capability key in WebDriverService::validatedCapabilities().

bug230615 (BiDi session support) will build on top of this to make use of
this capability to actually setup BiDi sessions.

Note: The platformSupportBidi() definitions are already split among the
port-specific files, so each port can enable it individually.

[1] <a href="https://w3c.github.io/webdriver-bidi/#websocket-url">https://w3c.github.io/webdriver-bidi/#websocket-url</a>

* Source/WebDriver/Capabilities.h:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::parseCapabilities const):
(WebDriver::WebDriverService::validatedCapabilities const):
(WebDriver::WebDriverService::matchCapabilities const):
* Source/WebDriver/WebDriverService.h:
* Source/WebDriver/glib/WebDriverServiceGLib.cpp:
(WebDriver::WebDriverService::platformSupportBidi const):
* Source/WebDriver/playstation/WebDriverServicePlayStation.cpp:
(WebDriver::WebDriverService::platformSupportBidi const):
* Source/WebDriver/win/WebDriverServiceWin.cpp:
(WebDriver::WebDriverService::platformSupportBidi const):

Canonical link: <a href="https://commits.webkit.org/283007@main">https://commits.webkit.org/283007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dca980967ddd7bb4419ff0a5cae77b27ab6162a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15453 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52119 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10666 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32736 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13481 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14329 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56191 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14327 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/928 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->