### PR TITLE
Add CryptoKit Implementation for create/addBytes/computeHash.

### DIFF
--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -112,6 +112,36 @@ public enum HashFunction {
 }
 
 public class Digest {
+    var ctx: any CryptoKit.HashFunction
+
+    public required init<T: CryptoKit.HashFunction>(_: T.Type) {
+        ctx = T()
+    }
+
+    public static func sha1Init() -> Digest {
+        return Self(Insecure.SHA1.self)
+    }
+
+    public static func sha256Init() -> Digest {
+        return Self(SHA256.self)
+    }
+
+    public static func sha384Init() -> Digest {
+        return Self(SHA384.self)
+    }
+
+    public static func sha512Init() -> Digest {
+        return Self(SHA512.self)
+    }
+
+    public func update(_ data: SpanConstUInt8) {
+        ctx.update(data: data)
+    }
+
+    public func finalize() -> VectorUInt8 {
+        ctx.finalize().copyToVectorUInt8()
+    }
+
     public static func sha1(_ data: SpanConstUInt8) -> VectorUInt8 {
         return digest(data, t: Insecure.SHA1.self)
     }

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -51,7 +51,6 @@ public:
     PAL_EXPORT void addBytes(std::span<const uint8_t>);
     PAL_EXPORT Vector<uint8_t> computeHash();
     PAL_EXPORT String toHexString();
-    PAL_EXPORT static std::optional<Vector<uint8_t>> computeHash(Algorithm, const Vector<uint8_t>&, UseCryptoKit);
     PAL_EXPORT CryptoDigest();
 
 private:

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
@@ -94,24 +94,4 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return result;
 }
 
-std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& input, UseCryptoKit)
-{
-    std::unique_ptr<CryptoDigest> digest = WTF::makeUnique<CryptoDigest>();
-    auto gcryptAlgorithm = getGcryptAlgorithm(algo);
-    digest->m_context->algorithm = gcryptAlgorithm;
-
-    gcry_md_open(&digest->m_context->md, gcryptAlgorithm, 0);
-    if (!digest->m_context->md)
-        return { };
-
-    size_t digestLen = gcry_md_get_algo_dlen(gcryptAlgorithm);
-
-    gcry_md_write(digest->m_context->md, input.data(), input.size());
-    gcry_md_final(digest->m_context->md);
-    Vector<uint8_t> result(std::span<uint8_t> { gcry_md_read(digest->m_context->md, 0), digestLen });
-    gcry_md_close(digest->m_context->md);
-
-    return result;
-
-}
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
+++ b/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
@@ -143,16 +143,4 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return m_context->computeHash();
 }
 
-std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& data, UseCryptoKit)
-{
-    std::unique_ptr<CryptoDigest> digest = WTF::makeUnique<CryptoDigest>();
-    if (!digest)
-        return { };
-    digest->m_context = createCryptoDigest(algo);
-    if (!digest->m_context)
-        return { };
-    digest->m_context->addBytes(data.span());
-    return digest->m_context->computeHash();
-}
-
 } // namespace PAL

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA224.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA224.cpp
@@ -43,19 +43,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmSHA224::identifier() const
 
 void CryptoAlgorithmSHA224::digest(Vector<uint8_t>&& message, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_224);
-    if (!digest) {
-        exceptionCallback(ExceptionCode::OperationError);
-        return;
-    }
-
-    workQueue.dispatch([digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.span());
-        auto result = digest->computeHash();
-        ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
-            callback(result);
-        });
-    });
+    CryptoAlgorithm::dispatchDigest(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback), WTFMove(message), PAL::CryptoDigest::Algorithm::SHA_224);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8e5527887dcff1ea16f48998e05a3d11086ae563
<pre>
Add CryptoKit Implementation for create/addBytes/computeHash.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278449">https://bugs.webkit.org/show_bug.cgi?id=278449</a>
<a href="https://rdar.apple.com/134394086">rdar://134394086</a>

Reviewed by Alex Christensen.

Earlier implementation was a oneshot API. That does not work well for
cases where multiple spans need to be added for calculating digest.
That also makes it harder to keep on supporting SHA224.

With this change we will keep on supporting SHA224 until we consciously remove it.

With this in place, we also delete the oneshot API and use the existing
create/addBytes/computeHash trio everywhere.
Also a minor improvement to SHA224 implementation in that it uses the dispatchDigest
utility function.

No new tests are needed as there is no beahavior change.

* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(Digest.ctx):
(Digest.sha1Init):
(Digest.sha256Init):
(Digest.sha384Init):
(Digest.sha512Init):
(Digest.update(_:)):
(Digest.finalize):
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::createCryptoDigest):
(PAL::CryptoDigest::addBytes):
(PAL::CryptoDigest::computeHash):
* Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp:
* Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp:
* Source/WebCore/crypto/CryptoAlgorithm.cpp:
(WebCore::CryptoAlgorithm::dispatchDigest):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA224.cpp:
(WebCore::CryptoAlgorithmSHA224::digest):

Canonical link: <a href="https://commits.webkit.org/282596@main">https://commits.webkit.org/282596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92f61e748e9c192c721ac1e636344765dc5c6b2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51124 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9753 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12356 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69210 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58432 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->