### PR TITLE
Disable unsupported JSC options in the UIWebView.

### DIFF
--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
 #import "WebKitVersionChecks.h"
 #import "WebNSObjectExtras.h"
 #import "WebPreferencesPrivate.h"
+#import "WebViewInternal.h"
 #import "WebViewPrivate.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/BackForwardCache.h>
@@ -98,9 +99,7 @@ WebBackForwardList *kit(BackForwardList* backForwardList)
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@
 #import "WebNSURLRequestExtras.h"
 #import "WebNSViewExtras.h"
 #import "WebPluginController.h"
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/BackForwardCache.h>
 #import <WebCore/HistoryItem.h>
@@ -126,9 +127,7 @@ void WKNotifyHistoryItemChanged()
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebCache.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCache.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,9 +62,7 @@ class DefaultStorageSessionProvider : public WebCore::StorageSessionProvider {
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007, 2008, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #import "WebFrameInternal.h"
 #import "WebKitLogging.h"
 #import "WebView.h"
+#import "WebViewInternal.h"
 #import "WebViewPrivate.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/DragController.h>
@@ -71,9 +72,7 @@ static void cacheValueForKey(const void *key, const void *value, void *self)
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 #import "WebIconDatabase.h"
 
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/Image.h>
 #import <WebCore/ThreadCheck.h>
@@ -97,9 +98,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 + (void)initialize
 {
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 }
 
 + (WebIconDatabase *)sharedIconDatabase

--- a/Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #import "WebStringTruncator.h"
 
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/FontCascade.h>
 #import <WebCore/FontPlatformData.h>
@@ -51,9 +52,7 @@ static WebCore::FontCascade& fontFromNSFont(NSFont *font)
 
 + (void)initialize
 {
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 }
 
 + (NSString *)centerTruncateString:(NSString *)string toWidth:(float)maxWidth

--- a/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005 Apple Inc.  All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #import "WebKitLogging.h"
 #import "WebKitNSStringExtras.h"
 #import "WebPluginPackage.h"
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/WebCoreJITOperations.h>
 #import <algorithm>
@@ -57,9 +58,7 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -134,9 +134,7 @@ static WebViewInsertAction kit(EditorInsertAction action)
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2092,9 +2092,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #import "WebKitLogging.h"
 #import "WebNSObjectExtras.h"
 #import "WebResourceInternal.h"
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/ArchiveResource.h>
 #import <WebCore/LegacyWebArchive.h>
@@ -69,9 +70,7 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2007, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -154,9 +154,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 {
     if (self == [WebDataSource class]) {
 #if !PLATFORM(IOS_FAMILY)
-        JSC::initialize();
-        WTF::initializeMainThread();
-        WebCore::populateJITOperations();
+        [WebView _initializeWebKit];
 #endif
     }
 }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *           (C) 2006, 2007 Graham Dennis (graham.dennis@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1042,9 +1042,7 @@ static NSControlStateValue kit(TriState state)
     // FIXME: Shouldn't all of this move into +[WebHTMLView initialize]?
     // And some of this work is likely redundant since +[WebHTMLView initialize] is guaranteed to run first.
 
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 
     if (!oldSetCursorForMouseLocationIMP) {
         Method setCursorMethod = class_getInstanceMethod([NSWindow class], @selector(_setCursorForMouseLocation:));
@@ -2557,9 +2555,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     [NSApp registerServicesMenuSendTypes:[[self class] _selectionPasteboardTypes] returnTypes:[[self class] _insertablePasteboardTypes]];
 
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 }
 
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *           (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@
 #import "WebNSURLExtras.h"
 #import "WebPreferenceKeysPrivate.h"
 #import "WebPreferencesDefinitions.h"
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/ApplicationCacheStorage.h>
 #import <WebCore/AudioSession.h>
@@ -385,9 +386,7 @@ public:
 + (void)initialize
 {
 #if PLATFORM(MAC)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 
     NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #import "WebNSDictionaryExtras.h"
 #import "WebNSObjectExtras.h"
 #import "WebNSURLExtras.h"
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/ArchiveResource.h>
 #import <WebCore/LegacyWebArchive.h>
@@ -68,9 +69,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2020 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #import "DOMNodeInternal.h"
 #import "DOMRangeInternal.h"
+#import "WebViewInternal.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/Range.h>
 #import <WebCore/TextIterator.h>
@@ -47,9 +48,7 @@
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 David Smith (catfish.man@gmail.com)
  * Copyright (C) 2010 Igalia S.L
  *
@@ -5019,9 +5019,7 @@ IGNORE_WARNINGS_END
     initialized = YES;
 
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 
     WTF::RefCountedBase::enableThreadingChecksGlobally();
@@ -8641,6 +8639,21 @@ FORWARD(toggleUnderline)
 + (BOOL)shouldIncludeInWebKitStatistics
 {
     return NO;
+}
+
++ (void)_initializeWebKit
+{
+    // The following JSC options must be disabled because UIWebViews don't have the
+    // needed entitlements to use them.
+    JSC::Options::usePollingTraps() = true;
+    JSC::Options::useSharedArrayBuffer() = false;
+    JSC::Options::useWasm() = false;
+    JSC::Options::useWasmFastMemory() = false;
+    JSC::Options::useWasmFaultSignalHandler() = false;
+
+    JSC::initialize();
+    WTF::initializeMainThread();
+    WebCore::populateJITOperations();
 }
 
 - (BOOL)_becomingFirstResponderFromOutside

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2007, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 David Smith (catfish.man@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -104,9 +104,7 @@ int pluginDatabaseClientCount = 0;
 + (void)initialize
 {
 #if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    [WebView _initializeWebKit];
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Igalia S.L
  *
  * Redistribution and use in source and binary forms, with or without
@@ -144,6 +144,7 @@ WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 @interface WebView (WebViewInternal)
 
 + (BOOL)shouldIncludeInWebKitStatistics;
++ (void)_initializeWebKit;
 
 - (WebCore::LocalFrame*)_mainCoreFrame;
 - (WebFrame *)_selectedOrMainFrame;


### PR DESCRIPTION
#### 99fc06f97e2f4b06d018da10fb40df758cf50642
<pre>
Disable unsupported JSC options in the UIWebView.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278401">https://bugs.webkit.org/show_bug.cgi?id=278401</a>
<a href="https://rdar.apple.com/134053581">rdar://134053581</a>

Reviewed by NOBODY (OOPS!).

Also consolidate the WebKit initialization code to a [WebView _initializeWebKit] function instead
of having a copy of it scattered throughout WebKitLegacy.

* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
(+[WebBackForwardList initialize]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(+[WebHistoryItem initialize]):
* Source/WebKitLegacy/mac/Misc/WebCache.mm:
(+[WebCache initialize]):
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm:
(+[WebElementDictionary initialize]):
* Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm:
* Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm:
(+[WebStringTruncator initialize]):
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(+[WebBasePluginPackage initialize]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(+[WebUndoStep initialize]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(+[WebFramePolicyListener initialize]):
* Source/WebKitLegacy/mac/WebView/WebArchive.mm:
(+[WebArchivePrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
(+[WebDataSource initialize]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(+[WebHTMLViewPrivate initialize]):
(+[WebHTMLView initialize]):
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(+[WebPreferences initialize]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
(+[WebResourcePrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebTextIterator.mm:
(+[WebTextIteratorPrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView initialize]):
(+[WebView _initializeWebKit]):
* Source/WebKitLegacy/mac/WebView/WebViewData.mm:
(+[WebViewPrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99fc06f97e2f4b06d018da10fb40df758cf50642

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13971 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14251 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/9660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39661 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54874 "Found 83 new API test failures: TestWebKitAPI.ContentFiltering.LoadAlternateAfterRedirectWK1, TestWebKitAPI.WebKitLegacy.WebViewCloseInsideDidFinishLoadForFrame, TestWebKitAPI.WebKitLegacy.SelectionAppearanceUpdatesInEditableWebView, TestWebKitAPI.WebKitLegacy.ElementAtPoint, TestWebKitAPI.WebKitLegacy.WebScriptObjectDescription, TestWebKitAPI.MessagePort.Providers, TestWebKitAPI.WebKitLegacy.DownloadThread, TestWebKitAPI.WebKitLegacy.SetDocumentURITestURL, TestWebKitAPI.WebKitLegacy.DidCreateJavaScriptContextSanity2, TestWebKitAPI.CandidateTests.DoNotRequestCandidatesForPasswordInput ... (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36342 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12224 "Found 60 new test failures: http/tests/cache/history-navigation-no-resource-revalidation.html http/tests/cache/loaded-from-cache-after-reload-within-iframe.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/WebAssembly-allowed.html http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-about-blank-iframe.html http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-external-script.html http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-subframe.html http/tests/security/contentSecurityPolicy/WebAssembly-blocked.html http/tests/security/contentSecurityPolicy/allow-wasm-after-window-open.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12843 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7310 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54945 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6092 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39619 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->