### PR TITLE
[TZone] WebCore/page Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/page/AlternativeTextClient.h
+++ b/Source/WebCore/page/AlternativeTextClient.h
@@ -28,7 +28,7 @@
 #include "DictationContext.h"
 #include "FloatRect.h"
 #include <wtf/CheckedRef.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -55,7 +55,7 @@ enum class AutocorrectionResponse : uint8_t {
 };
 
 class AlternativeTextClient : public CanMakeCheckedPtr<AlternativeTextClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AlternativeTextClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AlternativeTextClient);
 public:
     virtual ~AlternativeTextClient() = default;

--- a/Source/WebCore/page/AttachmentElementClient.h
+++ b/Source/WebCore/page/AttachmentElementClient.h
@@ -28,13 +28,14 @@
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class FloatSize;
 
 class AttachmentElementClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AttachmentElementClient);
 public:
     virtual ~AttachmentElementClient() { }
     virtual void requestAttachmentIcon(const String& identifier, const FloatSize&) = 0;

--- a/Source/WebCore/page/AudioOutputProvider.h
+++ b/Source/WebCore/page/AudioOutputProvider.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
 
 class Page;
 
 class WEBCORE_EXPORT AudioOutputProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioOutputProvider);
 public:
     AudioOutputProvider() = default;
     virtual ~AudioOutputProvider() = default;

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -39,8 +39,11 @@
 #include "RenderView.h"
 #include "ScrollView.h"
 #include "Settings.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AutoscrollController);
 
 // Delay time in second for start autoscroll if pointer is in border edge of scrollable element.
 static const Seconds autoscrollDelay { 200_ms };

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -27,6 +27,7 @@
 
 #include "IntPoint.h"
 #include "Timer.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 
 namespace WebCore {
@@ -54,7 +55,7 @@ constexpr Seconds autoscrollInterval { 50_ms };
 
 // AutscrollController handles autoscroll and pan scroll for EventHandler.
 class AutoscrollController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AutoscrollController);
 public:
     AutoscrollController();
     RenderBox* autoscrollRenderer() const;

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -43,9 +43,13 @@
 #include "UserStyleSheetTypes.h"
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <wtf/Language.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/unicode/Collator.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CaptionUserPreferences);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CaptionUserPreferencesTestingModeToken);
 
 Ref<CaptionUserPreferences> CaptionUserPreferences::create(PageGroup& group)
 {

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -32,6 +32,7 @@
 #include "Timer.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -52,7 +53,7 @@ enum class CaptionUserPreferencesDisplayMode : uint8_t {
 };
 
 class CaptionUserPreferences : public RefCounted<CaptionUserPreferences>, public CanMakeWeakPtr<CaptionUserPreferences> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CaptionUserPreferences);
 public:
     static Ref<CaptionUserPreferences> create(PageGroup&);
     virtual ~CaptionUserPreferences();
@@ -141,7 +142,7 @@ private:
 };
 
 class CaptionUserPreferencesTestingModeToken {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CaptionUserPreferencesTestingModeToken);
 public:
     CaptionUserPreferencesTestingModeToken(CaptionUserPreferences& parent)
         : m_parent(parent)

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -44,6 +44,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/SoftLinking.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/cf/VectorCF.h>
 #include <wtf/text/CString.h>
@@ -73,6 +74,8 @@ SOFT_LINK_OPTIONAL(MediaToolbox, MTEnableCaption2015Behavior, Boolean, (), ())
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CaptionUserPreferencesMediaAF);
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -31,6 +31,7 @@
 #include "CaptionPreferencesDelegate.h"
 #include "CaptionUserPreferences.h"
 #include "Color.h"
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(COCOA)
 OBJC_CLASS WebCaptionUserPreferencesMediaAFWeakObserver;
@@ -39,7 +40,7 @@ OBJC_CLASS WebCaptionUserPreferencesMediaAFWeakObserver;
 namespace WebCore {
 
 class CaptionUserPreferencesMediaAF : public CaptionUserPreferences {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CaptionUserPreferencesMediaAF);
 public:
     static Ref<CaptionUserPreferencesMediaAF> create(PageGroup&);
     virtual ~CaptionUserPreferencesMediaAF();

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -82,6 +82,7 @@
 #include "WindowFeatures.h"
 #include "markup.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -98,6 +99,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContextMenuController);
 
 using namespace WTF::Unicode;
 

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -31,6 +31,7 @@
 #include "ContextMenuItem.h"
 #include "HitTestRequest.h"
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakRef.h>
 
@@ -43,7 +44,7 @@ class HitTestResult;
 class Page;
 
 class ContextMenuController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContextMenuController);
 public:
     ContextMenuController(Page&, UniqueRef<ContextMenuClient>&&);
     ~ContextMenuController();

--- a/Source/WebCore/page/CryptoClient.h
+++ b/Source/WebCore/page/CryptoClient.h
@@ -26,12 +26,13 @@
 #pragma once
 
 #include <cstdint>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class CryptoClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CryptoClient);
 protected:
     CryptoClient() = default;
 public:

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -40,6 +40,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 #include "ContentChangeObserver.h"
@@ -54,6 +55,8 @@ static constexpr Seconds minIntervalForRepeatingTimers { 1_ms };
 static constexpr int maxTimerNestingLevel = 10;
 static constexpr int maxTimerNestingLevelForOneShotTimers = 10;
 static constexpr int maxTimerNestingLevelForRepeatingTimers = 5;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMTimer);
 
 class DOMTimerFireState {
 public:

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -33,6 +33,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -44,7 +45,7 @@ class ScheduledAction;
 
 class DOMTimer final : public RefCounted<DOMTimer>, public ActiveDOMObject, public CanMakeWeakPtr<DOMTimer> {
     WTF_MAKE_NONCOPYABLE(DOMTimer);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DOMTimer);
 public:
     WEBCORE_EXPORT virtual ~DOMTimer();
 

--- a/Source/WebCore/page/DeviceClient.h
+++ b/Source/WebCore/page/DeviceClient.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -40,7 +41,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DeviceClient
 namespace WebCore {
 
 class DeviceClient : public CanMakeWeakPtr<DeviceClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DeviceClient);
 public:
     virtual ~DeviceClient() = default;
 

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -29,8 +29,11 @@
 
 #include "DeviceClient.h"
 #include "Document.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceController);
 
 DeviceController::DeviceController(DeviceClient& client)
     : m_client(client)

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -32,6 +32,7 @@
 #include "Timer.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/HashCountedSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,7 +40,7 @@ class DeviceClient;
 class Page;
 
 class DeviceController : public Supplement<Page>, public CanMakeCheckedPtr<DeviceController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DeviceController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceController);
 public:
     explicit DeviceController(DeviceClient&);

--- a/Source/WebCore/page/DiagnosticLoggingClient.h
+++ b/Source/WebCore/page/DiagnosticLoggingClient.h
@@ -29,8 +29,8 @@
 #include <variant>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CryptographicallyRandomNumber.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -46,7 +46,7 @@ struct DiagnosticLoggingDictionary {
 };
 
 class DiagnosticLoggingClient : public CanMakeCheckedPtr<DiagnosticLoggingClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DiagnosticLoggingClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DiagnosticLoggingClient);
 public:
     virtual void logDiagnosticMessage(const String& message, const String& description, ShouldSample) = 0;

--- a/Source/WebCore/page/DragClient.h
+++ b/Source/WebCore/page/DragClient.h
@@ -30,6 +30,7 @@
 #include "DragItem.h"
 #include "FloatPoint.h"
 #include "IntPoint.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
     
@@ -44,7 +45,7 @@ struct PromisedAttachmentInfo;
 #endif
 
 class DragClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DragClient);
 public:
     virtual bool useLegacyDragClient() { return true; }
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -98,6 +98,7 @@
 #include "WebContentReader.h"
 #include "markup.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #endif
 
@@ -110,6 +111,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DragController);
 
 bool isDraggableLink(const Element& element)
 {

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -31,6 +31,7 @@
 #include "IntRect.h"
 #include "SimpleRange.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakRef.h>
 
@@ -56,7 +57,8 @@ struct PromisedAttachmentInfo;
 struct RemoteUserInputEventData;
 
 class DragController {
-    WTF_MAKE_NONCOPYABLE(DragController); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DragController);
+    WTF_MAKE_NONCOPYABLE(DragController);
 public:
     DragController(Page&, std::unique_ptr<DragClient>&&);
     ~DragController();

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -33,8 +33,8 @@
 #include "TextChecking.h"
 #include "UndoStep.h"
 #include <wtf/CheckedPtr.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -64,7 +64,7 @@ struct GrammarDetail;
 struct SimpleRange;
 
 class EditorClient : public CanMakeWeakPtr<EditorClient>, public CanMakeCheckedPtr<EditorClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EditorClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EditorClient);
 public:
     virtual ~EditorClient() = default;

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -67,9 +67,12 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "VisibilityAdjustment.h"
 #include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ElementTargetingController);
 
 static constexpr auto maximumNumberOfClasses = 5;
 static constexpr auto marginForTrackingAdjustmentRects = 5;
@@ -119,7 +122,7 @@ static float maximumAreaRatioForTrackingAdjustmentAreas(float viewportArea)
 
 class ClearVisibilityAdjustmentForScope {
     WTF_MAKE_NONCOPYABLE(ClearVisibilityAdjustmentForScope);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ClearVisibilityAdjustmentForScope);
 public:
     ClearVisibilityAdjustmentForScope(Element& element)
         : m_element(element)

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -36,6 +36,7 @@
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -49,7 +50,7 @@ class Node;
 class Page;
 
 class ElementTargetingController final : public CanMakeCheckedPtr<ElementTargetingController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ElementTargetingController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ElementTargetingController);
 public:
     ElementTargetingController(Page&);

--- a/Source/WebCore/page/EmptyAttachmentElementClient.h
+++ b/Source/WebCore/page/EmptyAttachmentElementClient.h
@@ -28,11 +28,12 @@
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 #include "AttachmentElementClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class EmptyAttachmentElementClient final : public AttachmentElementClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(EmptyAttachmentElementClient);
 public:
     EmptyAttachmentElementClient() = default;
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -136,6 +136,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(IOS_TOUCH_EVENTS)
 #include "PlatformTouchEventIOS.h"
@@ -163,6 +164,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(EventHandler);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -45,6 +45,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
@@ -126,7 +127,7 @@ enum AppendTrailingWhitespace { ShouldAppendTrailingWhitespace, DontAppendTraili
 enum CheckDragHysteresis { ShouldCheckDragHysteresis, DontCheckDragHysteresis };
 
 class EventHandler final : public CanMakeCheckedPtr<EventHandler> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(EventHandler);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventHandler);
 public:
     explicit EventHandler(LocalFrame&);

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -65,8 +65,11 @@
 #include "Widget.h"
 #include <limits>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FocusController);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -33,6 +33,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -50,7 +51,7 @@ class TreeScope;
 struct FocusCandidate;
 
 class FocusController final : public CanMakeCheckedPtr<FocusController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FocusController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FocusController);
 public:
     explicit FocusController(Page&, OptionSet<ActivityState>);

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -36,8 +36,11 @@
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderWidget.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameView);
 
 int FrameView::headerHeight() const
 {

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ScrollView.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class Frame;
 enum class RenderAsTextFlag : uint16_t;
 
 class FrameView : public ScrollView {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FrameView);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameView);
 public:
     enum class Type : bool { Local, Remote };

--- a/Source/WebCore/page/ImageAnalysisQueue.cpp
+++ b/Source/WebCore/page/ImageAnalysisQueue.cpp
@@ -40,6 +40,7 @@
 #include "Timer.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <pal/HysteresisActivity.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -47,6 +48,8 @@ static constexpr unsigned maximumPendingImageAnalysisCount = 5;
 static constexpr float minimumWidthForAnalysis = 20;
 static constexpr float minimumHeightForAnalysis = 20;
 static constexpr Seconds resumeProcessingDelay = 100_ms;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageAnalysisQueue);
 
 ImageAnalysisQueue::ImageAnalysisQueue(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -28,8 +28,8 @@
 #if ENABLE(IMAGE_ANALYSIS)
 
 #include "Timer.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/PriorityQueue.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakHashMap.h>
@@ -48,7 +48,7 @@ class Timer;
 class WeakPtrImplWithEventTargetData;
 
 class ImageAnalysisQueue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ImageAnalysisQueue);
 public:
     ImageAnalysisQueue(Page&);
     ~ImageAnalysisQueue();

--- a/Source/WebCore/page/ImageOverlayController.cpp
+++ b/Source/WebCore/page/ImageOverlayController.cpp
@@ -44,8 +44,11 @@
 #include "RenderStyleInlines.h"
 #include "SimpleRange.h"
 #include "VisiblePosition.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageOverlayController);
 
 class FloatQuad;
 

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -29,6 +29,7 @@
 #include "LayoutRect.h"
 #include "PageOverlay.h"
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -58,7 +59,7 @@ class ImageOverlayController final : private PageOverlayClient
     , DataDetectorHighlightClient
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ImageOverlayController);
 public:
     explicit ImageOverlayController(Page&);
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -49,9 +49,12 @@
 #include "RenderStyleInlines.h"
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalFrameViewLayoutContext);
 
 UpdateScrollInfoAfterLayoutTransaction::UpdateScrollInfoAfterLayoutTransaction() = default;
 UpdateScrollInfoAfterLayoutTransaction::~UpdateScrollInfoAfterLayoutTransaction() = default;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -29,6 +29,7 @@
 #include "RenderLayerModelObject.h"
 #include "Timer.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -60,7 +61,7 @@ struct UpdateScrollInfoAfterLayoutTransaction {
 };
 
 class LocalFrameViewLayoutContext final : public CanMakeCheckedPtr<LocalFrameViewLayoutContext> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LocalFrameViewLayoutContext);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocalFrameViewLayoutContext);
 public:
     LocalFrameViewLayoutContext(LocalFrameView&);

--- a/Source/WebCore/page/NavigatorLoginStatus.cpp
+++ b/Source/WebCore/page/NavigatorLoginStatus.cpp
@@ -34,8 +34,11 @@
 #include "Page.h"
 #include "RegistrableDomain.h"
 #include "SecurityOrigin.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigatorLoginStatus);
 
 NavigatorLoginStatus* NavigatorLoginStatus::from(Navigator& navigator)
 {

--- a/Source/WebCore/page/NavigatorLoginStatus.h
+++ b/Source/WebCore/page/NavigatorLoginStatus.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Supplementable.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ class Navigator;
 enum class IsLoggedIn : uint8_t;
 
 class NavigatorLoginStatus final : public Supplement<Navigator>, public CanMakeWeakPtr<NavigatorLoginStatus> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NavigatorLoginStatus);
 public:
     explicit NavigatorLoginStatus(Navigator& navigator)
         : m_navigator(navigator)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -190,6 +190,7 @@
 #include <wtf/RefCountedLeakCounter.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringHash.h>
@@ -232,6 +233,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Page);
 
 static HashSet<WeakRef<Page>>& allPages()
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -57,6 +57,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -320,7 +321,7 @@ constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<Render
 
 class Page : public RefCounted<Page>, public Supplementable<Page>, public CanMakeWeakPtr<Page> {
     WTF_MAKE_NONCOPYABLE(Page);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Page);
     friend class SettingsBase;
 
 public:

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -61,6 +61,7 @@
 #include "ValidationMessageClient.h"
 #include "VisitedLinkStore.h"
 #include "WebRTCProvider.h"
+#include <wtf/TZoneMallocInlines.h>
 #if ENABLE(WEB_AUTHN)
 #include "AuthenticatorCoordinatorClient.h"
 #include "CredentialRequestCoordinatorClient.h"
@@ -70,6 +71,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageConfiguration);
 
 PageConfiguration::PageConfiguration(
     std::optional<PageIdentifier> identifier,

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -36,6 +36,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
@@ -95,7 +96,8 @@ class VisitedLinkStore;
 class WebRTCProvider;
 
 class PageConfiguration {
-    WTF_MAKE_NONCOPYABLE(PageConfiguration); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageConfiguration);
+    WTF_MAKE_NONCOPYABLE(PageConfiguration);
 public:
 
     using ClientCreatorForMainFrame = std::variant<CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)>, CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>>;

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -68,6 +68,7 @@
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(OFFSCREEN_CANVAS)
@@ -86,6 +87,8 @@
 
 namespace WebCore {
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageConsoleClient);
 
 PageConsoleClient::PageConsoleClient(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 class ConsoleMessage;
@@ -49,7 +50,7 @@ class Document;
 class Page;
 
 class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr<PageConsoleClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(PageConsoleClient, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageConsoleClient);
 public:
     explicit PageConsoleClient(Page&);

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -34,10 +34,13 @@
 #include "Page.h"
 #include "Settings.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageDebuggable);
 
 PageDebuggable::PageDebuggable(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/PageDebuggable.h
+++ b/Source/WebCore/page/PageDebuggable.h
@@ -29,13 +29,14 @@
 
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Page;
 
 class PageDebuggable final : public Inspector::RemoteInspectionTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageDebuggable);
     WTF_MAKE_NONCOPYABLE(PageDebuggable);
 public:
     PageDebuggable(Page&);

--- a/Source/WebCore/page/PageGroup.cpp
+++ b/Source/WebCore/page/PageGroup.cpp
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StructureInlines.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(VIDEO)
 #if PLATFORM(MAC) || HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
@@ -45,6 +46,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageGroup);
 
 static unsigned getUniqueIdentifier()
 {

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -46,7 +47,8 @@ class CaptionUserPreferences;
 #endif
 
 class PageGroup : public CanMakeWeakPtr<PageGroup> {
-    WTF_MAKE_NONCOPYABLE(PageGroup); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageGroup);
+    WTF_MAKE_NONCOPYABLE(PageGroup);
 public:
     WEBCORE_EXPORT explicit PageGroup(const String& name);
     explicit PageGroup(Page&);

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -34,11 +34,14 @@
 #include "PageOverlayController.h"
 #include "PlatformMouseEvent.h"
 #include "ScrollbarTheme.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 static const Seconds fadeAnimationDuration { 200_ms };
 static const double fadeAnimationFrameRate = 30;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageOverlay);
 
 static PageOverlay::PageOverlayID generatePageOverlayID()
 {

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -30,6 +30,7 @@
 #include "IntRect.h"
 #include "Timer.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -61,8 +62,8 @@ public:
 };
 
 class PageOverlay final : public RefCounted<PageOverlay>, public CanMakeWeakPtr<PageOverlay> {
+    WTF_MAKE_TZONE_ALLOCATED(PageOverlay);
     WTF_MAKE_NONCOPYABLE(PageOverlay);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class OverlayType : bool {
         View, // Fixed to the view size; does not scale or scroll with the document, repaints on scroll.

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -37,10 +37,13 @@
 #include "ScrollingCoordinator.h"
 #include "Settings.h"
 #include "TiledBacking.h"
+#include <wtf/TZoneMallocInlines.h>
 
 // FIXME: Someone needs to call didChangeSettings() if we want dynamic updates of layer border/repaint counter settings.
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageOverlayController);
 
 PageOverlayController::PageOverlayController(Page& page)
     :  m_page(page)

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -29,6 +29,7 @@
 #include "GraphicsLayerClient.h"
 #include "PageOverlay.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
 
@@ -39,7 +40,7 @@ class Page;
 class PlatformMouseEvent;
 
 class PageOverlayController final : public GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageOverlayController);
     friend class MockPageOverlayClient;
 public:
     PageOverlayController(Page&);

--- a/Source/WebCore/page/PagePasteboardContext.h
+++ b/Source/WebCore/page/PagePasteboardContext.h
@@ -27,12 +27,13 @@
 
 #include "PageIdentifier.h"
 #include "PasteboardContext.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
 class PagePasteboardContext final : public PasteboardContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PagePasteboardContext);
 public:
     PagePasteboardContext(std::optional<PageIdentifier>&& pageID = std::nullopt)
         : PasteboardContext()

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -35,8 +35,11 @@
 #include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "Page.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceLogging);
 
 #if !RELEASE_LOG_DISABLED
 static ASCIILiteral toString(PerformanceLogging::PointOfInterest poi)

--- a/Source/WebCore/page/PerformanceLogging.h
+++ b/Source/WebCore/page/PerformanceLogging.h
@@ -27,6 +27,7 @@
 
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class Page;
 enum class ShouldIncludeExpensiveComputations : bool { No, Yes };
 
 class PerformanceLogging {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceLogging);
     WTF_MAKE_NONCOPYABLE(PerformanceLogging);
 public:
     explicit PerformanceLogging(Page&);

--- a/Source/WebCore/page/PerformanceLoggingClient.cpp
+++ b/Source/WebCore/page/PerformanceLoggingClient.cpp
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "PerformanceLoggingClient.h"
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceLoggingClient);
 
 String PerformanceLoggingClient::synchronousScrollingReasonsAsString(OptionSet<SynchronousScrollingReason> reasons)
 {

--- a/Source/WebCore/page/PerformanceLoggingClient.h
+++ b/Source/WebCore/page/PerformanceLoggingClient.h
@@ -26,15 +26,15 @@
 #pragma once
 
 #include "ScrollingCoordinatorTypes.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class PerformanceLoggingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceLoggingClient);
 public:
     enum class ScrollingEvent {
         LoggingEnabled,

--- a/Source/WebCore/page/PerformanceMonitor.cpp
+++ b/Source/WebCore/page/PerformanceMonitor.cpp
@@ -36,8 +36,11 @@
 #include "PerformanceLogging.h"
 #include "RegistrableDomain.h"
 #include "Settings.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceMonitor);
 
 #define PERFMONITOR_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - PerformanceMonitor::" fmt, this, ##__VA_ARGS__)
 

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -28,13 +28,14 @@
 #include "ActivityState.h"
 #include "Timer.h"
 #include <wtf/CPUTime.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Page;
 
 class PerformanceMonitor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceMonitor);
 public:
     explicit PerformanceMonitor(Page&);
 

--- a/Source/WebCore/page/PerformanceObserverEntryList.cpp
+++ b/Source/WebCore/page/PerformanceObserverEntryList.cpp
@@ -27,8 +27,11 @@
 #include "PerformanceObserverEntryList.h"
 
 #include "PerformanceEntry.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceObserverEntryList);
 
 Ref<PerformanceObserverEntryList> PerformanceObserverEntryList::create(Vector<Ref<PerformanceEntry>>&& entries)
 {

--- a/Source/WebCore/page/PerformanceObserverEntryList.h
+++ b/Source/WebCore/page/PerformanceObserverEntryList.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,7 +35,7 @@ namespace WebCore {
 class PerformanceEntry;
 
 class PerformanceObserverEntryList : public RefCounted<PerformanceObserverEntryList> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceObserverEntryList);
 public:
     static Ref<PerformanceObserverEntryList> create(Vector<Ref<PerformanceEntry>>&& entries);
 

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -38,9 +38,12 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceUserTiming);
 
 using NavigationTimingFunction = unsigned long long (PerformanceTiming::*)() const;
 

--- a/Source/WebCore/page/PerformanceUserTiming.h
+++ b/Source/WebCore/page/PerformanceUserTiming.h
@@ -29,6 +29,7 @@
 #include "PerformanceMark.h"
 #include "PerformanceMeasure.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace JSC {
@@ -42,7 +43,7 @@ class Performance;
 using PerformanceEntryMap = HashMap<String, Vector<Ref<PerformanceEntry>>>;
 
 class PerformanceUserTiming {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceUserTiming);
 public:
     explicit PerformanceUserTiming(Performance&);
 

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -34,12 +34,15 @@
 #include "Page.h"
 #include "PointerEvent.h"
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(POINTER_LOCK)
 #include "PointerLockController.h"
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerCaptureController);
 
 PointerCaptureController::PointerCaptureController(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -28,6 +28,7 @@
 #include "PlatformMouseEvent.h"
 #include "PointerID.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ class WindowProxy;
 
 class PointerCaptureController {
     WTF_MAKE_NONCOPYABLE(PointerCaptureController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PointerCaptureController);
 public:
     explicit PointerCaptureController(Page&);
 

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -40,8 +40,11 @@
 #include "PointerCaptureController.h"
 #include "UserGestureIndicator.h"
 #include "VoidCallback.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerLockController);
 
 class UnadjustedMovementPlatformMouseEvent : public PlatformMouseEvent {
 public:

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -32,6 +32,7 @@
 #include <optional>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -49,7 +50,7 @@ class WeakPtrImplWithEventTargetData;
 
 class PointerLockController {
     WTF_MAKE_NONCOPYABLE(PointerLockController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PointerLockController);
 public:
     explicit PointerLockController(Page&);
     ~PointerLockController();

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -33,9 +33,12 @@
 #include "StyleInheritedData.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PrintContext);
 
 PrintContext::PrintContext(LocalFrame* frame)
     : FrameDestructionObserver(frame)

--- a/Source/WebCore/page/PrintContext.h
+++ b/Source/WebCore/page/PrintContext.h
@@ -24,6 +24,7 @@
 #include "LengthBox.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,7 +40,7 @@ class LocalFrame;
 class Node;
 
 class PrintContext : public FrameDestructionObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PrintContext);
 public:
     WEBCORE_EXPORT explicit PrintContext(LocalFrame*);
     WEBCORE_EXPORT ~PrintContext();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -72,6 +72,7 @@
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/StackVisitor.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -83,6 +84,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Quirks);
 
 static inline OptionSet<AutoplayQuirk> allowedAutoplayQuirks(Document& document)
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -28,6 +28,7 @@
 #include "Event.h"
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -49,7 +50,8 @@ enum class IsSyntheticClick : bool;
 enum class StorageAccessWasGranted : uint8_t;
 
 class Quirks {
-    WTF_MAKE_NONCOPYABLE(Quirks); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Quirks);
+    WTF_MAKE_NONCOPYABLE(Quirks);
 public:
     Quirks(Document&);
     ~Quirks();

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "FrameLoaderClient.h"
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -40,7 +40,7 @@ enum class RenderAsTextFlag : uint16_t;
 struct MessageWithMessagePorts;
 
 class RemoteFrameClient : public FrameLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteFrameClient);
 public:
     virtual void frameDetached() = 0;
     virtual void sizeDidChange(IntSize) = 0;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -28,8 +28,11 @@
 
 #include "RemoteFrame.h"
 #include "RemoteFrameClient.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameView);
 
 RemoteFrameView::RemoteFrameView(RemoteFrame& frame)
     : m_frame(frame)

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -28,12 +28,14 @@
 #include "FrameView.h"
 #include "RemoteFrame.h"
 
+#include <wtf/TZoneMalloc.h>
+
 namespace WebCore {
 
 class RemoteFrame;
 
 class RemoteFrameView final : public FrameView {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RemoteFrameView);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteFrameView);
 public:
     static Ref<RemoteFrameView> create(RemoteFrame& frame) { return adoptRef(*new RemoteFrameView(frame)); }

--- a/Source/WebCore/page/RenderingUpdateScheduler.cpp
+++ b/Source/WebCore/page/RenderingUpdateScheduler.cpp
@@ -33,9 +33,12 @@
 #include "Page.h"
 #include "Timer.h"
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderingUpdateScheduler);
 
 RenderingUpdateScheduler::RenderingUpdateScheduler(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/RenderingUpdateScheduler.h
+++ b/Source/WebCore/page/RenderingUpdateScheduler.h
@@ -28,6 +28,7 @@
 #include "AnimationFrameRate.h"
 #include "DisplayRefreshMonitorClient.h"
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class Page;
 class Timer;
 
 class RenderingUpdateScheduler final : public DisplayRefreshMonitorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RenderingUpdateScheduler);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderingUpdateScheduler);
 public:
     static std::unique_ptr<RenderingUpdateScheduler> create(Page& page)

--- a/Source/WebCore/page/ResizeObserverEntry.h
+++ b/Source/WebCore/page/ResizeObserverEntry.h
@@ -30,6 +30,7 @@
 #include "FloatRect.h"
 #include "ResizeObserverSize.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -37,7 +38,7 @@ class Element;
 class ResizeObserverSize;
 
 class ResizeObserverEntry : public RefCounted<ResizeObserverEntry> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ResizeObserverEntry);
 public:
     static Ref<ResizeObserverEntry> create(Element* target, const FloatRect& contentRect, FloatSize borderBoxSize, FloatSize contentBoxSize)
     {

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -34,8 +34,11 @@
 #include "Page.h"
 #include "PageOverlayController.h"
 #include "PlatformMouseEvent.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ResourceUsageOverlay);
 
 ResourceUsageOverlay::ResourceUsageOverlay(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/ResourceUsageOverlay.h
+++ b/Source/WebCore/page/ResourceUsageOverlay.h
@@ -32,6 +32,7 @@
 #include "PageOverlay.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(COCOA)
 #include "PlatformCALayer.h"
@@ -48,7 +49,7 @@ class IntPoint;
 class IntRect;
 
 class ResourceUsageOverlay final : public PageOverlayClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ResourceUsageOverlay);
     WTF_MAKE_NONCOPYABLE(ResourceUsageOverlay);
 public:
     explicit ResourceUsageOverlay(Page&);

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -49,6 +49,7 @@
 #include "StorageMap.h"
 #include <limits>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_STREAM)
 #include "MockRealtimeMediaSourceCenter.h"
@@ -58,6 +59,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SettingsBase);
 
 static void invalidateAfterGenericFamilyChange(Page* page)
 {

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -47,6 +47,7 @@
 #include <unicode/uscript.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
@@ -59,7 +60,8 @@ namespace WebCore {
 class Page;
 
 class SettingsBase {
-    WTF_MAKE_NONCOPYABLE(SettingsBase); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SettingsBase);
+    WTF_MAKE_NONCOPYABLE(SettingsBase);
 public:
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/page/SpeechRecognitionProvider.h
+++ b/Source/WebCore/page/SpeechRecognitionProvider.h
@@ -27,11 +27,12 @@
 
 #include "SpeechRecognitionConnection.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class SpeechRecognitionProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SpeechRecognitionProvider);
 public:
     SpeechRecognitionProvider() = default;
     virtual ~SpeechRecognitionProvider() = default;

--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "UserScript.h"
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserScript);
 
 static WTF::URL generateUserScriptUniqueURL()
 {

--- a/Source/WebCore/page/UserScript.h
+++ b/Source/WebCore/page/UserScript.h
@@ -28,12 +28,13 @@
 #include <wtf/URL.h>
 #include "UserContentTypes.h"
 #include "UserScriptTypes.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class UserScript {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserScript);
 public:
     ~UserScript() = default;
     UserScript(const UserScript&) = default;

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "UserStyleSheet.h"
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserStyleSheet);
 
 static WTF::URL generateUserStyleUniqueURL()
 {

--- a/Source/WebCore/page/UserStyleSheet.h
+++ b/Source/WebCore/page/UserStyleSheet.h
@@ -28,13 +28,14 @@
 #include "PageIdentifier.h"
 #include "UserContentTypes.h"
 #include "UserStyleSheetTypes.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class UserStyleSheet {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UserStyleSheet);
 public:
     UserStyleSheet()
         : m_injectedFrames(UserContentInjectedFrames::InjectInAllFrames)

--- a/Source/WebCore/page/ValidationMessageClient.h
+++ b/Source/WebCore/page/ValidationMessageClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class Document;
 class Element;
 
 class ValidationMessageClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ValidationMessageClient);
 public:
     virtual ~ValidationMessageClient() = default;
 

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/TextStream.h>
 
@@ -37,6 +38,8 @@
 #endif
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewportConfiguration);
 
 static inline bool viewportArgumentValueIsValid(float value)
 {

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -31,6 +31,7 @@
 #include "ViewportArguments.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 class TextStream;
@@ -39,7 +40,8 @@ class TextStream;
 namespace WebCore {
 
 class ViewportConfiguration {
-    WTF_MAKE_NONCOPYABLE(ViewportConfiguration); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ViewportConfiguration);
+    WTF_MAKE_NONCOPYABLE(ViewportConfiguration);
 public:
     // FIXME: unify with ViewportArguments.
     struct Parameters {

--- a/Source/WebCore/page/WheelEventDeltaFilter.cpp
+++ b/Source/WebCore/page/WheelEventDeltaFilter.cpp
@@ -29,6 +29,7 @@
 #include "FloatSize.h"
 #include "Logging.h"
 #include "PlatformWheelEvent.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 #if PLATFORM(MAC)
@@ -37,6 +38,8 @@
 
 namespace WebCore {
     
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicWheelEventDeltaFilter);
+
 WheelEventDeltaFilter::WheelEventDeltaFilter() = default;
 
 WheelEventDeltaFilter::~WheelEventDeltaFilter() = default;

--- a/Source/WebCore/page/WheelEventDeltaFilter.h
+++ b/Source/WebCore/page/WheelEventDeltaFilter.h
@@ -28,6 +28,7 @@
 #include "FloatSize.h"
 #include "ScrollTypes.h"
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -57,7 +58,7 @@ protected:
 };
 
 class BasicWheelEventDeltaFilter final : public WheelEventDeltaFilter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BasicWheelEventDeltaFilter);
 public:
     BasicWheelEventDeltaFilter();
     void updateFromEvent(const PlatformWheelEvent&) final;

--- a/Source/WebCore/page/WorkerClient.h
+++ b/Source/WebCore/page/WorkerClient.h
@@ -26,14 +26,14 @@
 #pragma once
 
 #include "GraphicsClient.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/FunctionDispatcher.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
 class WorkerClient : public GraphicsClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WorkerClient);
 public:
 
     // Used for constructing clients for nested workers. Created on the worker thread of the outer worker, and then transferred to the nested worker.

--- a/Source/WebCore/page/cocoa/DataDetectionResultsStorage.h
+++ b/Source/WebCore/page/cocoa/DataDetectionResultsStorage.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS DDScannerResult;
 OBJC_CLASS NSArray;
@@ -39,7 +40,7 @@ namespace WebCore {
 
 class DataDetectionResultsStorage {
     WTF_MAKE_NONCOPYABLE(DataDetectionResultsStorage);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(DataDetectionResultsStorage);
 public:
     DataDetectionResultsStorage() = default;
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -64,6 +64,7 @@
 #include <pal/text/TextEncoding.h>
 #include <wtf/JSONValues.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringParsingBuffer.h>
@@ -71,6 +72,8 @@
 
 namespace WebCore {
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicy);
 
 static String consoleMessageForViolation(const ContentSecurityPolicyDirective& violatedDirective, const URL& blockedURL, ASCIILiteral prefix, ASCIILiteral subject = "it"_s)
 {

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -34,6 +34,7 @@
 #include <functional>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/TextPosition.h>
 
@@ -87,7 +88,7 @@ enum class AllowTrustedTypePolicy : uint8_t {
 };
 
 class ContentSecurityPolicy final : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentSecurityPolicy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ContentSecurityPolicy);
 public:
     explicit ContentSecurityPolicy(URL&&, ScriptExecutionContext&);

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirective.cpp
@@ -27,8 +27,11 @@
 #include "ContentSecurityPolicyDirective.h"
 
 #include "ContentSecurityPolicyDirectiveList.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicyDirective);
 
 ContentSecurityPolicyDirective::~ContentSecurityPolicyDirective()
 {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirective.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,7 +35,7 @@ namespace WebCore {
 class ContentSecurityPolicyDirectiveList;
 
 class ContentSecurityPolicyDirective {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentSecurityPolicyDirective);
 public:
     ContentSecurityPolicyDirective(const ContentSecurityPolicyDirectiveList& directiveList, const String& name, const String& value)
         : m_name(name)

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -33,10 +33,13 @@
 #include "LocalFrame.h"
 #include "ParsingUtilities.h"
 #include "SecurityContext.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicyDirectiveList);
 
 template<typename CharacterType> static bool isDirectiveNameCharacter(CharacterType c)
 {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -31,6 +31,7 @@
 #include "ContentSecurityPolicyMediaListDirective.h"
 #include "ContentSecurityPolicySourceListDirective.h"
 #include "ContentSecurityPolicyTrustedTypesDirective.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -38,7 +39,7 @@ namespace WebCore {
 class LocalFrame;
 
 class ContentSecurityPolicyDirectiveList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentSecurityPolicyDirectiveList);
 public:
     static std::unique_ptr<ContentSecurityPolicyDirectiveList> create(ContentSecurityPolicy&, const String&, ContentSecurityPolicyHeaderType, ContentSecurityPolicy::PolicyFrom);
     ContentSecurityPolicyDirectiveList(ContentSecurityPolicy&, ContentSecurityPolicyHeaderType);

--- a/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
@@ -30,9 +30,12 @@
 #include "ContentSecurityPolicy.h"
 #include "SecurityOriginData.h"
 #include <pal/text/TextEncoding.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicySource);
 
 ContentSecurityPolicySource::ContentSecurityPolicySource(const ContentSecurityPolicy& policy, const String& scheme, const String& host, std::optional<uint16_t> port, const String& path, bool hostHasWildcard, bool portHasWildcard, IsSelfSource isSelfSource)
     : m_policy(policy)

--- a/Source/WebCore/page/csp/ContentSecurityPolicySource.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySource.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ class SecurityOriginData;
 enum class IsSelfSource : bool { No, Yes };
 
 class ContentSecurityPolicySource {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentSecurityPolicySource);
 public:
     ContentSecurityPolicySource(const ContentSecurityPolicy&, const String& scheme, const String& host, std::optional<uint16_t> port, const String& path, bool hostHasWildcard, bool portHasWildcard, IsSelfSource);
 

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -43,11 +43,14 @@
 #include "RenderDescendantIterator.h"
 #include "RenderStyleInlines.h"
 #include "Settings.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 static const Seconds maximumDelayForTimers { 400_ms };
 static const Seconds maximumDelayForTransitions { 300_ms };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentChangeObserver);
 
 #if ENABLE(FULLSCREEN_API)
 static bool isHiddenBehindFullscreenElement(const Node& descendantCandidate)

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -37,6 +37,7 @@
 #include "WebAnimationTypes.h"
 #include <wtf/HashSet.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ class DOMTimer;
 class Element;
 
 class ContentChangeObserver : public CanMakeWeakPtr<ContentChangeObserver> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ContentChangeObserver);
 public:
     ContentChangeObserver(Document&);
 

--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.cpp
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.cpp
@@ -25,10 +25,13 @@
 
 #include "config.h"
 #include "DOMTimerHoldingTank.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMTimerHoldingTank);
 
 #if PLATFORM(IOS_SIMULATOR)
 constexpr Seconds maximumHoldTimeLimit { 50_ms };

--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.h
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.h
@@ -29,6 +29,7 @@
 
 #include "Timer.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ namespace WebCore {
 class DOMTimer;
 
 class DOMTimerHoldingTank {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DOMTimerHoldingTank);
 public:
     DOMTimerHoldingTank();
     ~DOMTimerHoldingTank();

--- a/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
@@ -36,6 +36,7 @@
 #include "ResourceUsageThread.h"
 #include "SystemFontDatabase.h"
 #include <JavaScriptCore/VM.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -70,7 +71,7 @@ static String gcTimerString(MonotonicTime timerFireDate, MonotonicTime now)
 static const float gFontSize = 14;
 
 class ResourceUsageOverlayPainter final : public GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ResourceUsageOverlayPainter);
 public:
     ResourceUsageOverlayPainter(ResourceUsageOverlay& overlay)
         : m_overlay(overlay)

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -34,6 +34,7 @@
 #include "Timer.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ enum class RenderingUpdateStep : uint32_t;
 struct GapRects;
 
 class ServicesOverlayController : private DataDetectorHighlightClient, private PageOverlayClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServicesOverlayController);
 public:
     explicit ServicesOverlayController(Page&);
     ~ServicesOverlayController();

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -48,9 +48,12 @@
 #import "Settings.h"
 #import "TextIterator.h"
 #import <QuartzCore/QuartzCore.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServicesOverlayController);
 
 ServicesOverlayController::ServicesOverlayController(Page& page)
     : m_page(page)

--- a/Source/WebCore/page/mac/TextIndicatorWindow.h
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.h
@@ -30,6 +30,7 @@
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSView;
 OBJC_CLASS WebTextIndicatorLayer;
@@ -39,7 +40,7 @@ namespace WebCore {
 #if PLATFORM(MAC)
 
 class TextIndicatorWindow {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TextIndicatorWindow);
     WTF_MAKE_NONCOPYABLE(TextIndicatorWindow);
 
 public:

--- a/Source/WebCore/page/mac/TextIndicatorWindow.mm
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.mm
@@ -37,6 +37,7 @@
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/NSColorSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 @interface WebTextIndicatorView : NSView
 
@@ -55,6 +56,8 @@
 using namespace WebCore;
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextIndicatorWindow);
 
 TextIndicatorWindow::TextIndicatorWindow(NSView *targetView)
     : m_targetView(targetView)

--- a/Source/WebCore/page/mac/WheelEventDeltaFilterMac.h
+++ b/Source/WebCore/page/mac/WheelEventDeltaFilterMac.h
@@ -30,13 +30,14 @@
 #include "WheelEventDeltaFilter.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS _NSScrollingPredominantAxisFilter;
 
 namespace WebCore {
 
 class WheelEventDeltaFilterMac final : public WheelEventDeltaFilter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(xWheelEventDeltaFilterMac);
 public:
     WheelEventDeltaFilterMac();
 

--- a/Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm
+++ b/Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm
@@ -32,8 +32,11 @@
 #import "Logging.h"
 #import "PlatformWheelEvent.h"
 #import <pal/spi/mac/NSScrollingInputFilterSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WheelEventDeltaFilterMac);
 
 WheelEventDeltaFilterMac::WheelEventDeltaFilterMac()
     : WheelEventDeltaFilter()

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -35,9 +35,12 @@
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnchoringController);
 
 ScrollAnchoringController::ScrollAnchoringController(ScrollableArea& owningScroller)
     : m_owningScrollableArea(owningScroller)

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -29,6 +29,7 @@
 #include "Element.h"
 #include "FloatPoint.h"
 #include "ScrollTypes.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -51,7 +52,7 @@ enum class CandidateExaminationResult {
 };
 
 class ScrollAnchoringController final : public CanMakeWeakPtr<ScrollAnchoringController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnchoringController);
 public:
     explicit ScrollAnchoringController(ScrollableArea&);
     ~ScrollAnchoringController();

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
@@ -34,9 +34,12 @@
 #include "Logging.h"
 #include "PlatformWheelEvent.h"
 #include "ScrollableArea.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollLatchingController);
 
 // See also ScrollTreeLatchingController.cpp
 static const Seconds resetLatchedStateTimeout { 100_ms };

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.h
@@ -29,6 +29,7 @@
 #include "ScrollTypes.h"
 #include "Timer.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
@@ -46,7 +47,7 @@ class ScrollableArea;
 class WeakPtrImplWithEventTargetData;
 
 class ScrollLatchingController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollLatchingController);
 public:
     ScrollLatchingController();
     ~ScrollLatchingController();

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -26,9 +26,13 @@
 #include "config.h"
 #include "ScrollingConstraints.h"
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AbsolutePositionConstraint);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AbsolutePositionConstraints);
 
 AbsolutePositionConstraints::AbsolutePositionConstraints(const FloatSize& alignmentOffset, const FloatPoint& layerPositionAtLastLayout)
     : m_alignmentOffset(alignmentOffset)

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -27,11 +27,12 @@
 
 #include "FloatRect.h"
 #include "ScrollTypes.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class AbsolutePositionConstraints {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AbsolutePositionConstraints);
 public:
     AbsolutePositionConstraints() = default;
     WEBCORE_EXPORT AbsolutePositionConstraints(const FloatSize&, const FloatPoint&);
@@ -52,7 +53,7 @@ private:
 // ViewportConstraints classes encapsulate data and logic required to reposition elements whose layout
 // depends on the viewport rect (positions fixed and sticky), when scrolling and zooming.
 class ViewportConstraints {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ViewportConstraints);
 public:
     enum ConstraintType {
         FixedPositionConstraint,

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -42,10 +42,13 @@
 #include "ScrollAnimator.h"
 #include "Settings.h"
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingCoordinator);
 
 #if PLATFORM(IOS_FAMILY) || !ENABLE(ASYNC_SCROLLING)
 Ref<ScrollingCoordinator> ScrollingCoordinator::create(Page* page)

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -37,6 +37,7 @@
 #include "WheelEventTestMonitor.h"
 #include <variant>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
@@ -66,7 +67,7 @@ using FramesPerSecond = unsigned;
 using PlatformDisplayID = uint32_t;
 
 class ScrollingCoordinator : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingCoordinator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingCoordinator);
 public:
     static Ref<ScrollingCoordinator> create(Page*);
     virtual ~ScrollingCoordinator();

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -31,11 +31,14 @@
 #include "ScrollingStateFixedNode.h"
 #include "ScrollingStateScrollingNode.h"
 #include "ScrollingStateTree.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStateNode);
 
 ScrollingStateNode::ScrollingStateNode(ScrollingNodeType nodeType, ScrollingStateTree& scrollingStateTree, ScrollingNodeID nodeID)
     : m_nodeType(nodeType)

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -31,6 +31,7 @@
 #include "ScrollingCoordinator.h"
 #include <stdint.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
@@ -273,7 +274,7 @@ enum class ScrollingStateNodeProperty : uint64_t {
 };
 
 class ScrollingStateNode : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingStateNode> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingStateNode);
 public:
     virtual ~ScrollingStateNode();
 

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -39,10 +39,13 @@
 #include "ScrollingStatePluginScrollingNode.h"
 #include "ScrollingStatePositionedNode.h"
 #include "ScrollingStateStickyNode.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStateTree);
 
 static bool nodeTypeAndParentMatch(ScrollingStateNode& node, ScrollingNodeType nodeType, ScrollingStateNode* parentNode)
 {

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -30,6 +30,7 @@
 #include "ScrollingStateNode.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
  
 namespace WebCore {
 
@@ -42,7 +43,7 @@ class ScrollingStateFrameScrollingNode;
 // the scrolling thread, avoiding locking. 
 
 class ScrollingStateTree final : public CanMakeCheckedPtr<ScrollingStateTree> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingStateTree);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollingStateTree);
     friend class ScrollingStateNode;
 public:

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -43,9 +43,12 @@
 #include "ScrollingTreePositionedNode.h"
 #include "ScrollingTreeScrollingNode.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTree);
 
 using OrphanScrollingNodeMap = HashMap<ScrollingNodeID, RefPtr<ScrollingTreeNode>>;
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -42,6 +42,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>
 
@@ -64,7 +65,7 @@ using PlatformDisplayID = uint32_t;
 enum class EventTargeting : uint8_t { NodeOnly, Propagate };
 
 class ScrollingTree : public ThreadSafeRefCounted<ScrollingTree> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTree);
     friend class ScrollingTreeLatchingController;
 public:
     WEBCORE_EXPORT ScrollingTree();

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
@@ -31,9 +31,12 @@
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeFrameScrollingNode.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeNode);
 
 ScrollingTreeNode::ScrollingTreeNode(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
     : m_scrollingTree(scrollingTree)

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -32,6 +32,7 @@
 #include "ScrollingCoordinator.h"
 #include "ScrollingStateNode.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 
@@ -43,7 +44,7 @@ class ScrollingTreeFrameScrollingNode;
 class ScrollingTreeScrollingNode;
 
 class ScrollingTreeNode : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingTreeNode> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeNode);
     friend class ScrollingTree;
 public:
     virtual ~ScrollingTreeNode();

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
@@ -26,11 +26,15 @@
 #include "config.h"
 #include "ScrollingTreeScrollingNodeDelegate.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingTreeScrollingNode.h"
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeScrollingNodeDelegate);
 
 ScrollingTreeScrollingNodeDelegate::ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode& scrollingNode)
     : m_scrollingNode(scrollingNode)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -29,10 +29,12 @@
 
 #include "ScrollingTreeScrollingNode.h"
 
+#include <wtf/TZoneMalloc.h>
+
 namespace WebCore {
 
 class ScrollingTreeScrollingNodeDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeScrollingNodeDelegate);
 public:
     WEBCORE_EXPORT explicit ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -33,6 +33,7 @@
 #include "ScrollerMac.h"
 #include "ScrollingStateScrollingNode.h"
 #include <wtf/RecursiveLockAdapter.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS NSScrollerImp;
@@ -48,7 +49,7 @@ namespace WebCore {
 
 // Controls a pair of NSScrollerImps via a pair of ScrollerMac. The NSScrollerImps need to remain internal to this class.
 class ScrollerPairMac : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollerPairMac> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ScrollerPairMac);
     friend class ScrollerMac;
 public:
     void init();

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -39,6 +39,7 @@
 #import <WebCore/ScrollableArea.h>
 #import <WebCore/ScrollingTreeScrollingNode.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 @interface WebScrollerImpPairDelegateMac : NSObject <NSScrollerImpPairDelegate> {
     ThreadSafeWeakPtr<WebCore::ScrollerPairMac> _scrollerPair;
@@ -132,6 +133,8 @@
 @end
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollerPairMac);
 
 ScrollerPairMac::ScrollerPairMac(ScrollingTreeScrollingNode& node)
     : m_scrollingNode(node)

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -31,7 +31,7 @@
 #import "WritingToolsCompositionCommand.h"
 #import "WritingToolsTypes.h"
 #import <wtf/CheckedPtr.h>
-#import <wtf/FastMalloc.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -49,7 +49,7 @@ struct SimpleRange;
 enum class TextAnimationRunMode : uint8_t;
 
 class WritingToolsController final : public CanMakeWeakPtr<WritingToolsController>, public CanMakeCheckedPtr<WritingToolsController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WritingToolsController);
     WTF_MAKE_NONCOPYABLE(WritingToolsController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WritingToolsController);
 
@@ -129,7 +129,8 @@ private:
     };
 
     class EditingScope {
-        WTF_MAKE_NONCOPYABLE(EditingScope); WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(EditingScope);
+        WTF_MAKE_NONCOPYABLE(EditingScope);
     public:
         EditingScope(Document&);
         ~EditingScope();

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -46,8 +46,12 @@
 #import "VisibleUnits.h"
 #import "WebContentReader.h"
 #import <ranges>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WritingToolsController);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(WritingToolsControllerEditingScope, WritingToolsController::EditingScope);
 
 #pragma mark - EditingScope
 


### PR DESCRIPTION
#### f3f4594c841728632df8cf83e85566df2b987ea7
<pre>
[TZone] WebCore/page Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278419">https://bugs.webkit.org/show_bug.cgi?id=278419</a>
<a href="https://rdar.apple.com/134372652">rdar://134372652</a>

Reviewed by Keith Miller.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebCore/page/AlternativeTextClient.h:
* Source/WebCore/page/AttachmentElementClient.h:
* Source/WebCore/page/AudioOutputProvider.h:
* Source/WebCore/page/AutoscrollController.cpp:
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/CaptionUserPreferences.cpp:
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/page/ContextMenuController.cpp:
* Source/WebCore/page/ContextMenuController.h:
* Source/WebCore/page/CryptoClient.h:
* Source/WebCore/page/DOMTimer.cpp:
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/DeviceClient.h:
* Source/WebCore/page/DeviceController.cpp:
* Source/WebCore/page/DeviceController.h:
* Source/WebCore/page/DiagnosticLoggingClient.h:
* Source/WebCore/page/DragClient.h:
* Source/WebCore/page/DragController.cpp:
* Source/WebCore/page/DragController.h:
* Source/WebCore/page/EditorClient.h:
* Source/WebCore/page/ElementTargetingController.cpp:
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/EmptyAttachmentElementClient.h:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.cpp:
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/FrameView.cpp:
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/ImageAnalysisQueue.cpp:
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/ImageOverlayController.cpp:
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/NavigatorLoginStatus.cpp:
* Source/WebCore/page/NavigatorLoginStatus.h:
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.cpp:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/PageConsoleClient.cpp:
* Source/WebCore/page/PageConsoleClient.h:
* Source/WebCore/page/PageDebuggable.cpp:
* Source/WebCore/page/PageDebuggable.h:
* Source/WebCore/page/PageGroup.cpp:
* Source/WebCore/page/PageGroup.h:
* Source/WebCore/page/PageOverlay.cpp:
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/PageOverlayController.cpp:
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/PagePasteboardContext.h:
* Source/WebCore/page/PerformanceLogging.cpp:
* Source/WebCore/page/PerformanceLogging.h:
* Source/WebCore/page/PerformanceLoggingClient.cpp:
* Source/WebCore/page/PerformanceLoggingClient.h:
* Source/WebCore/page/PerformanceMonitor.cpp:
* Source/WebCore/page/PerformanceMonitor.h:
* Source/WebCore/page/PerformanceObserverEntryList.cpp:
* Source/WebCore/page/PerformanceObserverEntryList.h:
* Source/WebCore/page/PerformanceUserTiming.cpp:
* Source/WebCore/page/PerformanceUserTiming.h:
* Source/WebCore/page/PointerCaptureController.cpp:
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/page/PointerLockController.cpp:
* Source/WebCore/page/PointerLockController.h:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/page/PrintContext.h:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebCore/page/RemoteFrameView.cpp:
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebCore/page/RenderingUpdateScheduler.cpp:
* Source/WebCore/page/RenderingUpdateScheduler.h:
* Source/WebCore/page/ResizeObserverEntry.h:
* Source/WebCore/page/ResourceUsageOverlay.cpp:
* Source/WebCore/page/ResourceUsageOverlay.h:
* Source/WebCore/page/SettingsBase.cpp:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/SpeechRecognitionProvider.h:
* Source/WebCore/page/UserScript.cpp:
* Source/WebCore/page/UserScript.h:
* Source/WebCore/page/UserStyleSheet.cpp:
* Source/WebCore/page/UserStyleSheet.h:
* Source/WebCore/page/ValidationMessageClient.h:
* Source/WebCore/page/ViewportConfiguration.cpp:
* Source/WebCore/page/ViewportConfiguration.h:
* Source/WebCore/page/WheelEventDeltaFilter.cpp:
* Source/WebCore/page/WheelEventDeltaFilter.h:
* Source/WebCore/page/WorkerClient.h:
* Source/WebCore/page/cocoa/DataDetectionResultsStorage.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirective.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicyDirective.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
* Source/WebCore/page/csp/ContentSecurityPolicySource.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicySource.h:
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
* Source/WebCore/page/ios/ContentChangeObserver.h:
* Source/WebCore/page/ios/DOMTimerHoldingTank.cpp:
* Source/WebCore/page/ios/DOMTimerHoldingTank.h:
* Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp:
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/mac/ServicesOverlayController.mm:
* Source/WebCore/page/mac/TextIndicatorWindow.h:
* Source/WebCore/page/mac/TextIndicatorWindow.mm:
* Source/WebCore/page/mac/WheelEventDeltaFilterMac.h:
* Source/WebCore/page/mac/WheelEventDeltaFilterMac.mm:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/page/scrolling/ScrollLatchingController.cpp:
* Source/WebCore/page/scrolling/ScrollLatchingController.h:
* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
* Source/WebCore/page/scrolling/ScrollingConstraints.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeNode.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:

Canonical link: <a href="https://commits.webkit.org/282576@main">https://commits.webkit.org/282576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/486d2a845fbfd8924c7cc37814b8c3b00d251e49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14133 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51167 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9778 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69242 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12286 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58461 "Found 1 new test failure: fast/forms/search/search-size-with-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58690 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6246 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9612 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38702 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->