### PR TITLE
Allow MobileMiniBrowser to become default web browser

### DIFF
--- a/Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig
+++ b/Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig
@@ -25,4 +25,5 @@ PRODUCT_NAME = MiniBrowser
 STRIP_STYLE=debugging
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator xros xrsimulator;
 CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = MobileMiniBrowser/MobileMiniBrowser.entitlements;
+CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = MobileMiniBrowser/MobileMiniBrowser.entitlements;
 OTHER_CODE_SIGN_FLAGS[sdk=*simulator] = ;

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser/Info.plist
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser/Info.plist
@@ -16,6 +16,18 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Web Site URL</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>http</string>
+				<string>https</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 	<key>com.apple.runningboard.assertions.webkit</key>
 	<true/>
 	<key>com.apple.private.security.enable-state-flags</key>

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
@@ -27,6 +27,8 @@
 
 #import "WebViewController.h"
 
+#import <WebKit/WebKit.h>
+
 @interface AppDelegate ()
 @end
 
@@ -42,6 +44,10 @@
     if (!viewController)
         return NO;
 
+    NSURL *url = launchOptions[UIApplicationLaunchOptionsURLKey];
+    if (url)
+        viewController.initialURL = url;
+
     if (!self.window)
         self.window = [[UIWindow alloc] init];
     self.window.rootViewController = viewController;
@@ -50,6 +56,12 @@
     return YES;
 }
 
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    WebViewController *controller = (WebViewController *)self.window.rootViewController;
+    [controller.currentWebView loadRequest:[NSURLRequest requestWithURL:url]];
+    return YES;
+}
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.h
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.h
@@ -38,6 +38,7 @@
 @property (strong, nonatomic) IBOutlet UIBarButtonItem *settingsButton;
 @property (strong, nonatomic) IBOutlet TabViewController *tabViewController;
 @property (strong, nonatomic) IBOutlet SettingsViewController *settingsViewController;
+@property (strong, nonatomic) NSURL *initialURL;
 @property (strong, nonatomic) WKWebView *currentWebView;
 @property (strong, nonatomic) NSMutableArray<WKWebView *> *webViews;
 

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
@@ -59,6 +59,7 @@ static const NSString * const kURLArgumentString = @"--url";
 
 @interface WebViewController () <WKNavigationDelegate> {
     WKWebView *_currentWebView;
+    NSURL *_initialURL;
 }
 - (WKWebView *)createWebView;
 - (void)removeWebView:(WKWebView *)webView;
@@ -248,6 +249,9 @@ void* URLContext = &URLContext;
 
 - (NSURL *)targetURLorDefaultURL
 {
+    if (_initialURL)
+        return _initialURL;
+
     NSArray *args = [[NSProcessInfo processInfo] arguments];
     const NSUInteger targetURLIndex = [args indexOfObject:kURLArgumentString];
 


### PR DESCRIPTION
#### c25bcef746bb4e52551300bfc436ebaf35fd3e50
<pre>
Allow MobileMiniBrowser to become default web browser
<a href="https://bugs.webkit.org/show_bug.cgi?id=278431">https://bugs.webkit.org/show_bug.cgi?id=278431</a>
<a href="https://rdar.apple.com/problem/134378296">rdar://problem/134378296</a>

Reviewed by Sihui Liu.

For testing purposes, it&apos;s useful to be able to set MobileMiniBrowser as the system default
browser. I also modified the browser so that it properly handles open URL commands.

* Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig:
* Tools/MobileMiniBrowser/MobileMiniBrowser/Info.plist:
* Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements:
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m:
(-[AppDelegate application:didFinishLaunchingWithOptions:]):
(-[AppDelegate application:openURL:options:]):
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.h:
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m:
(-[WebViewController targetURLorDefaultURL]):

Canonical link: <a href="https://commits.webkit.org/282546@main">https://commits.webkit.org/282546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/699a60b4173d88aab36f77e4e73f021b9d5d2bb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67452 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14319 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9702 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12197 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55000 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6149 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40799 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39430 "Failed to checkout and rebase branch from PR 32493") | | | 
<!--EWS-Status-Bubble-End-->