### PR TITLE
Digital Credentials API: handle mediation requirement

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
@@ -40,6 +40,7 @@
             digital: {
               providers: [],
             },
+            mediation: "required",
         });
 
         await promise_rejects_dom(t, "NotAllowedError", p);

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
@@ -105,6 +105,7 @@
                                 // Results in TypeError when allowed, NotAllowedError when disallowed
                                 providers: [],
                             },
+                            mediation: "required",
                         };
                         const { data } = await new Promise((resolve) => {
                             window.addEventListener("message", resolve, {

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
@@ -1,4 +1,9 @@
 export type ProviderType = "default" | "openid4vp";
+export type CredentialMediationRequirement =
+  | "conditional"
+  | "optional"
+  | "required"
+  | "silent";
 
 /**
  * @see https://wicg.github.io/digital-credentials/#dom-identityrequestprovider
@@ -26,12 +31,17 @@ export interface CredentialRequestOptions {
    * The digital credential request options.
    */
   digital: DigitalCredentialRequestOptions;
+  mediation: CredentialMediationRequirement;
 }
 
 /**
  * The actions that can be performed on the API via the iframe.
  */
-export type IframeActionType = "create" | "get" | "ping" | "preventSilentAccess" ;
+export type IframeActionType =
+  | "create"
+  | "get"
+  | "ping"
+  | "preventSilentAccess";
 
 /**
  * If present, when the abort controller should be aborted
@@ -53,8 +63,8 @@ export interface EventData {
    */
   options?: object;
   /**
-  * If the API needs to blessed before the action is performed.
-  */
+   * If the API needs to blessed before the action is performed.
+   */
   needsUserActivation?: boolean;
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html
@@ -7,8 +7,8 @@
 <script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body></body>
-<script>
-    "use strict";
+<script type="module">
+    import { makeGetOptions } from "./support/helper.js";
     const { HTTPS_REMOTE_ORIGIN } = get_host_info();
     const same_origin_src =
         "/permissions-policy/resources/digital-credentials-get.html";
@@ -19,7 +19,7 @@
         await promise_rejects_js(
             test,
             TypeError,
-            navigator.identity.get({ digital: { providers: [] } })
+            navigator.identity.get(makeGetOptions([]))
         );
 
         await test_feature_availability({

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html
@@ -7,8 +7,8 @@
 <script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body></body>
-<script>
-    "use strict";
+<script type="module">
+    import { makeGetOptions } from "/digital-credentials/support/helper.js";
     const { HTTPS_REMOTE_ORIGIN } = get_host_info();
     const same_origin_src =
         "/permissions-policy/resources/digital-credentials-get.html";
@@ -19,7 +19,7 @@
         await promise_rejects_dom(
             test,
             "NotAllowedError",
-            navigator.identity.get({ digital: { providers: [] } })
+            navigator.identity.get(makeGetOptions([]))
         );
     }, "Permissions-Policy header digital-credentials-get=() disallows the top-level document.");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -7,8 +7,8 @@
 <script src="/permissions-policy/resources/permissions-policy.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body></body>
-<script>
-    "use strict";
+<script type="module">
+    import { makeGetOptions } from "./support/helper.js";
     const { HTTPS_REMOTE_ORIGIN } = get_host_info();
     const same_origin_src =
         "/permissions-policy/resources/digital-credentials-get.html";
@@ -19,7 +19,7 @@
         await promise_rejects_js(
             test,
             TypeError,
-            navigator.identity.get({ digital: { providers: [] } })
+            navigator.identity.get(makeGetOptions([]))
         );
     }, "Permissions-Policy header digital-credentials-get=(self) allows the top-level document.");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
@@ -9,4 +9,5 @@ PASS navigator.identity.get() promise is rejected if called with an aborted sign
 PASS navigator.identity.get() promise is rejected if called with an aborted signal in cross-origin iframe.
 FAIL navigator.identity.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Not implemented" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.identity.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
+PASS Mediation is required to get a DigitalCredential.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https.html
@@ -192,4 +192,13 @@
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");
   }, "navigator.identity.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe.");
+
+  promise_test(async (t) => {
+    /** @type sequence<CredentialMediationRequirement> */
+    const disallowedMediations = [ "conditional", "optional", "silent"];
+    for (const mediation of disallowedMediations) {
+      const options = makeGetOptions("default", mediation);
+      await promise_rejects_js(t, TypeError, navigator.identity.get(options));
+    }
+  }, "Mediation is required to get a DigitalCredential.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
@@ -9,16 +9,17 @@
  */
 /**
  * @param {ProviderType | ProviderType[]} [providersToUse=["default"]]
+ * @param {CredentialMediationRequirement} [mediation="required"]
  * @returns {CredentialRequestOptions}
  */
-export function makeGetOptions(providersToUse = ["default"]) {
+export function makeGetOptions(providersToUse = ["default"], mediation = "required") {
   if (typeof providersToUse === "string") {
     if (providersToUse === "default" || providersToUse === "openid4vp"){
       return makeGetOptions([providersToUse]);
     }
   }
   if (!Array.isArray(providersToUse) || !providersToUse?.length) {
-    return { digital: { providers: providersToUse } };
+    return { digital: { providers: providersToUse }, mediation };
   }
   const providers = [];
   for (const provider of providersToUse) {
@@ -31,10 +32,9 @@ export function makeGetOptions(providersToUse = ["default"]) {
         break;
       default:
         throw new Error(`Unknown provider type: ${provider}`);
-        break;
     }
   }
-  return { digital: { providers } };
+  return { digital: { providers }, mediation };
 }
 /**
  *

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/digital-credentials-get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/digital-credentials-get.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8" />
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<body></body>
-<script>
+<script type="module">
+    import { makeGetOptions } from "/digital-credentials/support/helper.js";
     const type = "availability-result";
     async function notify() {
         if (!navigator.userActivation.isActive) {
@@ -11,7 +11,7 @@
         }
         let enabled = undefined;
         try {
-            await navigator.identity.get({ digital: { providers: [] } });
+            await navigator.identity.get(makeGetOptions([]));
         } catch (e) {
             switch (e.name) {
                 case "NotAllowedError":
@@ -27,7 +27,8 @@
             window.parent.postMessage({ type, enabled }, "*");
         }
     }
+    window.onload = notify;
 </script>
-<body onload="notify()">
+<body>
     <h1>Digital Credentials iframe</h1>
 </body>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
@@ -11,4 +11,5 @@ PASS navigator.identity.get() promise is rejected if called with an aborted sign
 PASS navigator.identity.get() promise is rejected if called with an aborted signal in cross-origin iframe.
 FAIL navigator.identity.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Not implemented" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.identity.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
+PASS Mediation is required to get a DigitalCredential.
 

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -37,6 +37,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSDigitalCredential.h"
 #include "LocalDOMWindow.h"
+#include "MediationRequirement.h"
 #include "Page.h"
 #include "VisibilityState.h"
 
@@ -53,6 +54,11 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
 
     if (!options.digital || options.publicKey) {
         promise.reject(Exception { ExceptionCode::NotSupportedError, "Only digital member is supported."_s });
+        return;
+    }
+
+    if (options.mediation != MediationRequirement::Required) {
+        promise.reject(Exception { ExceptionCode::TypeError, "User mediation is required for DigitalCredential."_s });
         return;
     }
 
@@ -84,9 +90,6 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
         promise.reject(Exception { ExceptionCode::TypeError, "At least one provider must be specified."_s });
         return;
     }
-
-    // FIXME: <https://webkit.org/b/277322> mediation requirement,
-    // which is waiting on https://github.com/WICG/digital-credentials/pull/149
 
     document->page()->credentialRequestCoordinator().discoverFromExternalSource(*document, WTFMove(options), WTFMove(promise));
 }


### PR DESCRIPTION
#### 58fcbbf0528d7eba283f558ff097a28c03fd5666
<pre>
Digital Credentials API: handle mediation requirement
<a href="https://bugs.webkit.org/show_bug.cgi?id=277322">https://bugs.webkit.org/show_bug.cgi?id=277322</a>
<a href="https://rdar.apple.com/133266859">rdar://133266859</a>

Reviewed by Anne van Kesteren.

Make sure mediation is alway required when getting digital credentials
as required by the spec:
<a href="https://github.com/WICG/digital-credentials/pull/149">https://github.com/WICG/digital-credentials/pull/149</a>

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js:
(export.makeGetOptions):
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/digital-credentials-get.html:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt:
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp:
(WebCore::IdentityCredentialsContainer::get):

Canonical link: <a href="https://commits.webkit.org/283148@main">https://commits.webkit.org/283148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4f6b4da115f7c2233d8300d0ea7b83ff48a65cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52493 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11050 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14853 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9322 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13748 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-activesourcebuffers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56639 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60090 "Found 10 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/hit-test, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/selections, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/iterator, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/list-markers, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed/focus, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/surrogate-pair (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1356 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->