### PR TITLE
REGRESSION (280738@main) [WebCodecs] Audio and Video codecs can be garbage collected with pending work.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1430,9 +1430,6 @@ http/wpt/service-workers/push-console-messages-showNotification-sync.https.html 
 
 http/tests/media/fairplay [ Skip ]
 
-# Requires specifc encoder behavior.
-http/wpt/webcodecs/encoder-task-failing.html [ Failure ]
-
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific tests.
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4532,6 +4532,8 @@ storage/indexeddb/modern/deleteindex-4-private.html [ Pass Crash ]
 # rdar://104694723 ([ iOS16+ debug ] media/vp9.html is a consistent timeout)
 [ Debug ] media/vp9.html [ Timeout ]
 
+# Requires specific encoder behavior.
+http/wpt/webcodecs/encoder-task-failing.html [ Failure ]
 
 # rdar://105103818 ([OOP] WebKit tests can timeout due to UIHelper.activateAndWaitForInputSession)
 editing/caret/ios/emoji.html [ Skip ] # TODO: marked failure below. Uncomment that line when this is resolved.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1668,10 +1668,6 @@ webkit.org/b/264266 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/css/filt
 
 webkit.org/b/264306 [ Sonoma+ ] fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html [ Pass ImageOnlyFailure Timeout ]
 
-# rdar://118901410 (NEW TEST (271087@main): [ macOS x86_64 wk2 ] 2 tests in http/wpt/webcodecs are a constant failure)
-http/wpt/webcodecs/h264-encoder-default-config.https.any.html [ Failure ]
-http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html [ Failure ]
-
 webkit.org/b/265599 [ Sonoma+ Debug x86_64 ] imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html [ Pass Crash ]
 
 # WindowProxy property access delegate callbacks are only implemented on Mac and iOS WK2.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -35,6 +35,7 @@
 #include "WebCodecsAudioDecoderConfig.h"
 #include "WebCodecsAudioDecoderSupport.h"
 #include "WebCodecsCodecState.h"
+#include "WebCodecsControlMessage.h"
 #include "WebCodecsEncodedAudioChunkType.h"
 #include <wtf/Deque.h>
 #include <wtf/Vector.h>
@@ -97,12 +98,11 @@ private:
     void setInternalDecoder(UniqueRef<AudioDecoder>&&);
     void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(Function<void()>&&);
+    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioDecoder>&&);
     void processControlMessageQueue();
 
     WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_decodeQueueSize { 0 };
-    size_t m_beingDecodedQueueSize { 0 };
     Ref<WebCodecsAudioDataOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     std::unique_ptr<AudioDecoder> m_internalDecoder;
@@ -110,9 +110,8 @@ private:
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };
     bool m_isKeyChunkRequired { false };
-    Deque<Function<void()>> m_controlMessageQueue;
+    Deque<WebCodecsControlMessage<WebCodecsAudioDecoder>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
-    bool m_isFlushing { false };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -34,6 +34,7 @@
 #include "JSDOMPromiseDeferredForward.h"
 #include "WebCodecsAudioEncoderConfig.h"
 #include "WebCodecsCodecState.h"
+#include "WebCodecsControlMessage.h"
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 
@@ -96,13 +97,12 @@ private:
     void setInternalEncoder(UniqueRef<AudioEncoder>&&);
     void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(Function<void()>&&);
+    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsAudioEncoder>&&);
     void processControlMessageQueue();
     WebCodecsEncodedAudioChunkMetadata createEncodedChunkMetadata();
 
     WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_encodeQueueSize { 0 };
-    size_t m_beingEncodedQueueSize { 0 };
     Ref<WebCodecsEncodedAudioChunkOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     std::unique_ptr<AudioEncoder> m_internalEncoder;
@@ -110,12 +110,11 @@ private:
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };
     bool m_isKeyChunkRequired { false };
-    Deque<Function<void()>> m_controlMessageQueue;
+    Deque<WebCodecsControlMessage<WebCodecsAudioEncoder>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
     WebCodecsAudioEncoderConfig m_baseConfiguration;
     AudioEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };
-    bool m_isFlushing { false };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "ActiveDOMObject.h"
+#include <wtf/Function.h>
+
+namespace WebCore {
+
+template <typename CodecType>
+class WebCodecsControlMessage final {
+public:
+    WebCodecsControlMessage(CodecType& codec, Function<void()>&& message)
+        : m_pendingActivity(codec.makePendingActivity(codec))
+        , m_message(WTFMove(message))
+    {
+    }
+
+    WebCodecsControlMessage(WebCodecsControlMessage&& other)
+        : m_pendingActivity(WTFMove(other.m_pendingActivity))
+        , m_message(WTFMove(other.m_message))
+    {
+    }
+
+    void operator()()
+    {
+        m_message();
+    }
+
+private:
+    Ref<ActiveDOMObject::PendingActivity<CodecType>> m_pendingActivity;
+    Function<void()> m_message;
+};
+
+}
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferredForward.h"
 #include "VideoDecoder.h"
 #include "WebCodecsCodecState.h"
+#include "WebCodecsControlMessage.h"
 #include "WebCodecsEncodedVideoChunkType.h"
 #include "WebCodecsVideoDecoderSupport.h"
 #include <wtf/Deque.h>
@@ -95,12 +96,11 @@ private:
     void setInternalDecoder(UniqueRef<VideoDecoder>&&);
     void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(Function<void()>&&);
+    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoDecoder>&&);
     void processControlMessageQueue();
 
     WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_decodeQueueSize { 0 };
-    size_t m_beingDecodedQueueSize { 0 };
     Ref<WebCodecsVideoFrameOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     std::unique_ptr<VideoDecoder> m_internalDecoder;
@@ -108,9 +108,8 @@ private:
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };
     bool m_isKeyChunkRequired { false };
-    Deque<Function<void()>> m_controlMessageQueue;
+    Deque<WebCodecsControlMessage<WebCodecsVideoDecoder>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
-    bool m_isFlushing { false };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -151,7 +151,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
     m_isKeyChunkRequired = true;
 
     if (m_internalEncoder) {
-        queueControlMessageAndProcess([this, config]() mutable {
+        queueControlMessageAndProcess({ *this, [this, config]() mutable {
             if (isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config) && updateRates(config))
                 return;
 
@@ -167,11 +167,11 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
                 protectedThis->m_isMessageQueueBlocked = false;
                 protectedThis->processControlMessageQueue();
             });
-        });
+        } });
     }
 
     bool isSupportedCodec = isSupportedEncoderCodec(config.codec, context.settingsValues());
-    queueControlMessageAndProcess([this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
+    queueControlMessageAndProcess({ *this, [this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
         if (isSupportedCodec && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config) && updateRates(config))
             return;
 
@@ -227,7 +227,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
             });
             m_output->handleEvent(WTFMove(chunk), createEncodedChunkMetadata(result.temporalIndex));
         }, WTFMove(postTaskCallback));
-    });
+    } });
     return { };
 }
 
@@ -280,16 +280,10 @@ ExceptionOr<void> WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&& frame
         return Exception { ExceptionCode::InvalidStateError, "VideoEncoder is not configured"_s };
 
     ++m_encodeQueueSize;
-    queueControlMessageAndProcess([this, internalFrame = internalFrame.releaseNonNull(), timestamp = frame->timestamp(), duration = frame->duration(), options = WTFMove(options)]() mutable {
-        ++m_beingEncodedQueueSize;
+    queueControlMessageAndProcess({ *this, [this, internalFrame = internalFrame.releaseNonNull(), timestamp = frame->timestamp(), duration = frame->duration(), options = WTFMove(options)]() mutable {
         --m_encodeQueueSize;
         scheduleDequeueEvent();
-        m_internalEncoder->encode({ WTFMove(internalFrame), timestamp, duration }, options.keyFrame, [weakThis = ThreadSafeWeakPtr { *this }](String&& result) {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-
-            --(protectedThis->m_beingEncodedQueueSize);
+        m_internalEncoder->encode({ WTFMove(internalFrame), timestamp, duration }, options.keyFrame, [protectedThis = Ref { *this }, pendingActivity = makePendingActivity(*this)](String&& result) {
             if (!result.isNull()) {
                 if (RefPtr context = protectedThis->scriptExecutionContext())
                     context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: "_s, result));
@@ -297,7 +291,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&& frame
                 return;
             }
         });
-    });
+    } });
     return { };
 }
 
@@ -308,18 +302,16 @@ void WebCodecsVideoEncoder::flush(Ref<DeferredPromise>&& promise)
         return;
     }
 
-    m_pendingFlushPromises.append(promise.copyRef());
-    m_isFlushing = true;
-    queueControlMessageAndProcess([this, clearFlushPromiseCount = m_clearFlushPromiseCount]() mutable {
-        m_internalEncoder->flush([weakThis = ThreadSafeWeakPtr { *this }, clearFlushPromiseCount] {
+    m_pendingFlushPromises.append(WTFMove(promise));
+    queueControlMessageAndProcess({ *this, [this, clearFlushPromiseCount = m_clearFlushPromiseCount]() mutable {
+        m_internalEncoder->flush([weakThis = ThreadSafeWeakPtr { *this }, clearFlushPromiseCount, pendingActivity = makePendingActivity(*this)] {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || clearFlushPromiseCount != protectedThis->m_clearFlushPromiseCount)
                 return;
 
             protectedThis->m_pendingFlushPromises.takeFirst()->resolve();
-            protectedThis->m_isFlushing = !protectedThis->m_pendingFlushPromises.isEmpty();
         });
-    });
+    } });
 }
 
 ExceptionOr<void> WebCodecsVideoEncoder::reset()
@@ -415,7 +407,7 @@ void WebCodecsVideoEncoder::setInternalEncoder(UniqueRef<VideoEncoder>&& interna
     m_internalEncoder = internalEncoder.moveToUniquePtr();
 }
 
-void WebCodecsVideoEncoder::queueControlMessageAndProcess(Function<void()>&& message)
+void WebCodecsVideoEncoder::queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoEncoder>&& message)
 {
     if (m_isMessageQueueBlocked) {
         m_controlMessageQueue.append(WTFMove(message));
@@ -448,7 +440,7 @@ void WebCodecsVideoEncoder::stop()
 
 bool WebCodecsVideoEncoder::virtualHasPendingActivity() const
 {
-    return m_state == WebCodecsCodecState::Configured && (m_encodeQueueSize || m_beingEncodedQueueSize || m_isFlushing);
+    return m_state == WebCodecsCodecState::Configured && (m_encodeQueueSize || m_isMessageQueueBlocked);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferredForward.h"
 #include "VideoEncoder.h"
 #include "WebCodecsCodecState.h"
+#include "WebCodecsControlMessage.h"
 #include "WebCodecsVideoEncoderConfig.h"
 #include <wtf/Vector.h>
 
@@ -96,14 +97,13 @@ private:
     void setInternalEncoder(UniqueRef<VideoEncoder>&&);
     void scheduleDequeueEvent();
 
-    void queueControlMessageAndProcess(Function<void()>&&);
+    void queueControlMessageAndProcess(WebCodecsControlMessage<WebCodecsVideoEncoder>&&);
     void processControlMessageQueue();
     WebCodecsEncodedVideoChunkMetadata createEncodedChunkMetadata(std::optional<unsigned>);
     bool updateRates(const WebCodecsVideoEncoderConfig&);
 
     WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_encodeQueueSize { 0 };
-    size_t m_beingEncodedQueueSize { 0 };
     Ref<WebCodecsEncodedVideoChunkOutputCallback> m_output;
     Ref<WebCodecsErrorCallback> m_error;
     std::unique_ptr<VideoEncoder> m_internalEncoder;
@@ -111,12 +111,11 @@ private:
     Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
     size_t m_clearFlushPromiseCount { 0 };
     bool m_isKeyChunkRequired { false };
-    Deque<Function<void()>> m_controlMessageQueue;
+    Deque<WebCodecsControlMessage<WebCodecsVideoEncoder>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
     WebCodecsVideoEncoderConfig m_baseConfiguration;
     VideoEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };
-    bool m_isFlushing { false };
 };
 
 }


### PR DESCRIPTION
#### dcc8d978d725f48b8f5abf2a93fdff1505847fe7
<pre>
REGRESSION (280738@main) [WebCodecs] Audio and Video codecs can be garbage collected with pending work.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278356">https://bugs.webkit.org/show_bug.cgi?id=278356</a>
<a href="https://rdar.apple.com/134297589">rdar://134297589</a>

Reviewed by Youenn Fablet.

In 280738@main http/wpt/webcodecs/hevc-encoder-config.https.any.html
became flaky. This is because the VideoEncoder object goes out of scope
as soon as the configure steps schedule the control message to reject
the configuration and sometimes gets garbage collected before the error
callback can be called. Prior to 280738@main the callback was a GC root
and so would never be collected. After this, though, the codec is
responsible for keeping its JS callbacks alive and so sometimes
everything gets collected.

Many of the WebCodecs steps require asynchronous work to be scheduled
which gives the algorithms many states where it is valid to have
outstanding work but all references to the codecs have been dropped in
JavaScript. In order to prevent them from being prematurely collected
this patch introduces an abstraction for the WebCodecs Control Message.
This object represents pending work and will hold a PendingActivity
for the codec which will prevent it from being garbage collected before
the spec algorithm steps have been completed. Additionally, we will
create a pending activity when we submit asynchronous work to the
internal codec implementation.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::configure):
(WebCore::WebCodecsAudioDecoder::decode):
(WebCore::WebCodecsAudioDecoder::flush):
(WebCore::WebCodecsAudioDecoder::closeDecoder):
(WebCore::WebCodecsAudioDecoder::resetDecoder):
(WebCore::WebCodecsAudioDecoder::queueControlMessageAndProcess):
(WebCore::WebCodecsAudioDecoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
(WebCore::WebCodecsAudioEncoder::encode):
(WebCore::WebCodecsAudioEncoder::flush):
(WebCore::WebCodecsAudioEncoder::closeEncoder):
(WebCore::WebCodecsAudioEncoder::resetEncoder):
(WebCore::WebCodecsAudioEncoder::queueControlMessageAndProcess):
(WebCore::WebCodecsAudioEncoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsControlMessage.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsFlushPromise.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
(WebCore::WebCodecsVideoDecoder::closeDecoder):
(WebCore::WebCodecsVideoDecoder::resetDecoder):
(WebCore::WebCodecsVideoDecoder::queueControlMessageAndProcess):
(WebCore::WebCodecsVideoDecoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCodecsVideoEncoder::flush):
(WebCore::WebCodecsVideoEncoder::closeEncoder):
(WebCore::WebCodecsVideoEncoder::resetEncoder):
(WebCore::WebCodecsVideoEncoder::queueControlMessageAndProcess):
(WebCore::WebCodecsVideoEncoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/282657@main">https://commits.webkit.org/282657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de81afa0ceb6c03de99e09d5b8bd2b3d68ab18ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14374 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51388 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69483 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58712 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58859 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6414 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38943 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->