### PR TITLE
Fix webpushtool on iOS

### DIFF
--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -68,6 +68,9 @@ public:
 
     void connectToService(WaitForServiceToExist);
 
+    String bundleIdentifier() const { return m_bundleIdentifier; }
+    String pushPartition() const { return m_pushPartition; }
+
     void sendPushMessage(PushMessageForTesting&&, CompletionHandler<void(String)>&&);
     void getPushPermissionState(const String& scope, CompletionHandler<void(WebCore::PushPermissionState)>&&);
     void requestPushPermission(const String& scope, CompletionHandler<void(bool)>&&);


### PR DESCRIPTION
#### c5b08c20f512784e37cc065945098dc26b90c755
<pre>
Fix webpushtool on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=278404">https://bugs.webkit.org/show_bug.cgi?id=278404</a>
<a href="https://rdar.apple.com/134359279">rdar://134359279</a>

Reviewed by Brady Eidson.

webpushtool no longer works on iOS as of 282035@main since that patch expects all connections to
webpushd to be associated with a host app. Fix this by allowing direct peers with the injection
entitlement (like webpushtool) to not need a host app.

I also changed the inject command in webpushtool to no longer take in bundleIdentifier and
pushPartition, since there are already existing global flags on the tool that control that. This
also allows this patch to play more nicely with an upcoming change (bug 278367) which restricts
incoming connections to known bundle IDs.

* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::create):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(printUsageAndTerminate):
(pushMessageFromArguments):
(WebKit::WebPushToolMain):

Canonical link: <a href="https://commits.webkit.org/282526@main">https://commits.webkit.org/282526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c0c206548bc3ea029ab36101f1007e94a7c3735

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13976 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14256 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36346 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12848 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12154 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54948 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6098 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38545 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->