### PR TITLE
Fix !ENABLE(VARIATION_FONTS) build following 282527@main

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -757,7 +757,7 @@ RefPtr<CSSValue> consumeFontStretchRange(CSSParserTokenRange& range)
 
 #else
 
-RefPtr<CSSPrimitiveValue> consumeFontStretch(CSSParserTokenRange& range)
+RefPtr<CSSValue> consumeFontStretch(CSSParserTokenRange& range)
 {
     if (RefPtr result = CSSPropertyParsing::consumeFontStretchAbsolute(range))
         return result;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -122,7 +122,7 @@ RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange&, CSSParserMode);
 #if ENABLE(VARIATION_FONTS)
 RefPtr<CSSValue> consumeFontStretchRange(CSSParserTokenRange&);
 #else
-RefPtr<CSSPrimitiveValue> consumeFontStretch(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeFontStretch(CSSParserTokenRange&);
 #endif
 
 // MARK: 'font-weight'


### PR DESCRIPTION
#### aef310031cad4c2bd4372046b2ec45c2f37c792e
<pre>
Fix !ENABLE(VARIATION_FONTS) build following 282527@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=278438">https://bugs.webkit.org/show_bug.cgi?id=278438</a>

Unreviewed build fix.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontStretch):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
Change return type from CSSPrimitiveValue to CSSValue;
it&apos;s not clear why this would need to be more specific with VARIATION_FONTS disabled.

Canonical link: <a href="https://commits.webkit.org/282545@main">https://commits.webkit.org/282545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc76c3902df67a221c5d12853d6bd67d35ec6417

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14338 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9716 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39738 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/54947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12930 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/57944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7397 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55024 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6170 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9592 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->