### PR TITLE
Make OrderIterator a STL iterator class

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -598,7 +598,7 @@
  * Turn BENABLE_MALLOC_HEAP_BREAKDOWN on in bmalloc together when using this.
  */
 #if !defined(ENABLE_MALLOC_HEAP_BREAKDOWN)
-#define ENABLE_MALLOC_HEAP_BREAKDOWN 0
+#define ENABLE_MALLOC_HEAP_BREAKDOWN 1
 #endif
 
 #if !defined(ENABLE_CFPREFS_DIRECT_MODE)

--- a/Source/WebCore/animation/AcceleratedTimeline.h
+++ b/Source/WebCore/animation/AcceleratedTimeline.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include "AcceleratedEffect.h"
+#include "AnimationMalloc.h"
 #include <wtf/HashSet.h>
 #include <wtf/Seconds.h>
 

--- a/Source/WebCore/animation/FrameRateAligner.h
+++ b/Source/WebCore/animation/FrameRateAligner.h
@@ -32,7 +32,7 @@
 #include <wtf/Seconds.h>
 
 namespace WebCore {
-
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FrameRateAligner);
 class FrameRateAligner {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:

--- a/Source/WebCore/rendering/OrderIterator.cpp
+++ b/Source/WebCore/rendering/OrderIterator.cpp
@@ -49,6 +49,40 @@ RenderBox* OrderIterator::first()
     return next();
 }
 
+OrderIterator OrderIterator::begin()
+{
+    OrderIterator it(*this);
+    it.reset();
+    return it;
+}
+
+OrderIterator OrderIterator::end()
+{
+    OrderIterator it(*this);
+    it.m_currentChild = nullptr;
+    it.m_orderValuesIterator = m_orderValues.end();
+    return it;
+}
+
+OrderIterator& OrderIterator::operator++()
+{
+    next();
+    return *this;
+}
+
+OrderIterator OrderIterator::operator++(int)
+{
+    OrderIterator temp = *this;
+    ++(*this);
+    return temp;
+}
+
+RenderBox* OrderIterator::operator*() const { return currentChild(); }
+
+
+bool OrderIterator::operator==(const OrderIterator& other) const { return m_orderValuesIterator == other.m_orderValuesIterator; }
+bool OrderIterator::operator!=(const OrderIterator& other) const { return m_orderValuesIterator != other.m_orderValuesIterator; }
+
 RenderBox* OrderIterator::next()
 {
     do {

--- a/Source/WebCore/rendering/OrderIterator.h
+++ b/Source/WebCore/rendering/OrderIterator.h
@@ -40,6 +40,23 @@ class RenderObject;
     
 class OrderIterator {
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = RenderBox;
+    using difference_type = std::ptrdiff_t;
+    using pointer = RenderBox*;
+    using reference = RenderBox&;
+    pointer operator*() const;
+
+    OrderIterator& operator++();
+    // Post Increment
+    OrderIterator operator++(int);
+
+    bool operator==(const OrderIterator& other) const;
+    bool operator!=(const OrderIterator& other) const;
+
+    OrderIterator begin();
+    OrderIterator end();
+
     friend class OrderIteratorPopulator;
 
     explicit OrderIterator(RenderBox&);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -463,7 +463,7 @@ void RenderFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
 
 void RenderFlexibleBox::appendFlexItemFrameRects(FlexItemFrameRects& flexItemFrameRects)
 {
-    for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (RenderBox* flexItem : m_orderIterator) {
         if (!flexItem->isOutOfFlowPositioned())
             flexItemFrameRects.append(flexItem->frameRect());
     }
@@ -472,7 +472,7 @@ void RenderFlexibleBox::appendFlexItemFrameRects(FlexItemFrameRects& flexItemFra
 void RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved(const FlexItemFrameRects& oldFlexItemRects)
 {
     size_t index = 0;
-    for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (RenderBox* flexItem : m_orderIterator) {
         if (flexItem->isOutOfFlowPositioned())
             continue;
 
@@ -488,7 +488,7 @@ void RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved(const FlexItemFrameR
 
 void RenderFlexibleBox::paintChildren(PaintInfo& paintInfo, const LayoutPoint& paintOffset, PaintInfo& paintInfoForFlexItem, bool usePrintRect)
 {
-    for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (RenderBox* flexItem : m_orderIterator) {
         if (!paintChild(*flexItem, paintInfo, paintOffset, paintInfoForFlexItem, usePrintRect, PaintAsInlineBlock))
             return;
     }
@@ -1282,7 +1282,7 @@ void RenderFlexibleBox::performFlexLayout(bool relayoutChildren)
     // TODO(cbiesinger): That second part is not yet true.
     FlexLayoutItems allItems;
     m_orderIterator.first();
-    for (RenderBox* flexItem = m_orderIterator.currentChild(); flexItem; flexItem = m_orderIterator.next()) {
+    for (RenderBox* flexItem : m_orderIterator) {
         if (m_orderIterator.shouldSkipChild(*flexItem)) {
             // Out-of-flow children are not flex items, so we skip them here.
             if (flexItem->isOutOfFlowPositioned())
@@ -2684,7 +2684,7 @@ const RenderBox* RenderFlexibleBox::firstBaselineCandidateOnLine(OrderIterator f
 
     size_t index = 0;
     const RenderBox* baselineFlexItem = nullptr;
-    for (auto* flexItem = flexItemIterator.first(); flexItem; flexItem = flexItemIterator.next()) {
+    for (RenderBox* flexItem : flexItemIterator) {
         if (flexItemIterator.shouldSkipChild(*flexItem))
             continue;
         if (alignmentForFlexItem(*flexItem) == baselinePosition && mainAxisIsFlexItemInlineAxis(*flexItem) && !hasAutoMarginsInCrossAxis(*flexItem))
@@ -2704,7 +2704,7 @@ const RenderBox* RenderFlexibleBox::lastBaselineCandidateOnLine(OrderIterator fl
 
     size_t index = 0;
     RenderBox* baselineFlexItem = nullptr;
-    for (auto* flexItem = flexItemIterator.first(); flexItem; flexItem = flexItemIterator.next()) {
+    for (RenderBox* flexItem : flexItemIterator) {
         if (flexItemIterator.shouldSkipChild(*flexItem))
             continue;
         if (alignmentForFlexItem(*flexItem) == baselinePosition && mainAxisIsFlexItemInlineAxis(*flexItem) && !hasAutoMarginsInCrossAxis(*flexItem))

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -331,7 +331,7 @@
 #endif
 
 /* Enable this to put each IsoHeap and other allocation categories into their own malloc heaps, so that tools like vmmap can show how big each heap is. */
-#define BENABLE_MALLOC_HEAP_BREAKDOWN 0
+#define BENABLE_MALLOC_HEAP_BREAKDOWN 1
 
 /* This is used for debugging when hacking on how bmalloc calculates its physical footprint. */
 #define ENABLE_PHYSICAL_PAGE_MAP 0


### PR DESCRIPTION
#### 95799c951a1a33f6108b287b5ea25efabff1552f
<pre>
Make OrderIterator a STL iterator class
<a href="https://bugs.webkit.org/show_bug.cgi?id=154590">https://bugs.webkit.org/show_bug.cgi?id=154590</a>
<a href="https://rdar.apple.com/problem/134356478">rdar://problem/134356478</a>

Reviewed by NOBODY (OOPS!).

Add the required methods and operators to use STL-like range-based for loops with and instance of an OrderIterator.

* Source/WebCore/rendering/OrderIterator.cpp:
(WebCore::OrderIterator::begin):
(WebCore::OrderIterator::end):
(WebCore::OrderIterator::operator++):
(WebCore::OrderIterator::operator* const):
(WebCore::OrderIterator::operator== const):
(WebCore::OrderIterator::operator!= const):
* Source/WebCore/rendering/OrderIterator.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::appendFlexItemFrameRects):
(WebCore::RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved):
(WebCore::RenderFlexibleBox::paintChildren):
(WebCore::RenderFlexibleBox::performFlexLayout):
(WebCore::RenderFlexibleBox::firstBaselineCandidateOnLine const):
(WebCore::RenderFlexibleBox::lastBaselineCandidateOnLine const):
</pre>
----------------------------------------------------------------------
#### 816bef6ef7682c50306ee25cb52f47beefc06ec6
<pre>
configured for mallocHeapBreakdown work
</pre>
----------------------------------------------------------------------
#### d6faca64203031346b903e8ba7324f1cfb261644
<pre>
Fix broken ENABLE_MALLOC_HEAP_BREAKDOWN feature.
Bug URL: <a href="https://bugs.webkit.org/show_bug.cgi?id=278260">https://bugs.webkit.org/show_bug.cgi?id=278260</a>
Radar Link: <a href="https://rdar.apple.com/134090283">rdar://134090283</a>

Reviewed by NOBODY (OOPS!).

Add a missing DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER macro to FrameRateAligner.h.
When WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER is used, AcceleratedTimeLine.h relies on a class defined in AnimationMalloc.h, but could not find it when compiling. Put in a missing include statement for AnimationMalloc.h and change the target membership for AnimationMalloc.h to be in WebCore. This fixed the problem.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AcceleratedTimeline.h:
* Source/WebCore/animation/FrameRateAligner.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95799c951a1a33f6108b287b5ea25efabff1552f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15967 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14258 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66439 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/56482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/12558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/62620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7317 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7349 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/54952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/6105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84376 "Hash 95799c95 for PR 32474 does not build (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/84376 "Hash 95799c95 for PR 32474 does not build (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->