### PR TITLE
Make OrderIterator a STL iterator class

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -2009,7 +2009,7 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
     bool hasCustomOrder = false;
 
     auto childOrderIterator = renderFlex.orderIterator();
-    for (RenderBox* renderChild = childOrderIterator.first(); renderChild; renderChild = childOrderIterator.next()) {
+    for (auto* renderChild : childOrderIterator) {
         if (childOrderIterator.shouldSkipChild(*renderChild))
             continue;
         renderChildrenInFlexOrder.append(renderChild);

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -80,8 +80,9 @@ void GridMasonryLayout::collectMasonryItems()
     m_itemsWithIndefiniteGridAxisPosition.shrink(0);
 
     auto& grid = m_renderGrid.currentGrid();
-    for (auto* gridItem = grid.orderIterator().first(); gridItem; gridItem = grid.orderIterator().next()) {
-        if (grid.orderIterator().shouldSkipChild(*gridItem))
+    OrderIterator& iterator = grid.orderIterator();
+    for (auto* gridItem : iterator) {
+        if (iterator.shouldSkipChild(*gridItem))
             continue;
 
         if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)

--- a/Source/WebCore/rendering/OrderIterator.h
+++ b/Source/WebCore/rendering/OrderIterator.h
@@ -40,24 +40,40 @@ class RenderObject;
     
 class OrderIterator {
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = RenderBox;
+    using difference_type = std::ptrdiff_t;
+    using pointer = RenderBox*;
+    using reference = RenderBox&;
+    pointer operator*();
+
+    OrderIterator& operator++();
+    // Post Increment
+    OrderIterator operator++(int);
+
+    bool operator==(const OrderIterator& other) const;
+    bool operator!=(const OrderIterator& other) const = default;
+
+    OrderIterator begin();
+    const OrderIterator end() const;
+
     friend class OrderIteratorPopulator;
 
     explicit OrderIterator(RenderBox&);
-
+    OrderIterator(const OrderIterator&) = default;
     RenderBox* currentChild() const { return m_currentChild; }
-    RenderBox* first();
-    RenderBox* next();
     OrderIterator reverse();
     bool shouldSkipChild(const RenderObject&) const;
 
 private:
     void reset();
-
+    RenderBox* first();
+    RenderBox* next();
     RenderBox& m_containerBox;
     RenderBox* m_currentChild;
 
     using OrderValues = StdSet<int>;
-    OrderValues m_orderValues;
+    std::shared_ptr<OrderValues> m_orderValues;
     OrderValues::const_iterator m_orderValuesIterator;
     bool m_isReset { false };
     bool m_reversedOrder { false };
@@ -68,7 +84,7 @@ public:
     explicit OrderIteratorPopulator(OrderIterator& iterator)
         : m_iterator(iterator)
     {
-        m_iterator.m_orderValues.clear();
+        m_iterator.m_orderValues->clear();
     }
     ~OrderIteratorPopulator();
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -365,7 +365,7 @@ bool RenderFlexibleBox::hitTestChildren(const HitTestRequest& request, HitTestRe
 
     // If collecting the children in reverse order is bad for performance, this Vector could be determined at layout time.
     Vector<RenderBox*> reversedOrderIteratorForHitTesting;
-    for (auto* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (auto* flexItem : m_orderIterator) {
         if (flexItem->isOutOfFlowPositioned())
             continue;
         reversedOrderIteratorForHitTesting.append(flexItem);
@@ -463,7 +463,7 @@ void RenderFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
 
 void RenderFlexibleBox::appendFlexItemFrameRects(FlexItemFrameRects& flexItemFrameRects)
 {
-    for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (auto* flexItem : m_orderIterator) {
         if (!flexItem->isOutOfFlowPositioned())
             flexItemFrameRects.append(flexItem->frameRect());
     }
@@ -472,7 +472,7 @@ void RenderFlexibleBox::appendFlexItemFrameRects(FlexItemFrameRects& flexItemFra
 void RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved(const FlexItemFrameRects& oldFlexItemRects)
 {
     size_t index = 0;
-    for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (auto* flexItem : m_orderIterator) {
         if (flexItem->isOutOfFlowPositioned())
             continue;
 
@@ -488,7 +488,7 @@ void RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved(const FlexItemFrameR
 
 void RenderFlexibleBox::paintChildren(PaintInfo& paintInfo, const LayoutPoint& paintOffset, PaintInfo& paintInfoForFlexItem, bool usePrintRect)
 {
-    for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
+    for (auto* flexItem : m_orderIterator) {
         if (!paintChild(*flexItem, paintInfo, paintOffset, paintInfoForFlexItem, usePrintRect, PaintAsInlineBlock))
             return;
     }
@@ -1282,8 +1282,7 @@ void RenderFlexibleBox::performFlexLayout(bool relayoutChildren)
     // should work off this list of a subset.
     // TODO(cbiesinger): That second part is not yet true.
     FlexLayoutItems allItems;
-    m_orderIterator.first();
-    for (RenderBox* flexItem = m_orderIterator.currentChild(); flexItem; flexItem = m_orderIterator.next()) {
+    for (auto* flexItem : m_orderIterator) {
         if (m_orderIterator.shouldSkipChild(*flexItem)) {
             // Out-of-flow children are not flex items, so we skip them here.
             if (flexItem->isOutOfFlowPositioned())
@@ -2683,7 +2682,7 @@ const RenderBox* RenderFlexibleBox::firstBaselineCandidateOnLine(OrderIterator f
 
     size_t index = 0;
     const RenderBox* baselineFlexItem = nullptr;
-    for (auto* flexItem = flexItemIterator.first(); flexItem; flexItem = flexItemIterator.next()) {
+    for (auto* flexItem : flexItemIterator) {
         if (flexItemIterator.shouldSkipChild(*flexItem))
             continue;
         if (alignmentForFlexItem(*flexItem) == baselinePosition && mainAxisIsFlexItemInlineAxis(*flexItem) && !hasAutoMarginsInCrossAxis(*flexItem))
@@ -2703,7 +2702,7 @@ const RenderBox* RenderFlexibleBox::lastBaselineCandidateOnLine(OrderIterator fl
 
     size_t index = 0;
     RenderBox* baselineFlexItem = nullptr;
-    for (auto* flexItem = flexItemIterator.first(); flexItem; flexItem = flexItemIterator.next()) {
+    for (auto* flexItem : flexItemIterator) {
         if (flexItemIterator.shouldSkipChild(*flexItem))
             continue;
         if (alignmentForFlexItem(*flexItem) == baselinePosition && mainAxisIsFlexItemInlineAxis(*flexItem) && !hasAutoMarginsInCrossAxis(*flexItem))

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -998,7 +998,7 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
 
     Vector<RenderBox*> autoMajorAxisAutoGridItems;
     Vector<RenderBox*> specifiedMajorAxisAutoGridItems;
-    for (auto* gridItem = currentGrid().orderIterator().first(); gridItem; gridItem = currentGrid().orderIterator().next()) {
+    for (auto* gridItem : currentGrid().orderIterator()) {
         if (currentGrid().orderIterator().shouldSkipChild(*gridItem))
             continue;
 
@@ -1049,7 +1049,7 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
     performAutoPlacement();
 
 #if ASSERT_ENABLED
-    for (auto* gridItem = currentGrid().orderIterator().first(); gridItem; gridItem = currentGrid().orderIterator().next()) {
+    for (auto* gridItem : currentGrid().orderIterator()) {
         if (currentGrid().orderIterator().shouldSkipChild(*gridItem))
             continue;
 
@@ -1068,7 +1068,7 @@ Vector<LayoutRect> RenderGrid::gridItemsLayoutRects()
 {
     Vector<LayoutRect> items;
 
-    for (RenderBox* gridItem = currentGrid().orderIterator().first(); gridItem; gridItem = currentGrid().orderIterator().next())
+    for (auto* gridItem : currentGrid().orderIterator())
         items.append(gridItem->frameRect());
 
     return items;
@@ -2488,7 +2488,7 @@ unsigned RenderGrid::numTracks(GridTrackSizingDirection direction) const
 void RenderGrid::paintChildren(PaintInfo& paintInfo, const LayoutPoint& paintOffset, PaintInfo& forChild, bool usePrintRect)
 {
     ASSERT(!currentGrid().needsItemsPlacement());
-    for (RenderBox* gridItem = currentGrid().orderIterator().first(); gridItem; gridItem = currentGrid().orderIterator().next())
+    for (auto* gridItem : currentGrid().orderIterator())
         paintChild(*gridItem, paintInfo, paintOffset, forChild, usePrintRect, PaintAsInlineBlock);
 }
 


### PR DESCRIPTION
#### be53304650ed535fa03c1cb9ac96b75a5d40da9c
<pre>
Make OrderIterator a STL iterator class
<a href="https://bugs.webkit.org/show_bug.cgi?id=154590">https://bugs.webkit.org/show_bug.cgi?id=154590</a>
<a href="https://rdar.apple.com/134356478">rdar://134356478</a>

Reviewed by NOBODY (OOPS!).

Add the required methods and operators to use STL-like range-based for loops with an instance of an OrderIterator.

* Source/WebCore/rendering/OrderIterator.cpp:
(WebCore::OrderIterator::begin):
(WebCore::OrderIterator::end):
(WebCore::OrderIterator::operator++):
(WebCore::OrderIterator::operator* const):
(WebCore::OrderIterator::operator== const):
(WebCore::OrderIterator::operator!= const):
* Source/WebCore/rendering/OrderIterator.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::appendFlexItemFrameRects):
(WebCore::RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved):
(WebCore::RenderFlexibleBox::paintChildren):
(WebCore::RenderFlexibleBox::performFlexLayout):
(WebCore::RenderFlexibleBox::firstBaselineCandidateOnLine const):
(WebCore::RenderFlexibleBox::lastBaselineCandidateOnLine const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be53304650ed535fa03c1cb9ac96b75a5d40da9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/73488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/20563 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55199 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/44521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/59919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41187 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17349 "Found 2 new test failures: fullscreen/element-clear-during-fullscreen-crash.html imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/18940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/17694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/75199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/13387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/62866 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/13426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62772 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4403 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/44609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/45683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/46878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/45424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->