### PR TITLE
[TZone] WebCore/inspector Convert FastMalloc to TZone

### DIFF
--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -51,6 +51,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEB_RTC)
 #include "JSRTCPeerConnection.h"
@@ -61,6 +62,8 @@ namespace WebCore {
 
 using namespace JSC;
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(CommandLineAPIHostInspectableObject, CommandLineAPIHost::InspectableObject);
 
 Ref<CommandLineAPIHost> CommandLineAPIHost::create()
 {

--- a/Source/WebCore/inspector/CommandLineAPIHost.h
+++ b/Source/WebCore/inspector/CommandLineAPIHost.h
@@ -32,6 +32,7 @@
 #include "InstrumentingAgents.h"
 #include <JavaScriptCore/PerGlobalObjectWrapperWorld.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -67,7 +68,7 @@ public:
     void copyText(const String& text);
 
     class InspectableObject {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(InspectableObject);
     public:
         virtual JSC::JSValue get(JSC::JSGlobalObject&);
         virtual ~InspectableObject() = default;

--- a/Source/WebCore/inspector/DOMEditor.cpp
+++ b/Source/WebCore/inspector/DOMEditor.cpp
@@ -40,8 +40,11 @@
 #include "Text.h"
 #include "markup.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMEditor);
 
 class DOMEditor::RemoveChildAction final : public InspectorHistory::Action {
     WTF_MAKE_NONCOPYABLE(RemoveChildAction);

--- a/Source/WebCore/inspector/DOMEditor.h
+++ b/Source/WebCore/inspector/DOMEditor.h
@@ -32,6 +32,8 @@
 
 #include "ExceptionOr.h"
 
+#include <wtf/TZoneMalloc.h>
+
 namespace WebCore {
 
 class ContainerNode;
@@ -43,7 +45,8 @@ class Text;
 typedef String ErrorString;
 
 class DOMEditor {
-    WTF_MAKE_NONCOPYABLE(DOMEditor); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DOMEditor);
+    WTF_MAKE_NONCOPYABLE(DOMEditor);
 public:
     explicit DOMEditor(InspectorHistory&);
     ~DOMEditor();

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -82,6 +82,7 @@
 #include <JavaScriptCore/InspectorScriptProfilerAgent.h>
 #include <JavaScriptCore/JSLock.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "PageDebuggable.h"
@@ -91,6 +92,8 @@ namespace WebCore {
 
 using namespace JSC;
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorController);
 
 InspectorController::InspectorController(Page& page, std::unique_ptr<InspectorClient>&& inspectorClient)
     : m_instrumentingAgents(InstrumentingAgents::create(*this))

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -36,6 +36,7 @@
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -64,7 +65,7 @@ struct PageAgentContext;
 
 class InspectorController final : public Inspector::InspectorEnvironment {
     WTF_MAKE_NONCOPYABLE(InspectorController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorController);
 public:
     InspectorController(Page&, std::unique_ptr<InspectorClient>&&);
     ~InspectorController() override;

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -57,12 +57,15 @@
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/Deque.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorFrontendClientLocal);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(InspectorFrontendClientLocalSettings, InspectorFrontendClientLocal::Settings);
 
 static constexpr ASCIILiteral inspectorAttachedHeightSetting = "inspectorAttachedHeight"_s;
 static const unsigned defaultAttachedHeight = 300;
@@ -72,7 +75,7 @@ static const float minimumAttachedWidth = 500.0f;
 static const float minimumAttachedInspectedWidth = 320.0f;
 
 class InspectorBackendDispatchTask : public RefCounted<InspectorBackendDispatchTask> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorBackendDispatchTask);
 public:
     static Ref<InspectorBackendDispatchTask> create(InspectorController* inspectedPageController)
     {

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -35,6 +35,7 @@
 #include "InspectorFrontendClient.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -50,10 +51,10 @@ class Page;
 
 class InspectorFrontendClientLocal : public InspectorFrontendClient {
     WTF_MAKE_NONCOPYABLE(InspectorFrontendClientLocal);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorFrontendClientLocal);
 public:
     class WEBCORE_EXPORT Settings {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Settings);
     public:
         Settings() = default;
         virtual ~Settings() = default;

--- a/Source/WebCore/inspector/InspectorHistory.cpp
+++ b/Source/WebCore/inspector/InspectorHistory.cpp
@@ -32,8 +32,12 @@
 #include "InspectorHistory.h"
 
 #include "Node.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorHistory);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(InspectorHistoryAction, InspectorHistory::Action);
 
 class UndoableStateMark : public InspectorHistory::Action {
 private:

--- a/Source/WebCore/inspector/InspectorHistory.h
+++ b/Source/WebCore/inspector/InspectorHistory.h
@@ -31,16 +31,17 @@
 #pragma once
 
 #include "ExceptionOr.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class InspectorHistory final {
+    WTF_MAKE_TZONE_ALLOCATED();
     WTF_MAKE_NONCOPYABLE(InspectorHistory);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     class Action {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Action);
     public:
         virtual ~Action() = default;
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -75,6 +75,7 @@
 #include "StyleResolver.h"
 #include "TextDirection.h"
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -82,6 +83,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorOverlay);
 
 static constexpr float rulerSize = 15;
 static constexpr float rulerLabelSize = 13;

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -39,6 +39,7 @@
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
@@ -138,7 +139,7 @@ struct InspectorOverlayHighlight {
 };
 
 class InspectorOverlay {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorOverlay);
 public:
     InspectorOverlay(Page&, InspectorClient*);
     ~InspectorOverlay();

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -35,9 +35,12 @@
 #include "FontCascadeDescription.h"
 #include "GraphicsContext.h"
 #include "Path.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorOverlayLabel);
 
 static constexpr float labelPadding = 4;
 static constexpr float labelArrowSize = 6;

--- a/Source/WebCore/inspector/InspectorOverlayLabel.h
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.h
@@ -31,6 +31,7 @@
 #include "Color.h"
 #include "FloatPoint.h"
 #include <wtf/ArgumentCoder.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -41,7 +42,7 @@ class GraphicsContext;
 class Path;
 
 class InspectorOverlayLabel {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorOverlayLabel);
 public:
     struct Arrow {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -69,6 +69,7 @@
 #include <JavaScriptCore/ContentSearchUtilities.h>
 #include <JavaScriptCore/RegularExpression.h>
 #include <wtf/NotFound.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -215,7 +216,7 @@ static std::optional<Inspector::Protocol::CSS::Grouping::Type> protocolGroupingT
 }
 
 class ParsedStyleSheet {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ParsedStyleSheet);
 public:
     ParsedStyleSheet();
 

--- a/Source/WebCore/inspector/InstrumentingAgents.cpp
+++ b/Source/WebCore/inspector/InstrumentingAgents.cpp
@@ -31,11 +31,14 @@
 
 #include "config.h"
 #include "InstrumentingAgents.h"
+#include <wtf/TZoneMallocInlines.h>
 
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InstrumentingAgents);
 
 InstrumentingAgents::InstrumentingAgents(InspectorEnvironment& environment)
     : m_environment(environment)

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -35,6 +35,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 class InspectorAgent;
@@ -139,7 +140,7 @@ class WebDebuggerAgent;
 
 class InstrumentingAgents : public RefCounted<InstrumentingAgents> {
     WTF_MAKE_NONCOPYABLE(InstrumentingAgents);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InstrumentingAgents);
 public:
     // FIXME: InstrumentingAgents could be uniquely owned by InspectorController if instrumentation
     // cookies kept only a weak reference to InstrumentingAgents. Then, reset() would be unnecessary.

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -34,9 +34,13 @@
 #include "InspectorNetworkAgent.h"
 #include "ResourceResponse.h"
 #include "TextResourceDecoder.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkResourcesData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(NetworkResourcesDataResourceData, NetworkResourcesData::ResourceData);
 
 using namespace Inspector;
 

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -33,6 +33,7 @@
 #include "SharedBuffer.h"
 #include <wtf/Deque.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
@@ -43,10 +44,10 @@ class ResourceResponse;
 class TextResourceDecoder;
 
 class NetworkResourcesData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NetworkResourcesData);
 public:
     class ResourceData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(ResourceData);
         friend class NetworkResourcesData;
     public:
         ResourceData(const String& requestId, const String& loaderId);

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -43,6 +43,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "WebCoreThreadInternal.h"
@@ -52,6 +53,8 @@
 namespace WebCore {
 using namespace JSC;
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageDebugger);
 
 PageDebugger::PageDebugger(Page& page)
     : Debugger(WebCore::commonVM())

--- a/Source/WebCore/inspector/PageDebugger.h
+++ b/Source/WebCore/inspector/PageDebugger.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <JavaScriptCore/Debugger.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class PageGroup;
 
 class PageDebugger final : public JSC::Debugger {
     WTF_MAKE_NONCOPYABLE(PageDebugger);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageDebugger);
 public:
     PageDebugger(Page&);
     ~PageDebugger() override = default;

--- a/Source/WebCore/inspector/UserGestureEmulationScope.cpp
+++ b/Source/WebCore/inspector/UserGestureEmulationScope.cpp
@@ -36,8 +36,11 @@
 #include "Document.h"
 #include "Page.h"
 #include "UserGestureIndicator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UserGestureEmulationScope);
 
 UserGestureEmulationScope::UserGestureEmulationScope(Page& inspectedPage, bool emulateUserGesture, Document* document)
     : m_pageChromeClient(inspectedPage.chrome().client())

--- a/Source/WebCore/inspector/UserGestureEmulationScope.h
+++ b/Source/WebCore/inspector/UserGestureEmulationScope.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "UserGestureIndicator.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,8 +40,8 @@ class Document;
 class Page;
 
 class UserGestureEmulationScope {
+    WTF_MAKE_TZONE_ALLOCATED(UserGestureEmulationScope);
     WTF_MAKE_NONCOPYABLE(UserGestureEmulationScope);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     UserGestureEmulationScope(Page&, bool emulateUserGesture, Document* = nullptr);
     ~UserGestureEmulationScope();

--- a/Source/WebCore/inspector/WebInjectedScriptManager.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.cpp
@@ -29,10 +29,13 @@
 #include "CommandLineAPIModule.h"
 #include "JSExecState.h"
 #include "LocalDOMWindow.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInjectedScriptManager);
 
 WebInjectedScriptManager::WebInjectedScriptManager(InspectorEnvironment& environment, Ref<InjectedScriptHost>&& host)
     : InjectedScriptManager(environment, WTFMove(host))

--- a/Source/WebCore/inspector/WebInjectedScriptManager.h
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.h
@@ -28,6 +28,7 @@
 #include "CommandLineAPIHost.h"
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class LocalDOMWindow;
 
 class WebInjectedScriptManager final : public Inspector::InjectedScriptManager {
     WTF_MAKE_NONCOPYABLE(WebInjectedScriptManager);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebInjectedScriptManager);
 public:
     WebInjectedScriptManager(Inspector::InspectorEnvironment&, Ref<Inspector::InjectedScriptHost>&&);
     ~WebInjectedScriptManager() override = default;

--- a/Source/WebCore/inspector/WorkerDebugger.cpp
+++ b/Source/WebCore/inspector/WorkerDebugger.cpp
@@ -39,10 +39,13 @@
 #include "WorkerRunLoop.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/VM.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerDebugger);
 
 WorkerDebugger::WorkerDebugger(WorkerOrWorkletGlobalScope& context)
     : Debugger(context.script()->vm())

--- a/Source/WebCore/inspector/WorkerDebugger.h
+++ b/Source/WebCore/inspector/WorkerDebugger.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <JavaScriptCore/Debugger.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -39,7 +40,7 @@ class WorkerOrWorkletGlobalScope;
 
 class WorkerDebugger final : public JSC::Debugger {
     WTF_MAKE_NONCOPYABLE(WorkerDebugger);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerDebugger);
 public:
     WorkerDebugger(WorkerOrWorkletGlobalScope&);
     ~WorkerDebugger() override = default;

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -54,11 +54,14 @@
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace JSC;
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerInspectorController);
 
 WorkerInspectorController::WorkerInspectorController(WorkerOrWorkletGlobalScope& globalScope)
     : m_instrumentingAgents(InstrumentingAgents::create(*this))

--- a/Source/WebCore/inspector/WorkerInspectorController.h
+++ b/Source/WebCore/inspector/WorkerInspectorController.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 class FrontendChannel;
@@ -46,7 +47,7 @@ struct WorkerAgentContext;
 
 class WorkerInspectorController final : public Inspector::InspectorEnvironment {
     WTF_MAKE_NONCOPYABLE(WorkerInspectorController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerInspectorController);
 public:
     explicit WorkerInspectorController(WorkerOrWorkletGlobalScope&);
     ~WorkerInspectorController() override;

--- a/Source/WebCore/inspector/WorkerToPageFrontendChannel.h
+++ b/Source/WebCore/inspector/WorkerToPageFrontendChannel.h
@@ -29,11 +29,12 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 class WorkerToPageFrontendChannel final : public Inspector::FrontendChannel {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WorkerToPageFrontendChannel);
 public:
     explicit WorkerToPageFrontendChannel(WorkerOrWorkletGlobalScope& globalScope)
         : m_globalScope(globalScope)

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -60,6 +60,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -68,6 +69,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAnimationAgent);
 
 static std::optional<double> protocolValueForSeconds(const Seconds& seconds)
 {

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/Forward.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 
 namespace WebCore {
@@ -51,7 +52,7 @@ struct Styleable;
 
 class InspectorAnimationAgent final : public InspectorAgentBase, public Inspector::AnimationBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorAnimationAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorAnimationAgent);
 public:
     InspectorAnimationAgent(PageAgentContext&);
     ~InspectorAnimationAgent();

--- a/Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.cpp
@@ -35,11 +35,14 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "PlatformStrategies.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorApplicationCacheAgent);
 
 InspectorApplicationCacheAgent::InspectorApplicationCacheAgent(PageAgentContext& context)
     : InspectorAgentBase("ApplicationCache"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 class ApplicationCacheFrontendDispatcher;
@@ -41,7 +42,7 @@ class Page;
 
 class InspectorApplicationCacheAgent final : public InspectorAgentBase, public Inspector::ApplicationCacheBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorApplicationCacheAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorApplicationCacheAgent);
 public:
     InspectorApplicationCacheAgent(PageAgentContext&);
     ~InspectorApplicationCacheAgent();

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -32,10 +32,13 @@
 #include "ResourceUsageThread.h"
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorCPUProfilerAgent);
 
 InspectorCPUProfilerAgent::InspectorCPUProfilerAgent(PageAgentContext& context)
     : InspectorAgentBase("CPUProfiler"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.h
@@ -31,12 +31,13 @@
 #include "ResourceUsageData.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class InspectorCPUProfilerAgent final : public InspectorAgentBase, public Inspector::CPUProfilerBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorCPUProfilerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorCPUProfilerAgent);
 public:
     InspectorCPUProfilerAgent(PageAgentContext&);
     ~InspectorCPUProfilerAgent();

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -75,6 +75,7 @@
 #include "StyleSheetList.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -82,6 +83,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorCSSAgent);
 
 class InspectorCSSAgent::StyleSheetAction : public InspectorHistory::Action {
     WTF_MAKE_NONCOPYABLE(StyleSheetAction);

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -37,6 +37,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
@@ -66,7 +67,7 @@ class Resolver;
 
 class InspectorCSSAgent final : public InspectorAgentBase , public Inspector::CSSBackendDispatcherHandler , public InspectorStyleSheet::Listener {
     WTF_MAKE_NONCOPYABLE(InspectorCSSAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorCSSAgent);
 public:
     explicit InspectorCSSAgent(PageAgentContext&);
     ~InspectorCSSAgent();

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -76,6 +76,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -87,6 +88,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorCanvasAgent);
 
 InspectorCanvasAgent::InspectorCanvasAgent(WebAgentContext& context)
     : InspectorAgentBase("Canvas"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -37,6 +37,7 @@
 #include <wtf/Forward.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -66,7 +67,7 @@ class WebGLRenderingContextBase;
 
 class InspectorCanvasAgent : public InspectorAgentBase, public Inspector::CanvasBackendDispatcherHandler, public CanvasObserver {
     WTF_MAKE_NONCOPYABLE(InspectorCanvasAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorCanvasAgent);
 public:
     ~InspectorCanvasAgent();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -130,6 +130,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -138,6 +139,8 @@
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorDOMAgent);
 
 using namespace Inspector;
 
@@ -194,7 +197,7 @@ static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
 }
 
 class RevalidateStyleAttributeTask {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RevalidateStyleAttributeTask);
 public:
     RevalidateStyleAttributeTask(InspectorDOMAgent*);
     void scheduleFor(Element*);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -40,6 +40,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/AtomString.h>
@@ -82,7 +83,7 @@ struct Styleable;
 
 class InspectorDOMAgent final : public InspectorAgentBase, public Inspector::DOMBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorDOMAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorDOMAgent);
 public:
     InspectorDOMAgent(PageAgentContext&, InspectorOverlay*);
     ~InspectorDOMAgent();

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -47,10 +47,13 @@
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/RegularExpression.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorDOMDebuggerAgent);
 
 InspectorDOMDebuggerAgent::InspectorDOMDebuggerAgent(WebAgentContext& context, InspectorDebuggerAgent* debuggerAgent)
     : InspectorAgentBase("DOMDebugger"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h
@@ -40,6 +40,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -55,7 +56,7 @@ class ScriptExecutionContext;
 
 class InspectorDOMDebuggerAgent : public InspectorAgentBase, public Inspector::DOMDebuggerBackendDispatcherHandler, public Inspector::InspectorDebuggerAgent::Listener {
     WTF_MAKE_NONCOPYABLE(InspectorDOMDebuggerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorDOMDebuggerAgent);
 public:
     ~InspectorDOMDebuggerAgent() override;
 

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -48,11 +48,14 @@
 #include "VoidCallback.h"
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorDOMStorageAgent);
 
 InspectorDOMStorageAgent::InspectorDOMStorageAgent(PageAgentContext& context)
     : InspectorAgentBase("DOMStorage"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h
@@ -32,6 +32,7 @@
 #include "InspectorWebAgentBase.h"
 #include "StorageArea.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -47,7 +48,7 @@ class Storage;
 
 class InspectorDOMStorageAgent final : public InspectorAgentBase, public Inspector::DOMStorageBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorDOMStorageAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorDOMStorageAgent);
 public:
     InspectorDOMStorageAgent(PageAgentContext&);
     ~InspectorDOMStorageAgent();

--- a/Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp
@@ -47,6 +47,7 @@
 #include "VoidCallback.h"
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -54,6 +55,8 @@ namespace WebCore {
 using namespace Inspector;
 
 using ExecuteSQLCallback = Inspector::DatabaseBackendDispatcherHandler::ExecuteSQLCallback;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorDatabaseAgent);
 
 namespace {
 

--- a/Source/WebCore/inspector/agents/InspectorDatabaseAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDatabaseAgent.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ class InspectorDatabaseResource;
 
 class InspectorDatabaseAgent final : public InspectorAgentBase, public Inspector::DatabaseBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorDatabaseAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorDatabaseAgent);
 public:
     InspectorDatabaseAgent(WebAgentContext&);
     ~InspectorDatabaseAgent();

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -66,12 +66,15 @@
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(x);
 
 namespace {
 

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
@@ -33,6 +33,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -45,7 +46,7 @@ class Page;
 
 class InspectorIndexedDBAgent final : public InspectorAgentBase, public Inspector::IndexedDBBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorIndexedDBAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorIndexedDBAgent);
 public:
     InspectorIndexedDBAgent(PageAgentContext&);
     ~InspectorIndexedDBAgent();

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -41,10 +41,13 @@
 #include "RenderLayerCompositor.h"
 #include "RenderView.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorLayerTreeAgent);
 
 InspectorLayerTreeAgent::InspectorLayerTreeAgent(WebAgentContext& context)
     : InspectorAgentBase("LayerTree"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
@@ -46,7 +47,7 @@ class WeakPtrImplWithEventTargetData;
 
 class InspectorLayerTreeAgent final : public InspectorAgentBase, public Inspector::LayerTreeBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorLayerTreeAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorLayerTreeAgent);
 public:
     InspectorLayerTreeAgent(WebAgentContext&);
     ~InspectorLayerTreeAgent();

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -32,11 +32,14 @@
 #include "ResourceUsageThread.h"
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorMemoryAgent);
 
 InspectorMemoryAgent::InspectorMemoryAgent(PageAgentContext& context)
     : InspectorAgentBase("Memory"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.h
@@ -32,12 +32,13 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class InspectorMemoryAgent final : public InspectorAgentBase, public Inspector::MemoryBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorMemoryAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorMemoryAgent);
 public:
     InspectorMemoryAgent(PageAgentContext&);
     ~InspectorMemoryAgent();

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -87,6 +87,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/persistence/PersistentEncoder.h>
 #include <wtf/text/Base64.h>
@@ -99,6 +100,10 @@ typedef Inspector::NetworkBackendDispatcherHandler::LoadResourceCallback LoadRes
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorNetworkAgent);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(InspectorNetworkAgentPendingInterceptRequest, InspectorNetworkAgent::AgentPendingInterceptRequest);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(InspectorNetworkAgentPendingInterceptResponse, InspectorNetworkAgent::PendingInterceptResponse);
 
 namespace {
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -41,6 +41,7 @@
 #include <wtf/Forward.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 class ConsoleMessage;
@@ -66,7 +67,7 @@ struct WebSocketFrame;
 
 class InspectorNetworkAgent : public InspectorAgentBase, public Inspector::NetworkBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorNetworkAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorNetworkAgent);
 public:
     ~InspectorNetworkAgent() override;
 
@@ -169,7 +170,7 @@ private:
 
     class PendingInterceptRequest {
         WTF_MAKE_NONCOPYABLE(PendingInterceptRequest);
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(PendingInterceptRequest);
     public:
         PendingInterceptRequest(RefPtr<ResourceLoader> loader, Function<void(const ResourceRequest&)>&& callback)
             : m_loader(loader)
@@ -194,7 +195,7 @@ private:
 
     class PendingInterceptResponse {
         WTF_MAKE_NONCOPYABLE(PendingInterceptResponse);
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(PendingInterceptResponse);
     public:
         PendingInterceptResponse(const ResourceResponse& originalResponse, CompletionHandler<void(const ResourceResponse&, RefPtr<FragmentedSharedBuffer>)>&& completionHandler)
             : m_originalResponse(originalResponse)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -72,6 +72,7 @@
 #include <JavaScriptCore/RegularExpression.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -91,6 +92,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorPageAgent);
 
 static bool decodeBuffer(std::span<const uint8_t> buffer, const String& textEncodingName, String* result)
 {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ class FragmentedSharedBuffer;
 
 class InspectorPageAgent final : public InspectorAgentBase, public Inspector::PageBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorPageAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorPageAgent);
 public:
     InspectorPageAgent(PageAgentContext&, InspectorClient*, InspectorOverlay*);
     ~InspectorPageAgent();

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -57,6 +57,7 @@
 #include <JavaScriptCore/ScriptArguments.h>
 #include <wtf/SetForScope.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -71,6 +72,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorTimelineAgent);
 
 #if PLATFORM(COCOA)
 static CFRunLoopRef currentRunLoop()

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -86,7 +87,7 @@ enum class TimelineRecordType {
 
 class InspectorTimelineAgent final : public InspectorAgentBase , public Inspector::TimelineBackendDispatcherHandler , public JSC::Debugger::Observer {
     WTF_MAKE_NONCOPYABLE(InspectorTimelineAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorTimelineAgent);
 public:
     InspectorTimelineAgent(PageAgentContext&);
     ~InspectorTimelineAgent();

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -28,10 +28,13 @@
 
 #include "Document.h"
 #include "InstrumentingAgents.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorWorkerAgent);
 
 InspectorWorkerAgent::InspectorWorkerAgent(WebAgentContext& context)
     : InspectorAgentBase("Worker"_s, context)

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -30,13 +30,14 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class InspectorWorkerAgent : public InspectorAgentBase, public Inspector::WorkerBackendDispatcherHandler, public WorkerInspectorProxy::PageChannel {
     WTF_MAKE_NONCOPYABLE(InspectorWorkerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorWorkerAgent);
 public:
     ~InspectorWorkerAgent();
 

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -31,10 +31,13 @@
 #include "InstrumentingAgents.h"
 #include "ScriptExecutionContext.h"
 #include "Timer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDebuggerAgent);
 
 WebDebuggerAgent::WebDebuggerAgent(WebAgentContext& context)
     : InspectorDebuggerAgent(context)

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.h
@@ -27,6 +27,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorDebuggerAgent.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ class TimerBase;
 
 class WebDebuggerAgent : public Inspector::InspectorDebuggerAgent {
     WTF_MAKE_NONCOPYABLE(WebDebuggerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebDebuggerAgent);
 public:
     ~WebDebuggerAgent() override;
     bool enabled() const override;

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -31,10 +31,13 @@
 #include <JavaScriptCore/InspectorProtocolTypes.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebHeapAgent);
 
 struct GarbageCollectionData {
     Inspector::Protocol::Heap::GarbageCollection::Type type;
@@ -43,7 +46,7 @@ struct GarbageCollectionData {
 };
 
 class SendGarbageCollectionEventsTask final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SendGarbageCollectionEventsTask);
 public:
     SendGarbageCollectionEventsTask(WebHeapAgent&);
     void addGarbageCollection(GarbageCollectionData&&);

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -28,6 +28,7 @@
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorHeapAgent.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ struct GarbageCollectionData;
 
 class WebHeapAgent : public Inspector::InspectorHeapAgent {
     WTF_MAKE_NONCOPYABLE(WebHeapAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WebHeapAgent);
     friend class SendGarbageCollectionEventsTask;
 public:
     WebHeapAgent(WebAgentContext&);

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
@@ -41,12 +41,15 @@
 #include <JavaScriptCore/JSLock.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageAuditAgent);
 
 PageAuditAgent::PageAuditAgent(PageAgentContext& context)
     : InspectorAuditAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.h
@@ -27,6 +27,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorAuditAgent.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class Page;
 
 class PageAuditAgent final : public Inspector::InspectorAuditAgent {
     WTF_MAKE_NONCOPYABLE(PageAuditAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageAuditAgent);
 public:
     PageAuditAgent(PageAgentContext&);
     ~PageAuditAgent();

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -44,6 +44,7 @@
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
 #include "Page.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(OFFSCREEN_CANVAS)
 #include "OffscreenCanvas.h"
@@ -52,6 +53,8 @@
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageCanvasAgent);
 
 PageCanvasAgent::PageCanvasAgent(PageAgentContext& context)
     : InspectorCanvasAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorCanvasAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class Page;
 
 class PageCanvasAgent final : public InspectorCanvasAgent {
     WTF_MAKE_NONCOPYABLE(PageCanvasAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageCanvasAgent);
 public:
     PageCanvasAgent(PageAgentContext&);
     ~PageCanvasAgent();

--- a/Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp
@@ -41,10 +41,13 @@
 #include "Page.h"
 #include "WebInjectedScriptManager.h"
 #include <JavaScriptCore/ConsoleMessage.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageConsoleAgent);
 
 PageConsoleAgent::PageConsoleAgent(PageAgentContext& context)
     : WebConsoleAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageConsoleAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageConsoleAgent.h
@@ -33,12 +33,13 @@
 
 #include "InspectorWebAgentBase.h"
 #include "WebConsoleAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class PageConsoleAgent final : public WebConsoleAgent {
     WTF_MAKE_NONCOPYABLE(PageConsoleAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageConsoleAgent);
 public:
     PageConsoleAgent(PageAgentContext&);
     ~PageConsoleAgent();

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -50,10 +50,13 @@
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageDebuggerAgent);
 
 PageDebuggerAgent::PageDebuggerAgent(PageAgentContext& context)
     : WebDebuggerAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "WebDebuggerAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ class UserGestureEmulationScope;
 
 class PageDebuggerAgent final : public WebDebuggerAgent {
     WTF_MAKE_NONCOPYABLE(PageDebuggerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageDebuggerAgent);
 public:
     PageDebuggerAgent(PageAgentContext&);
     ~PageDebuggerAgent();

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -25,11 +25,14 @@
 
 #include "config.h"
 #include "PageHeapAgent.h"
+#include <wtf/TZoneMallocInlines.h>
 
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageHeapAgent);
 
 PageHeapAgent::PageHeapAgent(PageAgentContext& context)
     : WebHeapAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -28,12 +28,13 @@
 #include "InspectorWebAgentBase.h"
 #include "InstrumentingAgents.h"
 #include "WebHeapAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class PageHeapAgent final : public WebHeapAgent {
     WTF_MAKE_NONCOPYABLE(PageHeapAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageHeapAgent);
 public:
     PageHeapAgent(PageAgentContext&);
     ~PageHeapAgent();

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -36,10 +36,13 @@
 #include "PageConsoleClient.h"
 #include "ThreadableWebSocketChannel.h"
 #include "WebSocket.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageNetworkAgent);
 
 PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorClient* client)
     : InspectorNetworkAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorNetworkAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class Page;
 
 class PageNetworkAgent final : public InspectorNetworkAgent {
     WTF_MAKE_NONCOPYABLE(PageNetworkAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageNetworkAgent);
 public:
     PageNetworkAgent(PageAgentContext&, InspectorClient*);
     ~PageNetworkAgent();

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -47,10 +47,13 @@
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageRuntimeAgent);
 
 PageRuntimeAgent::PageRuntimeAgent(PageAgentContext& context)
     : InspectorRuntimeAgent(context)

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
@@ -34,6 +34,7 @@
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorRuntimeAgent.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class CallFrame;
@@ -48,7 +49,7 @@ class SecurityOrigin;
 
 class PageRuntimeAgent final : public Inspector::InspectorRuntimeAgent {
     WTF_MAKE_NONCOPYABLE(PageRuntimeAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PageRuntimeAgent);
 public:
     PageRuntimeAgent(PageAgentContext&);
     ~PageRuntimeAgent();

--- a/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.cpp
@@ -29,10 +29,13 @@
 #include "SecurityOrigin.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "ServiceWorkerThread.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ServiceWorkerAgent);
 
 ServiceWorkerAgent::ServiceWorkerAgent(WorkerAgentContext& context)
     : InspectorAgentBase("ServiceWorker"_s, context)

--- a/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.h
@@ -27,6 +27,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class ServiceWorkerGlobalScope;
 
 class ServiceWorkerAgent final : public InspectorAgentBase, public Inspector::ServiceWorkerBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(ServiceWorkerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerAgent);
 public:
     ServiceWorkerAgent(WorkerAgentContext&);
     ~ServiceWorkerAgent();

--- a/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp
@@ -32,10 +32,14 @@
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/JSCInlines.h>
+WTF_MAKE_TZONE_ALLOCATED_IMPL(x);
+
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerAuditAgent);
 
 WorkerAuditAgent::WorkerAuditAgent(WorkerAgentContext& context)
     : InspectorAuditAgent(context)

--- a/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.h
@@ -27,6 +27,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorAuditAgent.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,7 +35,7 @@ class WorkerOrWorkletGlobalScope;
 
 class WorkerAuditAgent final : public Inspector::InspectorAuditAgent {
     WTF_MAKE_NONCOPYABLE(WorkerAuditAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerAuditAgent);
 public:
     WorkerAuditAgent(WorkerAgentContext&);
     ~WorkerAuditAgent();

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
@@ -27,10 +27,13 @@
 #include "WorkerCanvasAgent.h"
 
 #include "WorkerOrWorkletGlobalScope.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerCanvasAgent);
 
 WorkerCanvasAgent::WorkerCanvasAgent(WorkerAgentContext& context)
     : InspectorCanvasAgent(context)

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorCanvasAgent.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class WorkerOrWorkletGlobalScope;
 
 class WorkerCanvasAgent final : public InspectorCanvasAgent {
     WTF_MAKE_NONCOPYABLE(WorkerCanvasAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerCanvasAgent);
 public:
     WorkerCanvasAgent(WorkerAgentContext&);
     ~WorkerCanvasAgent();

--- a/Source/WebCore/inspector/agents/worker/WorkerConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerConsoleAgent.cpp
@@ -27,10 +27,13 @@
 #include "WorkerConsoleAgent.h"
 
 #include "WorkerOrWorkletGlobalScope.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerConsoleAgent);
 
 WorkerConsoleAgent::WorkerConsoleAgent(WorkerAgentContext& context)
     : WebConsoleAgent(context)

--- a/Source/WebCore/inspector/agents/worker/WorkerConsoleAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerConsoleAgent.h
@@ -27,12 +27,13 @@
 
 #include "InspectorWebAgentBase.h"
 #include "WebConsoleAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class WorkerConsoleAgent final : public WebConsoleAgent {
     WTF_MAKE_NONCOPYABLE(WorkerConsoleAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerConsoleAgent);
 public:
     WorkerConsoleAgent(WorkerAgentContext&);
     ~WorkerConsoleAgent();

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
@@ -34,11 +34,14 @@
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace JSC;
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerDebuggerAgent);
 
 WorkerDebuggerAgent::WorkerDebuggerAgent(WorkerAgentContext& context)
     : WebDebuggerAgent(context)

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WebDebuggerAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class WorkerOrWorkletGlobalScope;
 
 class WorkerDebuggerAgent final : public WebDebuggerAgent {
     WTF_MAKE_NONCOPYABLE(WorkerDebuggerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerDebuggerAgent);
 public:
     WorkerDebuggerAgent(WorkerAgentContext&);
     ~WorkerDebuggerAgent();

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -30,10 +30,13 @@
 #include "WorkerDebuggerProxy.h"
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerThread.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerNetworkAgent);
 
 WorkerNetworkAgent::WorkerNetworkAgent(WorkerAgentContext& context)
     : InspectorNetworkAgent(context)

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h
@@ -26,12 +26,13 @@
 #pragma once
 
 #include "InspectorNetworkAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class WorkerNetworkAgent final : public InspectorNetworkAgent {
     WTF_MAKE_NONCOPYABLE(WorkerNetworkAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerNetworkAgent);
 public:
     WorkerNetworkAgent(WorkerAgentContext&);
     ~WorkerNetworkAgent();

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
@@ -37,10 +37,13 @@
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerRuntimeAgent);
 
 WorkerRuntimeAgent::WorkerRuntimeAgent(WorkerAgentContext& context)
     : InspectorRuntimeAgent(context)

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h
@@ -33,6 +33,7 @@
 
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorRuntimeAgent.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ class WorkerOrWorkletGlobalScope;
 
 class WorkerRuntimeAgent final : public Inspector::InspectorRuntimeAgent {
     WTF_MAKE_NONCOPYABLE(WorkerRuntimeAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WorkerRuntimeAgent);
 public:
     WorkerRuntimeAgent(WorkerAgentContext&);
     ~WorkerRuntimeAgent();


### PR DESCRIPTION
#### 9a4e00abd622d7419587b20e1d4d5d98bae69f75
<pre>
[TZone] WebCore/inspector Convert FastMalloc to TZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=278430">https://bugs.webkit.org/show_bug.cgi?id=278430</a>
<a href="https://rdar.apple.com/134377811">rdar://134377811</a>

Reviewed by Devin Rousso.

Convert WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_TZONE_ALLOCATED in
preparation for enabling TZone (not yet enabled).

* Source/WebCore/inspector/CommandLineAPIHost.cpp:
* Source/WebCore/inspector/CommandLineAPIHost.h:
* Source/WebCore/inspector/DOMEditor.cpp:
* Source/WebCore/inspector/DOMEditor.h:
* Source/WebCore/inspector/InspectorController.cpp:
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/inspector/InspectorHistory.cpp:
* Source/WebCore/inspector/InspectorHistory.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
* Source/WebCore/inspector/InspectorOverlayLabel.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
* Source/WebCore/inspector/InstrumentingAgents.cpp:
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/NetworkResourcesData.cpp:
* Source/WebCore/inspector/NetworkResourcesData.h:
* Source/WebCore/inspector/PageDebugger.cpp:
* Source/WebCore/inspector/PageDebugger.h:
* Source/WebCore/inspector/UserGestureEmulationScope.cpp:
* Source/WebCore/inspector/UserGestureEmulationScope.h:
* Source/WebCore/inspector/WebInjectedScriptManager.cpp:
* Source/WebCore/inspector/WebInjectedScriptManager.h:
* Source/WebCore/inspector/WorkerDebugger.cpp:
* Source/WebCore/inspector/WorkerDebugger.h:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
* Source/WebCore/inspector/WorkerInspectorController.h:
* Source/WebCore/inspector/WorkerToPageFrontendChannel.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.h:
* Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.cpp:
* Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.h:
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.h:
* Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDatabaseAgent.h:
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::Inspector::ExecutableWithDatabase::ExecutableWithDatabase): Deleted.
(WebCore::Inspector::ExecutableWithDatabase::context const): Deleted.
(WebCore::Inspector::ExecutableWithDatabase::start): Deleted.
(WebCore::Inspector::keyPathFromIDBKeyPath): Deleted.
(WebCore::Inspector::transactionForDatabase): Deleted.
(WebCore::Inspector::objectStoreForTransaction): Deleted.
(WebCore::Inspector::indexForObjectStore): Deleted.
(WebCore::Inspector::idbKeyFromInspectorObject): Deleted.
(WebCore::Inspector::idbKeyRangeFromKeyRange): Deleted.
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h:
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h:
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
* Source/WebCore/inspector/agents/InspectorMemoryAgent.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(): Deleted.
(WebCore::Inspector::buildWebSocketMessage): Deleted.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
* Source/WebCore/inspector/agents/InspectorWorkerAgent.h:
* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/WebDebuggerAgent.h:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
* Source/WebCore/inspector/agents/WebHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageAuditAgent.cpp:
* Source/WebCore/inspector/agents/page/PageAuditAgent.h:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.h:
* Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp:
* Source/WebCore/inspector/agents/page/PageConsoleAgent.h:
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.h:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
* Source/WebCore/inspector/agents/page/PageHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.h:
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.h:
* Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.cpp:
* Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerAuditAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerConsoleAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerConsoleAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h:

Canonical link: <a href="https://commits.webkit.org/282574@main">https://commits.webkit.org/282574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4441c87ae620c287bf6f5768028116dba5bfa996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51079 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12912 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57927 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12608 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.serviceworker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58626 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14064 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6150 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9610 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39688 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->