### PR TITLE
Remove TestRunner.installStatisticsDidModifyDataRecordsCallback

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html
@@ -9,6 +9,26 @@ jsTestIsAsync = true;
 
 const statisticsUrl = "http://127.0.0.1:8000/temp";
 
+function completeTestWhenKeyDownIsReceived() {
+    if (testInput.value != "a") {
+        setTimeout(completeTestWhenKeyDownIsReceived, 100);
+        return;
+    }
+    shouldBeEqualToString("testInput.value", "a");
+
+    if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
+        testFailed("Origin did not get user interaction credit.");
+    else
+        testPassed("Origin was granted user interaction.");
+
+    setTimeout(function() {
+        testFrame.src = "about:blank";
+        setTimeout(function() {
+            setEnableFeature(false, finishJSTest);
+        }, 0);
+    }, 0);
+}
+
 onload = function() {
     const testFrame = document.getElementById("testFrame");
 
@@ -24,21 +44,6 @@ onload = function() {
 
                     testInput = document.getElementById("testInput");
 
-                    testRunner.installStatisticsDidModifyDataRecordsCallback(function() {
-                        shouldBeEqualToString("testInput.value", "a");
-
-                        if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
-                            testFailed("Origin did not get user interaction credit.");
-                        else
-                            testPassed("Origin was granted user interaction.");
-
-                        setTimeout(function() {
-                            testFrame.src = "about:blank";
-                            setTimeout(function() {
-                                setEnableFeature(false, finishJSTest);
-                            }, 0);
-                        }, 0);
-                    });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
                     await testRunner.statisticsProcessStatisticsAndDataRecords();
@@ -47,6 +52,7 @@ onload = function() {
                     testInput.focus();
                     if (window.eventSender)
                         eventSender.keyDown("a");
+                    completeTestWhenKeyDownIsReceived();
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-unhandled-keydown.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-unhandled-keydown.html
@@ -22,18 +22,6 @@ onload = function() {
                     if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get cleared of user interaction.");
 
-                    testRunner.installStatisticsDidModifyDataRecordsCallback(function() {
-
-                        if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
-                            testPassed("Origin did not get user interaction credit.");
-
-                        setTimeout(function() {
-                            testFrame.src = "about:blank";
-                            setTimeout(function() {
-                                setEnableFeature(false, finishJSTest);
-                            }, 0);
-                        }, 0);
-                    });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
 
@@ -42,6 +30,16 @@ onload = function() {
                         eventSender.keyDown("a", ["metaKey"]);
 
                     await testRunner.statisticsProcessStatisticsAndDataRecords();
+
+                    if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
+                        testPassed("Origin did not get user interaction credit.");
+
+                    setTimeout(function() {
+                        testFrame.src = "about:blank";
+                        setTimeout(function() {
+                            setEnableFeature(false, finishJSTest);
+                        }, 0);
+                    }, 0);
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html
@@ -13,6 +13,14 @@
     
     async function processStatistics() {
         await testRunner.statisticsProcessStatisticsAndDataRecords()
+
+        if (document.cookie !== "")
+            testFailed("Cookie not deleted: " + document.cookie);
+        else
+            testPassed("Cookie deleted.");
+        setEnableFeature(false, function() {
+            testRunner.notifyDone();
+        });
     }
     
     function runTestRunnerTest() {
@@ -31,15 +39,6 @@
                 if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                     testFailed("Host did not get logged for user interaction.");
 
-                testRunner.installStatisticsDidModifyDataRecordsCallback(function() {
-                    if (document.cookie !== "")
-                        testFailed("Cookie not deleted: " + document.cookie);
-                    else
-                        testPassed("Cookie deleted.");
-                    setEnableFeature(false, function() {
-                        testRunner.notifyDone();
-                    });
-                });
                 testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                 testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
                 testRunner.setStatisticsTimeToLiveUserInteraction(0);
@@ -54,7 +53,7 @@
         testRunner.waitUntilDone();
         setEnableFeature(true, function() {
             runTestRunnerTest();
-         });
+        });
     }
 </script>
 </body>

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction.html
@@ -36,18 +36,17 @@
                     if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get logged for user interaction.");
 
-                    testRunner.installStatisticsDidModifyDataRecordsCallback(function() {
-                        if (document.cookie === cookie)
-                            testPassed("Cookie not deleted.");
-                        else
-                            testFailed("Cookie deleted or document.cookie contains other cookies: " + document.cookie);
-                        setEnableFeature(false, function() {
-                            testRunner.notifyDone();
-                        });
-                    });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
                     await testRunner.statisticsProcessStatisticsAndDataRecords();
+
+                    if (document.cookie === cookie)
+                        testPassed("Cookie not deleted.");
+                    else
+                        testFailed("Cookie deleted or document.cookie contains other cookies: " + document.cookie);
+                    setEnableFeature(false, function() {
+                        testRunner.notifyDone();
+                    });
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html
@@ -38,12 +38,10 @@
                 if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                     testFailed("Host did not get cleared of user interaction.");
 
-                testRunner.installStatisticsDidModifyDataRecordsCallback(function() {
-                    setTimeout("finishTest()", 1000);
-                });
                 testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                 testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
                 await testRunner.statisticsProcessStatisticsAndDataRecords();
+                setTimeout("finishTest()", 1000);
             });
         });
     }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -429,8 +429,8 @@ void ResourceLoadStatisticsStore::removeDataRecords(CompletionHandler<void()>&& 
 
     setDataRecordsBeingRemoved(true);
 
-    RunLoop::main().dispatch([store = Ref { m_store }, domainsToDeleteOrRestrictWebsiteDataFor = crossThreadCopy(WTFMove(domainsToDeleteOrRestrictWebsiteDataFor)), completionHandler = WTFMove(completionHandler), weakThis = WeakPtr { *this }, shouldNotifyPagesWhenDataRecordsWereScanned = m_parameters.shouldNotifyPagesWhenDataRecordsWereScanned, workQueue = m_workQueue] () mutable {
-        store->deleteAndRestrictWebsiteDataForRegistrableDomains(WebResourceLoadStatisticsStore::monitoredDataTypes(), WTFMove(domainsToDeleteOrRestrictWebsiteDataFor), shouldNotifyPagesWhenDataRecordsWereScanned, [completionHandler = WTFMove(completionHandler), weakThis = WTFMove(weakThis), workQueue](HashSet<RegistrableDomain>&& domainsWithDeletedWebsiteData) mutable {
+    RunLoop::main().dispatch([store = Ref { m_store }, domainsToDeleteOrRestrictWebsiteDataFor = crossThreadCopy(WTFMove(domainsToDeleteOrRestrictWebsiteDataFor)), completionHandler = WTFMove(completionHandler), weakThis = WeakPtr { *this }, workQueue = m_workQueue] () mutable {
+        store->deleteAndRestrictWebsiteDataForRegistrableDomains(WebResourceLoadStatisticsStore::monitoredDataTypes(), WTFMove(domainsToDeleteOrRestrictWebsiteDataFor), [completionHandler = WTFMove(completionHandler), weakThis = WTFMove(weakThis), workQueue](HashSet<RegistrableDomain>&& domainsWithDeletedWebsiteData) mutable {
             workQueue->dispatch([domainsWithDeletedWebsiteData = crossThreadCopy(WTFMove(domainsWithDeletedWebsiteData)), completionHandler = WTFMove(completionHandler), weakThis = WTFMove(weakThis)] () mutable {
                 if (!weakThis) {
                     completionHandler();
@@ -458,9 +458,6 @@ void ResourceLoadStatisticsStore::removeDataRecords(CompletionHandler<void()>&& 
 void ResourceLoadStatisticsStore::processStatisticsAndDataRecords()
 {
     ASSERT(!RunLoop::isMain());
-
-    if (parameters().isRunningTest && !m_parameters.shouldNotifyPagesWhenDataRecordsWereScanned)
-        return;
 
     if (m_parameters.shouldClassifyResourcesBeforeDataRecordsRemoval)
         classifyPrevalentResources();

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -1530,12 +1530,12 @@ void WebResourceLoadStatisticsStore::registrableDomainsExemptFromWebsiteDataDele
     });
 }
 
-void WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domainsToDeleteAndRestrictWebsiteDataFor, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
+void WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domainsToDeleteAndRestrictWebsiteDataFor, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
     
     if (m_networkSession) {
-        m_networkSession->deleteAndRestrictWebsiteDataForRegistrableDomains(dataTypes, WTFMove(domainsToDeleteAndRestrictWebsiteDataFor), shouldNotifyPage, WTFMove(completionHandler));
+        m_networkSession->deleteAndRestrictWebsiteDataForRegistrableDomains(dataTypes, WTFMove(domainsToDeleteAndRestrictWebsiteDataFor), WTFMove(completionHandler));
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -135,7 +135,7 @@ public:
     void clearUserInteraction(TopFrameDomain&&, CompletionHandler<void()>&&);
     void setTimeAdvanceForTesting(Seconds, CompletionHandler<void()>&&);
     void removeDataForDomain(const RegistrableDomain, CompletionHandler<void()>&&);
-    void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
+    void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
     void registrableDomains(CompletionHandler<void(Vector<RegistrableDomain>&&)>&&);
     void registrableDomainsWithLastAccessedTime(CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>)>&&);
     void registrableDomainsExemptFromWebsiteDataDeletion(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -215,7 +215,7 @@ public:
     void registrableDomainsExemptFromWebsiteDataDeletion(PAL::SessionID, CompletionHandler<void(HashSet<RegistrableDomain>)>&&);
     void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
     void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
-    void deleteAndRestrictWebsiteDataForRegistrableDomains(PAL::SessionID, OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
+    void deleteAndRestrictWebsiteDataForRegistrableDomains(PAL::SessionID, OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
     void deleteCookiesForTesting(PAL::SessionID, RegistrableDomain, bool includeHttpOnlyCookies, CompletionHandler<void()>&&);
     void dumpResourceLoadStatistics(PAL::SessionID, CompletionHandler<void(String)>&&);
     void updatePrevalentDomainsToBlockCookiesFor(PAL::SessionID, const Vector<RegistrableDomain>& domainsToBlock, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -290,7 +290,7 @@ void NetworkSession::notifyResourceLoadStatisticsProcessed()
     m_networkProcess->parentProcessConnection()->send(Messages::NetworkProcessProxy::NotifyResourceLoadStatisticsProcessed(), 0);
 }
 
-void NetworkSession::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domains, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
+void NetworkSession::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domains, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
     if (auto* storageSession = networkStorageSession()) {
         for (auto& domain : domains.domainsToEnforceSameSiteStrictFor)
@@ -298,7 +298,7 @@ void NetworkSession::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet
     }
     domains.domainsToEnforceSameSiteStrictFor.clear();
 
-    m_networkProcess->deleteAndRestrictWebsiteDataForRegistrableDomains(m_sessionID, dataTypes, WTFMove(domains), shouldNotifyPage, WTFMove(completionHandler));
+    m_networkProcess->deleteAndRestrictWebsiteDataForRegistrableDomains(m_sessionID, dataTypes, WTFMove(domains), WTFMove(completionHandler));
 }
 
 void NetworkSession::registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType> dataTypes, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -132,7 +132,7 @@ public:
     void setTrackingPreventionEnabled(bool);
     bool isTrackingPreventionEnabled() const;
     void notifyResourceLoadStatisticsProcessed();
-    void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, bool shouldNotifyPage, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
+    void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     void registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType>, bool shouldNotifyPage, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     bool enableResourceLoadStatisticsLogTestingEvent() const { return m_enableResourceLoadStatisticsLogTestingEvent; }
     void setResourceLoadStatisticsLogTestingEvent(bool log) { m_enableResourceLoadStatisticsLogTestingEvent = log; }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1211,11 +1211,6 @@ void NetworkProcessProxy::notifyResourceLoadStatisticsProcessed()
     WebProcessProxy::notifyPageStatisticsAndDataRecordsProcessed();
 }
 
-void NetworkProcessProxy::notifyWebsiteDataDeletionForRegistrableDomainsFinished()
-{
-    WebProcessProxy::notifyWebsiteDataDeletionForRegistrableDomainsFinished();
-}
-
 void NetworkProcessProxy::notifyWebsiteDataScanForRegistrableDomainsFinished()
 {
     WebProcessProxy::notifyWebsiteDataScanForRegistrableDomainsFinished();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -377,7 +377,6 @@ private:
     void logDiagnosticMessageWithValue(WebPageProxyIdentifier, const String& message, const String& description, double value, unsigned significantFigures, WebCore::ShouldSample);
     void logTestingEvent(PAL::SessionID, const String& event);
     void notifyResourceLoadStatisticsProcessed();
-    void notifyWebsiteDataDeletionForRegistrableDomainsFinished();
     void notifyWebsiteDataScanForRegistrableDomainsFinished();
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -37,7 +37,6 @@ messages -> NetworkProcessProxy LegacyReceiver {
 
     LogTestingEvent(PAL::SessionID sessionID, String event)
     NotifyResourceLoadStatisticsProcessed()
-    NotifyWebsiteDataDeletionForRegistrableDomainsFinished()
     NotifyWebsiteDataScanForRegistrableDomainsFinished()
     RequestStorageAccessConfirm(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain, std::optional<WebCore::OrganizationStorageAccessPromptQuirk> organizationStorageAccessPromptQuirk) -> (bool userDidGrantAccess)
     DeleteWebsiteDataInUIProcessForRegistrableDomains(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> dataTypes, OptionSet<WebKit::WebsiteDataFetchOption> fetchOptions, Vector<WebCore::RegistrableDomain> domains) -> (HashSet<WebCore::RegistrableDomain> domainsWithMatchingDataRecords)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -767,12 +767,6 @@ void WebProcessProxy::notifyWebsiteDataScanForRegistrableDomainsFinished()
         page->postMessageToInjectedBundle("WebsiteDataScanForRegistrableDomainsFinished"_s, nullptr);
 }
 
-void WebProcessProxy::notifyWebsiteDataDeletionForRegistrableDomainsFinished()
-{
-    for (Ref page : globalPages())
-        page->postMessageToInjectedBundle("WebsiteDataDeletionForRegistrableDomainsFinished"_s, nullptr);
-}
-
 void WebProcessProxy::setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode thirdPartyCookieBlockingMode, CompletionHandler<void()>&& completionHandler)
 {
     sendWithAsyncReply(Messages::WebProcess::SetThirdPartyCookieBlockingMode(thirdPartyCookieBlockingMode), WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -303,7 +303,6 @@ public:
 
     static void notifyPageStatisticsAndDataRecordsProcessed();
 
-    static void notifyWebsiteDataDeletionForRegistrableDomainsFinished();
     static void notifyWebsiteDataScanForRegistrableDomainsFinished();
 
     void setThirdPartyCookieBlockingMode(WebCore::ThirdPartyCookieBlockingMode, CompletionHandler<void()>&&);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -313,7 +313,6 @@ interface TestRunner {
     boolean doesStatisticsDomainIDExistInDatabase(unsigned long domainID);
     undefined setStatisticsEnabled(boolean value);
     boolean isStatisticsEphemeral();
-    undefined installStatisticsDidModifyDataRecordsCallback(object callback);
     undefined installStatisticsDidScanDataRecordsCallback(object callback);
     undefined setStatisticsDebugMode(boolean value, object completionHandler);
     undefined setStatisticsPrevalentResourceForDebugMode(DOMString hostName, object completionHandler);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -297,12 +297,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "WebsiteDataDeletionForRegistrableDomainsFinished")) {
-        if (m_testRunner)
-            m_testRunner->statisticsDidModifyDataRecordsCallback();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "WebsiteDataScanForRegistrableDomainsFinished")) {
         if (m_testRunner)
             m_testRunner->statisticsDidScanDataRecordsCallback();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -613,7 +613,6 @@ enum {
     WillEndSwipeCallbackID,
     DidEndSwipeCallbackID,
     DidRemoveSwipeSnapshotCallbackID,
-    StatisticsDidModifyDataRecordsCallbackID,
     StatisticsDidScanDataRecordsCallbackID,
     TextDidChangeInTextFieldCallbackID,
     TextFieldDidBeginEditingCallbackID,
@@ -1412,20 +1411,6 @@ void TestRunner::setStatisticsCrossSiteLoadWithLinkDecoration(JSStringRef fromHo
 void TestRunner::setStatisticsTimeToLiveUserInteraction(double seconds)
 {
     postSynchronousMessage("SetStatisticsTimeToLiveUserInteraction", seconds);
-}
-
-void TestRunner::installStatisticsDidModifyDataRecordsCallback(JSContextRef context, JSValueRef callback)
-{
-    if (!!callback) {
-        cacheTestRunnerCallback(context, StatisticsDidModifyDataRecordsCallbackID, callback);
-        // Setting a callback implies we expect to receive callbacks. So register for them.
-        setStatisticsNotifyPagesWhenDataRecordsWereScanned(true);
-    }
-}
-
-void TestRunner::statisticsDidModifyDataRecordsCallback()
-{
-    callTestRunnerCallback(StatisticsDidModifyDataRecordsCallbackID);
 }
 
 void TestRunner::installStatisticsDidScanDataRecordsCallback(JSContextRef context, JSValueRef callback)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -411,9 +411,7 @@ public:
     bool doesStatisticsDomainIDExistInDatabase(unsigned domainID);
     void setStatisticsEnabled(bool value);
     bool isStatisticsEphemeral();
-    void installStatisticsDidModifyDataRecordsCallback(JSContextRef, JSValueRef callback);
     void installStatisticsDidScanDataRecordsCallback(JSContextRef, JSValueRef callback);
-    void statisticsDidModifyDataRecordsCallback();
     void statisticsDidScanDataRecordsCallback();
     void statisticsNotifyObserver(JSContextRef, JSValueRef completionHandler);
     void statisticsProcessStatisticsAndDataRecords(JSContextRef, JSValueRef completionHandler);


### PR DESCRIPTION
#### 9368e4b24a798fb2bf5beddc5114273c81ea1247
<pre>
Remove TestRunner.installStatisticsDidModifyDataRecordsCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=278465">https://bugs.webkit.org/show_bug.cgi?id=278465</a>

Reviewed by Charlie Wolfe.

This reduces state in the web content process and makes the tests work better with site isolation
because we no longer use cacheTestRunnerCallback.

All the tests that use installStatisticsDidModifyDataRecordsCallback also call
await testRunner.statisticsProcessStatisticsAndDataRecords()
which is sufficient waiting for the didModifyDataRecords to have happened except in one test,
http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html
where we need the keyDown to also have been processed, which we can accomplish by polling
and checking if the &apos;a&apos; key&apos;s effects have been observed.

Since we are removing the installStatisticsDidModifyDataRecordsCallback call, we can also remove
some infrastructure in WebKit that existed only to make that work.  We also remove the layering
violation where WebKit.framework had code that sent a &quot;WebsiteDataDeletionForRegistrableDomainsFinished&quot;
message that was only intended for WebKitTestRunner, and I remove a few places where we pass around
a now-unneeded parameter bool shouldNotifyPage because we should never notify the page, as well
as a now-unused message NotifyWebsiteDataDeletionForRegistrableDomainsFinished.

* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-unhandled-keydown.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::removeDataRecords):
(WebKit::ResourceLoadStatisticsStore::processStatisticsAndDataRecords):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableDomains):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains):
(WebKit::NetworkProcess::deleteCookiesForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::deleteAndRestrictWebsiteDataForRegistrableDomains):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::notifyWebsiteDataDeletionForRegistrableDomainsFinished): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::notifyWebsiteDataDeletionForRegistrableDomainsFinished): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::installStatisticsDidModifyDataRecordsCallback): Deleted.
(WTR::TestRunner::statisticsDidModifyDataRecordsCallback): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/282575@main">https://commits.webkit.org/282575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/977f993ba4b5f325310eeda89dee45d6fda108b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51157 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9777 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69246 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12288 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58479 "Found 1 new test failure: http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58693 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6247 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->