### PR TITLE
[Text Directionality] Fix directionality for shadow tree

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8034,12 +8034,6 @@ webkit.org/b/261557 media/video-remove-insert-repaints.html [ Pass Crash ]
 # Out-of-flow line break handling
 [ Debug ] fast/text/remove-renderer-and-select-crash.html [ Skip ]
 
-# web-platform-tests/html/dom/elements/global-attributes failures
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-06.html [ ImageOnlyFailure ]
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html [ ImageOnlyFailure ]
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html [ ImageOnlyFailure ]
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html [ ImageOnlyFailure ]
-
 webkit.org/b/250795 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html [ Skip ]
 
 # web-platform-tests/svg/painting/reftests failures

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
@@ -1,25 +1,22 @@
 
 PASS dynamic insertion of RTL text in a child element
 PASS dir=auto changes for content insertion and removal, in and out of document
-FAIL dir=auto changes for slot reassignment assert_true: #one with LTR child span expected true got false
+PASS dir=auto changes for slot reassignment
 FAIL text changes affecting both slot and ancestor with dir=auto assert_false: slot after first text change expected false got true
 PASS dynamic changes to subtrees excluded as a result of the dir attribute
 PASS dynamic changes inside of non-HTML elements
-FAIL slotted non-HTML elements assert_true: initial state (slot) expected true got false
+FAIL slotted non-HTML elements assert_true: state after first change (slot) expected true got false
 PASS slotted non-HTML elements after dynamically assigning dir=auto, and dir attribute ignored on non-HTML elements
 PASS dir=auto ancestor considers text in subtree after removing dir=ltr from it
 PASS Slotted content affects multiple dir=auto slots
-FAIL Removing slotted content resets direction on dir=auto slot assert_equals: slot initially rtl expected "rtl" but got "ltr"
-FAIL Removing child of slotted content changes direction on dir=auto slot assert_equals: slot initially rtl expected "rtl" but got "ltr"
+PASS Removing slotted content resets direction on dir=auto slot
+FAIL Removing child of slotted content changes direction on dir=auto slot assert_equals: slot is reset to ltr expected "ltr" but got "rtl"
 PASS Child directionality gets updated when dir=auto is set on parent
-FAIL dir=auto slot is updated by text in value of input element children assert_equals: expected "rtl" but got "ltr"
-FAIL dir=auto slot is updated if input stops being auto-directionality form-associated assert_equals: expected "rtl" but got "ltr"
+FAIL dir=auto slot is updated by text in value of input element children assert_equals: expected "ltr" but got "rtl"
+FAIL dir=auto slot is updated if input stops being auto-directionality form-associated assert_equals: expected "ltr" but got "rtl"
 PASS slot provides updated directionality from host to a dir=auto container
-A א
 א
-A א
+א א
 א
-اختبر
-اختبر
 
  abc

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt
@@ -1,19 +1,14 @@
-اختبر
-اختبر
-Text
-اختبر
-
 
 PASS Slots: Directionality: dir=rtl on slot
 PASS Slots: Directionality: dir=rtl on host
 PASS Slots: Directionality: dir=auto on host with Arabic shadow tree content
 PASS Slots: Directionality: dir=auto in shadow tree with Arabic light tree content
-FAIL Slots: Directionality: dir=auto in shadow tree with Arabic shadow tree content assert_equals: expected "ltr" but got "rtl"
-FAIL Slots: Directionality: dir=auto on slot with Arabic light tree content assert_equals: expected "rtl" but got "ltr"
-FAIL slot provides its directionality (from host) to a dir=auto container assert_equals: expected "rtl" but got "ltr"
+PASS Slots: Directionality: dir=auto in shadow tree with Arabic shadow tree content
+PASS Slots: Directionality: dir=auto on slot with Arabic light tree content
+PASS slot provides its directionality (from host) to a dir=auto container
 PASS children with dir attribute are skipped by dir=auto
 PASS slot with dir attribute is skipped by dir=auto
-FAIL dir=auto slot ignores dir attribute of assigned nodes assert_equals: expected "rtl" but got "ltr"
-FAIL dir=auto slot considers text in bdi assigned nodes assert_equals: expected "rtl" but got "ltr"
-FAIL dir=auto slot considers text in value of input element children assert_equals: expected "rtl" but got "ltr"
+PASS dir=auto slot ignores dir attribute of assigned nodes
+PASS dir=auto slot considers text in bdi assigned nodes
+PASS dir=auto slot considers text in value of input element children
 

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -64,7 +64,7 @@ static void notifyNodeInsertedIntoTree(ContainerNode& parentOfInsertedTree, Node
 
     for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
         auto result = currentNode->insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ false, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
-        ASSERT_UNUSED(result, result == Node::InsertedIntoAncestorResult::Done);
+        UNUSED_PARAM(result);
         if (RefPtr root = currentNode->shadowRoot())
             notifyNodeInsertedIntoTree(parentOfInsertedTree, *root, TreeScopeChange::DidNotChange);
     }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -817,8 +817,15 @@ public:
     bool hasCustomState(const AtomString& state) const;
     CustomStateSet& ensureCustomStateSet();
 
-    bool hasDirectionAuto() const;
-    std::optional<TextDirection> directionalityIfDirIsAuto() const;
+    bool hasValidTextDirectionState() const;
+    bool hasAutoTextDirectionState() const;
+
+    std::optional<TextDirection> computeAutoTextDirection() const;
+    std::optional<TextDirection> computeTextDirectionIfDirIsAuto() const;
+
+    void updateEffectiveTextDirectionOfDescendants(std::optional<TextDirection>, Element* exclude = nullptr);
+    void updateEffectiveTextDirectionOfAncestors(Element* exclude = nullptr);
+    void updateEffectiveTextDirection();
 
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
@@ -847,9 +854,6 @@ protected:
 
     void disconnectFromIntersectionObservers();
     static AtomString makeTargetBlankIfHasDanglingMarkup(const AtomString& target);
-
-    void updateTextDirectionalityAfterInputTypeChange();
-    void updateEffectiveDirectionalityOfDirAuto();
 
 private:
     LocalFrame* documentFrameWithNonNullView() const;
@@ -949,16 +953,7 @@ private:
     WEBCORE_EXPORT bool fastAttributeLookupAllowed(const QualifiedName&) const;
 #endif
 
-    void dirAttributeChanged(const AtomString&);
-    void updateEffectiveDirectionality(std::optional<TextDirection>);
-    void adjustDirectionalityIfNeededAfterChildAttributeChanged(Element* child);
-    void adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type);
-
-    struct TextDirectionWithStrongDirectionalityNode {
-        TextDirection direction;
-        RefPtr<Node> strongDirectionalityNode;
-    };
-    TextDirectionWithStrongDirectionalityNode computeDirectionalityFromText() const;
+    void dirAttributeChanged(const AtomString& newValue);
 
     bool hasEffectiveLangState() const;
     void updateEffectiveLangState();

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -314,6 +314,9 @@ void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowR
 
     if (shadowRoot.shouldFireSlotchangeEvent())
         slotElement->enqueueSlotChangeEvent();
+
+    if (slotElement->selfOrPrecedingNodesAffectDirAuto())
+        slotElement->updateEffectiveTextDirection();
 }
 
 void NamedSlotAssignment::didRemoveAllChildrenOfShadowHost(ShadowRoot& shadowRoot)

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -561,8 +561,8 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     m_inputType->createShadowSubtreeIfNeeded();
 
     // https://html.spec.whatwg.org/multipage/dom.html#auto-directionality
-    if (oldType == InputType::Type::Telephone || m_inputType->type() == InputType::Type::Telephone || (hasDirectionAuto() && didDirAutoUseValue != m_inputType->dirAutoUsesValue()))
-        updateTextDirectionalityAfterInputTypeChange();
+    if (oldType == InputType::Type::Telephone || m_inputType->type() == InputType::Type::Telephone || (hasAutoTextDirectionState() && didDirAutoUseValue != m_inputType->dirAutoUsesValue()))
+        updateEffectiveTextDirection();
 
     if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
         emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClass::ReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClass::ReadOnly, willSupportReadOnly } });
@@ -662,7 +662,7 @@ void HTMLInputElement::subtreeHasChanged()
     m_inputType->subtreeHasChanged();
     // When typing in an input field, childrenChanged is not called, so we need to force the directionality check.
     if (selfOrPrecedingNodesAffectDirAuto())
-        updateEffectiveDirectionalityOfDirAuto();
+        updateEffectiveTextDirection();
 }
 
 const AtomString& HTMLInputElement::formControlType() const
@@ -812,7 +812,7 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         }
         updateValidity();
         if (selfOrPrecedingNodesAffectDirAuto())
-            updateEffectiveDirectionalityOfDirAuto();
+            updateEffectiveTextDirection();
         m_valueAttributeWasUpdatedAfterParsing = !m_parsingInProgress;
         break;
     case AttributeNames::nameAttr:
@@ -1178,7 +1178,7 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
     setFormControlValueMatchesRenderer(false);
     m_inputType->setValue(WTFMove(sanitizedValue), valueChanged, eventBehavior, selection);
     if (selfOrPrecedingNodesAffectDirAuto())
-        updateEffectiveDirectionalityOfDirAuto();
+        updateEffectiveTextDirection();
 
     if (valueChanged && eventBehavior == DispatchNoEvent)
         setTextAsOfLastFormControlChangeEvent(sanitizedValue);

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -65,9 +65,11 @@ HTMLSlotElement::InsertedIntoAncestorResult HTMLSlotElement::insertedIntoAncesto
     if (insertionType.treeScopeChanged && isInShadowTree()) {
         if (auto* shadowRoot = containingShadowRoot())
             shadowRoot->addSlotElementByName(attributeWithoutSynchronization(nameAttr), *this);
+
+        return Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback;
     }
 
-    return InsertedIntoAncestorResult::Done;
+    return Node::InsertedIntoAncestorResult::Done;
 }
 
 void HTMLSlotElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
@@ -99,6 +101,13 @@ void HTMLSlotElement::attributeChanged(const QualifiedName& name, const AtomStri
         if (RefPtr shadowRoot = containingShadowRoot())
             shadowRoot->renameSlotElement(*this, oldValue, newValue);
     }
+}
+
+void HTMLSlotElement::didFinishInsertingNode()
+{
+    HTMLElement::didFinishInsertingNode();
+    if (selfOrPrecedingNodesAffectDirAuto())
+        updateEffectiveTextDirection();
 }
 
 const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* HTMLSlotElement::assignedNodes() const
@@ -225,5 +234,4 @@ void HTMLSlotElement::dispatchSlotChangeEvent()
     dispatchEvent(event);
 }
 
-}
-
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -62,11 +62,11 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+    void didFinishInsertingNode() final;
 
     bool m_inSignalSlotList { false };
     bool m_isInInsertedIntoAncestor { false };
     Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_manuallyAssignedNodes;
 };
 
-}
-
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -263,7 +263,7 @@ void HTMLTextAreaElement::subtreeHasChanged()
         frame->editor().textDidChangeInTextArea(*this);
     // When typing in a textarea, childrenChanged is not called, so we need to force the directionality check.
     if (selfOrPrecedingNodesAffectDirAuto())
-        updateEffectiveDirectionalityOfDirAuto();
+        updateEffectiveTextDirection();
 }
 
 void HTMLTextAreaElement::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& event) const
@@ -379,7 +379,7 @@ void HTMLTextAreaElement::setValueCommon(const String& newValue, TextFieldEventB
     updatePlaceholderVisibility();
     invalidateStyleForSubtree();
     if (selfOrPrecedingNodesAffectDirAuto())
-        updateEffectiveDirectionalityOfDirAuto();
+        updateEffectiveTextDirection();
     setFormControlValueMatchesRenderer(true);
 
     auto endOfString = m_value.length();

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -871,7 +871,7 @@ String HTMLTextFormControlElement::directionForFormData() const
             if (equalLettersIgnoringASCIICase(value, "ltr"_s))
                 return TextDirection::LTR;
             if (equalLettersIgnoringASCIICase(value, "auto"_s))
-                return element.directionalityIfDirIsAuto().value_or(TextDirection::LTR);
+                return element.computeAutoTextDirection().value_or(TextDirection::LTR);
         }
         return TextDirection::LTR;
     }();

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -812,7 +812,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
     bool wasInRange = isInRange(element->value());
     bool inRange = isInRange(sanitizedValue);
 
-    auto oldDirection = element->directionalityIfDirIsAuto();
+    auto oldDirection = element->computeTextDirectionIfDirIsAuto();
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (wasInRange != inRange)
@@ -820,7 +820,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
 
     element->setValueInternal(sanitizedValue, eventBehavior);
 
-    if (oldDirection.value_or(TextDirection::LTR) != element->directionalityIfDirIsAuto().value_or(TextDirection::LTR))
+    if (oldDirection.value_or(TextDirection::LTR) != element->computeTextDirectionIfDirIsAuto().value_or(TextDirection::LTR))
         element->invalidateStyleInternal();
 
     switch (eventBehavior) {

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -823,10 +823,10 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
         addElementStyleProperties(styledElement->additionalPresentationalHintStyle(), RuleSet::cascadeLayerPriorityForPresentationalHints);
 
         if (auto* htmlElement = dynamicDowncast<HTMLElement>(*styledElement)) {
-            auto result = htmlElement->directionalityIfDirIsAuto();
-            auto& properties = result.value_or(TextDirection::LTR) == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration();
-            if (result)
+            if (auto textDirection = htmlElement->computeTextDirectionIfDirIsAuto()) {
+                auto& properties = *textDirection == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration();
                 addMatchedProperties({ properties }, DeclarationOrigin::Author);
+            }
         }
     }
 

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -70,12 +70,6 @@ static inline bool parentElementPreventsSharing(const Element& parentElement)
     return parentElement.hasFlagsSetDuringStylingOfChildren();
 }
 
-static inline bool elementHasDirectionAuto(const Element& element)
-{
-    auto* htmlElement = dynamicDowncast<HTMLElement>(element);
-    return htmlElement && htmlElement->hasDirectionAuto();
-}
-
 std::unique_ptr<RenderStyle> SharingResolver::resolve(const Styleable& searchStyleable, const Update& update)
 {
     auto* element = dynamicDowncast<StyledElement>(searchStyleable.element);
@@ -101,7 +95,7 @@ std::unique_ptr<RenderStyle> SharingResolver::resolve(const Styleable& searchSty
         return nullptr;
     if (element == m_document.cssTarget())
         return nullptr;
-    if (elementHasDirectionAuto(*element))
+    if (is<HTMLElement>(*element) && element->hasAutoTextDirectionState())
         return nullptr;
     if (element->shadowRoot() && element->shadowRoot()->styleScope().resolver().ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.hostPseudoClassRules().isEmpty(); }))
         return nullptr;
@@ -259,7 +253,7 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
     if (candidateElement.hasTagName(HTMLNames::embedTag) || candidateElement.hasTagName(HTMLNames::objectTag) || candidateElement.hasTagName(HTMLNames::appletTag) || candidateElement.hasTagName(HTMLNames::canvasTag))
         return false;
 
-    if (elementHasDirectionAuto(candidateElement))
+    if (is<HTMLElement>(candidateElement) && candidateElement.hasAutoTextDirectionState())
         return false;
 
     if (candidateElement.isRelevantToUser() != element.isRelevantToUser())


### PR DESCRIPTION
#### b6ee5d981582cff85e203d2403d422a86c53d922
<pre>
[Text Directionality] Fix directionality for shadow tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=277862">https://bugs.webkit.org/show_bug.cgi?id=277862</a>
<a href="https://rdar.apple.com/133549820">rdar://133549820</a>

Reviewed by Ryosuke Niwa.

This patch aligns the TextDirection computations with the specs [1].

Be aware of this difference in this patch:

(a) TextDirection: is an enum which has only two values: LTR and RTL.
(b) TextDirectionState: is enum which is similar to TextDirection but has an
additional values for Auto and Undefined.

Invalidating the Node textDirection and usesTextDirection was fixed in some
places. This fixed most of the WPT failures. But there are still a few failures
left in the test dir-auto-dynamic-changes.window.html.

[1] <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-dir">https://html.spec.whatwg.org/multipage/dom.html#attr-dir</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt:
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeInsertedIntoTree):
* Source/WebCore/dom/Element.cpp:
(WebCore::parseTextDirectionState):
(WebCore::elementTextDirectionState):
(WebCore::elementHasValidTextDirectionState):
(WebCore::elementHasAutoTextDirectionState):
(WebCore::updateHasDirAutoFlagForSubtree):
(WebCore::updateElementHasDirAutoFlag):
(WebCore::computeTextDirectionFromText):
(WebCore::computeTextDirection):
(WebCore::computeContainedTextAutoDirection):
(WebCore::computeTextDirectionOfSlotElement):
(WebCore::updateEffectiveTextDirectionOfElementAndShadowTree):
(WebCore::updateEffectiveTextDirectionState):
(WebCore::Element::hasValidTextDirectionState const):
(WebCore::Element::hasAutoTextDirectionState const):
(WebCore::Element::computeAutoTextDirection const):
(WebCore::Element::computeTextDirectionIfDirIsAuto const):
(WebCore::Element::updateEffectiveTextDirectionOfDescendants):
(WebCore::Element::updateEffectiveTextDirectionOfAncestors):
(WebCore::Element::updateEffectiveTextDirection):
(WebCore::Element::dirAttributeChanged):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::childrenChanged):
(WebCore::parseTextDirection): Deleted.
(WebCore::isValidDirValue): Deleted.
(WebCore::elementAffectsDirectionality): Deleted.
(WebCore::setHasDirAutoFlagRecursively): Deleted.
(WebCore::Element::hasDirectionAuto const): Deleted.
(WebCore::Element::directionalityIfDirIsAuto const): Deleted.
(WebCore::Element::updateEffectiveDirectionality): Deleted.
(WebCore::Element::adjustDirectionalityIfNeededAfterChildrenChanged): Deleted.
(WebCore::Element::updateTextDirectionalityAfterInputTypeChange): Deleted.
(WebCore::Element::updateEffectiveDirectionalityOfDirAuto): Deleted.
(WebCore::Element::computeDirectionalityFromText const): Deleted.
(WebCore::Element::adjustDirectionalityIfNeededAfterChildAttributeChanged): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::didChangeSlot):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::subtreeHasChanged):
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::setValue):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::insertedIntoAncestor):
(WebCore::HTMLSlotElement::didFinishInsertingNode):
* Source/WebCore/html/HTMLSlotElement.h:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::subtreeHasChanged):
(WebCore::HTMLTextAreaElement::setValueCommon):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::directionForFormData const):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::setValue):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchAllRules):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::resolve):
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
(WebCore::Style::elementHasDirectionAuto): Deleted.

Canonical link: <a href="https://commits.webkit.org/282648@main">https://commits.webkit.org/282648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90070bbd213a7abf740b1764516b2895b5941c72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51416 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32033 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55334 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14116 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6447 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40063 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->