### PR TITLE
[JSC] Fix error message of `Temporal.Instant.fromEpochMilliseconds`

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -158,6 +158,19 @@ function shouldThrow(func, errorType, message) {
     shouldThrow(() => Temporal.Instant.fromEpochNanoseconds(ns), RangeError, messageMatch);
 });
 
+[
+    // too large
+    [86400_0000_0000_001, /\b8640000000000001000000\b/],
+    // too small
+    [-86400_0000_0000_001, /-8640000000000001000000\b/],
+    // test 2^53 - 1
+    [Number.MAX_SAFE_INTEGER, /\b9007199254740991000000\b/],
+    // test -(2^53 - 1)
+    [-Number.MAX_SAFE_INTEGER, /-9007199254740991000000\b/],
+].forEach(([ms, messageMatch = undefined]) => {
+    shouldThrow(() => Temporal.Instant.fromEpochMilliseconds(ms), RangeError, messageMatch);
+});
+
 // constructs from string
 shouldBe(new Temporal.Instant('0').epochNanoseconds, 0n);
 // throws on number

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -167,7 +167,7 @@ private:
     {
         if (value > 9)
             asStringImpl(builder, value / 10);
-        builder.append(static_cast<uint64_t>(value % 10) + '0');
+        builder.append(static_cast<LChar>(static_cast<unsigned>(value % 10) + '0'));
     }
 
     static Int128 round(Int128 quantity, unsigned increment, TemporalUnit, RoundingMode);


### PR DESCRIPTION
#### df250e04fa34c4f1d4c1220cc7ed5def2ff53912
<pre>
[JSC] Fix error message of `Temporal.Instant.fromEpochMilliseconds`
<a href="https://bugs.webkit.org/show_bug.cgi?id=278440">https://bugs.webkit.org/show_bug.cgi?id=278440</a>

Reviewed by Yusuke Suzuki.

In the current JSC, the `RangeError` message is corrupted when an invalid value is passed to
`Temporal.Instant.fromEpochMilliseconds`.

For example, `Temporal.Instant.fromEpochMilliseconds(86400_0000_0000_001)` throws a `RangeError`
with the message `56545248484848484848484848484849484848484848 epoch nanoseconds is outside of
supported range for Temporal.Instant`. This is clearly broken.

This patch fixes the `asString` method of `ISO8601::ExactTime`, ensuring that a correct `RangeError`
message is thrown.

* JSTests/stress/temporal-instant.js:
(forEach):
* Source/JavaScriptCore/runtime/ISO8601.h:

Canonical link: <a href="https://commits.webkit.org/282587@main">https://commits.webkit.org/282587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7455f3b2f9ce91e6ce77d4653a2f533b170d6dee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14060 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51094 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12932 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56564 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69169 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62697 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58637 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6174 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84458 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38629 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14894 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->