### PR TITLE
Resync web-platform-tests/pointerevents from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom-expected.txt
@@ -2,5 +2,5 @@ PointerEvent: Verifies that mouse boundary events don't point to shadow-dom
 
 
 
-FAIL PointerEvent: Verifies that mouse boundary events don't point to shadow-dom assert_array_equals: Moved into <input> expected property 1 to be "pointerover target=INPUT relatedTarget=BODY" but got "mouseout target=BODY relatedTarget=INPUT" (expected array ["pointerout target=BODY relatedTarget=INPUT", "pointerover target=INPUT relatedTarget=BODY", "mouseout target=BODY relatedTarget=INPUT", "mouseover target=INPUT relatedTarget=BODY"] got ["pointerout target=BODY relatedTarget=INPUT", "mouseout target=BODY relatedTarget=INPUT", "pointerover target=INPUT relatedTarget=BODY", "mouseover target=INPUT relatedTarget=BODY"])
+PASS PointerEvent: Verifies that mouse boundary events don't point to shadow-dom
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html
@@ -12,63 +12,75 @@
 <input id="target" style="margin: 20px">
 
 <script>
-function name(node) {
-  return node? node.tagName : "(null)";
-}
+  function name(node) {
+    return node? node.tagName : "(null)";
+  }
 
-promise_test(async () => {
-  var targetEvents = ["mouseout", "pointerout", "mouseover", "pointerover"];
-  var receivedEvents = [];
-  var moveReceived = false;
+  function get_event_details(e) {
+      return e.type + " target=" + name(e.target) + " relatedTarget=" + name(e.relatedTarget);
+  }
 
+  function events_match_expected(actualEvents, expectedEventDetails) {
+      if (actualEvents.length != expectedEventDetails.length)
+        return false;
 
-  targetEvents.forEach(function(eventName) {
-    window.addEventListener(eventName, function(e) {
-      var eventDetails = e.type +
-                         " target=" + name(e.target) +
-                         " relatedTarget=" + name(e.relatedTarget);
-      receivedEvents.push(eventDetails);
+      let actualEventDetails = actualEvents.map(e => get_event_details(e));
+      return (expectedEventDetails.every(expected => actualEventDetails.includes(expected)) &&
+              arePointerEventsBeforeCompatMouseEvents(actualEvents) &&
+              actualEventDetails[0] == expectedEventDetails[0]);
+  }
+
+  promise_test(async () => {
+    let rect = document.getElementById("target").getBoundingClientRect();
+    let targetEvents = ["mouseout", "pointerout", "mouseover", "pointerover"];
+    let receivedEvents = [];
+    var moveReceived = false;
+
+    targetEvents.forEach(function(eventName) {
+      window.addEventListener(eventName, function(e) {
+        receivedEvents.push(e);
+      });
     });
-  });
-  window.addEventListener('pointermove', () => { moveReceived = true; });
-  var rect = document.getElementById("target").getBoundingClientRect();
 
-  await new test_driver.Actions()
-             .addPointer("default-mouse")
-             .pointerMove(Math.ceil(rect.left - 10), Math.ceil(rect.top - 10))
-             .send()
-  await resolveWhen(() => { return moveReceived == true });
-  receivedEvents = [];
-  moveReceived = false;
+    window.addEventListener('pointermove', () => { moveReceived = true; });
 
-  await new test_driver.Actions()
-             .addPointer("default-mouse")
-             .pointerMove(Math.ceil(rect.left + 10), Math.ceil(rect.top + 10))
-             .send()
-  await resolveWhen(() => { return moveReceived == true });
+    await new test_driver.Actions()
+               .addPointer("default-mouse")
+               .pointerMove(Math.ceil(rect.left - 10), Math.ceil(rect.top - 10))
+               .send()
+    await resolveWhen(() => { return moveReceived == true });
 
-  assert_array_equals(receivedEvents, [
-    "pointerout target=BODY relatedTarget=INPUT",
-    "pointerover target=INPUT relatedTarget=BODY",
-    "mouseout target=BODY relatedTarget=INPUT",
-    "mouseover target=INPUT relatedTarget=BODY",
-  ], "Moved into <input>");
+    moveReceived = false;
+    receivedEvents.length = 0;
+    await new test_driver.Actions()
+               .addPointer("default-mouse")
+               .pointerMove(Math.ceil(rect.left + 10), Math.ceil(rect.top + 10))
+               .send()
+    await resolveWhen(() => { return moveReceived == true });
+
+    let intoInputExpected = [
+      "pointerout target=BODY relatedTarget=INPUT",
+      "pointerover target=INPUT relatedTarget=BODY",
+      "mouseout target=BODY relatedTarget=INPUT",
+      "mouseover target=INPUT relatedTarget=BODY",
+    ];
+    assert_true(events_match_expected(receivedEvents, intoInputExpected), "Moved into <input>");
 
 
-  receivedEvents = [];
-  moveReceived = false;
+    moveReceived = false;
+    receivedEvents.length = 0;
+    await new test_driver.Actions()
+               .addPointer("default-mouse")
+               .pointerMove(Math.ceil(rect.left - 10), Math.ceil(rect.top - 10))
+               .send()
+    await resolveWhen(() => { return moveReceived == true });
 
-  await new test_driver.Actions()
-             .addPointer("default-mouse")
-             .pointerMove(Math.ceil(rect.left - 10), Math.ceil(rect.top - 10))
-             .send()
-  await resolveWhen(() => { return moveReceived == true });
-
-  assert_array_equals(receivedEvents, [
-    "pointerout target=INPUT relatedTarget=BODY",
-    "pointerover target=BODY relatedTarget=INPUT",
-    "mouseout target=INPUT relatedTarget=BODY",
-    "mouseover target=BODY relatedTarget=INPUT",
-  ], "Moved out of <input>");
-}, "PointerEvent: Verifies that mouse boundary events don't point to shadow-dom");
+    let outOfInputExpected = [
+      "pointerout target=INPUT relatedTarget=BODY",
+      "pointerover target=BODY relatedTarget=INPUT",
+      "mouseout target=INPUT relatedTarget=BODY",
+      "mouseover target=BODY relatedTarget=INPUT",
+    ];
+    assert_true(events_match_expected(receivedEvents, outOfInputExpected), "Moved out of <input>");
+  }, "PointerEvent: Verifies that mouse boundary events don't point to shadow-dom");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer-expected.txt
@@ -1,0 +1,5 @@
+Hover me!
+Move pointer here first!
+
+PASS Generating text content under pointer
+

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>Making generated content under pointer at hover should keep targeting the boundary event target to parent element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+"use strict";
+
+addEventListener("load", () => {
+  promise_test(async () => {
+    const div = document.querySelector("div");
+    await new test_driver.Actions()
+      .pointerMove(0, 0, {origin: div})
+      .send();
+    const span = document.querySelector("span");
+    const promisePointerOver = new Promise(resolve => {
+      span.addEventListener("pointerover", event => resolve(event.target), {once: true});
+    });
+    const promiseMouseOver = new Promise(resolve => {
+      span.addEventListener("mouseover", event => resolve(event.target), {once: true});
+    });
+    await new test_driver.Actions()
+      .pointerMove(0, 0, {origin: span})
+      .pointerDown()
+      .pointerUp()
+      .send();
+    const pointerOverTarget = await promisePointerOver;
+    assert_equals(
+      pointerOverTarget,
+      span,
+      "pointerover target should be the <span>"
+    );
+    const mouseOverTarget = await promiseMouseOver;
+    assert_equals(
+      mouseOverTarget,
+      span,
+      "mouseover target should be the <span>"
+    );
+  }, "Generating text content under pointer");
+}, {once: true});
+</script>
+<style>
+span:hover::before {
+  content: "Here is generated content... ";
+}
+</style>
+</head>
+<body><span>Hover me!</span><div>Move pointer here first!</div></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/w3c-import.log
@@ -28,6 +28,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change-scrollbar.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll-will-change.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointer-events-none-skip-scroll.html
+/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_appended.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_appended_interleaved.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_removed.html


### PR DESCRIPTION
#### 185980be2bca72ed2fb18fd6c924cbea0f465a25
<pre>
Resync web-platform-tests/pointerevents from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=278476">https://bugs.webkit.org/show_bug.cgi?id=278476</a>
<a href="https://rdar.apple.com/134435795">rdar://134435795</a>

Reviewed by Wenson Hsieh.

This WPT sync is prompted by a fix we recently contributed to address
web-platform-tests/interop#682.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/2fd0573aaf9f954bd96a001c2b2030b20802a126.">https://github.com/web-platform-tests/wpt/commit/2fd0573aaf9f954bd96a001c2b2030b20802a126.</a>

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent-boundary-event-target-when-hover-generates-content-under-pointer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/282578@main">https://commits.webkit.org/282578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbd41dd12e05a1815b88261e3853c3b00111e722

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14164 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51177 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9797 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31862 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12405 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13036 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69273 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58486 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14068 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6262 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39812 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40924 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->