### PR TITLE
[Navigation] Fix dispatching wrong event on abort

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.back() same-document preventDefault assert_equals: expected 1 but got 0
+FAIL navigation.back() same-document preventDefault assert_equals: expected "http://localhost:8800/navigation-api/navigate-event/navigation-back-same-document-preventDefault.html#" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-preventDefault-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event.preventDefault() signals event.signal assert_array_equals: lengths differ, expected array ["onabort", "onnavigateerror"] length 2, got ["onabort"] length 1
+PASS event.preventDefault() signals event.signal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL If forward pruning clobbers the target of a traverse, abort assert_equals: expected 1 but got 2
+FAIL If forward pruning clobbers the target of a traverse, abort assert_unreached: navigateerror should not fire Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Should be BFCached but actually wasn't
+NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Could have been BFCached but actually wasn't
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Basic tests for navigation.currentEntry assert_not_equals: got disallowed value "http://web-platform.test:8800/navigation-api/navigation-history-entry/current-basic.html#6"
+PASS Basic tests for navigation.currentEntry
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -602,7 +602,7 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
     m_ongoingNavigateEvent = nullptr;
 
     // FIXME: Fill in exception information.
-    dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, { }, 0, 0, { globalObject->vm(), domException }));
+    dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, exception.message(), { }, 0, 0, { globalObject->vm(), domException }));
 
     if (m_ongoingAPIMethodTracker)
         rejectFinishedPromise(m_ongoingAPIMethodTracker.get(), exception, domException);


### PR DESCRIPTION
#### e4b5bb94c21ce0689a3b9a180900157fd6d136c1
<pre>
[Navigation] Fix dispatching wrong event on abort
<a href="https://bugs.webkit.org/show_bug.cgi?id=278472">https://bugs.webkit.org/show_bug.cgi?id=278472</a>

Reviewed by Alex Christensen.

The wrong constructor was used for ErrorEvent so the Event&apos;s type
was used as a message instead.

Fixing this also exposed that pagehide should not cause an error.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/defaultPrevented-navigation-preempted-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-after-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-204-205-download-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::stopAllLoaders):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::abortOngoingNavigation):

Canonical link: <a href="https://commits.webkit.org/282691@main">https://commits.webkit.org/282691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bde2af2dc03181090d3fd6349ff937507a5e0e94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51467 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10018 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40041 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36719 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12679 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13356 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69593 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7822 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12548 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58790 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58934 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6499 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9674 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->