### PR TITLE
Improve sidebarAction API test coverage.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -321,6 +321,7 @@ void WebExtensionContext::sidebarSetTitle(const std::optional<WebExtensionWindow
         completionHandler(makeUnexpected(sidebar.error()));
         return;
     }
+    sidebar.value()->setTitle(title);
 
     completionHandler({ });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2659,18 +2659,18 @@ WebExtensionSidebar& WebExtensionContext::defaultSidebar()
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getSidebar(WebExtensionWindow const& window)
 {
-    if (auto *windowAction = m_sidebarWindowMap.get(window))
-        return *windowAction;
+    if (RefPtr windowSidebar = m_sidebarWindowMap.get(window))
+        return *windowSidebar;
 
-    return Ref { defaultSidebar() };
+    return std::nullopt;
 }
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getSidebar(WebExtensionTab const& tab)
 {
-    if (auto *tabAction = m_sidebarTabMap.get(tab))
-        return *tabAction;
+    if (RefPtr tabSidebar = m_sidebarTabMap.get(tab))
+        return *tabSidebar;
 
-    return Ref { defaultSidebar() };
+    return std::nullopt;
 }
 
 std::optional<Ref<WebExtensionSidebar>> WebExtensionContext::getOrCreateSidebar(WebExtensionWindow& window)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -99,7 +99,7 @@ private:
     std::optional<String> m_titleOverride;
     std::optional<String> m_sidebarPathOverride;
 
-    WeakRef<WebExtensionContext> m_context;
+    WeakPtr<WebExtensionContext> m_extensionContext;
     const std::optional<Ref<WebExtensionTab>> m_tab;
     const std::optional<Ref<WebExtensionWindow>> m_window;
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -91,7 +91,7 @@ static std::variant<std::monostate, String, SidebarError> parseDetailsStringFrom
         return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]) };
     }
 
-    return SidebarError { (NSString *)maybeValue };
+    return String((NSString *)maybeValue);
 }
 
 template<typename VariantType>
@@ -197,7 +197,7 @@ void WebExtensionAPISidebarAction::setPanel(NSDictionary *details, Ref<WebExtens
 
     const auto [windowId, tabId] = getIdentifiers(result);
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(windowId, tabId, std::nullopt, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(windowId, tabId, panelPath, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
@@ -33,6 +33,8 @@
 
 namespace TestWebKitAPI {
 
+#pragma mark - Constants
+
 static constexpr auto *sidebarActionManifest = @{
     @"manifest_version": @3,
     @"name": @"SidebarAction Test",
@@ -113,6 +115,8 @@ static auto *neitherSidebarActionNorPanelManifest = @{
     },
 };
 
+#pragma mark - Test Fixture
+
 // This test fixture allows us to use sidebarConfig (which enables the sidebar feature flag) without manually constructing one on each run
 class WKWebExtensionAPISidebar : public testing::Test {
 protected:
@@ -128,8 +132,27 @@ protected:
         }
     }
 
+    RetainPtr<TestWebExtensionManager> getManagerFor(NSArray<NSString *> *script, NSDictionary<NSString *, id> *manifest)
+    {
+        auto *resources = @{
+            @"background.js" : Util::constructScript(script),
+        };
+        return getManagerFor(resources, manifest);
+    }
+
+    RetainPtr<TestWebExtensionManager> getManagerFor(NSDictionary<NSString *, id> *resources, NSDictionary<NSString *, id> *manifest)
+    {
+        extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+        auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get() extensionControllerConfiguration:sidebarConfig]);
+
+        return manager;
+    }
+
     WKWebExtensionControllerConfiguration *sidebarConfig;
+    RetainPtr<WKWebExtension> extension;
 };
+
+#pragma mark - Common Tests
 
 TEST_F(WKWebExtensionAPISidebar, APISUnavailableWhenManifestDoesNotRequest)
 {
@@ -141,6 +164,8 @@ TEST_F(WKWebExtensionAPISidebar, APISUnavailableWhenManifestDoesNotRequest)
 
     Util::loadAndRunExtension(neitherSidebarActionNorPanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
 }
+
+#pragma mark - SidebarAction Tests
 
 TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIAvailableWhenManifestRequests)
 {
@@ -162,24 +187,6 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIAvailableWhenManifestRequests)
     ];
 
     Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
-}
-
-TEST_F(WKWebExtensionAPISidebar, SidePanelAPIAvailableWhenManifestRequests)
-{
-    auto *script = @[
-        @"browser.test.assertFalse(browser.sidePanel === undefined)",
-        @"browser.test.assertFalse(browser.sidePanel?.open === undefined)",
-        @"browser.test.assertFalse(browser.sidePanel?.getOptions === undefined)",
-        @"browser.test.assertFalse(browser.sidePanel?.setOptions === undefined)",
-        @"browser.test.assertFalse(browser.sidePanel?.getPanelBehavior === undefined)",
-        @"browser.test.assertFalse(browser.sidePanel?.setPanelBehavior === undefined)",
-
-        @"browser.test.assertDeepEq(browser.sidebarAction, undefined)",
-
-        @"browser.test.notifyPass()",
-    ];
-
-    Util::loadAndRunExtension(sidePanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
 }
 
 TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIAvailableWhenManifestRequestsBoth)
@@ -217,6 +224,514 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIDisallowsMissingArguments)
     ];
 
     Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIGlobalTitlePersists)
+{
+    auto *script = @[
+        @"await browser.sidebarAction.setTitle({ title: 'Here is a title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'Here is a title')",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIWindowSpecificTitlePersists)
+{
+    auto *script = @[
+        @"let windows = await browser.windows.getAll()",
+        @"let [window1, window2] = windows",
+
+        @"await browser.sidebarAction.setTitle({ windowId: window1.id, title: 'window-specific title' })",
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window1.id }), 'window-specific title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window2.id }), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPITabSpecificTitlePersists)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab1, tab2] = tabs",
+
+        @"await browser.sidebarAction.setTitle({ tabId: tab1.id, title: 'tab-specific title' })",
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab1.id }), 'tab-specific title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab2.id }), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager.get().defaultWindow openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIMixedSpecificityTitlesNotConfused)
+{
+    auto *script = @[
+        @"let allWindows = await browser.windows.getAll()",
+        @"let [window1, window2] = allWindows",
+        @"let window1Tabs = await browser.tabs.query({ windowId: window1.id })",
+        @"let window2Tabs = await browser.tabs.query({ windowId: window2.id })",
+
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+        @"await browser.sidebarAction.setTitle({ windowId: window1.id, title: 'window specific title' })",
+        @"await browser.sidebarAction.setTitle({ tabId: window1Tabs[0].id, title: 'window 1 tab specific title' })",
+        @"await browser.sidebarAction.setTitle({ tabId: window2Tabs[0].id, title: 'window 2 tab specific title' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: window1Tabs[0].id }), 'window 1 tab specific title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: window1Tabs[1].id }), 'window specific title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window1.id }), 'window specific title')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: window2Tabs[0].id }), 'window 2 tab specific title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: window2Tabs[1].id }), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window2.id }), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager.get().defaultWindow openNewTab];
+    auto window2 = [manager openNewWindow];
+    [window2 openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIWindowSpecificPanelPersists)
+{
+    auto *script = @[
+        @"let windows = await browser.windows.getAll()",
+        @"let [window1, window2] = windows",
+
+        @"await browser.sidebarAction.setPanel({ windowId: window1.id, panel: '/sidebar-1.html' })",
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-2.html' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window1.id }), '/sidebar-1.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-2.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window2.id }), '/sidebar-2.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-1.html" : @"<h1>Sidebar 1</h1>",
+        @"sidebar-2.html" : @"<h1>Sidebar 2</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPITabSpecificDocumentPersists)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab1, tab2] = tabs",
+
+        @"await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: '/sidebar-1.html' })",
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-2.html' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab1.id }), '/sidebar-1.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-2.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab2.id }), '/sidebar-2.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-1.html" : @"<h1>Sidebar 1</h1>",
+        @"sidebar-2.html" : @"<h1>Sidebar 2</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionDocumentsMixedSpecificityNotConfused)
+{
+    auto *script = @[
+        @"let allWindows = await browser.windows.getAll()",
+        @"let [window1, window2] = allWindows",
+        @"let window1Tabs = await browser.tabs.query({ windowId: window1.id })",
+        @"let window2Tabs = await browser.tabs.query({ windowId: window2.id })",
+
+        @"await browser.sidebarAction.setPanel({ panel: '/global-sidebar.html' })",
+        @"await browser.sidebarAction.setPanel({ windowId: window1.id, panel: '/window-1-window-sidebar.html' })",
+        @"await browser.sidebarAction.setPanel({ tabId: window1Tabs[0].id, panel: '/window-1-tab-sidebar.html' })",
+        @"await browser.sidebarAction.setPanel({ tabId: window2Tabs[0].id, panel: '/window-2-tab-sidebar.html' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: window1Tabs[0].id }), '/window-1-tab-sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: window1Tabs[1].id }), '/window-1-window-sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window1.id }), '/window-1-window-sidebar.html')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: window2Tabs[0].id }), '/window-2-tab-sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: window2Tabs[1].id }), '/global-sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window2.id }), '/global-sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/global-sidebar.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"window1-window-sidebar.html" : @"<h1>Window 1 Window Sidebar</h1>",
+        @"window1-tab-sidebar.html" : @"<h1>Window 1 Tab Sidebar</h1>",
+        @"window2-tab-sidebar.html" : @"<h1>Window 2 Tab Sidebar</h1>",
+        @"global-sidebar.html" : @"<h1>Global Sidebar</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager.get().defaultWindow openNewTab];
+    auto window2 = [manager openNewWindow];
+    [window2 openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionChangeGlobalTitle)
+{
+    auto *script = @[
+        @"await browser.sidebarAction.setTitle({ title: 'Here is a title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'Here is a title')",
+        @"await browser.sidebarAction.setTitle({ title: 'Here is a different title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'Here is a different title')",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionChangeWindowTitle)
+{
+    auto *script = @[
+        @"let windows = await browser.windows.getAll()",
+        @"let [window1, window2] = windows",
+
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+        @"await browser.sidebarAction.setTitle({ windowId: window1.id, title: 'window-specific title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window1.id }), 'window-specific title')",
+
+        @"await browser.sidebarAction.setTitle({ windowId: window1.id, title: 'another window-specific title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window1.id }), 'another window-specific title')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window2.id }), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionChangeTabTitle)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab1, tab2] = tabs",
+
+        @"await browser.sidebarAction.setTitle({ tabId: tab1.id, title: 'tab-specific title' })",
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab1.id }), 'tab-specific title')",
+        @"await browser.sidebarAction.setTitle({ tabId: tab1.id, title: 'new tab-specific title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab1.id }), 'new tab-specific title')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab2.id }), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager.get().defaultWindow openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionChangeGlobalPanel)
+{
+    auto *script = @[
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-1.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-1.html')",
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-2.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-2.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-1.html" : @"<h1>Sidebar 1</h1>",
+        @"sidebar-2.html" : @"<h1>Sidebar 2</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionChangeWindowPanel)
+{
+    auto *script = @[
+        @"let windows = await browser.windows.getAll()",
+        @"let [window1, window2] = windows",
+
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-global.html' })",
+
+        @"await browser.sidebarAction.setPanel({ windowId: window1.id, panel: '/sidebar-1.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window1.id }), '/sidebar-1.html')",
+        @"await browser.sidebarAction.setPanel({ windowId: window1.id, panel: '/sidebar-2.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window1.id }), '/sidebar-2.html')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-global.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window2.id }), '/sidebar-global.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-global.html" : @"<h1>Global Sidebar</h1>",
+        @"sidebar-1.html" : @"<h1>Sidebar 2</h1>",
+        @"sidebar-2.html" : @"<h1>Sidebar 2</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionChangeTabPanel)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab1, tab2] = tabs",
+
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-global.html' })",
+
+        @"await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: '/sidebar-1.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab1.id }), '/sidebar-1.html')",
+        @"await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: '/sidebar-2.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab1.id }), '/sidebar-2.html')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-global.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab2.id }), '/sidebar-global.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-global.html" : @"<h1>Global Sidebar</h1>",
+        @"sidebar-1.html" : @"<h1>Sidebar 2</h1>",
+        @"sidebar-2.html" : @"<h1>Sidebar 2</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionClearGlobalTitle)
+{
+    auto *script = @[
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'Test Sidebar')",
+
+        @"await browser.sidebarAction.setTitle({ title: 'A new global title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'A new global title')",
+
+        @"await browser.sidebarAction.setTitle({ title: null })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'Test Sidebar')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionClearWindowTitle)
+{
+    auto *script = @[
+        @"let windows = await browser.windows.getAll()",
+        @"let [window1, window2] = windows",
+
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+
+        @"await browser.sidebarAction.setTitle({ windowId: window1.id, title: 'window-specific title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window1.id }), 'window-specific title')",
+
+        @"await browser.sidebarAction.setTitle({ windowId: window1.id, title: null })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window1.id }), 'global title')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ windowId: window2.id }), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionClearTabTitle)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab1, tab2] = tabs",
+
+        @"await browser.sidebarAction.setTitle({ tabId: tab1.id, title: 'tab-specific title' })",
+        @"await browser.sidebarAction.setTitle({ title: 'global title' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab1.id }), 'tab-specific title')",
+
+        @"await browser.sidebarAction.setTitle({ tabId: tab1.id, title: null })",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab1.id }), 'global title')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({}), 'global title')",
+        @"browser.test.assertEq(await browser.sidebarAction.getTitle({ tabId: tab2.id }), 'global title')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto manager = getManagerFor(script, sidebarActionManifest);
+    [manager.get().defaultWindow openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionClearGlobalPanel)
+{
+    auto *script = @[
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), 'sidebar.html')",
+
+        @"await browser.sidebarAction.setPanel({ panel: '/sidebar-1.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), '/sidebar-1.html')",
+
+        @"await browser.sidebarAction.setPanel({ panel: null })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), 'sidebar.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-1.html" : @"<h1>Sidebar 1</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionClearWindowPanel)
+{
+    auto *script = @[
+        @"let windows = await browser.windows.getAll()",
+        @"let [window1, window2] = windows",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), 'sidebar.html')",
+
+        @"await browser.sidebarAction.setPanel({ windowId: window1.id, panel: '/sidebar-1.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window1.id }), '/sidebar-1.html')",
+        @"await browser.sidebarAction.setPanel({ windowId: window1.id, panel: null })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window1.id }), 'sidebar.html')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), 'sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ windowId: window2.id }), 'sidebar.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-1.html" : @"<h1>Sidebar 1</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarAcionClearTabPanel)
+{
+    auto *script = @[
+        @"let tabs = await browser.tabs.query({})",
+        @"let [tab1, tab2] = tabs",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), 'sidebar.html')",
+
+        @"await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: '/sidebar-1.html' })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab1.id }), '/sidebar-1.html')",
+        @"await browser.sidebarAction.setPanel({ tabId: tab1.id, panel: null })",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab1.id }), 'sidebar.html')",
+
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({}), 'sidebar.html')",
+        @"browser.test.assertEq(await browser.sidebarAction.getPanel({ tabId: tab2.id }), 'sidebar.html')",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    auto *resources = @{
+        @"background.js"  : Util::constructScript(script),
+        @"sidebar-1.html" : @"<h1>Sidebar 1</h1>",
+    };
+
+    auto manager = getManagerFor(resources, sidebarActionManifest);
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+#pragma mark - SidePanel Tests
+
+TEST_F(WKWebExtensionAPISidebar, SidePanelAPIAvailableWhenManifestRequests)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(browser.sidePanel === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.open === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.getOptions === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.setOptions === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.getPanelBehavior === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.setPanelBehavior === undefined)",
+
+        @"browser.test.assertDeepEq(browser.sidebarAction, undefined)",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidePanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
 }
 
 TEST_F(WKWebExtensionAPISidebar, SidePanelAPIDisallowsMissingArguments)


### PR DESCRIPTION
#### 0f149866988c4425bb777f4747bf9273a5a2aa5e
<pre>
Improve sidebarAction API test coverage.
<a href="https://webkit.org/b/278395">https://webkit.org/b/278395</a>
<a href="https://rdar.apple.com/134355062">rdar://134355062</a>

Reviewed by Timothy Hatcher.

This PR improves test coverage for the sidebarAction JavaScript
extensions API, especially as pertaining to the semantics of the API
methods relating to the panel URL and panel title. It also adds several
drive-by fixes for bugs I found while writing these tests.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::WebExtensionContext::sidebarSetTitle): Actually set title on
sidebar object in this method
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getSidebar): Return nullopt rather than
default sidebar when no sidebar is found.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(WebKit::getDefaultSidebarTitleFromExtension): Default to extension
display name when no title is found in manifest
(WebKit::WebExtensionSidebar::extensionContext const): Switch to WeakPtr
for holding a reference to the current extension context
(WebKit::WebExtensionSidebar::parent const): Add nil check before we
attempt to get the sidebar for *(tab-&gt;window()), use extensionContext()
for context validity check rather than m_context
(WebKit::WebExtensionSidebar::setTitle): When setting the title to
std::nullopt on the default sidebar, retrieve manifest-default display
name instead.
(WebKit::WebExtensionSidebar::setSidebarPath): When setting the path to
std::nullopt on the default sidebar, retrieve manifest-default sidebar
path instead.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseDetailsStringFromKey): Return String variant in happy case
(was mistakenly returning SidebarError instead).
(WebKit::WebExtensionAPISidebarAction::setPanel): Set panelPath argument
in message to panel path rather than std::nullopt.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::WKWebExtensionAPISidebar::getManagerFor): Add helper
method to set up TestWebExtensionManager.
(TestWebKitAPI::TEST_F): Add assorted tests exercising the title and
panel URL semantics of the sidebarAction API, including setting,
modifying, retrieving, and clearing these &quot;properties.&quot;
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Switch to
WeakPtr for holding a reference to the current WebExtensionContext,
rather than WeakRef, rename m_context to m_extensionContext

Canonical link: <a href="https://commits.webkit.org/282533@main">https://commits.webkit.org/282533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc3abc6b607bfa6b42f3e02f8b657677473e12c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16018 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/14029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14309 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/14029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66490 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/7368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/7400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9584 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->