### PR TITLE
[JSC] Implement Iterator.prototype.constructor & Iterator.prototype[@@toStringTag]

### DIFF
--- a/JSTests/stress/iterator-prototype-constructor-new.js
+++ b/JSTests/stress/iterator-prototype-constructor-new.js
@@ -1,0 +1,24 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+function assert(a, b) {
+    if (a !== b)
+        throw new Error("Expected: " + b + " but got: " + a);
+}
+
+function assertThrows(expectedError, f) {
+    try {
+        f();
+    } catch (e) {
+        assert(e instanceof expectedError, true);
+    }
+}
+
+// https://tc39.es/proposal-iterator-helpers/#sec-iterator
+assertThrows(TypeError, function () {
+    new Iterator();
+});
+
+// https://tc39.es/proposal-iterator-helpers/#sec-iterator
+class MyIterator extends Iterator {};
+const myIterator = new MyIterator();
+assert(myIterator instanceof Iterator, true);

--- a/JSTests/stress/iterator-prototype-constructor-setter.js
+++ b/JSTests/stress/iterator-prototype-constructor-setter.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+function assert(a, b) {
+    if (a !== b)
+        throw new Error("Expected: " + b + " but got: " + a);
+}
+
+function assertThrows(expectedError, f) {
+    try {
+        f();
+    } catch (e) {
+        assert(e instanceof expectedError, true);
+    }
+}
+
+// see https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-constructor
+assertThrows(TypeError, function () {
+    Iterator.prototype.constructor = {};
+});

--- a/JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js
+++ b/JSTests/stress/iterator-prototype-to-string-tag-basic-setter.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--useIteratorHelpers=1")
+
+function assert(a, b) {
+    if (a !== b)
+        throw new Error("Expected: " + b + " but got: " + a);
+}
+
+function assertThrows(expectedError, f) {
+    try {
+        f();
+    } catch (e) {
+        assert(e instanceof expectedError, true);
+    }
+}
+
+// see https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-@@tostringtag
+assertThrows(TypeError, function () {
+    Iterator.prototype[Symbol.toStringTag] = "foo";
+});

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -3,6 +3,7 @@
 flags:
   SharedArrayBuffer: useSharedArrayBuffer
   Atomics: useSharedArrayBuffer
+  iterator-helpers: useIteratorHelpers
   Temporal: useTemporal
   ShadowRealm: useShadowRealm
   promise-try: usePromiseTryMethod
@@ -13,7 +14,6 @@ skip:
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
-    - iterator-helpers
     - explicit-resource-management
     - regexp-modifiers
     - source-phase-imports

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -58,6 +58,945 @@ test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
 test/built-ins/Function/prototype/toString/built-in-function-object.js:
   default: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
   strict mode: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
+test/built-ins/Iterator/from/callable.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from(g())', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from(g())', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/get-next-method-only-once.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iterator)', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iterator)', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/from/is-function.js:
+  default: 'Test262Error: The value of `typeof Iterator.from` is "function" Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: The value of `typeof Iterator.from` is "function" Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/from/iterable-primitives.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from(new Number(5))', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from(new Number(5))', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/iterable-to-iterator-fallback.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iter)', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iter)', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/from/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/from/primitives.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from('string')', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from('string')', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/prop-desc.js:
+  default: 'Test262Error: obj should have an own property from'
+  strict mode: 'Test262Error: obj should have an own property from'
+test/built-ins/Iterator/from/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.from)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.from)')"
+test/built-ins/Iterator/from/result-proto.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iter)', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iter)', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/supports-iterable.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from([0, 1, 2, 3])', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from([0, 1, 2, 3])', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/from/supports-iterator.js:
+  default: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iter)', 'Iterator.from' is undefined)"
+  strict mode: "TypeError: Iterator.from is not a function. (In 'Iterator.from(iter)', 'Iterator.from' is undefined)"
+test/built-ins/Iterator/prototype/drop/argument-effect-order.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+test/built-ins/Iterator/prototype/drop/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+test/built-ins/Iterator/prototype/drop/exhaustion-does-not-call-return.js:
+  default: "TypeError: iterator.drop is not a function. (In 'iterator.drop(0)', 'iterator.drop' is undefined)"
+  strict mode: "TypeError: iterator.drop is not a function. (In 'iterator.drop(0)', 'iterator.drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/get-next-method-only-once.js:
+  default: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+  strict mode: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/drop/get-return-method-throws.js:
+  default: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(1)', 'new TestIterator().drop' is undefined)"
+  strict mode: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(1)', 'new TestIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/drop/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/drop/limit-equals-total.js:
+  default: "TypeError: g().drop is not a function. (In 'g().drop(2)', 'g().drop' is undefined)"
+  strict mode: "TypeError: g().drop is not a function. (In 'g().drop(2)', 'g().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/limit-greater-than-total.js:
+  default: "TypeError: g().drop is not a function. (In 'g().drop(3)', 'g().drop' is undefined)"
+  strict mode: "TypeError: g().drop is not a function. (In 'g().drop(3)', 'g().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/limit-less-than-total.js:
+  default: "TypeError: g().drop is not a function. (In 'g().drop(1)', 'g().drop' is undefined)"
+  strict mode: "TypeError: g().drop is not a function. (In 'g().drop(1)', 'g().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/limit-rangeerror.js:
+  default: "TypeError: iterator.drop is not a function. (In 'iterator.drop(0)', 'iterator.drop' is undefined)"
+  strict mode: "TypeError: iterator.drop is not a function. (In 'iterator.drop(0)', 'iterator.drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/limit-tonumber-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/drop/limit-tonumber.js:
+  default: 'TypeError: iterator'
+  strict mode: 'TypeError: iterator'
+test/built-ins/Iterator/prototype/drop/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/drop/next-method-returns-non-object.js:
+  default: "TypeError: new NonObjectIterator().drop is not a function. (In 'new NonObjectIterator().drop(0)', 'new NonObjectIterator().drop' is undefined)"
+  strict mode: "TypeError: new NonObjectIterator().drop is not a function. (In 'new NonObjectIterator().drop(0)', 'new NonObjectIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/next-method-returns-throwing-done.js:
+  default: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/next-method-returns-throwing-value-done.js:
+  default: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/next-method-returns-throwing-value.js:
+  default: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/next-method-throws.js:
+  default: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().drop is not a function. (In 'new ThrowingIterator().drop(0)', 'new ThrowingIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/prop-desc.js:
+  default: 'Test262Error: obj should have an own property drop'
+  strict mode: 'Test262Error: obj should have an own property drop'
+test/built-ins/Iterator/prototype/drop/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.drop)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.drop)')"
+test/built-ins/Iterator/prototype/drop/result-is-iterator.js:
+  default: "TypeError: (function* () {})().drop is not a function. (In '(function* () {})().drop(0)', '(function* () {})().drop' is undefined)"
+  strict mode: "TypeError: (function* () {})().drop is not a function. (In '(function* () {})().drop(0)', '(function* () {})().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/return-is-forwarded.js:
+  default: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(0)', 'new TestIterator().drop' is undefined)"
+  strict mode: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(0)', 'new TestIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/return-is-not-forwarded-after-exhaustion.js:
+  default: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(0)', 'new TestIterator().drop' is undefined)"
+  strict mode: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(0)', 'new TestIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/this-non-callable-next.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+test/built-ins/Iterator/prototype/drop/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.drop.call')"
+test/built-ins/Iterator/prototype/drop/throws-typeerror-when-generator-is-running.js:
+  default: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(100)', 'new TestIterator().drop' is undefined)"
+  strict mode: "TypeError: new TestIterator().drop is not a function. (In 'new TestIterator().drop(100)', 'new TestIterator().drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/underlying-iterator-advanced-in-parallel.js:
+  default: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+  strict mode: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/underlying-iterator-closed-in-parallel.js:
+  default: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+  strict mode: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+test/built-ins/Iterator/prototype/drop/underlying-iterator-closed.js:
+  default: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+  strict mode: "TypeError: iterator.drop is not a function. (In 'iterator.drop(2)', 'iterator.drop' is undefined)"
+test/built-ins/Iterator/prototype/every/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.every.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.every.call')"
+test/built-ins/Iterator/prototype/every/get-next-method-only-once.js:
+  default: "TypeError: iterator.every is not a function. (In 'iterator.every(() => true)', 'iterator.every' is undefined)"
+  strict mode: "TypeError: iterator.every is not a function. (In 'iterator.every(() => true)', 'iterator.every' is undefined)"
+test/built-ins/Iterator/prototype/every/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/get-return-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/every/iterator-already-exhausted.js:
+  default: "TypeError: iterator.every is not a function. (In 'iterator.every(() => true)', 'iterator.every' is undefined)"
+  strict mode: "TypeError: iterator.every is not a function. (In 'iterator.every(() => true)', 'iterator.every' is undefined)"
+test/built-ins/Iterator/prototype/every/iterator-has-no-return.js:
+  default: "TypeError: iterator.every is not a function. (In 'iterator.every(v => v < 4)', 'iterator.every' is undefined)"
+  strict mode: "TypeError: iterator.every is not a function. (In 'iterator.every(v => v < 4)', 'iterator.every' is undefined)"
+test/built-ins/Iterator/prototype/every/iterator-return-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/every/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/every/next-method-returns-throwing-done.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/next-method-returns-throwing-value-done.js:
+  default: "TypeError: iterator.every is not a function. (In 'iterator.every(() => {})', 'iterator.every' is undefined)"
+  strict mode: "TypeError: iterator.every is not a function. (In 'iterator.every(() => {})', 'iterator.every' is undefined)"
+test/built-ins/Iterator/prototype/every/next-method-returns-throwing-value.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/predicate-args.js:
+  default: "TypeError: iter.every is not a function. (In 'iter.every((v, count) => {"
+  strict mode: "TypeError: iter.every is not a function. (In 'iter.every((v, count) => {"
+test/built-ins/Iterator/prototype/every/predicate-returns-falsey.js:
+  default: "TypeError: iter.every is not a function. (In 'iter.every(v => {"
+  strict mode: "TypeError: iter.every is not a function. (In 'iter.every(v => {"
+test/built-ins/Iterator/prototype/every/predicate-returns-non-boolean.js:
+  default: "TypeError: iter.every is not a function. (In 'iter.every(v => {"
+  strict mode: "TypeError: iter.every is not a function. (In 'iter.every(v => {"
+test/built-ins/Iterator/prototype/every/predicate-returns-truthy-then-falsey.js:
+  default: "TypeError: iter.every is not a function. (In 'iter.every(v => {"
+  strict mode: "TypeError: iter.every is not a function. (In 'iter.every(v => {"
+test/built-ins/Iterator/prototype/every/predicate-returns-truthy.js:
+  default: "TypeError: g().every is not a function. (In 'g().every(() => true)', 'g().every' is undefined)"
+  strict mode: "TypeError: g().every is not a function. (In 'g().every(() => true)', 'g().every' is undefined)"
+test/built-ins/Iterator/prototype/every/predicate-this.js:
+  default: "TypeError: iter.every is not a function. (In 'iter.every(function (v, count) {"
+  strict mode: "TypeError: iter.every is not a function. (In 'iter.every(function (v, count) {"
+test/built-ins/Iterator/prototype/every/predicate-throws-then-closing-iterator-also-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/predicate-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/every/prop-desc.js:
+  default: 'Test262Error: obj should have an own property every'
+  strict mode: 'Test262Error: obj should have an own property every'
+test/built-ins/Iterator/prototype/every/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.every)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.every)')"
+test/built-ins/Iterator/prototype/every/result-is-boolean.js:
+  default: "TypeError: iter.every is not a function. (In 'iter.every(() => {})', 'iter.every' is undefined)"
+  strict mode: "TypeError: iter.every is not a function. (In 'iter.every(() => {})', 'iter.every' is undefined)"
+test/built-ins/Iterator/prototype/every/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.every.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.every.call')"
+test/built-ins/Iterator/prototype/filter/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.filter.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.filter.call')"
+test/built-ins/Iterator/prototype/filter/exhaustion-does-not-call-return.js:
+  default: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => false)', 'new TestIterator().filter' is undefined)"
+  strict mode: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => false)', 'new TestIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/get-next-method-only-once.js:
+  default: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => false)', 'iterator.filter' is undefined)"
+  strict mode: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => false)', 'iterator.filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/filter/get-return-method-throws.js:
+  default: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => true)', 'new TestIterator().filter' is undefined)"
+  strict mode: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => true)', 'new TestIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/filter/iterator-already-exhausted.js:
+  default: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+  strict mode: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/iterator-return-method-throws.js:
+  default: "TypeError: new IteratorThrows().filter is not a function. (In 'new IteratorThrows().filter(() => false)', 'new IteratorThrows().filter' is undefined)"
+  strict mode: "TypeError: new IteratorThrows().filter is not a function. (In 'new IteratorThrows().filter(() => false)', 'new IteratorThrows().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/filter/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/filter/next-method-returns-non-object.js:
+  default: "TypeError: new NonObjectIterator().filter is not a function. (In 'new NonObjectIterator().filter(() => true)', 'new NonObjectIterator().filter' is undefined)"
+  strict mode: "TypeError: new NonObjectIterator().filter is not a function. (In 'new NonObjectIterator().filter(() => true)', 'new NonObjectIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/next-method-returns-throwing-done.js:
+  default: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/next-method-returns-throwing-value-done.js:
+  default: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/next-method-returns-throwing-value.js:
+  default: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/next-method-throws.js:
+  default: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().filter is not a function. (In 'new ThrowingIterator().filter(() => true)', 'new ThrowingIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/predicate-args.js:
+  default: "TypeError: g().filter is not a function. (In 'g().filter((v, count) => {"
+  strict mode: "TypeError: g().filter is not a function. (In 'g().filter((v, count) => {"
+test/built-ins/Iterator/prototype/filter/predicate-filters.js:
+  default: "TypeError: iterator.filter is not a function. (In 'iterator.filter(value => {"
+  strict mode: "TypeError: iterator.filter is not a function. (In 'iterator.filter(value => {"
+test/built-ins/Iterator/prototype/filter/predicate-returns-non-boolean.js:
+  default: "TypeError: iter.filter is not a function. (In 'iter.filter(v => {"
+  strict mode: "TypeError: iter.filter is not a function. (In 'iter.filter(v => {"
+test/built-ins/Iterator/prototype/filter/predicate-this.js:
+  default: "TypeError: iter.filter is not a function. (In 'iter.filter(function (v, count) {"
+  strict mode: "TypeError: iter.filter is not a function. (In 'iter.filter(function (v, count) {"
+test/built-ins/Iterator/prototype/filter/predicate-throws-then-closing-iterator-also-throws.js:
+  default: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => {"
+  strict mode: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => {"
+test/built-ins/Iterator/prototype/filter/predicate-throws.js:
+  default: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => {"
+  strict mode: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => {"
+test/built-ins/Iterator/prototype/filter/prop-desc.js:
+  default: 'Test262Error: obj should have an own property filter'
+  strict mode: 'Test262Error: obj should have an own property filter'
+test/built-ins/Iterator/prototype/filter/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.filter)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.filter)')"
+test/built-ins/Iterator/prototype/filter/result-is-iterator.js:
+  default: "TypeError: (function* () {})().filter is not a function. (In '(function* () {})().filter(() => true)', '(function* () {})().filter' is undefined)"
+  strict mode: "TypeError: (function* () {})().filter is not a function. (In '(function* () {})().filter(() => true)', '(function* () {})().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/return-is-forwarded.js:
+  default: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => false)', 'new TestIterator().filter' is undefined)"
+  strict mode: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => false)', 'new TestIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/return-is-not-forwarded-after-exhaustion.js:
+  default: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => true)', 'new TestIterator().filter' is undefined)"
+  strict mode: "TypeError: new TestIterator().filter is not a function. (In 'new TestIterator().filter(() => true)', 'new TestIterator().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/this-non-callable-next.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.filter.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.filter.call')"
+test/built-ins/Iterator/prototype/filter/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.filter.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.filter.call')"
+test/built-ins/Iterator/prototype/filter/throws-typeerror-when-generator-is-running.js:
+  default: "TypeError: g().filter is not a function. (In 'g().filter(predicate)', 'g().filter' is undefined)"
+  strict mode: "TypeError: g().filter is not a function. (In 'g().filter(predicate)', 'g().filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/underlying-iterator-advanced-in-parallel.js:
+  default: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+  strict mode: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/underlying-iterator-closed-in-parallel.js:
+  default: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+  strict mode: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+test/built-ins/Iterator/prototype/filter/underlying-iterator-closed.js:
+  default: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+  strict mode: "TypeError: iterator.filter is not a function. (In 'iterator.filter(() => true)', 'iterator.filter' is undefined)"
+test/built-ins/Iterator/prototype/find/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.find.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.find.call')"
+test/built-ins/Iterator/prototype/find/get-next-method-only-once.js:
+  default: "TypeError: iterator.find is not a function. (In 'iterator.find(() => true)', 'iterator.find' is undefined)"
+  strict mode: "TypeError: iterator.find is not a function. (In 'iterator.find(() => true)', 'iterator.find' is undefined)"
+test/built-ins/Iterator/prototype/find/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/get-return-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/find/iterator-already-exhausted.js:
+  default: "TypeError: iterator.find is not a function. (In 'iterator.find(() => true)', 'iterator.find' is undefined)"
+  strict mode: "TypeError: iterator.find is not a function. (In 'iterator.find(() => true)', 'iterator.find' is undefined)"
+test/built-ins/Iterator/prototype/find/iterator-has-no-return.js:
+  default: "TypeError: iterator.find is not a function. (In 'iterator.find(v => v > 3)', 'iterator.find' is undefined)"
+  strict mode: "TypeError: iterator.find is not a function. (In 'iterator.find(v => v > 3)', 'iterator.find' is undefined)"
+test/built-ins/Iterator/prototype/find/iterator-return-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/find/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/find/next-method-returns-throwing-done.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/next-method-returns-throwing-value-done.js:
+  default: "TypeError: iterator.find is not a function. (In 'iterator.find(() => {})', 'iterator.find' is undefined)"
+  strict mode: "TypeError: iterator.find is not a function. (In 'iterator.find(() => {})', 'iterator.find' is undefined)"
+test/built-ins/Iterator/prototype/find/next-method-returns-throwing-value.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/predicate-args.js:
+  default: "TypeError: iter.find is not a function. (In 'iter.find((v, count) => {"
+  strict mode: "TypeError: iter.find is not a function. (In 'iter.find((v, count) => {"
+test/built-ins/Iterator/prototype/find/predicate-returns-falsey-then-truthy.js:
+  default: "TypeError: iter.find is not a function. (In 'iter.find(v => {"
+  strict mode: "TypeError: iter.find is not a function. (In 'iter.find(v => {"
+test/built-ins/Iterator/prototype/find/predicate-returns-falsey.js:
+  default: "TypeError: g().find is not a function. (In 'g().find(() => false)', 'g().find' is undefined)"
+  strict mode: "TypeError: g().find is not a function. (In 'g().find(() => false)', 'g().find' is undefined)"
+test/built-ins/Iterator/prototype/find/predicate-returns-non-boolean.js:
+  default: "TypeError: iter.find is not a function. (In 'iter.find(v => {"
+  strict mode: "TypeError: iter.find is not a function. (In 'iter.find(v => {"
+test/built-ins/Iterator/prototype/find/predicate-returns-truthy.js:
+  default: "TypeError: iter.find is not a function. (In 'iter.find(v => {"
+  strict mode: "TypeError: iter.find is not a function. (In 'iter.find(v => {"
+test/built-ins/Iterator/prototype/find/predicate-this.js:
+  default: "TypeError: iter.find is not a function. (In 'iter.find(function (v, count) {"
+  strict mode: "TypeError: iter.find is not a function. (In 'iter.find(function (v, count) {"
+test/built-ins/Iterator/prototype/find/predicate-throws-then-closing-iterator-also-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/predicate-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/find/prop-desc.js:
+  default: 'Test262Error: obj should have an own property find'
+  strict mode: 'Test262Error: obj should have an own property find'
+test/built-ins/Iterator/prototype/find/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.find)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.find)')"
+test/built-ins/Iterator/prototype/find/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.find.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.find.call')"
+test/built-ins/Iterator/prototype/flatMap/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.flatMap.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.flatMap.call')"
+test/built-ins/Iterator/prototype/flatMap/exhaustion-does-not-call-return.js:
+  default: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => [])', 'new TestIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => [])', 'new TestIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/flattens-iterable.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap((v, count) => {"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap((v, count) => {"
+test/built-ins/Iterator/prototype/flatMap/flattens-iterator.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap((v, count) => {"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap((v, count) => {"
+test/built-ins/Iterator/prototype/flatMap/flattens-only-depth-1.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => v)', 'g().flatMap' is undefined)"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => v)', 'g().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/get-next-method-only-once.js:
+  default: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(() => [])', 'iterator.flatMap' is undefined)"
+  strict mode: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(() => [])', 'iterator.flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/flatMap/get-return-method-throws.js:
+  default: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(x => [x])', 'new TestIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(x => [x])', 'new TestIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/flatMap/iterable-primitives-are-not-flattened.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => new Number(5))', 'g().flatMap' is undefined)"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => new Number(5))', 'g().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/iterable-to-iterator-fallback.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => {"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => {"
+test/built-ins/Iterator/prototype/flatMap/iterator-already-exhausted.js:
+  default: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(x => [x])', 'iterator.flatMap' is undefined)"
+  strict mode: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(x => [x])', 'iterator.flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/iterator-return-method-throws.js:
+  default: "TypeError: new IteratorThrows().flatMap is not a function. (In 'new IteratorThrows().flatMap(() => [])', 'new IteratorThrows().flatMap' is undefined)"
+  strict mode: "TypeError: new IteratorThrows().flatMap is not a function. (In 'new IteratorThrows().flatMap(() => [])', 'new IteratorThrows().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/flatMap/mapper-args.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap((v, count) => {"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap((v, count) => {"
+test/built-ins/Iterator/prototype/flatMap/mapper-returns-closed-iterator.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => closed)', 'g().flatMap' is undefined)"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => closed)', 'g().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/mapper-returns-non-object.js:
+  default: "TypeError: iter.flatMap is not a function. (In 'iter.flatMap(v => {"
+  strict mode: "TypeError: iter.flatMap is not a function. (In 'iter.flatMap(v => {"
+test/built-ins/Iterator/prototype/flatMap/mapper-this.js:
+  default: "TypeError: iter.flatMap is not a function. (In 'iter.flatMap(function (v, count) {"
+  strict mode: "TypeError: iter.flatMap is not a function. (In 'iter.flatMap(function (v, count) {"
+test/built-ins/Iterator/prototype/flatMap/mapper-throws-then-closing-iterator-also-throws.js:
+  default: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => {"
+  strict mode: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => {"
+test/built-ins/Iterator/prototype/flatMap/mapper-throws.js:
+  default: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => {"
+  strict mode: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => {"
+test/built-ins/Iterator/prototype/flatMap/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/flatMap/next-method-returns-non-object.js:
+  default: "TypeError: new NonObjectIterator().flatMap is not a function. (In 'new NonObjectIterator().flatMap(x => [x])', 'new NonObjectIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new NonObjectIterator().flatMap is not a function. (In 'new NonObjectIterator().flatMap(x => [x])', 'new NonObjectIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/next-method-returns-throwing-done.js:
+  default: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/next-method-returns-throwing-value-done.js:
+  default: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/next-method-returns-throwing-value.js:
+  default: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/next-method-throws.js:
+  default: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().flatMap is not a function. (In 'new ThrowingIterator().flatMap(x => [x])', 'new ThrowingIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/prop-desc.js:
+  default: 'Test262Error: obj should have an own property flatMap'
+  strict mode: 'Test262Error: obj should have an own property flatMap'
+test/built-ins/Iterator/prototype/flatMap/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.flatMap)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.flatMap)')"
+test/built-ins/Iterator/prototype/flatMap/result-is-iterator.js:
+  default: "TypeError: (function* () {})().flatMap is not a function. (In '(function* () {})().flatMap(() => [])', '(function* () {})().flatMap' is undefined)"
+  strict mode: "TypeError: (function* () {})().flatMap is not a function. (In '(function* () {})().flatMap(() => [])', '(function* () {})().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/return-is-forwarded-to-mapper-result.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => ({"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => ({"
+test/built-ins/Iterator/prototype/flatMap/return-is-forwarded-to-underlying-iterator.js:
+  default: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => [])', 'new TestIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(() => [])', 'new TestIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/return-is-not-forwarded-after-exhaustion.js:
+  default: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(x => [x])', 'new TestIterator().flatMap' is undefined)"
+  strict mode: "TypeError: new TestIterator().flatMap is not a function. (In 'new TestIterator().flatMap(x => [x])', 'new TestIterator().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/strings-are-not-flattened.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => new String('string'))', 'g().flatMap' is undefined)"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(v => new String('string'))', 'g().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/this-non-callable-next.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.flatMap.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.flatMap.call')"
+test/built-ins/Iterator/prototype/flatMap/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.flatMap.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.flatMap.call')"
+test/built-ins/Iterator/prototype/flatMap/throws-typeerror-when-generator-is-running.js:
+  default: "TypeError: g().flatMap is not a function. (In 'g().flatMap(mapper)', 'g().flatMap' is undefined)"
+  strict mode: "TypeError: g().flatMap is not a function. (In 'g().flatMap(mapper)', 'g().flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/underlying-iterator-advanced-in-parallel.js:
+  default: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(x => [x])', 'iterator.flatMap' is undefined)"
+  strict mode: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(x => [x])', 'iterator.flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/underlying-iterator-closed-in-parallel.js:
+  default: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(x => [x])', 'iterator.flatMap' is undefined)"
+  strict mode: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(x => [x])', 'iterator.flatMap' is undefined)"
+test/built-ins/Iterator/prototype/flatMap/underlying-iterator-closed.js:
+  default: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(() => [])', 'iterator.flatMap' is undefined)"
+  strict mode: "TypeError: iterator.flatMap is not a function. (In 'iterator.flatMap(() => [])', 'iterator.flatMap' is undefined)"
+test/built-ins/Iterator/prototype/forEach/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
+test/built-ins/Iterator/prototype/forEach/fn-args.js:
+  default: "TypeError: iter.forEach is not a function. (In 'iter.forEach((v, count) => {"
+  strict mode: "TypeError: iter.forEach is not a function. (In 'iter.forEach((v, count) => {"
+test/built-ins/Iterator/prototype/forEach/fn-called-for-each-yielded-value.js:
+  default: "TypeError: g().forEach is not a function. (In 'g().forEach((value, count) => {"
+  strict mode: "TypeError: g().forEach is not a function. (In 'g().forEach((value, count) => {"
+test/built-ins/Iterator/prototype/forEach/fn-this.js:
+  default: "TypeError: iter.forEach is not a function. (In 'iter.forEach(function (v, count) {"
+  strict mode: "TypeError: iter.forEach is not a function. (In 'iter.forEach(function (v, count) {"
+test/built-ins/Iterator/prototype/forEach/fn-throws-then-closing-iterator-also-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/forEach/fn-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/forEach/get-next-method-only-once.js:
+  default: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
+  strict mode: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
+test/built-ins/Iterator/prototype/forEach/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/forEach/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/forEach/iterator-already-exhausted.js:
+  default: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {"
+  strict mode: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {"
+test/built-ins/Iterator/prototype/forEach/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/forEach/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/forEach/next-method-returns-throwing-done.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/forEach/next-method-returns-throwing-value-done.js:
+  default: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
+  strict mode: "TypeError: iterator.forEach is not a function. (In 'iterator.forEach(() => {})', 'iterator.forEach' is undefined)"
+test/built-ins/Iterator/prototype/forEach/next-method-returns-throwing-value.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/forEach/next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/forEach/prop-desc.js:
+  default: 'Test262Error: obj should have an own property forEach'
+  strict mode: 'Test262Error: obj should have an own property forEach'
+test/built-ins/Iterator/prototype/forEach/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.forEach)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.forEach)')"
+test/built-ins/Iterator/prototype/forEach/result-is-undefined.js:
+  default: "TypeError: iter.forEach is not a function. (In 'iter.forEach(() => {})', 'iter.forEach' is undefined)"
+  strict mode: "TypeError: iter.forEach is not a function. (In 'iter.forEach(() => {})', 'iter.forEach' is undefined)"
+test/built-ins/Iterator/prototype/forEach/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.forEach.call')"
+test/built-ins/Iterator/prototype/map/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
+test/built-ins/Iterator/prototype/map/exhaustion-does-not-call-return.js:
+  default: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+  strict mode: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/get-next-method-only-once.js:
+  default: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+  strict mode: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+test/built-ins/Iterator/prototype/map/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/map/get-return-method-throws.js:
+  default: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+  strict mode: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/map/iterator-already-exhausted.js:
+  default: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+  strict mode: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+test/built-ins/Iterator/prototype/map/iterator-return-method-throws.js:
+  default: "TypeError: new IteratorThrows().map is not a function. (In 'new IteratorThrows().map(() => 0)', 'new IteratorThrows().map' is undefined)"
+  strict mode: "TypeError: new IteratorThrows().map is not a function. (In 'new IteratorThrows().map(() => 0)', 'new IteratorThrows().map' is undefined)"
+test/built-ins/Iterator/prototype/map/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/map/mapper-args.js:
+  default: "TypeError: g().map is not a function. (In 'g().map((v, count) => {"
+  strict mode: "TypeError: g().map is not a function. (In 'g().map((v, count) => {"
+test/built-ins/Iterator/prototype/map/mapper-this.js:
+  default: "TypeError: iter.map is not a function. (In 'iter.map(function (v, count) {"
+  strict mode: "TypeError: iter.map is not a function. (In 'iter.map(function (v, count) {"
+test/built-ins/Iterator/prototype/map/mapper-throws-then-closing-iterator-also-throws.js:
+  default: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => {"
+  strict mode: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => {"
+test/built-ins/Iterator/prototype/map/mapper-throws.js:
+  default: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => {"
+  strict mode: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => {"
+test/built-ins/Iterator/prototype/map/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/map/next-method-returns-non-object.js:
+  default: "TypeError: new NonObjectIterator().map is not a function. (In 'new NonObjectIterator().map(() => 0)', 'new NonObjectIterator().map' is undefined)"
+  strict mode: "TypeError: new NonObjectIterator().map is not a function. (In 'new NonObjectIterator().map(() => 0)', 'new NonObjectIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/next-method-returns-throwing-done.js:
+  default: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/next-method-returns-throwing-value-done.js:
+  default: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/next-method-returns-throwing-value.js:
+  default: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/next-method-throws.js:
+  default: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().map is not a function. (In 'new ThrowingIterator().map(() => 0)', 'new ThrowingIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/prop-desc.js:
+  default: 'Test262Error: obj should have an own property map'
+  strict mode: 'Test262Error: obj should have an own property map'
+test/built-ins/Iterator/prototype/map/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.map)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.map)')"
+test/built-ins/Iterator/prototype/map/result-is-iterator.js:
+  default: "TypeError: (function* () {})().map is not a function. (In '(function* () {})().map(() => 0)', '(function* () {})().map' is undefined)"
+  strict mode: "TypeError: (function* () {})().map is not a function. (In '(function* () {})().map(() => 0)', '(function* () {})().map' is undefined)"
+test/built-ins/Iterator/prototype/map/return-is-forwarded-to-underlying-iterator.js:
+  default: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+  strict mode: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/return-is-not-forwarded-after-exhaustion.js:
+  default: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+  strict mode: "TypeError: new TestIterator().map is not a function. (In 'new TestIterator().map(() => 0)', 'new TestIterator().map' is undefined)"
+test/built-ins/Iterator/prototype/map/returned-iterator-yields-mapper-return-values.js:
+  default: "TypeError: g().map is not a function. (In 'g().map(x => x)', 'g().map' is undefined)"
+  strict mode: "TypeError: g().map is not a function. (In 'g().map(x => x)', 'g().map' is undefined)"
+test/built-ins/Iterator/prototype/map/this-non-callable-next.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
+test/built-ins/Iterator/prototype/map/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.map.call')"
+test/built-ins/Iterator/prototype/map/throws-typeerror-when-generator-is-running.js:
+  default: "TypeError: g().map is not a function. (In 'g().map(mapper)', 'g().map' is undefined)"
+  strict mode: "TypeError: g().map is not a function. (In 'g().map(mapper)', 'g().map' is undefined)"
+test/built-ins/Iterator/prototype/map/underlying-iterator-advanced-in-parallel.js:
+  default: "TypeError: iterator.map is not a function. (In 'iterator.map(x => x)', 'iterator.map' is undefined)"
+  strict mode: "TypeError: iterator.map is not a function. (In 'iterator.map(x => x)', 'iterator.map' is undefined)"
+test/built-ins/Iterator/prototype/map/underlying-iterator-closed-in-parallel.js:
+  default: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+  strict mode: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+test/built-ins/Iterator/prototype/map/underlying-iterator-closed.js:
+  default: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+  strict mode: "TypeError: iterator.map is not a function. (In 'iterator.map(() => 0)', 'iterator.map' is undefined)"
+test/built-ins/Iterator/prototype/reduce/argument-effect-order.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.reduce.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.reduce.call')"
+test/built-ins/Iterator/prototype/reduce/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.reduce.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.reduce.call')"
+test/built-ins/Iterator/prototype/reduce/get-next-method-only-once.js:
+  default: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(x => x)', 'iterator.reduce' is undefined)"
+  strict mode: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(x => x)', 'iterator.reduce' is undefined)"
+test/built-ins/Iterator/prototype/reduce/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/reduce/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/reduce/iterator-already-exhausted-initial-value.js:
+  default: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {}, initialValue)', 'iterator.reduce' is undefined)"
+  strict mode: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {}, initialValue)', 'iterator.reduce' is undefined)"
+test/built-ins/Iterator/prototype/reduce/iterator-already-exhausted-no-initial-value.js:
+  default: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {}, 0)', 'iterator.reduce' is undefined)"
+  strict mode: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {}, 0)', 'iterator.reduce' is undefined)"
+test/built-ins/Iterator/prototype/reduce/iterator-yields-once-initial-value.js:
+  default: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+  strict mode: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+test/built-ins/Iterator/prototype/reduce/iterator-yields-once-no-initial-value.js:
+  default: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+  strict mode: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+test/built-ins/Iterator/prototype/reduce/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/reduce/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/reduce/next-method-returns-throwing-done.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/reduce/next-method-returns-throwing-value-done.js:
+  default: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {}, 0)', 'iterator.reduce' is undefined)"
+  strict mode: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {}, 0)', 'iterator.reduce' is undefined)"
+test/built-ins/Iterator/prototype/reduce/next-method-returns-throwing-value.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/reduce/next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/reduce/non-callable-reducer.js:
+  default: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {})', 'iterator.reduce' is undefined)"
+  strict mode: "TypeError: iterator.reduce is not a function. (In 'iterator.reduce(() => {})', 'iterator.reduce' is undefined)"
+test/built-ins/Iterator/prototype/reduce/prop-desc.js:
+  default: 'Test262Error: obj should have an own property reduce'
+  strict mode: 'Test262Error: obj should have an own property reduce'
+test/built-ins/Iterator/prototype/reduce/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.reduce)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.reduce)')"
+test/built-ins/Iterator/prototype/reduce/reducer-args-initial-value.js:
+  default: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+  strict mode: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+test/built-ins/Iterator/prototype/reduce/reducer-args-no-initial-value.js:
+  default: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+  strict mode: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+test/built-ins/Iterator/prototype/reduce/reducer-memo-can-be-any-type.js:
+  default: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+  strict mode: "TypeError: iter.reduce is not a function. (In 'iter.reduce((memo, v, count) => {"
+test/built-ins/Iterator/prototype/reduce/reducer-this.js:
+  default: "TypeError: iter.reduce is not a function. (In 'iter.reduce(function (memo, v, count) {"
+  strict mode: "TypeError: iter.reduce is not a function. (In 'iter.reduce(function (memo, v, count) {"
+test/built-ins/Iterator/prototype/reduce/reducer-throws-then-closing-iterator-also-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/reduce/reducer-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/reduce/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.reduce.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.reduce.call')"
+test/built-ins/Iterator/prototype/some/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.some.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.some.call')"
+test/built-ins/Iterator/prototype/some/get-next-method-only-once.js:
+  default: "TypeError: iterator.some is not a function. (In 'iterator.some(() => true)', 'iterator.some' is undefined)"
+  strict mode: "TypeError: iterator.some is not a function. (In 'iterator.some(() => true)', 'iterator.some' is undefined)"
+test/built-ins/Iterator/prototype/some/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/get-return-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/some/iterator-already-exhausted.js:
+  default: "TypeError: iterator.some is not a function. (In 'iterator.some(() => true)', 'iterator.some' is undefined)"
+  strict mode: "TypeError: iterator.some is not a function. (In 'iterator.some(() => true)', 'iterator.some' is undefined)"
+test/built-ins/Iterator/prototype/some/iterator-has-no-return.js:
+  default: "TypeError: iterator.some is not a function. (In 'iterator.some(v => v > 3)', 'iterator.some' is undefined)"
+  strict mode: "TypeError: iterator.some is not a function. (In 'iterator.some(v => v > 3)', 'iterator.some' is undefined)"
+test/built-ins/Iterator/prototype/some/iterator-return-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/some/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/some/next-method-returns-throwing-done.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/next-method-returns-throwing-value-done.js:
+  default: "TypeError: iterator.some is not a function. (In 'iterator.some(() => {})', 'iterator.some' is undefined)"
+  strict mode: "TypeError: iterator.some is not a function. (In 'iterator.some(() => {})', 'iterator.some' is undefined)"
+test/built-ins/Iterator/prototype/some/next-method-returns-throwing-value.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/predicate-args.js:
+  default: "TypeError: iter.some is not a function. (In 'iter.some((v, count) => {"
+  strict mode: "TypeError: iter.some is not a function. (In 'iter.some((v, count) => {"
+test/built-ins/Iterator/prototype/some/predicate-returns-falsey-then-truthy.js:
+  default: "TypeError: iter.some is not a function. (In 'iter.some(v => {"
+  strict mode: "TypeError: iter.some is not a function. (In 'iter.some(v => {"
+test/built-ins/Iterator/prototype/some/predicate-returns-falsey.js:
+  default: "TypeError: g().some is not a function. (In 'g().some(() => false)', 'g().some' is undefined)"
+  strict mode: "TypeError: g().some is not a function. (In 'g().some(() => false)', 'g().some' is undefined)"
+test/built-ins/Iterator/prototype/some/predicate-returns-non-boolean.js:
+  default: "TypeError: iter.some is not a function. (In 'iter.some(v => {"
+  strict mode: "TypeError: iter.some is not a function. (In 'iter.some(v => {"
+test/built-ins/Iterator/prototype/some/predicate-returns-truthy.js:
+  default: "TypeError: iter.some is not a function. (In 'iter.some(v => {"
+  strict mode: "TypeError: iter.some is not a function. (In 'iter.some(v => {"
+test/built-ins/Iterator/prototype/some/predicate-this.js:
+  default: "TypeError: iter.some is not a function. (In 'iter.some(function (v, count) {"
+  strict mode: "TypeError: iter.some is not a function. (In 'iter.some(function (v, count) {"
+test/built-ins/Iterator/prototype/some/predicate-throws-then-closing-iterator-also-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/predicate-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/some/prop-desc.js:
+  default: 'Test262Error: obj should have an own property some'
+  strict mode: 'Test262Error: obj should have an own property some'
+test/built-ins/Iterator/prototype/some/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.some)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.some)')"
+test/built-ins/Iterator/prototype/some/result-is-boolean.js:
+  default: "TypeError: iter.some is not a function. (In 'iter.some(() => {})', 'iter.some' is undefined)"
+  strict mode: "TypeError: iter.some is not a function. (In 'iter.some(() => {})', 'iter.some' is undefined)"
+test/built-ins/Iterator/prototype/some/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.some.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.some.call')"
+test/built-ins/Iterator/prototype/take/argument-effect-order.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+test/built-ins/Iterator/prototype/take/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+test/built-ins/Iterator/prototype/take/exhaustion-calls-return.js:
+  default: "TypeError: iterator.take is not a function. (In 'iterator.take(0)', 'iterator.take' is undefined)"
+  strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(0)', 'iterator.take' is undefined)"
+test/built-ins/Iterator/prototype/take/get-next-method-only-once.js:
+  default: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+  strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+test/built-ins/Iterator/prototype/take/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/take/get-return-method-throws.js:
+  default: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(1)', 'new TestIterator().take' is undefined)"
+  strict mode: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(1)', 'new TestIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/take/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/take/limit-greater-than-or-equal-to-total.js:
+  default: "TypeError: g().take is not a function. (In 'g().take(3)', 'g().take' is undefined)"
+  strict mode: "TypeError: g().take is not a function. (In 'g().take(3)', 'g().take' is undefined)"
+test/built-ins/Iterator/prototype/take/limit-less-than-total.js:
+  default: "TypeError: g().take is not a function. (In 'g().take(0)', 'g().take' is undefined)"
+  strict mode: "TypeError: g().take is not a function. (In 'g().take(0)', 'g().take' is undefined)"
+test/built-ins/Iterator/prototype/take/limit-rangeerror.js:
+  default: "TypeError: iterator.take is not a function. (In 'iterator.take(0)', 'iterator.take' is undefined)"
+  strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(0)', 'iterator.take' is undefined)"
+test/built-ins/Iterator/prototype/take/limit-tonumber-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/take/limit-tonumber.js:
+  default: "TypeError: g().take is not a function. (In 'g().take({"
+  strict mode: "TypeError: g().take is not a function. (In 'g().take({"
+test/built-ins/Iterator/prototype/take/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/take/next-method-returns-non-object.js:
+  default: "TypeError: new NonObjectIterator().take is not a function. (In 'new NonObjectIterator().take(0)', 'new NonObjectIterator().take' is undefined)"
+  strict mode: "TypeError: new NonObjectIterator().take is not a function. (In 'new NonObjectIterator().take(0)', 'new NonObjectIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/next-method-returns-throwing-done.js:
+  default: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/next-method-returns-throwing-value-done.js:
+  default: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/next-method-returns-throwing-value.js:
+  default: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/next-method-throws.js:
+  default: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+  strict mode: "TypeError: new ThrowingIterator().take is not a function. (In 'new ThrowingIterator().take(0)', 'new ThrowingIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/prop-desc.js:
+  default: 'Test262Error: obj should have an own property take'
+  strict mode: 'Test262Error: obj should have an own property take'
+test/built-ins/Iterator/prototype/take/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.take)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.take)')"
+test/built-ins/Iterator/prototype/take/result-is-iterator.js:
+  default: "TypeError: (function* () {})().take is not a function. (In '(function* () {})().take(0)', '(function* () {})().take' is undefined)"
+  strict mode: "TypeError: (function* () {})().take is not a function. (In '(function* () {})().take(0)', '(function* () {})().take' is undefined)"
+test/built-ins/Iterator/prototype/take/return-is-forwarded.js:
+  default: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(0)', 'new TestIterator().take' is undefined)"
+  strict mode: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(0)', 'new TestIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/return-is-not-forwarded-after-exhaustion.js:
+  default: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(0)', 'new TestIterator().take' is undefined)"
+  strict mode: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(0)', 'new TestIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/this-non-callable-next.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+test/built-ins/Iterator/prototype/take/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.take.call')"
+test/built-ins/Iterator/prototype/take/throws-typeerror-when-generator-is-running.js:
+  default: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(100)', 'new TestIterator().take' is undefined)"
+  strict mode: "TypeError: new TestIterator().take is not a function. (In 'new TestIterator().take(100)', 'new TestIterator().take' is undefined)"
+test/built-ins/Iterator/prototype/take/underlying-iterator-advanced-in-parallel.js:
+  default: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+  strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+test/built-ins/Iterator/prototype/take/underlying-iterator-closed-in-parallel.js:
+  default: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+  strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+test/built-ins/Iterator/prototype/take/underlying-iterator-closed.js:
+  default: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+  strict mode: "TypeError: iterator.take is not a function. (In 'iterator.take(2)', 'iterator.take' is undefined)"
+test/built-ins/Iterator/prototype/toArray/callable.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
+test/built-ins/Iterator/prototype/toArray/get-next-method-only-once.js:
+  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
+  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
+test/built-ins/Iterator/prototype/toArray/get-next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/toArray/is-function.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Iterator/prototype/toArray/iterator-already-exhausted.js:
+  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
+  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
+test/built-ins/Iterator/prototype/toArray/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/toArray/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/Iterator/prototype/toArray/next-method-returns-throwing-done.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/toArray/next-method-returns-throwing-value-done.js:
+  default: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
+  strict mode: "TypeError: iterator.toArray is not a function. (In 'iterator.toArray()', 'iterator.toArray' is undefined)"
+test/built-ins/Iterator/prototype/toArray/next-method-returns-throwing-value.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/toArray/next-method-throws.js:
+  default: 'Test262Error: Expected a Test262Error but got a TypeError'
+  strict mode: 'Test262Error: Expected a Test262Error but got a TypeError'
+test/built-ins/Iterator/prototype/toArray/prop-desc.js:
+  default: 'Test262Error: obj should have an own property toArray'
+  strict mode: 'Test262Error: obj should have an own property toArray'
+test/built-ins/Iterator/prototype/toArray/proto.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.toArray)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(Iterator.prototype.toArray)')"
+test/built-ins/Iterator/prototype/toArray/this-plain-iterator.js:
+  default: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Iterator.prototype.toArray.call')"
 test/built-ins/Object/entries/order-after-define-property-with-function.js:
   default: 'Test262Error: Expected [a, name] and [name, a] to have the same contents. '
   strict mode: 'Test262Error: Expected [a, name] and [name, a] to have the same contents. '
@@ -1033,9 +1972,6 @@ test/intl402/DurationFormat/prototype/resolvedOptions/return-keys-order-default.
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'
   strict mode: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'
-test/intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js:
-  default: 'Test262Error: notation: "compact" Expected SameValue(«1K», «1T») to be true'
-  strict mode: 'Test262Error: notation: "compact" Expected SameValue(«1K», «1T») to be true'
 test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js:
   default: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -85,6 +85,8 @@ set(JavaScriptCore_OBJECT_LUT_SOURCES
     runtime/IntlSegmenterConstructor.cpp
     runtime/IntlSegmenterPrototype.cpp
     runtime/IntlSegmentsPrototype.cpp
+    runtime/JSIterator.cpp
+    runtime/JSIteratorConstructor.cpp
     runtime/JSDataViewPrototype.cpp
     runtime/JSGlobalObject.cpp
     runtime/JSInternalPromiseConstructor.cpp
@@ -1081,6 +1083,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSImmutableButterfly.h
     runtime/JSInternalFieldObjectImpl.h
     runtime/JSInternalPromise.h
+    runtime/JSIterator.h
+    runtime/JSIteratorConstructor.h
     runtime/JSLexicalEnvironment.h
     runtime/JSLock.h
     runtime/JSMap.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2531,6 +2531,10 @@
 
 /* Begin PBXFileReference section */
 		000BEAF0DF604481AF6AB68C /* ModuleScopeData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleScopeData.h; sourceTree = "<group>"; };
+		05517C9F2C74004600ED0CD5 /* JSIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSIterator.cpp; sourceTree = "<group>"; };
+		05517CA02C74004700ED0CD5 /* JSIteratorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIteratorConstructor.h; sourceTree = "<group>"; };
+		05517CA12C74004700ED0CD5 /* JSIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIterator.h; sourceTree = "<group>"; };
+		05517CA22C74004700ED0CD5 /* JSIteratorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSIteratorConstructor.cpp; sourceTree = "<group>"; };
 		0F0123301944EA1B00843A0C /* DFGValueStrength.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGValueStrength.cpp; path = dfg/DFGValueStrength.cpp; sourceTree = "<group>"; };
 		0F0123311944EA1B00843A0C /* DFGValueStrength.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGValueStrength.h; path = dfg/DFGValueStrength.h; sourceTree = "<group>"; };
 		0F0332BF18ADFAE1005F979A /* ExitingJITType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExitingJITType.cpp; sourceTree = "<group>"; };
@@ -8383,6 +8387,10 @@
 				E33F50771B84225700413856 /* JSInternalPromiseConstructor.h */,
 				E33F50721B8421C000413856 /* JSInternalPromisePrototype.cpp */,
 				E33F50731B8421C000413856 /* JSInternalPromisePrototype.h */,
+				05517C9F2C74004600ED0CD5 /* JSIterator.cpp */,
+				05517CA12C74004700ED0CD5 /* JSIterator.h */,
+				05517CA22C74004700ED0CD5 /* JSIteratorConstructor.cpp */,
+				05517CA02C74004700ED0CD5 /* JSIteratorConstructor.h */,
 				14DA818F0D99FD2000B0A4FB /* JSLexicalEnvironment.cpp */,
 				14DA818E0D99FD2000B0A4FB /* JSLexicalEnvironment.h */,
 				276B39032A71D2B300252F4E /* JSLexicalEnvironmentInlines.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -928,6 +928,8 @@ runtime/JSImmutableButterfly.cpp
 runtime/JSInternalPromise.cpp
 runtime/JSInternalPromiseConstructor.cpp
 runtime/JSInternalPromisePrototype.cpp
+runtime/JSIterator.cpp
+runtime/JSIteratorConstructor.cpp
 runtime/JSLexicalEnvironment.cpp
 runtime/JSLock.cpp
 runtime/JSMap.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -52,6 +52,7 @@
 #include "JITStubRoutineSet.h"
 #include "JITWorklistInlines.h"
 #include "JSFinalizationRegistry.h"
+#include "JSIterator.h"
 #include "JSRemoteFunction.h"
 #include "JSVirtualMachineInternal.h"
 #include "JSWeakMap.h"

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -130,6 +130,7 @@ class Heap;
     v(numberObjectSpace, cellHeapCellType, NumberObject) \
     v(plainObjectSpace, cellHeapCellType, JSNonFinalObject) \
     v(promiseSpace, cellHeapCellType, JSPromise) \
+    v(iteratorSpace, cellHeapCellType, JSIterator) \
     v(propertyNameEnumeratorSpace, cellHeapCellType, JSPropertyNameEnumerator) \
     v(propertyTableSpace, destructibleCellHeapCellType, PropertyTable) \
     v(regExpSpace, destructibleCellHeapCellType, RegExp) \

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -44,6 +44,7 @@
     macro(Function) \
     macro(Infinity) \
     macro(Intl) \
+    macro(Iterator) \
     macro(ListFormat) \
     macro(Loader) \
     macro(Locale) \

--- a/Source/JavaScriptCore/runtime/IteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorPrototype.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2015 Yusuke Suzuki <utatane.tea@gmail.com>.
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,12 +30,21 @@
 
 #include "JSCBuiltins.h"
 #include "JSCInlines.h"
+#include "JSGlobalObject.h"
+#include "JSIterator.h"
+#include "JSIteratorConstructor.h"
+#include "JSObject.h"
+#include <wtf/PlatformCallingConventions.h>
 
 namespace JSC {
 
 const ClassInfo IteratorPrototype::s_info = { "Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(IteratorPrototype) };
 
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncIterator);
+static JSC_DECLARE_CUSTOM_GETTER(iteratorProtoConstructorGetter);
+static JSC_DECLARE_CUSTOM_SETTER(iteratorProtoConstructorSetter);
+static JSC_DECLARE_CUSTOM_GETTER(iteratorProtoToStringTagGetter);
+static JSC_DECLARE_CUSTOM_SETTER(iteratorProtoToStringTagSetter);
 
 void IteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
@@ -41,11 +52,75 @@ void IteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     ASSERT(inherits(info()));
     JSFunction* iteratorFunction = JSFunction::create(vm, globalObject, 0, "[Symbol.iterator]"_s, iteratorProtoFuncIterator, ImplementationVisibility::Public, IteratorIntrinsic);
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, iteratorFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::useIteratorHelpers()) {
+        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.constructor
+        putDirectCustomGetterSetterWithoutTransition(vm, vm.propertyNames->constructor, CustomGetterSetter::create(vm, iteratorProtoConstructorGetter, iteratorProtoConstructorSetter), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor));
+        // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
+        putDirectCustomGetterSetterWithoutTransition(vm, vm.propertyNames->toStringTagSymbol, CustomGetterSetter::create(vm, iteratorProtoToStringTagGetter, iteratorProtoToStringTagSetter), static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor));
+    }
 }
 
 JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIterator, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
+}
+
+// https://tc39.es/proposal-iterator-helpers/#sec-get-iteratorprototype-constructor
+JSC_DEFINE_CUSTOM_GETTER(iteratorProtoConstructorGetter, (JSGlobalObject* globalObject, EncodedJSValue, PropertyName))
+{
+    return JSValue::encode(globalObject->iteratorConstructor());
+}
+
+// https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-constructor
+JSC_DEFINE_CUSTOM_SETTER(iteratorProtoConstructorSetter, (JSGlobalObject* globalObject, EncodedJSValue encodedThisValue, EncodedJSValue value, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = JSValue::decode(encodedThisValue);
+
+    if (!thisValue.isObject())
+        return throwVMTypeError(globalObject, scope, "Iterator.prototype.constructor setter expected |this| to be an object."_s);
+
+    JSObject* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (thisObject == globalObject->iteratorPrototype())
+        return throwVMTypeError(globalObject, scope, "Iterator.prototype.constructor setter cannot be applied to Iterator.prototype."_s);
+
+    thisObject->putDirect(vm, propertyName, JSValue::decode(value), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+
+    return JSValue::encode(jsUndefined());
+}
+
+// https://tc39.es/proposal-iterator-helpers/#sec-get-iteratorprototype-@@tostringtag
+JSC_DEFINE_CUSTOM_GETTER(iteratorProtoToStringTagGetter, (JSGlobalObject* globalObject, EncodedJSValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    return JSValue::encode(jsNontrivialString(vm, "Iterator"_s));
+}
+
+// https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-@@tostringtag
+JSC_DEFINE_CUSTOM_SETTER(iteratorProtoToStringTagSetter, (JSGlobalObject* globalObject, EncodedJSValue encodedThisValue, EncodedJSValue value, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = JSValue::decode(encodedThisValue);
+
+    if (!thisValue.isObject())
+        return throwVMTypeError(globalObject, scope, "Iterator.prototype[Symbol.toStringTag] setter expected |this| to be an object."_s);
+
+    JSObject* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (thisObject == globalObject->iteratorPrototype())
+        return throwVMTypeError(globalObject, scope, "Iterator.prototype[Symbol.toStringTag] setter cannot be applied to Iterator.prototype."_s);
+
+    thisObject->putDirect(vm, propertyName, JSValue::decode(value), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+
+    return JSValue::encode(jsUndefined());
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -145,6 +145,7 @@ using JSResizableOrGrowableSharedBigUint64Array = JSGenericResizableOrGrowableSh
     macro(JSArrayIterator, JSType::JSArrayIteratorType, JSType::JSArrayIteratorType) \
     macro(JSArrayBuffer, JSType::ArrayBufferType, JSType::ArrayBufferType) \
     macro(JSArrayBufferView, FirstTypedArrayType, LastTypedArrayType) \
+    macro(JSIterator, JSType::JSIteratorType, JSType::JSIteratorType) \
     macro(JSPromise, JSType::JSPromiseType, JSType::JSPromiseType) \
     macro(JSGlobalProxy, JSType::GlobalProxyType, JSType::GlobalProxyType) \
     macro(JSSet, JSType::JSSetType, JSType::JSSetType) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1,6 +1,8 @@
 /*
  * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich (cwzwarich@uwaterloo.ca)
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,6 +108,7 @@
 #include "IntlSegmenterPrototype.h"
 #include "IntlSegments.h"
 #include "IntlSegmentsPrototype.h"
+#include "IteratorPrototype.h"
 #include "IteratorPrototypeInlines.h"
 #include "JSAPIWrapperObject.h"
 #include "JSArrayBuffer.h"
@@ -140,6 +143,8 @@
 #include "JSInternalPromise.h"
 #include "JSInternalPromiseConstructor.h"
 #include "JSInternalPromisePrototype.h"
+#include "JSIterator.h"
+#include "JSIteratorConstructor.h"
 #include "JSLexicalEnvironmentInlines.h"
 #include "JSMapInlines.h"
 #include "JSMapIteratorInlines.h"
@@ -1105,6 +1110,9 @@ void JSGlobalObject::init(VM& vm)
         });
 
     m_iteratorPrototype.set(vm, this, IteratorPrototype::create(vm, this, IteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
+    if (Options::useIteratorHelpers())
+        m_iteratorStructure.set(vm, this, JSIterator::createStructure(vm, this, m_iteratorPrototype.get()));
+
     m_asyncIteratorPrototype.set(vm, this, AsyncIteratorPrototype::create(vm, this, AsyncIteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
 
     m_generatorPrototype.set(vm, this, GeneratorPrototype::create(vm, this, GeneratorPrototype::createStructure(vm, this, m_iteratorPrototype.get())));
@@ -1252,6 +1260,12 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     putDirectWithoutTransition(vm, vm.propertyNames->Function, functionConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->Array, arrayConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->RegExp, regExpConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
+
+    if (Options::useIteratorHelpers()) {
+        JSIteratorConstructor* iteratorConstructor = JSIteratorConstructor::create(vm, JSIteratorConstructor::createStructure(vm, this, m_functionPrototype.get()), m_iteratorPrototype.get());
+        m_iteratorConstructor.set(vm, this, iteratorConstructor);
+        putDirectWithoutTransition(vm, vm.propertyNames->Iterator, iteratorConstructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
 
     if (Options::useSharedArrayBuffer())
         putDirectWithoutTransition(vm, vm.propertyNames->SharedArrayBuffer, m_sharedArrayBufferStructure.constructor(this), static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -2491,6 +2505,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_regExpConstructor);
     visitor.append(thisObject->m_objectConstructor);
     visitor.append(thisObject->m_functionConstructor);
+    visitor.append(thisObject->m_iteratorConstructor);
     visitor.append(thisObject->m_promiseConstructor);
     visitor.append(thisObject->m_internalPromiseConstructor);
     visitor.append(thisObject->m_stringConstructor);
@@ -2605,6 +2620,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_asyncGeneratorFunctionStructure);
     visitor.append(thisObject->m_generatorStructure);
     visitor.append(thisObject->m_asyncGeneratorStructure);
+    visitor.append(thisObject->m_iteratorStructure);
     visitor.append(thisObject->m_arrayIteratorStructure);
     visitor.append(thisObject->m_mapIteratorStructure);
     visitor.append(thisObject->m_setIteratorStructure);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1,6 +1,8 @@
 /*
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  *  Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ *  Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ *  Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -80,6 +82,8 @@ class JSCustomGetterFunction;
 class JSCustomSetterFunction;
 class JSGlobalObjectDebuggable;
 class JSInternalPromise;
+class JSIterator;
+class JSIteratorConstructor;
 class JSModuleLoader;
 class JSModuleRecord;
 class JSPromise;
@@ -227,6 +231,7 @@ public:
     WriteBarrier<FunctionConstructor> m_functionConstructor;
     WriteBarrier<JSPromiseConstructor> m_promiseConstructor;
     WriteBarrier<JSInternalPromiseConstructor> m_internalPromiseConstructor;
+    WriteBarrier<JSIteratorConstructor> m_iteratorConstructor;
     WriteBarrier<StringConstructor> m_stringConstructor;
 
     LazyProperty<JSGlobalObject, IntlCollator> m_defaultCollator;
@@ -344,6 +349,7 @@ public:
     WriteBarrierStructureID m_generatorFunctionStructure;
     WriteBarrierStructureID m_generatorStructure;
     WriteBarrierStructureID m_asyncGeneratorStructure;
+    WriteBarrierStructureID m_iteratorStructure;
     WriteBarrierStructureID m_arrayIteratorStructure;
     WriteBarrierStructureID m_mapIteratorStructure;
     WriteBarrierStructureID m_setIteratorStructure;
@@ -676,6 +682,7 @@ public:
     FunctionConstructor* functionConstructor() const { return m_functionConstructor.get(); }
     JSPromiseConstructor* promiseConstructor() const { return m_promiseConstructor.get(); }
     JSInternalPromiseConstructor* internalPromiseConstructor() const { return m_internalPromiseConstructor.get(); }
+    JSIteratorConstructor* iteratorConstructor() const { return m_iteratorConstructor.get(); }
 
     IntlCollator* defaultCollator() const { return m_defaultCollator.get(this); }
     IntlNumberFormat* defaultNumberFormat() const { return m_defaultNumberFormat.get(this); }
@@ -837,6 +844,7 @@ public:
     Structure* generatorFunctionStructure() const { return m_generatorFunctionStructure.get(); }
     Structure* asyncFunctionStructure() const { return m_asyncFunctionStructure.get(); }
     Structure* asyncGeneratorFunctionStructure() const { return m_asyncGeneratorFunctionStructure.get(); }
+    Structure* iteratorStructure() const { return m_iteratorStructure.get(); }
     Structure* arrayIteratorStructure() const { return m_arrayIteratorStructure.get(); }    
     Structure* mapIteratorStructure() const { return m_mapIteratorStructure.get(); }
     Structure* setIteratorStructure() const { return m_setIteratorStructure.get(); }

--- a/Source/JavaScriptCore/runtime/JSIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSIterator.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSIterator.h"
+
+#include "AbstractSlotVisitor.h"
+#include "JSCInlines.h"
+#include "JSIteratorConstructor.h"
+#include "SlotVisitor.h"
+
+namespace JSC {
+
+const ClassInfo JSIterator::s_info = { "Iterator"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSIterator) };
+
+Structure* JSIterator::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(JSIteratorType, StructureFlags), info());
+}
+
+JSIterator* JSIterator::create(VM& vm, Structure* structure)
+{
+    JSIterator* instance = new (NotNull, allocateCell<JSIterator>(vm)) JSIterator(vm, structure);
+    instance->finishCreation(vm);
+    return instance;
+}
+
+template<typename Visitor>
+void JSIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSIterator*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSIterator);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIterator.h
+++ b/Source/JavaScriptCore/runtime/JSIterator.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSObject.h"
+
+namespace JSC {
+
+class JSIterator final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return &vm.iteratorSpace();
+    }
+
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+    static JSIterator* create(VM&, Structure*);
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+private:
+    JSIterator(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSIteratorConstructor.h"
+
+#include "AbstractSlotVisitor.h"
+#include "BuiltinNames.h"
+#include "GetterSetter.h"
+#include "IteratorPrototype.h"
+#include "JSCInlines.h"
+#include "JSIterator.h"
+#include "SlotVisitor.h"
+
+namespace JSC {
+
+const ClassInfo JSIteratorConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSIteratorConstructor) };
+
+Structure* JSIteratorConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+JSIteratorConstructor* JSIteratorConstructor::create(VM& vm, Structure* structure, IteratorPrototype* iteratorPrototype)
+{
+    JSIteratorConstructor* constructor = new (NotNull, allocateCell<JSIteratorConstructor>(vm)) JSIteratorConstructor(vm, structure);
+    constructor->finishCreation(vm, iteratorPrototype);
+    return constructor;
+}
+
+void JSIteratorConstructor::finishCreation(VM& vm, IteratorPrototype* iteratorPrototype)
+{
+    Base::finishCreation(vm, 0, vm.propertyNames->Iterator.string(), PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, iteratorPrototype, static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
+}
+
+template<typename Visitor>
+void JSIteratorConstructor::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSIteratorConstructor*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSIteratorConstructor);
+
+static JSC_DECLARE_HOST_FUNCTION(callIterator);
+static JSC_DECLARE_HOST_FUNCTION(constructIterator);
+
+JSIteratorConstructor::JSIteratorConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callIterator, constructIterator)
+{
+}
+
+JSC_DEFINE_HOST_FUNCTION(callIterator, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Iterator"_s));
+}
+
+// https://tc39.es/proposal-iterator-helpers/#sec-iterator
+JSC_DEFINE_HOST_FUNCTION(constructIterator, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    JSIteratorConstructor* iteratorConstructor = jsCast<JSIteratorConstructor*>(callFrame->jsCallee());
+    if (newTarget == iteratorConstructor)
+        return JSValue::encode(throwTypeError(globalObject, scope, "Iterator cannot be constructed directly"_s));
+
+    Structure* iteratorStructure = JSC_GET_DERIVED_STRUCTURE(vm, iteratorStructure, newTarget, callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSIterator::create(vm, iteratorStructure)));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InternalFunction.h"
+
+namespace JSC {
+
+class IteratorPrototype;
+
+// https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor
+class JSIteratorConstructor final : public InternalFunction {
+public:
+    typedef InternalFunction Base;
+
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+    static JSIteratorConstructor* create(VM&, Structure*, IteratorPrototype*);
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+private:
+    JSIteratorConstructor(VM&, Structure*);
+
+    void finishCreation(VM&, IteratorPrototype*);
+};
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSIteratorConstructor, InternalFunction);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSType.cpp
+++ b/Source/JavaScriptCore/runtime/JSType.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ * Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -104,6 +106,7 @@ void printInternal(PrintStream& out, JSC::JSType type)
     CASE(JSGeneratorType)
     CASE(JSAsyncGeneratorType)
     CASE(JSArrayIteratorType)
+    CASE(JSIteratorType)
     CASE(JSMapIteratorType)
     CASE(JSSetIteratorType)
     CASE(JSStringIteratorType)

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2006-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ *  Copyright (C) 2024 Sosuke Suzuki <aosukeke@gmail.com>.
+ *  Copyright (C) 2024 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -118,6 +120,7 @@ namespace JSC {
     macro(JSGeneratorType, SpecObjectOther) \
     macro(JSAsyncGeneratorType, SpecObjectOther) \
     macro(JSArrayIteratorType, SpecObjectOther) \
+    macro(JSIteratorType, SpecObjectOther) \
     macro(JSMapIteratorType, SpecObjectOther) \
     macro(JSSetIteratorType, SpecObjectOther) \
     macro(JSStringIteratorType, SpecObjectOther) \

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -584,6 +584,7 @@ bool hasCapacityToUseLargeGigacage();
     /* Feature Flags */\
     \
     v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
+    v(Bool, useIteratorHelpers, false, Normal, "Expose the Iterator Helpers."_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -71,6 +71,7 @@
 #include "JSBigInt.h"
 #include "JSGlobalObject.h"
 #include "JSImmutableButterflyInlines.h"
+#include "JSIterator.h"
 #include "JSLock.h"
 #include "JSMap.h"
 #include "JSMicrotask.h"


### PR DESCRIPTION
#### 39448a8ea6f9780be180683610d755bf0d6a54dd
<pre>
[JSC] Implement Iterator.prototype.constructor &amp; Iterator.prototype[@@toStringTag]

<a href="https://bugs.webkit.org/show_bug.cgi?id=278393">https://bugs.webkit.org/show_bug.cgi?id=278393</a>

Reviewed by Yusuke Suzuki.

This implements:

- <a href="https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.constructor">https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.constructor</a>
- <a href="https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag">https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag</a>

This splits the original patch by #27865
into a small piece to make it easy to review and land the patch.

* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/IteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::JSC_DEFINE_CUSTOM_SETTER):
(JSC::IteratorPrototype::finishCreation):
* Source/JavaScriptCore/runtime/JSCast.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::iteratorConstructor const):
(JSC::JSGlobalObject::iteratorStructure const):
* Source/JavaScriptCore/runtime/JSType.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/JSType.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/VM.cpp:

Canonical link: <a href="https://commits.webkit.org/282687@main">https://commits.webkit.org/282687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1110226d3f82a2d0de809002ca38eb3750cd2ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14445 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51443 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12649 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13318 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69554 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63082 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58764 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58909 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6477 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84843 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9670 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39014 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14967 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40093 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->