### PR TITLE
Disable use of JSC signal handlers by default on Apple embedded platforms.

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.cpp
+++ b/Source/JavaScriptCore/API/tests/testapi.cpp
@@ -1183,6 +1183,15 @@ void TestAPI::testBigInt()
 void configureJSCForTesting()
 {
     JSC::Config::configureForTesting();
+    {
+        // These need to be enabled explicitly because they are disabled by default.
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::Options::initialize();
+        JSC::Options::usePollingTraps() = false;
+        JSC::Options::useWasmFastMemory() = true;
+        JSC::Options::useWasmFaultSignalHandler() = true;
+        JSC::Options::notifyOptionsChanged();
+    }
 }
 
 #define RUN(test) do {                                 \

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3969,7 +3969,10 @@ void CommandLine::parseArguments(int argc, char** argv)
     Options::AllowUnfinalizedAccessScope scope;
     Options::initialize();
     Options::useSharedArrayBuffer() = true;
-    
+    Options::usePollingTraps() = false;
+    Options::useWasmFastMemory() = true;
+    Options::useWasmFaultSignalHandler() = true;
+
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(APPLETV) && !PLATFORM(WATCHOS)
     Options::crashIfCantAllocateJITMemory() = true;
 #endif

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -126,12 +126,10 @@ void initialize()
         if (VM::isInMiniMode())
             WTF::fastEnableMiniMode();
 
-        if (Wasm::isSupported() || !Options::usePollingTraps()) {
-            if (!Options::usePollingTraps())
-                VMTraps::initializeSignals();
-            if (Wasm::isSupported())
-                Wasm::prepareSignalingMemory();
-        }
+        if (!Options::usePollingTraps())
+            VMTraps::initializeSignals();
+        if (Options::useWasmFaultSignalHandler())
+            Wasm::prepareSignalingMemory();
 
         assertInvariants();
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -39,8 +39,12 @@ using WTF::PrintStream;
 namespace JSC {
 
 #if PLATFORM(IOS_FAMILY)
+#define DEFAULT_USE_POLLING_TRAPS true
+#define DEFAULT_USE_WASM_FAULT_SIGNAL_HANDLER false
 #define MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS 2
 #else
+#define DEFAULT_USE_POLLING_TRAPS false
+#define DEFAULT_USE_WASM_FAULT_SIGNAL_HANDLER true
 #define MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS 8
 #endif
 
@@ -474,7 +478,7 @@ bool hasCapacityToUseLargeGigacage();
     v(OptionString, functionOverrides, nullptr, Restricted, "file with debugging overrides for function bodies"_s) \
     \
     v(Unsigned, watchdog, 0, Normal, "watchdog timeout (0 = Disabled, N = a timeout period of N milliseconds)"_s) \
-    v(Bool, usePollingTraps, false, Normal, "use polling (instead of signalling) VM traps"_s) \
+    v(Bool, usePollingTraps, DEFAULT_USE_POLLING_TRAPS, Normal, "use polling (instead of signalling) VM traps"_s) \
     \
     v(Bool, useMachForExceptions, true, Normal, "Use mach exceptions rather than signals to handle faults and pass thread messages. (This does nothing on platforms without mach)"_s) \
     v(Bool, allowNonSPTagging, true, Normal, "allow use of the pacib instruction instead of just pacibsp (This can break lldb/posix signals as it puts live data below SP)"_s) \
@@ -566,7 +570,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
-    v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
+    v(Bool, useWasmFaultSignalHandler, DEFAULT_USE_WASM_FAULT_SIGNAL_HANDLER, Normal, nullptr) \
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
     v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,10 +135,8 @@ void prepareSignalingMemory()
 {
     static std::once_flag once;
     std::call_once(once, [] {
+        RELEASE_ASSERT(Options::useWasmFaultSignalHandler());
         if (!Wasm::isSupported())
-            return;
-
-        if (!Options::useWasmFaultSignalHandler())
             return;
 
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)

--- a/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
+++ b/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,5 +50,5 @@ void WEBCONTENT_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t in
     InitWebCoreThreadSystemInterface();
 #endif // PLATFORM(IOS_FAMILY)
 
-    WebKit::XPCServiceInitializer<WebKit::WebProcess, WebKit::XPCServiceInitializerDelegate>(connection, initializerMessage);
+    WebKit::XPCServiceInitializer<WebKit::WebProcess, WebKit::XPCServiceInitializerDelegate, true>(connection, initializerMessage);
 }

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *           (C) 2007 Graham Dennis (graham.dennis@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1187,6 +1187,15 @@ void dumpRenderTree(int argc, const char *argv[])
     initializeGlobalsFromCommandLineOptions(argc, argv);
     prepareConsistentTestingEnvironment();
     addTestPluginsToPluginSearchPath(argv[0]);
+
+    {
+        JSC::Options::AllowUnfinalizedAccessScope scope;
+        JSC::Options::initialize();
+        JSC::Options::usePollingTraps() = false;
+        JSC::Options::useWasmFastMemory() = true;
+        JSC::Options::useWasmFaultSignalHandler() = true;
+        JSC::Options::notifyOptionsChanged();
+    }
 
     JSC::initialize();
     WTF::initializeMainThread();


### PR DESCRIPTION
#### f185d24f17763b799f15dd7b674cecf27581be39
<pre>
Disable use of JSC signal handlers by default on Apple embedded platforms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278401">https://bugs.webkit.org/show_bug.cgi?id=278401</a>
<a href="https://rdar.apple.com/134053581">rdar://134053581</a>

Reviewed by NOBODY (OOPS!).

This is because mach exception handlers are only allowed by the WebContent process
sandbox.  So, we&apos;ll change the default behavior to disallow its use, and explicitly
allow options that depend on it only for the WebContent process.  These options
are: usePollingTraps, and useWasmFaultSignalHandler.

Additionally, when enabling these options, we&apos;ll also have to re-enable useWasmFastMemory.
This is because useWasmFastMemory could have been disabled due to useWasmFaultSignalHandler
defaulting to false.  After emabling useWasmFaultSignalHandler, we&apos;ll also need to
enable useWasmFastMemory to give it a chance to stay enabled.

We&apos;ll also need to enable these options in the jsc shell, testapi, and DumpRenderTree
because their initialization does not use XPCServiceInitializer.

Also, XPCServiceInitializer is used by the WebContent process as well as the GPU and
Network processes.  To only enable the mach exception handler dependent options for
WebContent process and not the others, we need to add a canAllowSignalHandlers template
argument to XPCServiceInitializer.  Only WebContent process sets this argument to true.

* Source/JavaScriptCore/API/tests/testapi.cpp:
(configureJSCForTesting):
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::prepareSignalingMemory):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):
* Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm:
(WEBCONTENT_SERVICE_INITIALIZER):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(dumpRenderTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f185d24f17763b799f15dd7b674cecf27581be39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67532 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51146 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12991 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56623 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69228 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62756 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58452 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58679 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6234 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38688 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14896 "jscore-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->