### PR TITLE
[GTK] Crash in FenceMonitor::addFileDescriptor when using Google Maps

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -656,45 +656,45 @@ void AcceleratedBackingStoreDMABuf::update(const LayerTreeContext& context)
         m_webPage.legacyMainFrameProcess().addMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID, *this);
 }
 
-bool AcceleratedBackingStoreDMABuf::prepareForRendering()
+bool AcceleratedBackingStoreDMABuf::swapBuffersIfNeeded()
 {
-    if (m_pendingBuffer && !m_fenceMonitor.hasFileDescriptor()) {
-        if (m_pendingBuffer->type() == Buffer::Type::EglImage) {
-            ensureGLContext();
-            gdk_gl_context_make_current(m_gdkGLContext.get());
-        }
-        m_pendingBuffer->didUpdateContents(m_committedBuffer.get(), m_pendingDamageRegion);
-        m_pendingDamageRegion = { };
+    if (!m_pendingBuffer || m_fenceMonitor.hasFileDescriptor())
+        return false;
 
-        if (m_committedBuffer)
-            m_committedBuffer->release();
-
-        m_committedBuffer = WTFMove(m_pendingBuffer);
+    if (m_pendingBuffer->type() == Buffer::Type::EglImage) {
+        ensureGLContext();
+        gdk_gl_context_make_current(m_gdkGLContext.get());
     }
+    m_pendingBuffer->didUpdateContents(m_committedBuffer.get(), m_pendingDamageRegion);
+    m_pendingDamageRegion = { };
 
-    return !!m_committedBuffer;
+    if (m_committedBuffer)
+        m_committedBuffer->release();
+
+    m_committedBuffer = WTFMove(m_pendingBuffer);
+    return true;
 }
 
 #if USE(GTK4)
 void AcceleratedBackingStoreDMABuf::snapshot(GtkSnapshot* gtkSnapshot)
 {
-    bool framePending = !!m_pendingBuffer;
-    if (!prepareForRendering())
+    bool didSwapBuffers = swapBuffersIfNeeded();
+    if (!m_committedBuffer)
         return;
 
     m_committedBuffer->snapshot(gtkSnapshot);
-    if (framePending)
+    if (didSwapBuffers)
         frameDone();
 }
 #else
 bool AcceleratedBackingStoreDMABuf::paint(cairo_t* cr, const WebCore::IntRect& clipRect)
 {
-    bool framePending = !!m_pendingBuffer;
-    if (!prepareForRendering())
+    bool didSwapBuffers = swapBuffersIfNeeded();
+    if (!m_committedBuffer)
         return false;
 
     m_committedBuffer->paint(cr, clipRect);
-    if (framePending)
+    if (didSwapBuffers)
         frameDone();
 
     return true;

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -87,7 +87,7 @@ private:
     void frame(uint64_t id, WebCore::Region&&, WTF::UnixFileDescriptor&&);
     void frameDone();
     void ensureGLContext();
-    bool prepareForRendering();
+    bool swapBuffersIfNeeded();
 
 #if USE(GTK4)
     void snapshot(GtkSnapshot*) override;


### PR DESCRIPTION
#### 802d54adc70e232328c849657cf52bd18d5fcead
<pre>
[GTK] Crash in FenceMonitor::addFileDescriptor when using Google Maps
<a href="https://bugs.webkit.org/show_bug.cgi?id=278402">https://bugs.webkit.org/show_bug.cgi?id=278402</a>

Reviewed by Miguel Gomez.

The problem is actually earlier, frame is called when we already have a
pending buffer, which is not expected to happen, but in this case it&apos;s
protected by a debug assert, so release builds don&apos;t catch it.
This can happen now with the explicit sync when GTK itself schedules a
draw when we have a pending buffer, but we are still waiting on the
fence. In that ase we don&apos;t swap the buffers, but still send the
FrameDone message to the web process that can start rendering a new one
and send the Frame message while we are still processing the previous
one. This patch renames prepareForRendering() as swapBuffersIfNeeded()
that returns true only when buffers were swapped, so that we use that to
decide whether to send the FrameDone message or not.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::swapBuffersIfNeeded):
(WebKit::AcceleratedBackingStoreDMABuf::snapshot):
(WebKit::AcceleratedBackingStoreDMABuf::paint):
(WebKit::AcceleratedBackingStoreDMABuf::prepareForRendering): Deleted.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/282608@main">https://commits.webkit.org/282608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/614f48944f9a1b07ae9fc619de9aab7786f254d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51131 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36470 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12979 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58439 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58663 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6221 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9629 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38676 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->