### PR TITLE
[GLIB] Add more signpost marks related to graphics

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -178,6 +178,8 @@ enum TracePointCode {
     FrameCompositionEnd,
     LayerFlushStart,
     LayerFlushEnd,
+    UpdateLayerContentBuffersStart,
+    UpdateLayerContentBuffersEnd,
 #endif
 
 };

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -149,6 +149,7 @@ public:
         case RenderServerSnapshotStart:
         case TakeSnapshotStart:
         case SyntheticMomentumStart:
+        case UpdateLayerContentBuffersStart:
         case CommitLayerTreeStart:
         case ProcessLaunchStart:
         case InitializeSandboxStart:
@@ -207,6 +208,7 @@ public:
         case RenderServerSnapshotEnd:
         case TakeSnapshotEnd:
         case SyntheticMomentumEnd:
+        case UpdateLayerContentBuffersEnd:
         case CommitLayerTreeEnd:
         case ProcessLaunchEnd:
         case InitializeSandboxEnd:
@@ -409,6 +411,9 @@ private:
             return "RemoteLayerTreeScheduleRenderingUpdate"_s;
         case DisplayLinkUpdate:
             return "DisplayLinkUpdate"_s;
+        case UpdateLayerContentBuffersStart:
+        case UpdateLayerContentBuffersEnd:
+            return "UpdateLayerContentBuffers"_s;
 
         case CommitLayerTreeStart:
         case CommitLayerTreeEnd:

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -41,6 +41,7 @@
 #ifndef NDEBUG
 #include <wtf/SetForScope.h>
 #endif
+#include <wtf/SystemTracing.h>
 #include <wtf/text/CString.h>
 
 #if USE(CAIRO)
@@ -1143,6 +1144,10 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
     if (!m_nicosia.backingStore)
         return;
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    TraceScope traceScope(UpdateLayerContentBuffersStart, UpdateLayerContentBuffersEnd);
+#endif
+
     // Prepare for painting on the impl-contained backing store. isFlushing is used there
     // for internal sanity checks.
     auto& layerState = m_nicosia.backingStore->layerState();
@@ -1202,15 +1207,22 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
     // With all the affected tiles created and/or invalidated, we can finally paint them.
     auto dirtyTiles = layerState.mainBackingStore->dirtyTiles();
     if (!dirtyTiles.isEmpty()) {
+        auto dirtyTilesCount = dirtyTiles.size();
         bool didUpdateTiles = false;
 
-        for (auto& tileReference : dirtyTiles) {
-            auto& tile = tileReference.get();
+        WTFBeginSignpost(this, UpdateTiles, "dirty tiles: %lu", dirtyTilesCount);
+
+        for (unsigned dirtyTileIndex = 0; dirtyTileIndex < dirtyTilesCount; ++dirtyTileIndex) {
+            auto& tile = dirtyTiles[dirtyTileIndex].get();
             tile.ensureTileID();
+
+            WTFBeginSignpost(this, UpdateTile, "%u/%lu, id: %d", dirtyTileIndex + 1, dirtyTilesCount, tile.tileID());
 
             auto& tileRect = tile.rect();
             auto& dirtyRect = tile.dirtyRect();
             auto buffer = paintTile(dirtyRect, layerState.mainBackingStore->mapToContents(dirtyRect), layerState.mainBackingStore->contentsScale());
+
+            WTFBeginSignpost(this, UpdateTileBackingStore, "rect %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
 
             IntRect updateRect(dirtyRect);
             updateRect.move(-tileRect.x(), -tileRect.y());
@@ -1218,10 +1230,15 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
 
             tile.markClean();
             didUpdateTiles |= true;
+
+            WTFEndSignpost(this, UpdateTileBackingStore);
+            WTFEndSignpost(this, UpdateTile);
         }
 
         if (didUpdateTiles)
             didUpdateTileBuffers();
+
+        WTFEndSignpost(this, UpdateTiles);
     }
 
     // Request a new update immediately if some tiles are still pending creation. Do this on a timer

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
@@ -43,6 +43,7 @@
 #include <skia/gpu/gl/GrGLTypes.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/RunLoop.h>
+#include <wtf/SystemTracing.h>
 #include <wtf/Vector.h>
 #include <wtf/WorkerPool.h>
 
@@ -81,7 +82,10 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
     if (auto* acceleratedBufferPool = m_coordinator->skiaAcceleratedBufferPool()) {
         PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
         if (auto buffer = acceleratedBufferPool->acquireBuffer(tileRect.size(), !contentsOpaque())) {
+            WTFBeginSignpost(this, PaintTile, "Skia accelerated, dirty region %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
             paintBuffer(*buffer);
+            WTFEndSignpost(this, PaintTile);
+
             return Ref { *buffer };
         }
     }
@@ -91,26 +95,37 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
 
     // Non-blocking, multi-threaded variant.
     if (auto* workerPool = m_coordinator->skiaUnacceleratedThreadedRenderingPool()) {
+        WTFBeginSignpost(this, RecordTile);
+
         // Threaded rendering: record display lists, and asynchronously replay them using dedicated worker threads.
         buffer->beginPainting();
 
         auto recordingContext = makeUnique<DisplayList::DrawingContext>(tileRect.size());
         paintIntoGraphicsContext(recordingContext->context());
 
-        workerPool->postTask([buffer = Ref { buffer }, recordingContext = WTFMove(recordingContext)] {
+        workerPool->postTask([buffer = Ref { buffer }, recordingContext = WTFMove(recordingContext), tileRect] {
             RELEASE_ASSERT(buffer->surface());
             if (auto* canvas = buffer->surface()->getCanvas()) {
+                WTFBeginSignpost(canvas, PaintTile, "Skia unaccelerated multithread, dirty region %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
+
                 GraphicsContextSkia context(*canvas, RenderingMode::Unaccelerated, RenderingPurpose::LayerBacking);
                 recordingContext->replayDisplayList(context);
+
+                WTFEndSignpost(canvas, PaintTile);
             }
             buffer->completePainting();
         });
+
+        WTFEndSignpost(this, RecordTile);
 
         return buffer;
     }
 
     // Blocking, single-thread variant.
+    WTFBeginSignpost(this, PaintTile, "Skia unaccelerated, dirty region %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
     paintBuffer(buffer.get());
+    WTFEndSignpost(this, PaintTile);
+
     return buffer;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5026,12 +5026,16 @@ bool WebPage::shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCo
 
 void WebPage::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> flags)
 {
+    WTFBeginSignpost(this, FinalizeRenderingUpdate);
+
     m_page->finalizeRenderingUpdate(flags);
 #if ENABLE(GPU_PROCESS)
     if (m_remoteRenderingBackendProxy)
         m_remoteRenderingBackendProxy->finalizeRenderingUpdate();
 #endif
     flushDeferredDidReceiveMouseEvent();
+
+    WTFEndSignpost(this, FinalizeRenderingUpdate);
 }
 
 void WebPage::willStartRenderingUpdateDisplay()


### PR DESCRIPTION
#### f6853da27ea8bf30133d2c1b6cdc3265ec75b37c
<pre>
[GLIB] Add more signpost marks related to graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=278411">https://bugs.webkit.org/show_bug.cgi?id=278411</a>

Reviewed by Nikolas Zimmermann.

Add a series of marks that act as submarks of BackingStoreFlush. In
particular, the important ones are the marks tile renders.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::updateContentBuffers):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::commitSceneState):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::finalizeRenderingUpdate):

Canonical link: <a href="https://commits.webkit.org/282779@main">https://commits.webkit.org/282779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29893bd91328176135e83f8384b8f3cf54155a31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51678 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13679 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57309 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69918 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63442 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59155 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14180 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6736 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/424 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39374 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->