### PR TITLE
[WebGPU] Validation error in RenderBundleEncoder::drawIndexed

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-278049-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-278049-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-278049.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-278049.html
@@ -1,0 +1,21746 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {label: '\u3943\ucb46\u{1f6f0}\u{1f871}\u08bf'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 153365728,
+    maxStorageBufferBindingSize: 180821639,
+    maxInterStageShaderVariables: 16,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1fc0a}\u3d27\u04b4\u{1f931}\u1366\u{1fae2}\u0f11',
+  entries: [
+    {
+      binding: 117,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\ud48f\u{1fcdb}\u0928\u{1fde8}\uafdc\uce39\u29b3\ua003\u0fc8\u707b',
+  bindGroupLayouts: [bindGroupLayout0],
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\uded6\ua1f7\u0798\u{1f6e8}\u0e0b\ue91e\u2ace\ub983\uf3a8\u{1fc54}',
+  colorFormats: ['rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise0;
+} catch {}
+await gc();
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\ude65\ueb3f\u0bca\u0d4b\u{1fa34}\u07db\u42b9',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: atomic<i32>,
+}
+struct T1 {
+  f0: array<mat4x2f>,
+}
+struct T2 {
+  f0: array<mat2x3f>,
+}
+struct T3 {
+  f0: atomic<i32>,
+  f1: atomic<u32>,
+}
+
+@group(0) @binding(117) var tex0: texture_cube<f32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(5) @interpolate(flat) f0: vec3u,
+  @location(0) f1: vec4i
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(a0) {
+    discard;
+  }
+  return out;
+}
+`,
+  hints: {},
+});
+let buffer0 = device0.createBuffer({
+  size: 24329,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer0, 'uint16', 5_020, 4_121);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(0, buffer0, 5_364, 457);
+} catch {}
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1fab9}\u4101\u053f\u31be\uc92a\u0de7\u{1fa88}\u76d5'});
+let pipeline0 = device0.createComputePipeline({
+  label: '\u0b4b\ub66f\u2247\udd35\u030b\u6b4f\ucd10',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, constants: {}},
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 337,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 399,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 4458366, hasDynamicOffset: false },
+    },
+    {
+      binding: 397,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 173, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 296,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 314,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 222,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 62, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 251,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 292,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 1979667, hasDynamicOffset: false },
+    },
+    {
+      binding: 310,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 117,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 256,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 297,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 437,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 456,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder0 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder0.finish({label: '\u110c\u64bc\uf753\u{1fd88}\uea14\ue966\u9dc7\u203e\u047f\uc27f'});
+let texture0 = device0.createTexture({
+  label: '\u0e9a\ucdb7\ubcda\ua3f9\u0aa2\u13d6\u0c9d\u174a\uc075\u4058\u588e',
+  size: [1440],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\u0da5\u6883\u2220\u3471\ubd53\u01d0',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0},
+});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0}});
+try {
+  await promise1;
+} catch {}
+try {
+adapter0.label = '\ud341\ud093\u{1fa35}\u573d\u{1f6c0}\u002c\u06fc\u{1fbf4}';
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u3091\u{1f6cd}\uc295\u9836\u6c40\u3053\u74b6\u0243\u0bf2'});
+let pipeline3 = device0.createComputePipeline({
+  label: '\u0b16\u{1fc84}\u25c6\u278a',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, constants: {}},
+});
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u{1fe10}\u8698\u5eaf\u{1f8fc}',
+  entries: [
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\u8665\u0780',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<array<array<array<vec3u, 1>, 1>, 1>>,
+}
+
+@group(0) @binding(117) var tex1: texture_2d<f32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32) {
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+@fragment
+fn fragment0() -> @location(200) vec4i {
+  var out: vec4i;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 216 */
+  offset: 216,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 220, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandBuffer1 = commandEncoder1.finish({label: '\uc38b\u0224\u{1fea9}\u{1fcb3}\u664c\u{1ffb0}\u2ff1\u4fd2\u07c3\ud622'});
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule1, constants: {}}});
+let commandEncoder2 = device0.createCommandEncoder({label: '\uc107\u059c\uc2b8\u{1fbb1}\u9c96\u8010'});
+let commandBuffer2 = commandEncoder2.finish();
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({label: '\u2dd5\u72b0', colorFormats: ['rgba16sint'], depthReadOnly: true});
+let video0 = await videoWithData();
+let commandEncoder3 = device0.createCommandEncoder({label: '\u5745\u7854\ua2b2\u0168\u1d7a'});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 1_076, 331);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 1184 widthInBlocks: 148 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 152 */
+  offset: 152,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 148, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({label: '\u4ab1\u{1f6fd}\u6023\u{1fcfe}\u{1f8e4}\u6ece\u{1fa21}\u{1fb92}\u6528\ub596'});
+let commandEncoder5 = device0.createCommandEncoder();
+let commandBuffer3 = commandEncoder4.finish({label: '\u{1f97c}\u01ad\uea21\uda26\u7d44\uf976\u0064\u00d9'});
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer0, 4_320);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(131), /* required buffer size: 131 */
+{offset: 131}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView0 = texture0.createView({dimension: '1d'});
+let computePassEncoder0 = commandEncoder5.beginComputePass();
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u0888\u6ed1\ua077\u092e\uaf99\ua353\uec03\ua327\u{1f671}\u5740\u{1fd9f}'});
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 1608 widthInBlocks: 201 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4168 */
+  offset: 4168,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 159, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 201, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let commandBuffer4 = commandEncoder3.finish({});
+let texture1 = device0.createTexture({
+  size: [180, 3, 16],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({label: '\uaac1\uc03a\u{1ff8a}\u4582\u{1f769}\u5b76\u4e0a', colorFormats: ['rgba16sint']});
+try {
+computePassEncoder0.insertDebugMarker('\u{1f840}');
+} catch {}
+try {
+renderBundleEncoder2.insertDebugMarker('\u{1f9d5}');
+} catch {}
+await gc();
+let buffer1 = device0.createBuffer({
+  label: '\u0037\u3b4d\u038c\u80f2\u{1fe48}\u0b8d\u054e\u139a\u790b\u0be4\u79fb',
+  size: 7759,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u{1ff9a}\u{1fa89}\ub2a6\u0d94\u0822\u8fe7\u408b\u5eb3'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let commandBuffer5 = commandEncoder6.finish({label: '\u3572\u0c5d\u{1ff50}\u5eb9\u0da4\u09ae\u5166\u{1fad3}\u{1ffce}\ua920'});
+let textureView1 = texture1.createView({
+  label: '\u09af\u43e9\u256d\u{1fd10}\u3e3c\uf413\u0e04\ue65d\u{1f8a8}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(0, buffer0, 1_924, 2_519);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let texture2 = device0.createTexture({
+  label: '\u05c9\udefc\u07f4\u4501\u{1f95a}\u8fa0\u0661',
+  size: [1440, 28, 363],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\uc060\u0728\u{1faef}\u{1fdea}\u08a2\ua3f3\u02a4'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 12_944, 6_227);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(2, buffer0, 0, 1_118);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u04fc\u72a9\u0cdf\u0b4d\u{1fdf6}\u617b\uca65\u7568\u7b91\uc31a'});
+let renderBundle4 = renderBundleEncoder0.finish();
+let externalTexture0 = device0.importExternalTexture({label: '\uf345\u{1f677}\uacfe\u{1fe61}\u0bff\ud200', source: video0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint16', 1_076, 7_128);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(7, buffer0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 1_256, 6_263);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(4, buffer0, 0, 5_457);
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({
+  label: '\u04cc\u003f\u7f0f\u9fdc\u65a9\ub24d\uec92\ue0b8\u16b0',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, constants: {}},
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 39.53,
+  lodMaxClamp: 67.89,
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u75d5\u950f\u{1ff4a}\u35ff\u0bb6\u0230\u420e'});
+let computePassEncoder1 = commandEncoder10.beginComputePass({label: '\u01e0\ua8be\u{1fedb}\u0b5e\uf2e7\uc108\u092e'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint32', 7_008, 408);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(0, buffer0, 0, 1_159);
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({label: '\u592e\u8604\u087d\u65e2\u{1f65e}\u364a\u0f1d\u{1fa75}\u{1f84b}', entries: []});
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+adapter0.label = '\u0fe2\u0d72\u7248';
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder();
+let commandBuffer6 = commandEncoder11.finish({label: '\ua6cb\uef29\u3ecc\ucc0d\u09a8'});
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(0, buffer0, 2_392);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+  label: '\u01cb\u0669\u{1f68c}\u{1fe0d}\u2ca7',
+  layout: pipelineLayout0,
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule1, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let video1 = await videoWithData();
+let commandBuffer7 = commandEncoder7.finish({label: '\uc18c\uf47a\u3dc6\u0d49\u071f\u0d77'});
+let renderBundle5 = renderBundleEncoder1.finish();
+try {
+computePassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint16', 6_056, 3_224);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video1);
+let commandEncoder12 = device0.createCommandEncoder({label: '\u070c\ucac9\u{1fbdd}\udfa4\u{1fdf6}\udc04\u94ef'});
+let renderBundle6 = renderBundleEncoder1.finish({label: '\u04a3\uf208\ufad1'});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 519, y: 0, z: 20},
+  aspect: 'all',
+}, new ArrayBuffer(165), /* required buffer size: 165 */
+{offset: 165}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer8 = commandEncoder12.finish({label: '\u8839\ubab4\u8d84\u0b3e\ubec6\u8e45\u2023\u298d'});
+let textureView2 = texture0.createView({label: '\u0e68\u4cde\ua056\u{1fcf6}\u0385\u038f'});
+let renderBundle7 = renderBundleEncoder2.finish({});
+let externalTexture1 = device0.importExternalTexture({
+  label: '\ue9e6\u039e\u08fd\u{1f6d3}\ude35\u3112\u4b60\ucbeb',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+let promise2 = shaderModule0.getCompilationInfo();
+try {
+buffer0.unmap();
+} catch {}
+let commandBuffer9 = commandEncoder9.finish({label: '\u96e5\u4114\ub73d\u{1f7d4}\u7f1b\u0455\u299e\ubcd6\u535a\u7266'});
+let textureView3 = texture2.createView({mipLevelCount: 1});
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 86, y: 1, z: 39},
+  aspect: 'all',
+},
+{width: 163, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer6]);
+} catch {}
+let renderPassEncoder0 = commandEncoder8.beginRenderPass({
+  label: '\u{1fe45}\uf2f2',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 179,
+  clearValue: { r: -47.53, g: -955.6, b: -777.5, a: -751.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer0, 0, 2_180);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({label: '\u1cea\u{1f8c5}\u{1fe72}\u2807\uf7a5\u{1fdb5}\u6af2\ub40d\u{1ff7f}'});
+let commandBuffer10 = commandEncoder5.finish({label: '\ua578\u5015'});
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle4, renderBundle6, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer0, 1_632, 1_174);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 464 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1392 */
+  offset: 1392,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 123, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 335, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(343), /* required buffer size: 343 */
+{offset: 343}, {width: 221, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder1 = commandEncoder13.beginRenderPass({
+  label: '\u3dff\u{1f9d1}\u{1f6f4}\u{1ff9b}\u2a88\u0738\u9706\u0ff8\u4ef7\u30df',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 90,
+  clearValue: { r: -613.2, g: 906.1, b: -367.1, a: 712.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let imageData0 = new ImageData(64, 8);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(405.3814435183365, 20.461276977075585, 97.71705146097912, 2.946064669604954, 0.8500903514984457, 0.8969907586356395);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline6);
+} catch {}
+let imageData1 = new ImageData(32, 32);
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0da3\u{1f69f}\u090f\u0724\u8938\u36da\u{1fe21}\u0f8f\u6c4e\u2324\u6237'});
+let computePassEncoder2 = commandEncoder14.beginComputePass();
+let renderBundle8 = renderBundleEncoder0.finish();
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint16', 3_976, 358);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer0, 4_888, 3_785);
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u{1fcfd}\ub14a\u86e2\u{1f93a}\ue34d\u08ef\u{1f704}\ud8ae\u0aa5\u{1fcb7}',
+  bindGroupLayouts: [],
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u{1fdcb}\u85b7\u3d89\u{1ffa9}\uc52e'});
+let computePassEncoder3 = commandEncoder15.beginComputePass({label: '\ufa71\u365d\u{1f76a}\u643f'});
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline6);
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync({
+  label: '\u{1fecf}\ucdff\u7b36\u{1fe27}\u0ace\u0286\u0e2b\u4d5c\u0842',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x28f779d7},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32'},
+});
+await gc();
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u0923\u13fa\u{1f9cb}\u{1fffa}\u7434\u19d1\u4f3f\u56db\uc5a6\u06ce\u{1f6a0}',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout0],
+});
+let commandEncoder16 = device0.createCommandEncoder({label: '\u{1f8e5}\uf29e'});
+let computePassEncoder4 = commandEncoder16.beginComputePass({label: '\u08dc\u3ab4\u{1fe37}\u09ff'});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setViewport(402.00081367170077, 0.7459877105005193, 103.98955935233195, 18.2640852943028, 0.5441799951887617, 0.90028104038492);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let renderPassEncoder2 = commandEncoder10.beginRenderPass({
+  label: '\u12eb\ue322\u{1fd08}\u0887\ucb8d',
+  colorAttachments: [{view: textureView3, depthSlice: 137, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 74576527,
+});
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 12},
+  aspect: 'all',
+}, new ArrayBuffer(18_172), /* required buffer size: 18_172 */
+{offset: 68, bytesPerRow: 6052}, {width: 750, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let textureView4 = texture1.createView({label: '\u0283\u9a6f\u{1fab7}\uae98\u6f1f\u46bf\ue0e3\u6910\u{1fa43}', mipLevelCount: 1});
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle5, renderBundle6, renderBundle3, renderBundle7, renderBundle0, renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer0, 1_872, 913);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+window.someLabel = sampler0.label;
+} catch {}
+let texture3 = device0.createTexture({
+  label: '\u{1fc80}\u{1f8b7}\u3bbf\u81bc',
+  size: [1440, 28, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle9 = renderBundleEncoder2.finish();
+try {
+computePassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle8, renderBundle9, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer0, 1_376);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas0 = document.createElement('canvas');
+let img0 = await imageWithData(10, 109, '#10101010', '#20202020');
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer0, 0, 261);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 46, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  label: '\u0404\u{1fbc0}\u0844\u0d4a\uaf6a\u455f\u1caa\u8eeb\u389e',
+  size: {width: 180, height: 3, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder3 = commandEncoder17.beginRenderPass({
+  label: '\u7353\ucd70\uf220\u6352\u8b60\u{1ffab}\u{1fd1c}',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 136,
+  clearValue: { r: 89.36, g: 648.3, b: -277.0, a: -219.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 296633463,
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint32', 1_216, 797);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer0, 1_360, 4_803);
+} catch {}
+try {
+canvas0.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 107});
+let renderPassEncoder4 = commandEncoder18.beginRenderPass({
+  label: '\u{1fba7}\ud0c4\u0628\u06a9\u{1fbc5}\u07fb',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 291,
+  clearValue: { r: 210.3, g: 364.0, b: -441.7, a: 521.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 130451875,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle8, renderBundle8, renderBundle5]);
+} catch {}
+let renderBundle10 = renderBundleEncoder2.finish({label: '\uaab7\u{1f657}\u{1f622}\u1a4d\u3ea8\u0d4d\u{1fa04}\u8cb5'});
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle8, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(548, 7, 73, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let promise5 = adapter0.requestAdapterInfo();
+let commandBuffer11 = commandEncoder14.finish({label: '\u0897\u8e01\u{1f8b9}\u5d0d\u0c68'});
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint32', 508, 3_032);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder();
+let textureView5 = texture2.createView({
+  label: '\u9ee5\u066e\u1bbc\uca20\u{1fa69}\u0359\u18b7\u8eea',
+  aspect: 'all',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+let renderPassEncoder5 = commandEncoder19.beginRenderPass({
+  label: '\u05cf\u094f\ud7d7\u{1fee3}',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 242,
+  clearValue: { r: 808.6, g: 992.7, b: -81.38, a: -827.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 347472924,
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle10, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(435, 3, 30, 2);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer0, 'uint16', 2_846, 2_363);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 18, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 524, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer10, commandBuffer5]);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u37c2\u8676\u0b8c\u5fef\ub5dd\u0323',
+  size: 32564,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let commandBuffer12 = commandEncoder15.finish({label: '\u0112\u{1f8c5}\u0290'});
+try {
+renderPassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer0, 0, 4_282);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\uf2e7\u{1fc95}\u0a75\u679b\u3059\ufe96\u0f19\ucbba'});
+let commandBuffer13 = commandEncoder20.finish({label: '\u0961\udb2b\u{1fcb4}\u{1f939}\u08e7\u080a\u499c\u07cf\u{1ff2b}\u018e\u{1fac8}'});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer2, 'uint16', 19_236, 253);
+} catch {}
+let renderBundle11 = renderBundleEncoder1.finish({label: '\u{1f78a}\u1765\u8c05\u09ed\u0117\u{1f7a3}\u0c19\u03ee\u7958\u008b\ubc8e'});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer2, 'uint32', 2_216, 152);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 1448, 128);
+} catch {}
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u25b2\u0939\u39c7\u07b2\u903f\u8696\u1200\u{1ff35}\u030a\u20a1\u7348',
+  colorFormats: ['rgba16sint'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u4586');
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({label: '\u{1f9f6}\u{1f74e}\u0dc9\u07c6\ud6c8\u{1fb58}'});
+let texture5 = device0.createTexture({
+  label: '\u{1f63b}\u{1fd4b}\u7ac7\u2c0d',
+  size: {width: 180, height: 3, depthOrArrayLayers: 116},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder6 = commandEncoder21.beginRenderPass({
+  label: '\uecc8\u0230\u683f',
+  colorAttachments: [{view: textureView3, depthSlice: 262, loadOp: 'clear', storeOp: 'store'}],
+});
+let renderBundle12 = renderBundleEncoder0.finish({label: '\u{1fb8b}\u18b3\uf4c1\u{1f7bc}\u{1fa43}'});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 364, 11_843);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 118, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(58), /* required buffer size: 58 */
+{offset: 58}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet1 = device0.createQuerySet({label: '\u{1f932}\u0c8a\u{1f7a9}\uf07e', type: 'occlusion', count: 291});
+let texture6 = device0.createTexture({
+  label: '\uadd8\u2ba0\u05d3\u0c0d\u02b6\u07bb\uf007\u5649\u18ae\u{1feae}\u09a9',
+  size: {width: 1440},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer0, 2_500);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u1c91\u0e5b\u091f\ub31f\u6498'});
+let computePassEncoder5 = commandEncoder22.beginComputePass({label: '\u0f55\u3ff7\u0925\ufbca\u08da\u5b88'});
+let renderBundle13 = renderBundleEncoder1.finish({label: '\uc3f0\u0676\ue641\u{1fc04}\u6a85\u0d25\uad2f'});
+try {
+renderBundleEncoder3.setPipeline(pipeline7);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u046a\ud36a\u02e1\u09db\u0570\u0900\uab09\uf7d6\uc78a\u0f74\u0fc1'});
+let renderPassEncoder7 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 88,
+  clearValue: { r: 458.6, g: -186.4, b: 131.8, a: -874.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u03d6\uc1b2\u73cf\u8473', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -154.4, g: 460.8, b: -810.9, a: -437.4, });
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer0, 0, 3_303);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let commandEncoder24 = device0.createCommandEncoder({label: '\u0b42\u0d01\ubd82'});
+let commandBuffer14 = commandEncoder24.finish({label: '\uf259\u06d8\ud57f\u4f97\u3e9c\uabc5\u3f33\uc530'});
+let renderBundle14 = renderBundleEncoder0.finish({label: '\u46e8\u{1fc08}\uc53c\u5410\u0436'});
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer2, 'uint32', 2_152, 4_299);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, buffer0, 0, 3_968);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({label: '\ua030\u35be\u003b\u4d36\ub9f0\u098f\ueb06'});
+let commandBuffer15 = commandEncoder25.finish({label: '\u0040\u570e\u9fd3\u1722\u2bbe\uaca8'});
+try {
+renderPassEncoder7.setIndexBuffer(buffer0, 'uint32', 448, 364);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer2, 'uint16', 3_894, 11_356);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(157), /* required buffer size: 157 */
+{offset: 157}, {width: 124, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let renderPassEncoder8 = commandEncoder26.beginRenderPass({
+  label: '\uc943\u6987\u084e\u2844\u0f90',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 289,
+  clearValue: { r: -201.0, g: -310.9, b: -91.55, a: 7.004, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+adapter0.label = '\u00e7\u00cf\u{1f88d}\u02d9';
+} catch {}
+let texture7 = device0.createTexture({
+  label: '\u4fb1\u4f3e\u03f5\u0850\u3620\uf5f8\u9128',
+  size: {width: 720, height: 14, depthOrArrayLayers: 30},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle15 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder5.setPipeline(pipeline2);
+} catch {}
+let texture8 = device0.createTexture({
+  label: '\u0497\u{1f877}\u9ce3\ufef5\ucb8c',
+  size: {width: 180},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder7.executeBundles([renderBundle10, renderBundle7, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, undefined);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer2, 'uint32', 2_624, 2_731);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 22, y: 7, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(13_781), /* required buffer size: 13_781 */
+{offset: 83, bytesPerRow: 4621}, {width: 557, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer0, 9_500, 1_726);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(1, buffer0, 6_924);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(168), /* required buffer size: 168 */
+{offset: 168, bytesPerRow: 675}, {width: 77, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle16 = renderBundleEncoder2.finish({label: '\u03b2\ua6e3'});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle4, renderBundle15, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(467);
+} catch {}
+try {
+renderPassEncoder6.setViewport(177.563377411937, 27.73865361872084, 446.25194076948395, 0.18903057290002037, 0.8413459174027403, 0.9786594931812039);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer0);
+} catch {}
+try {
+texture4.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise7 = navigator.gpu.requestAdapter({});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u0c7d\u6f48\u4451\u{1f71e}'});
+let querySet2 = device0.createQuerySet({label: '\udbde\uaa70\ud823\u{1fa9d}\u6bb7\u0f78\u0ee3\u1f2d', type: 'occlusion', count: 69});
+let textureView6 = texture7.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder9 = commandEncoder27.beginRenderPass({
+  label: '\u0bf5\u4602\ubcf4\ub0ec\u0da3\ufb14',
+  colorAttachments: [{view: textureView5, depthSlice: 177, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet0,
+});
+let externalTexture3 = device0.importExternalTexture({label: '\u99bf\u{1fdb0}\u1720\u8621\u9883\u02d8\u{1fc76}', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer2, 'uint32', 1_732, 2_093);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 8_778, 5_488);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView7 = texture3.createView({
+  label: '\u848d\u51cb\u354c\ue007\ua8df\u{1fbde}\ud42f',
+  dimension: '2d-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+let renderBundle17 = renderBundleEncoder1.finish({label: '\u04dd\u876a\u41f6\u9996\u{1fbc2}'});
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer0, 'uint32', 2_280, 4_057);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer0);
+} catch {}
+let arrayBuffer0 = buffer1.getMappedRange(1448, 8);
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(20), /* required buffer size: 20 */
+{offset: 20, rowsPerImage: 3}, {width: 82, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\uf12d\u07d5\u0158\u81bb\u77b7\u0065\ue929\u0bf6',
+  size: 11847,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f7a5}\u0874\u3617\u{1fec5}\u0f2d\u2c62\u5307\u1bf2\u0d20\ufc3d',
+  colorFormats: ['rgba16sint'],
+});
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer0, 7_544, 2_325);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 221, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({label: '\u{1f754}\uc7a5'});
+let renderPassEncoder10 = commandEncoder28.beginRenderPass({
+  label: '\uc32e\u0999\ube0a\u132d\u5e37\u06e0\u09c5\u{1f81b}\u6ee8\u{1f614}',
+  colorAttachments: [{
+  view: textureView7,
+  clearValue: { r: -182.7, g: -194.7, b: 557.6, a: -653.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint32', 1_724, 1_334);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(3, buffer0, 264, 6_196);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 181, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3096 widthInBlocks: 387 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3936 */
+  offset: 3936,
+  buffer: buffer2,
+}, {width: 387, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(141), /* required buffer size: 141 */
+{offset: 141, bytesPerRow: 265}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let querySet3 = device0.createQuerySet({label: '\u8c6c\u5716', type: 'occlusion', count: 1217});
+let commandBuffer16 = commandEncoder22.finish({});
+let texture9 = device0.createTexture({
+  label: '\u{1fad2}\u{1fd2f}\u0d12\u0628\u04e4\u4e0b\u{1fb55}\u036b',
+  size: [1440],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setIndexBuffer(buffer2, 'uint16', 15_824, 3_315);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer0, 0, 2_625);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img0);
+await gc();
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1, commandBuffer12]);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 57});
+let commandBuffer17 = commandEncoder29.finish({label: '\u83d9\u{1faf2}\u9f2d\u0a71\ub1a8\u0b13'});
+try {
+renderPassEncoder7.executeBundles([renderBundle10, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+document.body.prepend(video0);
+let texture10 = device0.createTexture({
+  label: '\u8c35\u14c1\ubaf2\u0a28\u{1fb57}\u2198\u9bb2\u4f56',
+  size: {width: 360},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({label: '\ud187\u{1fbe2}\ue275\u{1fa23}\u0430\u9cd5', colorFormats: ['rg16float'], depthReadOnly: true});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 1_224, 7_601);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, undefined);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder();
+let commandBuffer18 = commandEncoder30.finish();
+let sampler1 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMinClamp: 32.77,
+  lodMaxClamp: 39.39,
+});
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer0, 0, 4_843);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+let texture11 = device0.createTexture({
+  label: '\u0f67\u0769\udd42',
+  size: [360, 7, 18],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer0, 0, 2_959);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 1_460, 407);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 824, new Int16Array(41047), 8128, 588);
+} catch {}
+try {
+  await promise8;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u5cfd\u0cfb\u842b\uac07\u0f8e\u9857'});
+let textureView8 = texture8.createView({label: '\ub283\u0c74\u8822\u{1f8fc}\u0f3f\u1558\u0b40'});
+let renderBundle18 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer0, 0);
+} catch {}
+let renderBundle19 = renderBundleEncoder4.finish({label: '\ue703\u4025\ude96\u08d2\u{1faa3}\u663b\u0d3a'});
+try {
+computePassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer15, commandBuffer11]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 1148, new BigUint64Array(946), 79, 320);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u6a8d\u0194\u{1fd8b}\u{1f9b7}',
+  entries: [{binding: 109, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }}],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1, bindGroupLayout4, bindGroupLayout5]});
+let commandEncoder32 = device0.createCommandEncoder({label: '\u0ea9\u0496\u0e89\u023b\u0b44'});
+let commandBuffer19 = commandEncoder31.finish({label: '\u08a5\u48cd\ud9e7\u8de2\ue8a2\u{1fa75}\u0c0b\u{1fb48}\u07b2'});
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 768, 240);
+} catch {}
+let renderPassEncoder11 = commandEncoder32.beginRenderPass({
+  label: '\u00e8\u0980\u05c2\u70d0',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 312,
+  clearValue: { r: 101.8, g: 216.3, b: -315.5, a: 149.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 66322193,
+});
+try {
+device0.queue.submit([commandBuffer14, commandBuffer9, commandBuffer19]);
+} catch {}
+try {
+  await promise6;
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let querySet5 = device0.createQuerySet({label: '\u02c7\u{1f9c3}\u5dc6\u{1fe93}\u4586', type: 'occlusion', count: 1148});
+try {
+computePassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle17, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer0, 7_120);
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer0, 'uint32', 3_392, 4_580);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer0, 6_984, 444);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer0, 'uint32', 1_176, 996);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let renderBundle20 = renderBundleEncoder5.finish({label: '\u0fc1\u5db1'});
+try {
+renderPassEncoder10.executeBundles([renderBundle19, renderBundle10, renderBundle19, renderBundle14]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let texture12 = device0.createTexture({
+  label: '\u0fc7\u6d79\u0ee3\ud6c6',
+  size: [180, 3, 145],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer0, 0, 9_359);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder33 = device0.createCommandEncoder({label: '\u{1fcb4}\u0e06\uaad1\u1da2\u573b'});
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(244), /* required buffer size: 244 */
+{offset: 244}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({label: '\u03d8\u0a73\u1c1a\ua1b7\ueb62\u29f0\ue8de'});
+let renderBundle21 = renderBundleEncoder4.finish({label: '\u{1fdbb}\u{1fdd1}\u5212\u0406\u{1f7a8}\u074c\ua56b\u0c26\ud46f'});
+let externalTexture4 = device0.importExternalTexture({
+  label: '\u{1fe11}\u0a6a\u{1ff10}\u52b0\u1f17\ud900\u{1fdc9}\u97b5',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer3, 3060, 2604);
+} catch {}
+let renderPassEncoder12 = commandEncoder34.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 329,
+  clearValue: { r: -351.6, g: 593.3, b: -981.2, a: 255.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 65382093,
+});
+try {
+renderPassEncoder7.setViewport(1099.6710748408582, 24.273008113067306, 10.3549521348073, 1.0095248105147685, 0.7897272290726387, 0.969375238386794);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer2);
+} catch {}
+let querySet6 = device0.createQuerySet({label: '\u{1fc5d}\u6338\u8f06\u7308\ue9de', type: 'occlusion', count: 599});
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(buffer0, 2360, buffer2, 1424, 3500);
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker('\u77f8');
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(50, 3);
+try {
+offscreenCanvas0.getContext('webgl');
+} catch {}
+let texture13 = device0.createTexture({
+  size: [360],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder13 = commandEncoder33.beginRenderPass({
+  label: '\u02ee\uca1d',
+  colorAttachments: [{
+  view: textureView6,
+  depthSlice: 12,
+  clearValue: { r: 538.5, g: 348.9, b: -160.3, a: 302.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 27175688,
+});
+try {
+renderPassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 776 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1120 */
+  offset: 1120,
+  buffer: buffer1,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 192, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 97, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+let commandBuffer20 = commandEncoder16.finish({label: '\u02c0\u3ed0\u01dc\u056e\u{1fbc5}\u5483\uc388\u{1f97a}'});
+let renderBundle22 = renderBundleEncoder0.finish({label: '\u15fb\u{1f71c}\u0430\u0221\u{1f608}\ub1a0'});
+let sampler2 = device0.createSampler({
+  label: '\u9998\u637d\u08bb\u4a95\u4d25\u{1f84a}\u0ba5\ub422\uced1\u985b\uef3e',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 44.00,
+});
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\u{1fab8}\u9d4a'});
+try {
+renderPassEncoder6.setIndexBuffer(buffer2, 'uint16', 2_212, 2_649);
+} catch {}
+let imageBitmap0 = await createImageBitmap(video0);
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u7cc3\u883d\u{1f61b}\u5e8b\uac8f\u{1f813}\u{1fd9b}\u045e\u{1f828}\u6fea',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0],
+});
+let commandEncoder36 = device0.createCommandEncoder();
+let computePassEncoder6 = commandEncoder35.beginComputePass({label: '\u5eb5\u{1fe83}\u69cb\uf2cb\uf8be\u{1f7f6}'});
+let sampler3 = device0.createSampler({
+  label: '\ub9c5\ud4b9\u5ea9\u0f52',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.65,
+});
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 318, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3992 widthInBlocks: 499 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 272 */
+  offset: 272,
+  rowsPerImage: 39,
+  buffer: buffer2,
+}, {width: 499, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\uf861\u0a2f\uf5c8\uee06\ud239',
+  entries: [
+    {
+      binding: 141,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 77,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 401,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 14880408, hasDynamicOffset: false },
+    },
+    {binding: 173, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 294,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 255,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 74,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 187,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 227,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 26110922, hasDynamicOffset: false },
+    },
+    {binding: 129, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 146,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 76, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 149,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 70, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 268,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 164,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 416,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 7, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 111, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 29,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 311,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 266,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 22456409, hasDynamicOffset: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 93,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 135,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 137,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 483,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 45542575, hasDynamicOffset: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 159, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+  ],
+});
+let computePassEncoder7 = commandEncoder36.beginComputePass({});
+let externalTexture5 = device0.importExternalTexture({label: '\u0dd9\u080e\u0a23\ufc85', source: videoFrame0});
+try {
+renderPassEncoder7.setViewport(1228.1455372601413, 24.1368653521128, 15.6286830433634, 0.47510434040127, 0.21152675077228644, 0.9770548767557943);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(81, 7);
+let commandEncoder37 = device0.createCommandEncoder({label: '\u{1fc13}\u0a4c\u07c6\u0232\udcbc\u1d4d\u{1f647}\uffc7\u0f42\uc76b\u097f'});
+let commandBuffer21 = commandEncoder37.finish({label: '\u389e\ubddf\u0b28\uf2db\u2c46\ucb53\u0af7\u{1f9e2}'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder6.setIndexBuffer(buffer2, 'uint16', 4_664, 6_050);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(7, undefined, 674_568_069, 822_964_363);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21]);
+} catch {}
+await gc();
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u{1fe64}\u070a\u5293\u7afd\u{1ff3c}\u{1fc41}\u280c\u{1f732}\u0665\u39a0\u0f4b',
+  entries: [{binding: 229, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u0610\u1f71\u269c\u05a1\u09bc\u01ef\u{1ffd2}\u040c\ub9c5', bindGroupLayouts: []});
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer0, 0, 1_786);
+} catch {}
+let arrayBuffer1 = buffer3.getMappedRange(776, 36);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+video0.width = 31;
+try {
+renderPassEncoder4.executeBundles([renderBundle8, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(171.393035060843, 8.07837178646502, 663.0262052934136, 15.637097994301602, 0.493155343599711, 0.972189677812098);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer2, 'uint32', 216, 6_643);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(20), /* required buffer size: 20 */
+{offset: 20, rowsPerImage: 30}, {width: 329, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], stencilReadOnly: true});
+let renderBundle23 = renderBundleEncoder4.finish({label: '\u{1fb4b}\uff97'});
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 18},
+  aspect: 'all',
+}, new ArrayBuffer(89_457), /* required buffer size: 89_457 */
+{offset: 177, bytesPerRow: 465, rowsPerImage: 12}, {width: 95, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let querySet7 = device0.createQuerySet({label: '\u2f00\u0f16\ue4b0\u7771\uad5a\u{1fc26}\u0a66\u00ca', type: 'occlusion', count: 1293});
+let computePassEncoder8 = commandEncoder38.beginComputePass({label: '\u0982\u02b3\u0fbc\u07e3\u{1fcfd}\u{1fc9e}\u65d2\uc973\u4f5d\u05d1'});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({label: '\u6ce6\u62c7\u{1f6cd}', type: 'occlusion', count: 627});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer0, 4_008, 4_066);
+} catch {}
+let promise10 = shaderModule1.getCompilationInfo();
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 105, y: 13, z: 86},
+  aspect: 'all',
+},
+{width: 383, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let externalTexture6 = device0.importExternalTexture({label: '\u0710\u7c22\u0e17', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer2, 'uint32', 2_056, 2_191);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer0, 208, 20);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+let commandBuffer22 = commandEncoder39.finish({});
+try {
+computePassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle11, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(287, 11, 59, 2);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData2 = new ImageData(116, 72);
+let commandBuffer23 = commandEncoder36.finish({label: '\ueff3\u{1ff2a}'});
+let texture14 = device0.createTexture({
+  label: '\u6221\uab9a\u763c\ub3ed\u03c0\u6eee\u03c9',
+  size: {width: 1440},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle24 = renderBundleEncoder5.finish({label: '\u{1facd}\uf900\u7ebe'});
+try {
+renderPassEncoder4.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 11, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(245), /* required buffer size: 245 */
+{offset: 245, bytesPerRow: 2073}, {width: 257, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u9838\u21fa\u1c88\u0578\u86d9\ud28b\u{1f7e9}\u0f9c\u{1f915}'});
+let renderPassEncoder14 = commandEncoder35.beginRenderPass({
+  label: '\u523f\u7cb5\u2a3a\u109d\uf186\ueb44\ude4b\uf461',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 335,
+  clearValue: { r: -329.6, g: 878.2, b: -320.2, a: 518.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+try {
+renderPassEncoder14.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer0, 4_052, 109);
+} catch {}
+try {
+commandEncoder40.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 784 */
+  offset: 784,
+  buffer: buffer2,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+  await promise11;
+} catch {}
+let commandBuffer24 = commandEncoder40.finish();
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer0, 3_012);
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({label: '\u{1fd48}\u{1fdec}\u0eae\ub593', layout: pipelineLayout0, compute: {module: shaderModule0}});
+await gc();
+try {
+renderPassEncoder14.beginOcclusionQuery(60);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({label: '\u0711\ufa76'});
+let commandBuffer25 = commandEncoder41.finish({label: '\uba04\u0b38\ud198\u0f2b\u{1f6e1}\u888d\u{1f828}\u{1f671}'});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer2, 'uint16', 762, 2_490);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer0, 0, 1_596);
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\uf04a\u5b9c\uafaa\u0418\ud898\u3d5c\u03b5\u2241'});
+let commandBuffer26 = commandEncoder42.finish({label: '\u02d0\uff85\u{1ff9d}\u08d7\u{1fc2c}'});
+let textureView9 = texture7.createView({
+  label: '\u4626\u01f0\u{1f983}\u0b1c\u794b\u33e6\u{1fbdf}\u00d4\u{1f997}\u{1fc60}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundle25 = renderBundleEncoder1.finish({label: '\u0e52\u36a1\u6f4b\u0cb6\ufae4\u076d\u{1fb59}\u893b\u44ec'});
+try {
+renderPassEncoder14.beginOcclusionQuery(27);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer2, 'uint16', 154, 8_816);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter1.label = '\u4ada\u8a2e\u58e6\u{1fdc1}\ua478\u0750\u00a0\u9946';
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u48d6\u07d1\ucdd7\u0b20\u{1f771}',
+  entries: [
+    {
+      binding: 18,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({label: '\u071f\ubb9b\uacb7', colorFormats: ['rgba16sint']});
+try {
+renderPassEncoder7.setPipeline(pipeline6);
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer4 = device0.createBuffer({
+  label: '\u{1f71c}\u0be6\u069b\u{1fe46}\uf431',
+  size: 27466,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u098a\ufc0c\ua8c2\uc188\u{1fd1b}\udebb\u{1fe51}\ud42f',
+  colorFormats: ['rg16float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer4, 'uint32', 88, 9_185);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer4, 'uint16', 2_748, 3_751);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+  await promise12;
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u0cd9\uf60e\uaff6\u6bc6\uee19\u0f4a\u0c81\uca65',
+  entries: [
+    {
+      binding: 139,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer5 = device0.createBuffer({
+  label: '\ucab5\ub1b1\u0320',
+  size: 8275,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder43 = device0.createCommandEncoder({label: '\ude5f\u39a1\ue04c\uf1bb\ud1bd\uebf6\ub599\ua35d\ua654\u34da'});
+let commandBuffer27 = commandEncoder43.finish({});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer4, 'uint16', 14_650, 2_885);
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({label: '\u6108\ub254\u60b1\u{1fea5}\u{1f9e8}\u{1fe45}\u{1f90b}'});
+let textureView10 = texture10.createView({label: '\u{1ff40}\ued8e', dimension: '1d'});
+try {
+computePassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint32', 2_344, 7_032);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer5, 248, 2_481);
+} catch {}
+try {
+externalTexture0.label = '\u0588\u34a4';
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u{1f70e}\u{1f7a9}\u{1fb8e}\u0714\ubdda'});
+let renderPassEncoder15 = commandEncoder44.beginRenderPass({
+  label: '\u6bff\ub2e7\u876c\u0f19',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 14,
+  clearValue: { r: 739.8, g: -262.1, b: 309.5, a: 68.89, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 178410385,
+});
+let renderBundle26 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(104, 0, 64, 8);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 512 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 128 */
+  offset: 128,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer4, 3_176, 27);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer4, 'uint32', 1_412, 1_522);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 3040 widthInBlocks: 380 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1872 */
+  offset: 1872,
+  buffer: buffer0,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 116, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 380, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2104 widthInBlocks: 263 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 304 */
+  offset: 304,
+  bytesPerRow: 2304,
+  rowsPerImage: 113,
+  buffer: buffer5,
+}, {width: 263, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({label: '\u6346\u4c4a\u{1fce1}', type: 'occlusion', count: 606});
+let renderBundle27 = renderBundleEncoder1.finish({label: '\u3622\u0cfc\u9fcc\u059d\u0849'});
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer4, 0, 4_214);
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(buffer5, 1272, buffer3, 6000, 2740);
+} catch {}
+let imageData3 = new ImageData(8, 16);
+let commandBuffer28 = commandEncoder38.finish({label: '\u4550\udc04\u856c'});
+let sampler4 = device0.createSampler({
+  label: '\u7533\u00fc\u1da2\u0f8c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 79.78,
+  compare: 'equal',
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({
+  label: '\u0356\udf38\u720b\u0c07\u{1fbdf}\u{1f80e}\u{1f8ad}\u{1fc9c}\u383a\u1dc0\u1bdf',
+  type: 'occlusion',
+  count: 150,
+});
+let commandBuffer29 = commandEncoder47.finish({});
+let computePassEncoder9 = commandEncoder46.beginComputePass({label: '\u{1ffe7}\uac44\u6fc6\u0252\ua5f7\ud662\u0e77'});
+let renderBundle28 = renderBundleEncoder6.finish({label: '\u34af\u9c12\u0e67\u4ea5\u{1fa9f}'});
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint32', 2_424, 1_494);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27]);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+video1.width = 40;
+let bindGroup0 = device0.createBindGroup({label: '\u7514\u076d\uf3cb\u2c0d', layout: bindGroupLayout4, entries: []});
+let buffer6 = device0.createBuffer({
+  label: '\uc0bd\uf7e1\u{1f6da}\u8021\u88cd\uabee',
+  size: 11518,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder49 = device0.createCommandEncoder({label: '\u0d12\u7b79\ue64e\u2695\u{1f912}'});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup0, new Uint32Array(699), 3, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(1371);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint32', 5_980, 3_903);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({label: '\u08b0\u0ef1\u310a\u495f\u6fda\u0413\u4588\ufd33'});
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint32', 1_244, 2_120);
+} catch {}
+try {
+commandEncoder49.copyBufferToBuffer(buffer1, 1412, buffer4, 11244, 3344);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer5, 72, 432);
+} catch {}
+try {
+renderBundleEncoder9.insertDebugMarker('\u85b4');
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({label: '\u6396\u052c\u3723\uf6c4'});
+let commandBuffer30 = commandEncoder49.finish({});
+let computePassEncoder10 = commandEncoder51.beginComputePass({label: '\u061e\u4497\u{1f8e9}\ua015\u1ed2\ubefc\u988d\u5bcb\u{1f9ff}\u4165\u2ae9'});
+let renderPassEncoder16 = commandEncoder48.beginRenderPass({
+  label: '\u{1f7e5}\u33e8\u3270\u0e73\u0eb0\u0309\u6b0e\u823c\ua78d\u922b',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 155,
+  clearValue: { r: -211.1, g: -888.4, b: 514.4, a: 510.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup0, new Uint32Array(600), 70, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer2, 'uint32', 1_500, 1_215);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 90, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder17 = commandEncoder50.beginRenderPass({
+  label: '\ue045\uef4c\ubf19\u018b\ufca3\uea69\u67d9\u37a3\u6131\u7a61\u06a8',
+  colorAttachments: [{
+  view: textureView7,
+  clearValue: { r: 506.4, g: 272.1, b: -237.2, a: -602.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(2588), 785, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let computePassEncoder11 = commandEncoder45.beginComputePass({label: '\u{1f7ae}\u3f57\u{1f740}\u45be\ua5ec\u{1f74c}\u{1f8e7}\u4153\u0c5e\u0498'});
+let renderBundle29 = renderBundleEncoder3.finish({label: '\ud69b\u{1fab2}\u5446'});
+try {
+device0.queue.submit([commandBuffer25, commandBuffer30]);
+} catch {}
+try {
+adapter1.label = '\u{1fe5d}\u6ed5\ube15\u1859\u0d16\uec70';
+} catch {}
+let texture15 = device0.createTexture({
+  label: '\u05f4\u{1f65a}\u0b52\u354c',
+  size: [720],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer4, 'uint16', 7_330, 166);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint16', 7_170, 6_650);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 380, new BigUint64Array(36071), 1903, 60);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup0, new Uint32Array(97), 6, 0);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(520);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup0, new Uint32Array(861), 60, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer28]);
+} catch {}
+await gc();
+let renderBundle30 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer5, 0, 1_044);
+} catch {}
+try {
+renderPassEncoder16.insertDebugMarker('\u7bf9');
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u012f\u{1ffbb}\u99b4\u057b\u{1f9bc}\ub785\u05bd\u07ed',
+  entries: [
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 15777095, hasDynamicOffset: false },
+    },
+    {binding: 103, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+  ],
+});
+let externalTexture7 = device0.importExternalTexture({label: '\u00c2\u069a\u08ac\u4a51', source: video0});
+try {
+renderBundleEncoder9.setIndexBuffer(buffer2, 'uint32', 6_308, 859);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer0, 5_640);
+} catch {}
+let imageData4 = new ImageData(196, 8);
+let buffer7 = device0.createBuffer({
+  label: '\u0ae2\u0185\u91e5\ue43a\ua421\u{1fd2d}',
+  size: 1502,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer4);
+} catch {}
+let arrayBuffer2 = buffer3.getMappedRange(768, 0);
+try {
+commandEncoder45.copyBufferToBuffer(buffer5, 580, buffer3, 1408, 2444);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 24, y: 6, z: 208},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({label: '\uf1fc\u{1f646}'});
+let commandBuffer31 = commandEncoder52.finish({label: '\u{1ffd2}\u6340\u1dc1\u06fb\u08f6'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup0, new Uint32Array(18), 4, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle23]);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({label: '\u0c02\udeab', bindGroupLayouts: [bindGroupLayout6]});
+let commandEncoder53 = device0.createCommandEncoder({label: '\u2f06\u2228\u04c6\u6fca\u0b91'});
+try {
+renderPassEncoder10.executeBundles([renderBundle6, renderBundle23]);
+} catch {}
+document.body.prepend(video0);
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u{1fc1a}\u2b9a\u7d2b\u92db\u1f56\u95cb\u6647\u2411',
+  entries: [
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u0d3f\u{1fb71}\u{1fd41}\uc699\u27ac\ua2b8\u88e8'});
+let renderPassEncoder18 = commandEncoder45.beginRenderPass({
+  label: '\u0d78\u4f2b\u01f6\u6e14',
+  colorAttachments: [{view: textureView6, depthSlice: 4, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet5,
+});
+try {
+renderPassEncoder4.setIndexBuffer(buffer2, 'uint32', 5_624, 652);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer4, 540, 3_288);
+} catch {}
+try {
+device0.queue.submit([commandBuffer22, commandBuffer29, commandBuffer26]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(107), /* required buffer size: 107 */
+{offset: 107, bytesPerRow: 122}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(4, 40);
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer0, 3_956, 11_105);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer5, 0, 516);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer5, 224, 1024);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u{1fc44}\u953a\u0588\u{1fa83}\u{1f7c2}\uc160\u0ecb\u087e\u5e53\u{1fb70}\u1e3a',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout1],
+});
+let commandEncoder55 = device0.createCommandEncoder({label: '\u11b3\u09f3\u58c3\u{1f9a9}'});
+let renderBundle31 = renderBundleEncoder5.finish({label: '\u0ed9\u{1fc4b}\u2b78\u0dad\u{1fa3f}\u{1fc10}\u67c0'});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer4, 'uint16', 10_470, 3_484);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer4, 22_464, 849);
+} catch {}
+try {
+texture13.destroy();
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let renderPassEncoder19 = commandEncoder54.beginRenderPass({
+  label: '\u{1fe75}\u70aa\u5929\u0d0e\u19ba\ud453\uc40d\udad4\u0ce2\u7c01\u80c5',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 10,
+  clearValue: { r: 695.4, g: 422.3, b: 76.40, a: -980.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder15.setIndexBuffer(buffer2, 'uint16', 2_306, 839);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer7, 460);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 0, 584);
+} catch {}
+try {
+commandEncoder55.insertDebugMarker('\u{1fba1}');
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageBitmap0);
+let commandBuffer32 = commandEncoder53.finish({label: '\u022b\u0397\u02a4\u307a\u0f3a'});
+let renderPassEncoder20 = commandEncoder55.beginRenderPass({
+  label: '\u{1fdab}\u8f29',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 0,
+  clearValue: { r: -286.8, g: 794.7, b: -470.4, a: 459.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer4, 'uint32', 2_448, 11_175);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, undefined, 383_931_320, 314_503_445);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint32', 928, 5_318);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer7, 0, 255);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(3, buffer4);
+} catch {}
+let querySet11 = device0.createQuerySet({label: '\u0d83\u{1fd24}\u002b', type: 'occlusion', count: 536});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup0, new Uint32Array(3478), 298, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline9 = device0.createComputePipeline({label: '\u02b1\u0dd2\ud7e1', layout: pipelineLayout0, compute: {module: shaderModule0}});
+let commandEncoder56 = device0.createCommandEncoder({label: '\udcce\u0e6f\u2b93\u0868\u9e84\u0237\u1764\u00ae\u00f5'});
+let commandBuffer33 = commandEncoder56.finish({label: '\u5947\u{1f912}\u{1fc6d}\ua31a\u0ace\uec0f\u95c2\u32bc\u0e61\u0f7c'});
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer5);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer4, 8_952, 404);
+} catch {}
+let arrayBuffer3 = buffer1.getMappedRange(32, 52);
+document.body.prepend(canvas0);
+let canvas1 = document.createElement('canvas');
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u0354\uaf0d\u{1f7f5}\u872b\u1dc4\u9f75\u015c\ue311\u{1fa67}\u{1fb41}',
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u4289\u04b7\u524a\u3ff9\u{1fe49}\u{1fdb6}\u0797'});
+let renderBundle32 = renderBundleEncoder7.finish({label: '\u07e2\uf5d3\ue061'});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer5, 652, 34);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer7, 52, buffer6, 6832, 356);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u{1fb39}\udca4\u{1ff2f}\u0ffb',
+  code: `
+enable f16;
+enable f16;
+enable f16;
+
+struct T0 {
+  f0: atomic<u32>,
+}
+
+@group(0) @binding(117) var tex2: texture_2d_array<f32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_index) a0: u32, @builtin(workgroup_id) a1: vec3u, @builtin(local_invocation_id) a2: vec3u, @builtin(global_invocation_id) a3: vec3u) {
+}
+
+struct VertexOutput0 {
+  @location(0) f1: vec4i,
+  @builtin(position) f2: vec4f
+}
+
+@vertex
+fn vertex0(@location(1) a0: u32, @builtin(vertex_index) a1: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(6) @interpolate(flat, sample) f0: vec4u,
+  @location(0) f1: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer34 = commandEncoder57.finish({label: '\u{1f63a}\ufb74\u5527\uce2d'});
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer4, 6_584, 106);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint16', 3_264, 4_460);
+} catch {}
+try {
+computePassEncoder9.insertDebugMarker('\u{1fb86}');
+} catch {}
+try {
+device0.queue.submit([commandBuffer32, commandBuffer34]);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  label: '\u{1fd86}\u9afa',
+  layout: bindGroupLayout2,
+  entries: [{binding: 33, resource: {buffer: buffer0, offset: 3584, size: 19456}}],
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u08cf\u{1fb38}\u09f6\uc84b\u91d1\u0d06\u0527\u40d3\ude7b\u00e8',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle7]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  label: '\u{1f879}\u0ad2\u{1ff54}\u{1fd36}\u0c28\u8e89\u753f\u6168\u9449',
+  size: [180, 3, 206],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture17 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder21 = commandEncoder58.beginRenderPass({
+  label: '\u7204\u{1f6e7}\u059c',
+  colorAttachments: [{view: textureView9, depthSlice: 11, loadOp: 'clear', storeOp: 'store'}],
+});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5280 widthInBlocks: 660 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4160 */
+  offset: 4160,
+  buffer: buffer4,
+}, {width: 660, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+try {
+device0.queue.submit([commandBuffer31]);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+let imageData6 = new ImageData(68, 64);
+let commandBuffer35 = commandEncoder51.finish({label: '\u08a6\uffa5\u3a27\u6409\u14a1\uf2e6\ufb83\u0591\u0d46'});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer7, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer0, 1344, buffer3, 3504, 1088);
+} catch {}
+try {
+  await promise3;
+} catch {}
+try {
+commandBuffer5.label = '\u012d\u0618\u207b\u0d01\u2779\u018c';
+} catch {}
+let buffer8 = device0.createBuffer({
+  label: '\u{1ffac}\u0dc8\u00f5\u{1fc0b}\u0a37\u8c4d\u{1fe7f}',
+  size: 6380,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder10.setIndexBuffer(buffer4, 'uint16', 4_844, 509);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer0, 'uint16', 6_714, 10_316);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer0, 0, 847);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer5, 4904, 780);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas2 = document.createElement('canvas');
+let computePassEncoder12 = commandEncoder46.beginComputePass({label: '\u814d\u986f'});
+let renderBundle33 = renderBundleEncoder5.finish({});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer4, 'uint16', 1_696, 5_622);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer35]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 182, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(119), /* required buffer size: 119 */
+{offset: 119}, {width: 358, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise13 = navigator.gpu.requestAdapter({});
+let commandEncoder59 = device0.createCommandEncoder();
+let renderPassEncoder22 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 25,
+  clearValue: { r: 421.9, g: -955.8, b: 714.1, a: 912.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler5 = device0.createSampler({
+  label: '\ufc75\u{1fd64}\ud8ac\ud40d\u9606\u58a7\u2e32\u{1ffa2}\u0e37\u8060',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 54.68,
+  lodMaxClamp: 97.82,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer2, 'uint16', 5_260, 9_248);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint16', 1_616, 275);
+} catch {}
+let textureView11 = texture16.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle34 = renderBundleEncoder7.finish();
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(181), /* required buffer size: 181 */
+{offset: 181}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture18 = device0.createTexture({
+  label: '\u5668\u{1f9f9}\u222b\uaac0\u{1fd08}\u35e6\u0fa6\u067f\ucfd4\u{1fe0b}\u6cc5',
+  size: [720, 14, 675],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup1, new Uint32Array(593), 14, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(268.45970246976225, 2.394701866902885, 45.388248283328345, 2.030956860082344, 0.7229068763754571, 0.9468743504183386);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer0, 'uint16', 3_732, 938);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer2, 'uint32', 4_500, 3_620);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(247), /* required buffer size: 247 */
+{offset: 247}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let commandEncoder60 = device0.createCommandEncoder();
+let commandBuffer36 = commandEncoder60.finish({label: '\u3ed9\ud0ac\u771a\u0369\uf1f0\u041b\u0858\u1e99\uc566'});
+let externalTexture8 = device0.importExternalTexture({label: '\u{1fa04}\u{1f786}\u808d\u6a63', source: video1});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(309), 27, 0);
+} catch {}
+try {
+adapter1.label = '\u5ca9\u6dde\uda0e\u7495';
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup0, new Uint32Array(1614), 669, 0);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline7);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({label: '\u0fd5\u0309\u3627\u9c67\u2f99\ub74e\u4fd6\u{1fa1a}'});
+let textureView12 = texture0.createView({label: '\u6ff4\u{1fb49}\u{1fdb1}\u{1fceb}\u{1fe06}\udbcb\u32b3\u0431\u77a2\u8416'});
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 1816, 1528);
+} catch {}
+try {
+externalTexture8.label = '\u8519\u8306\uf1a9\u0c29\udd03\u0cbb\u2f04\u0611\u09f7';
+} catch {}
+let renderPassEncoder23 = commandEncoder61.beginRenderPass({
+  label: '\u0d20\uef86',
+  colorAttachments: [{view: textureView6, depthSlice: 8, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet0,
+});
+let renderBundle35 = renderBundleEncoder2.finish({label: '\u{1f6db}\u{1f944}\uada9\ucabe\u012e\u085e\u5cdf\u{1f69b}'});
+try {
+renderPassEncoder17.setIndexBuffer(buffer2, 'uint32', 14_748, 793);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer8, 1_024, 364);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 180, new Int16Array(26125), 4265, 72);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\u4da4\u0351\u0678\u1d63\u008c\u0d0c\uc4a6\u0837\u0cde'});
+let textureView13 = texture15.createView({label: '\ude6d\u{1fa73}\ufaf1\ucb60\u1e71\u8bb5\u0b98'});
+let renderBundle36 = renderBundleEncoder7.finish({label: '\u0447\u4c26\u0ce9'});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup1, new Uint32Array(1450), 631, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer4, 3_396, 2_581);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer4, 0, 7_889);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 111});
+let renderBundle37 = renderBundleEncoder6.finish();
+try {
+renderPassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\ua1bb');
+} catch {}
+let buffer9 = device0.createBuffer({
+  label: '\u{1fcca}\ufe24\ue4cf\u0c16\udaa1\u0193\u{1fbb8}\u11a7\u0c14',
+  size: 1623,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer37 = commandEncoder62.finish({label: '\u30ea\u4722\u0127\u{1fd9c}'});
+let renderBundle38 = renderBundleEncoder0.finish({label: '\u{1fe9a}\u0faf\u7613\u{1fac2}\u1f29\u0a82\ud04a\u426d\u{1feee}'});
+try {
+computePassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup0, new Uint32Array(175), 2, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer9, 'uint32', 8, 96);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(1, buffer7);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer4, 'uint32', 3_236, 1_754);
+} catch {}
+let texture19 = device0.createTexture({
+  label: '\u7afb\u0c9d\u{1fbdd}\u803b',
+  size: {width: 360, height: 7, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer2, 'uint16', 5_022, 303);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, undefined, 15_574_371, 623_354_561);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout12, bindGroupLayout12]});
+let texture20 = device0.createTexture({
+  label: '\u5347\u{1ff9c}',
+  size: [180],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup0, new Uint32Array(255), 24, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer9, 'uint16', 16, 97);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer9);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 212, new BigUint64Array(3955), 388, 0);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(3, buffer4, 4_152);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(0, buffer4, 0);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer37]);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: -39.25, g: 486.8, b: 165.5, a: -439.1, });
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint16', 3_556, 288);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer5);
+} catch {}
+let texture21 = device0.createTexture({
+  label: '\u2cc8\u0534\u5166\u{1ffa1}\u8ac8\u0e1c\u0764\u7959\u011a\u3abf\u0844',
+  size: {width: 360, height: 7, depthOrArrayLayers: 40},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView14 = texture3.createView({label: '\u068d\uc410\u420a\u{1f986}\uf29a\uabcc\u0db0\u{1fe28}\ueadb\uf8f6\u260d', mipLevelCount: 1});
+try {
+renderPassEncoder17.beginOcclusionQuery(64);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer2, 'uint16', 14_326, 368);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 290, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1_000), /* required buffer size: 1_000 */
+{offset: 1000}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle39 = renderBundleEncoder10.finish({label: '\u{1fab7}\u{1fbb9}\u{1f69f}\u37bf\u{1fe4e}'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup0, new Uint32Array(2597), 260, 0);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer9, 'uint32', 24, 104);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise14;
+} catch {}
+document.body.prepend(img0);
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let renderBundle40 = renderBundleEncoder3.finish({label: '\u{1fe4d}\u9fdf\u1056\ubf6b\u0672\u4b16\u0625\u0a99\u65f2'});
+try {
+computePassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer9, 'uint32', 136, 35);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer4, 3_764, 2_755);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint32', 2_984, 2_738);
+} catch {}
+let arrayBuffer4 = buffer1.getMappedRange(184, 60);
+let querySet13 = device0.createQuerySet({label: '\u3d40\u{1ff20}\u5f12\u7748\u994d\ua935\u0652\u00e9', type: 'occlusion', count: 389});
+let textureView15 = texture7.createView({label: '\u06b2\u41ef\u04da\ubf69\u72ad', baseMipLevel: 2, mipLevelCount: 2});
+let renderBundle41 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup0, new Uint32Array(87), 17, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\u079a');
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+try {
+computePassEncoder12.setPipeline(pipeline5);
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\ub9c2\u{1f800}\ud9c6\ubc9a\u5241\u0804\u0212',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout3, bindGroupLayout0, bindGroupLayout12],
+});
+let commandEncoder63 = device0.createCommandEncoder({label: '\u5a87\u6957\u0688\u{1ffbf}\u0c53\uc25c\ue917\u305a\uee80\u325d\u02f3'});
+let commandBuffer38 = commandEncoder63.finish({label: '\u054c\ube86\u650d\u{1f7d7}\u468b\u04f2\u0570\u{1f9ad}'});
+try {
+renderPassEncoder18.beginOcclusionQuery(396);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(184);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint32', 3_544, 3_327);
+} catch {}
+try {
+device0.queue.submit([commandBuffer33]);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\u0a09\ud3ee\u4297\u8fee\u5173\u4cc2\u{1f7f5}\udb58\ue640\u01a1',
+  layout: bindGroupLayout12,
+  entries: [{binding: 16, resource: {buffer: buffer9, offset: 512, size: 76}}],
+});
+let commandEncoder64 = device0.createCommandEncoder({label: '\u606a\uc902\u0a9b'});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer8, 264);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer8, 544, buffer6, 2588, 208);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer10 = device0.createBuffer({
+  label: '\u6011\u09c0',
+  size: 7681,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+let commandBuffer39 = commandEncoder46.finish({});
+let computePassEncoder13 = commandEncoder64.beginComputePass({});
+try {
+renderPassEncoder13.executeBundles([renderBundle13]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture22 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture9 = device0.importExternalTexture({
+  label: '\u{1fb7f}\uad8e\u0034\u0cbf\ude0b\u07ba\u06fb\u{1f8a7}\u021c\u0e1d\u0f65',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, undefined, 0, 23_689_242);
+} catch {}
+let video2 = await videoWithData();
+let commandEncoder65 = device0.createCommandEncoder({label: '\u04c7\u0b34\u{1fb3d}\u{1fb0c}\ue831\u0731\u4fed\u9a2f\u5a4a\u69cd\ud777'});
+let commandBuffer40 = commandEncoder65.finish({label: '\ub965\ufd3b'});
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+video1.width = 8;
+try {
+computePassEncoder13.setBindGroup(0, bindGroup1, new Uint32Array(4494), 568, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer0, 'uint32', 540, 1_427);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer4, 5_692);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4_294_967_295, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 452, new BigUint64Array(2921), 106, 384);
+} catch {}
+try {
+renderBundle13.label = '\ue0f3\u2771';
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder();
+let commandBuffer41 = commandEncoder66.finish({label: '\u33a8\udafd\u30e7\uf8c8\u47ee\u0b8c\u057f\u090c\u{1fb88}\u03c5\u0202'});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer0, 'uint32', 5_312, 3_933);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint16', 4_568, 75);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer4, 6_212);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u01e6');
+} catch {}
+let renderBundle42 = renderBundleEncoder5.finish({label: '\u0ef2\u270b\u{1fb4a}\u04c9\u{1fbf5}'});
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(7, buffer4, 0, 1_763);
+} catch {}
+let arrayBuffer5 = buffer1.getMappedRange(272, 48);
+let imageData7 = new ImageData(8, 4);
+let shaderModule3 = device0.createShaderModule({
+  label: '\u01e0\u{1f77f}\uee7a\u{1fbe4}\ufaca\u9a92\u58c7\u0229\u1392',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<mat3x3h>,
+}
+struct T1 {
+  f0: vec4f,
+  f1: array<mat4x2f>,
+}
+
+@group(1) @binding(117) var tex3: texture_cube_array<f32>;
+@group(0) @binding(202) var st0: texture_storage_1d<r32float, read_write>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f3: vec4f,
+  @location(6) @interpolate(perspective) f4: vec2f
+}
+
+@vertex
+fn vertex0(@location(13) @interpolate(flat, sample) a0: vec2i, @location(15) a1: vec2u, @location(12) a2: vec4i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = a0;
+  if bool(a0[1]) {
+    var v: vec4f;
+  }
+  if bool(a0[0]) {
+    out.f3 = bitcast<vec4f>(a0.yyyy);
+  }
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(2) @interpolate(flat, sample) f0: vec4f,
+  @location(0) @interpolate(perspective) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f1 = textureLoad(st0, 0);
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let commandEncoder67 = device0.createCommandEncoder({label: '\uc205\u4a38\u8569\u679e\u1ab2\u0d6b\u{1ffcb}\ud7c7\u{1ff82}\udd57\u07e0'});
+let renderPassEncoder24 = commandEncoder67.beginRenderPass({
+  label: '\uc868\u921e\u9228',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 289,
+  clearValue: { r: 528.4, g: 343.2, b: 114.1, a: -636.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+});
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({label: '\u08d0\ud026\ua2d9\u080b\u1e5a\u0cd4\u254f\u{1ff0d}\u{1fe91}\ue265'});
+let texture23 = device0.createTexture({
+  label: '\u3928\u0aec\u0a3e\u0cee\u007c\u{1ffc7}\u09da\u6cc0',
+  size: [180, 3, 39],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder25 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 829.1, g: 902.4, b: -497.2, a: 737.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer4, 0, 6_798);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 968, new Float32Array(1196), 180, 200);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer2, 'uint32', 6_176, 4_907);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup0, new Uint32Array(225), 38, 0);
+} catch {}
+try {
+texture0.destroy();
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let texture24 = device0.createTexture({
+  label: '\uc03d\u{1f792}\u9577\u9809\ub1de\u433c\u57fc\u{1f75e}\u9fc5\u2965',
+  size: [8, 5, 11],
+  dimension: '2d',
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer9, 'uint16', 44, 339);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint32', 8_244, 169);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer9, 0, 408);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({label: '\u6126\u{1f855}\u03e1'});
+let texture25 = device0.createTexture({
+  label: '\u09e1\ue2a7\u0a92\u0041\u1d19\u3f99\ud83e',
+  size: [720, 14, 14],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle43 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup2, new Uint32Array(2120), 572, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer0, 'uint32', 3_628, 435);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+device0.queue.submit([commandBuffer40, commandBuffer36]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({label: '\ufbf0\u0f6a\u330e\u{1fd12}\u{1fe7b}\u2dd8\u0949\u0cb6'});
+let commandBuffer42 = commandEncoder69.finish({});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+texture8.destroy();
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 840 widthInBlocks: 105 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 136 */
+  offset: 136,
+  bytesPerRow: 1024,
+  buffer: buffer5,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 105, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder8.insertDebugMarker('\uefab');
+} catch {}
+document.body.prepend(img0);
+let texture26 = device0.createTexture({
+  size: [360, 7, 4],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView16 = texture23.createView({label: '\u681e\u471f\u{1fe6d}\u9798\u34a3\u08db', baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder26 = commandEncoder70.beginRenderPass({
+  label: '\uc424\u{1fbf4}\uad57\u{1f744}\u98a2\ue50d\u1369',
+  colorAttachments: [{view: textureView16, depthSlice: 8, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 41854628,
+});
+let renderBundle44 = renderBundleEncoder8.finish({label: '\u2f4a\ub93d'});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup0, new Uint32Array(216), 5, 0);
+} catch {}
+try {
+renderPassEncoder16.pushDebugGroup('\u{1f710}');
+} catch {}
+let imageData8 = new ImageData(104, 80);
+let commandEncoder71 = device0.createCommandEncoder({label: '\u7677\u{1fc05}\u0847\uac45'});
+let computePassEncoder14 = commandEncoder71.beginComputePass({label: '\u2adc\u0fae\u0b90\ude3d\u0afe\u8f12\ua22a\u39a6\u{1f626}\uaf1f'});
+let renderBundle45 = renderBundleEncoder10.finish({label: '\u{1f7ae}\u0106\u996b'});
+document.body.prepend(img0);
+let texture27 = device0.createTexture({
+  size: {width: 1440, height: 28, depthOrArrayLayers: 374},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle46 = renderBundleEncoder6.finish({label: '\u{1fed1}\u688f\u40a7\ucf87\u0aa5\u88c8\u8ff3\ub861\u0a4d\ua0bb\u{1fc51}'});
+try {
+renderPassEncoder22.setViewport(891.6467970317797, 23.37907837458145, 2.9415016517786388, 0.6029728702979739, 0.27889046973131104, 0.48976619703553925);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint32', 6_252, 2_467);
+} catch {}
+try {
+device0.queue.submit([commandBuffer42, commandBuffer38]);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 36, new Int16Array(49167), 33754, 780);
+} catch {}
+document.body.prepend(canvas3);
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer9, 'uint32', 896, 125);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer9, 0, 398);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({label: '\u023e\uf423\u60be\u0de9\u{1fa9e}\uec48\u0f57'});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint16', 6_412, 7_844);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer9, 4, 38);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet2, 19, 1, buffer7, 0);
+} catch {}
+try {
+renderPassEncoder16.popDebugGroup();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandBuffer43 = commandEncoder71.finish();
+let textureView17 = texture12.createView({format: 'rg16float', baseMipLevel: 0});
+let renderPassEncoder27 = commandEncoder72.beginRenderPass({
+  label: '\u{1f8d7}\u0ad7\ub29d\ua1e0\u387e',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 12,
+  clearValue: { r: -887.6, g: 890.2, b: -380.0, a: -8.421, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+let renderBundle47 = renderBundleEncoder9.finish();
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer7, 156);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: canvas1,
+  origin: { x: 127, y: 0 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({label: '\u4a2d\u{1f95d}\ue35d\uaba8\u2794\u{1f6c5}\ue244\u0435\ub8f8'});
+let commandBuffer44 = commandEncoder73.finish({label: '\u09ed\u696b\u035b\ufcda\ucb31\u{1f742}\u5a85\u5495\ue209\u2869'});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup0, new Uint32Array(197), 61, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer9, 'uint16', 6, 1_068);
+} catch {}
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer5, 84, 307);
+} catch {}
+let texture28 = device0.createTexture({
+  label: '\ua487\udf4c\u229c\u07a0\ucbeb\ue144\u8be8\udb59\u{1fb18}',
+  size: {width: 720, height: 14, depthOrArrayLayers: 66},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(424);
+} catch {}
+let arrayBuffer6 = buffer8.getMappedRange();
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let bindGroup3 = device0.createBindGroup({
+  label: '\u0b5d\u{1fde0}\u0917\u4d63\u0308\u03cb\u09f2\u212f\u907c',
+  layout: bindGroupLayout9,
+  entries: [{binding: 139, resource: {buffer: buffer7, offset: 0, size: 12}}],
+});
+try {
+renderPassEncoder24.executeBundles([renderBundle11, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer0, 'uint16', 380, 2_301);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer8, 784, 867);
+} catch {}
+let buffer11 = device0.createBuffer({
+  label: '\u5111\u2e18',
+  size: 26385,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet14 = device0.createQuerySet({label: '\u8edd\u7150\u2348\u{1fd4d}\u0ec4', type: 'occlusion', count: 1164});
+let texture29 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle48 = renderBundleEncoder5.finish({label: '\u09cd\u{1fe48}\u{1f76f}\ucaca\u03f8\u95a0\ud4d0'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(0, bindGroup1, new Uint32Array(621), 2, 0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup1, new Uint32Array(693), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video2.width = 26;
+let promise16 = adapter2.requestAdapterInfo();
+try {
+computePassEncoder13.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer9, 'uint32', 828, 157);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer0, 0, 10_360);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u{1fc93}\u{1f9d5}\u{1f64a}\u82c4\u7080\u059b'});
+let commandBuffer45 = commandEncoder74.finish({label: '\u{1ff09}\ua62c\ub2d6\u0757\u0e2f\u9fc2\ud67c\u7b73'});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setViewport(189.92327595409176, 16.69350759484956, 1214.8069739766277, 10.15572387501383, 0.23119592595940586, 0.49091849975214463);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u{1f623}');
+} catch {}
+document.body.prepend(video2);
+await gc();
+let imageData9 = new ImageData(4, 8);
+let commandEncoder75 = device0.createCommandEncoder({label: '\u5e35\u03cc'});
+let computePassEncoder15 = commandEncoder75.beginComputePass({label: '\u1a27\u0d48'});
+try {
+computePassEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder26.setViewport(65.02756369474693, 0.866853697840877, 11.666706853932896, 0.02436812348201337, 0.7578288974916605, 0.9085150860109703);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer11, 2_552);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(91), /* required buffer size: 91 */
+{offset: 91, rowsPerImage: 80}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\ufaf3\uee52\u{1fdcf}\u0fbe\uabe5\u0676\uba06\u02ff\u{1f839}\u06c8',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout3],
+});
+let renderBundle49 = renderBundleEncoder4.finish();
+try {
+computePassEncoder15.setBindGroup(1, bindGroup2, new Uint32Array(959), 196, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+let imageData10 = new ImageData(12, 4);
+let buffer12 = device0.createBuffer({
+  label: '\udfc1\u909b\u{1fe43}\uf331\u{1fa45}\u0cbe\u0793\ud309',
+  size: 8451,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder76 = device0.createCommandEncoder({label: '\u{1ffb6}\uf8b4\u49b8\u{1fa1a}'});
+let computePassEncoder16 = commandEncoder76.beginComputePass({label: '\u0680\u{1fe5c}\uf353\u{1fd9e}\u{1fb6b}\u{1f7e0}'});
+try {
+computePassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup3, new Uint32Array(302), 30, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle27]);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(629);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+let buffer13 = device0.createBuffer({
+  label: '\u{1fa22}\u0e47',
+  size: 18733,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder77 = device0.createCommandEncoder({label: '\u015e\u{1fd64}\u0b61\u0518\u0bf7\u{1f744}\u3de5'});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 296, 1220);
+} catch {}
+await gc();
+let renderBundle50 = renderBundleEncoder3.finish({label: '\ua520\u007f\ue586\u7946\u1617\ue483\u36d8'});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup3, new Uint32Array(829), 228, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 3, depthOrArrayLayers: 39}
+*/
+{
+  source: canvas1,
+  origin: { x: 13, y: 14 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let imageBitmap2 = await createImageBitmap(imageData8);
+let commandBuffer46 = commandEncoder77.finish({label: '\u7171\ub8ed\u8940\uf63e\u815e\ua6cf\u0aa2\u0798\u{1f93c}'});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup3, new Uint32Array(172), 49, 0);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({label: '\uedad\u08a1\uf325\ub775\u3d99\u3d1c'});
+let texture30 = device0.createTexture({
+  size: [720],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder15.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle50]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -288.9, g: -288.2, b: 319.4, a: -656.5, });
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet4, 16, 11, buffer5, 512);
+} catch {}
+try {
+device0.queue.submit([commandBuffer46, commandBuffer43]);
+} catch {}
+let commandBuffer47 = commandEncoder78.finish({label: '\u{1f725}\u417d\u2f46\u0162\u{1fdc1}\u065a\u04ff\u3b44\ua37e'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup2, new Uint32Array(962), 150, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle13, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer11, 0, 6_089);
+} catch {}
+let renderBundle51 = renderBundleEncoder5.finish({label: '\uee9b\u2dd1\u5d3e'});
+let commandEncoder79 = device0.createCommandEncoder();
+let commandBuffer48 = commandEncoder79.finish();
+try {
+computePassEncoder13.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer13, 'uint32', 4_944, 6_393);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: canvas3,
+  origin: { x: 49, y: 117 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture31 = device0.createTexture({
+  size: [360],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle52 = renderBundleEncoder10.finish({label: '\u{1f889}\u669b'});
+try {
+renderPassEncoder25.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+adapter1.label = '\u13e6\u{1fed2}';
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u081a\u059c\u2b1d\u1335\ua91c\u{1f674}\u6bd8\u091b\u9e4b\u0e53',
+  entries: [
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture32 = device0.createTexture({
+  label: '\u{1fe6e}\u447b',
+  size: [360],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer5, 740, 581);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(3, bindGroup1, new Uint32Array(3781), 1629, 0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline6);
+} catch {}
+let arrayBuffer7 = buffer3.getMappedRange(448, 24);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle53 = renderBundleEncoder4.finish({label: '\u87d5\u144d\u1337\u{1f91f}\u{1f778}\u{1f893}\u6275\u0631\u00d8'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer2, 'uint16', 6_890, 2_901);
+} catch {}
+try {
+  await promise15;
+} catch {}
+await gc();
+let buffer14 = device0.createBuffer({
+  label: '\u0bfa\ucba9\u60a0\u{1ff33}\u{1ff4a}\u{1facf}\u0526\u038b\ucbc1',
+  size: 3800,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder24.setIndexBuffer(buffer4, 'uint16', 9_608, 2_322);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer0, 5_924, 379);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer8 = buffer14.getMappedRange(920);
+try {
+buffer10.unmap();
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({});
+let computePassEncoder17 = commandEncoder80.beginComputePass({});
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle1, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer0);
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder();
+try {
+computePassEncoder17.setBindGroup(2, bindGroup2, new Uint32Array(3430), 119, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle53, renderBundle22, renderBundle40]);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline7);
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({label: '\u246a\u06ee\u992d\u{1ff1e}\u7433\u042c\u{1fd1b}\u{1fd84}\u0c81\u{1ff46}\ued1c'});
+let textureView18 = texture15.createView({label: '\u{1f74e}\u0554\u1258\u5b15\uf540\u097a\ue594\u02f2\ue3b8\u{1fe20}', arrayLayerCount: 1});
+let computePassEncoder18 = commandEncoder82.beginComputePass({});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline6);
+} catch {}
+await gc();
+try {
+renderPassEncoder24.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder81.insertDebugMarker('\ua716');
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({label: '\u{1fffe}\u0add'});
+let externalTexture10 = device0.importExternalTexture({label: '\u0618\u2ede\u10cf\u{1ffe7}\u{1f6fa}', source: videoFrame0});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3, new Uint32Array(6651), 6651, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle15, renderBundle40, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder20.setViewport(96.84930675599935, 1.1752649670347357, 43.79436793391478, 3.3734231020461403, 0.730103618677019, 0.9129030514229229);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer4, 'uint16', 4_284, 11_734);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer7, 0, 25);
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet11, 188, 123, buffer7, 0);
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u0b8f\u94ad\u015a\u02ef\u6c8e',
+  size: 9455,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder84 = device0.createCommandEncoder();
+let commandBuffer49 = commandEncoder84.finish({label: '\u692e\u6ad7\u00fa\u{1f894}\u5b3f\u494a\uca89\u90b2'});
+let renderPassEncoder28 = commandEncoder81.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 13,
+  clearValue: { r: 314.9, g: 754.8, b: 910.7, a: 230.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder27.executeBundles([renderBundle42, renderBundle47]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer45]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 19600, new DataView(new ArrayBuffer(1662)), 145, 420);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup2, new Uint32Array(477), 84, 0);
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer13, 'uint16', 626, 2_953);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer0, 0, 3_254);
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(buffer15, 440, buffer2, 9628, 1340);
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 416 widthInBlocks: 104 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 732 */
+  offset: 732,
+  buffer: buffer2,
+}, {width: 104, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView19 = texture24.createView({label: '\u04f3\u0dd0', baseArrayLayer: 2, arrayLayerCount: 2});
+let renderPassEncoder29 = commandEncoder83.beginRenderPass({
+  label: '\ub8df\u{1f7d6}\u0eab\u39ee\u3c87\u1c79\u{1fa12}\u0bc9',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 118,
+  clearValue: { r: 146.8, g: -525.6, b: 41.56, a: -997.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup1, new Uint32Array(6276), 2, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder75.insertDebugMarker('\u97b8');
+} catch {}
+let texture33 = device0.createTexture({
+  label: '\u09b3\u4a7d\u{1f883}\u{1fd4a}\u009c\u068a\ud557\u21a8\udbbc',
+  size: [360],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(buffer5, 152, buffer3, 1664, 2484);
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder();
+let commandBuffer50 = commandEncoder75.finish({label: '\u45f6\u63ab'});
+let textureView20 = texture3.createView({label: '\u0a31\u0eb6\u{1f9bd}\ub674\u5aa3', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle54 = renderBundleEncoder9.finish({label: '\u30f2\u34b9'});
+try {
+computePassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer8, 0, 3_323);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(32, 69);
+let commandEncoder86 = device0.createCommandEncoder();
+let commandBuffer51 = commandEncoder86.finish({label: '\u3055\u0a44\u{1fa77}\u{1fde5}'});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup0, new Uint32Array(1682), 79, 0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder85.pushDebugGroup('\u4c08');
+} catch {}
+try {
+renderPassEncoder19.insertDebugMarker('\u{1f6dd}');
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+await gc();
+let imageData11 = new ImageData(124, 68);
+let commandEncoder87 = device0.createCommandEncoder({label: '\ucca0\u0a07\u493d\u08f4\u0b20\u{1fc94}\u{1f96d}\u9a91\u14b5\uc27a\u2044'});
+let commandBuffer52 = commandEncoder87.finish({label: '\u20f4\u085a\uddd6\u3bc1\u005f\u0766\u0518'});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup3, new Uint32Array(1452), 478, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle10, renderBundle27, renderBundle0, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer52, commandBuffer49, commandBuffer47]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 4372, new DataView(new ArrayBuffer(6559)), 527, 32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData6,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder30 = commandEncoder85.beginRenderPass({
+  label: '\u{1fb99}\u0de7\u59e5\uef37',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 10,
+  clearValue: { r: -513.6, g: -403.8, b: 33.09, a: 554.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+device0.queue.submit([commandBuffer41, commandBuffer51]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 212, new DataView(new ArrayBuffer(4863)), 457, 92);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup0, new Uint32Array(2144), 678, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -129.2, g: -749.3, b: -606.7, a: 856.5, });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 18},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderBundle55 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(0, buffer10, 0, 978);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 180, new BigUint64Array(12322), 2004, 544);
+} catch {}
+let computePassEncoder19 = commandEncoder76.beginComputePass({label: '\u0cdd\u799c\uf1d3\u0c59\u{1f8a8}\u0d44\u{1fed8}\u02e2\ua152'});
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(1331.9078753573601, 16.464377233185544, 89.35104907404042, 9.435159174060168, 0.5577326718497736, 0.6395153396739588);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer9, 'uint32', 164, 27);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: canvas2,
+  origin: { x: 26, y: 2 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView21 = texture31.createView({label: '\u0478\ua5a1\u{1fb6b}\u{1f921}', arrayLayerCount: 1});
+try {
+renderPassEncoder23.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle54, renderBundle26, renderBundle54]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer9, 'uint16', 178, 46);
+} catch {}
+let promise19 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {mask: 0x700caffc},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'replace'},
+    stencilReadMask: 211323691,
+    stencilWriteMask: 35763590,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 872, attributes: []},
+      {arrayStride: 2016, attributes: []},
+      {arrayStride: 2048, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 124, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 376,
+        attributes: [
+          {format: 'uint32x4', offset: 24, shaderLocation: 15},
+          {format: 'sint32x3', offset: 192, shaderLocation: 12},
+          {format: 'sint16x4', offset: 4, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+video1.width = 222;
+try {
+computePassEncoder13.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.submit([commandBuffer48]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 68 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer9);
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({label: '\u{1f9cb}\uf710\u0f98\u{1f7d7}\u65a7\u{1fbe7}\u{1fe11}\u01a7'});
+let commandBuffer53 = commandEncoder88.finish({label: '\u{1f910}\u0887\u7edc\u1310\u271c\u0a07'});
+let renderBundle56 = renderBundleEncoder8.finish({label: '\u7c5b\u0bf1\ufa93\u{1f64d}\uaa82'});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup3, new Uint32Array(2267), 729, 0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup0);
+} catch {}
+canvas2.height = 534;
+let externalTexture11 = device0.importExternalTexture({label: '\u{1fa06}\u0904\u{1f703}\u0ffa', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup0, new Uint32Array(1995), 922, 0);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer9, 0, 421);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 2,
+  origin: {x: 80, y: 0, z: 9},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1442 */
+  offset: 1442,
+  rowsPerImage: 68,
+  buffer: buffer6,
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({label: '\u6cc3\u05d1\u04ee\u7d82\u061e\u33d3\u9bdf\u{1fbdc}\u0bde\ubf31'});
+let texture34 = device0.createTexture({size: {width: 360}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder31 = commandEncoder76.beginRenderPass({
+  label: '\u0adc\ue7c4\u01f4\udd76',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 3,
+  clearValue: { r: 519.0, g: -677.2, b: -51.19, a: -338.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle57 = renderBundleEncoder7.finish();
+document.body.prepend(img0);
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1804, new Float32Array(2802), 350, 872);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas2.getContext('webgpu');
+let textureView22 = texture28.createView({label: '\u0d7b\u298d\u805a\u0e64\u{1f8e9}\u688b\u0f23\u0bb0\u3018', baseMipLevel: 2});
+let renderPassEncoder32 = commandEncoder89.beginRenderPass({
+  label: '\u0c44\u{1ffb9}\u{1f735}',
+  colorAttachments: [{view: textureView16, depthSlice: 15, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+});
+let sampler6 = device0.createSampler({
+  label: '\u{1f858}\u08fa\u714f\u3e77\u081b\u{1fdd3}\u{1f8e5}\ubc95',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 76.35,
+  lodMaxClamp: 87.65,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer5, 0, 2_803);
+} catch {}
+let arrayBuffer9 = buffer3.getMappedRange(296, 40);
+let commandEncoder90 = device0.createCommandEncoder();
+let renderPassEncoder33 = commandEncoder90.beginRenderPass({
+  label: '\u{1fb7d}\ue4b4\u{1fde7}',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 213,
+  clearValue: { r: 680.7, g: -525.5, b: 204.4, a: 47.96, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle58 = renderBundleEncoder8.finish({label: '\uf515\u{1ff2f}\u0fae\u0ed4\u0c07\ua5ac'});
+try {
+computePassEncoder17.setPipeline(pipeline3);
+} catch {}
+let device1 = await adapter2.requestDevice({
+  label: '\ue401\u5cf6\u{1fe5c}\u01fb',
+  requiredLimits: {maxUniformBufferBindingSize: 14724960, maxStorageBufferBindingSize: 154075279},
+});
+let commandEncoder91 = device1.createCommandEncoder();
+try {
+gpuCanvasContext1.configure({device: device1, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+try {
+computePassEncoder18.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle14, renderBundle49]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(55, 328);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device1, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let commandEncoder92 = device1.createCommandEncoder({});
+try {
+offscreenCanvas3.getContext('webgpu');
+} catch {}
+let commandEncoder93 = device1.createCommandEncoder({});
+let commandBuffer54 = commandEncoder91.finish({label: '\u95c9\u0c39\u1edc\u39d2\u{1fafc}\u{1fd7a}\u{1fbe2}'});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+video2.height = 137;
+let promise20 = adapter0.requestAdapterInfo();
+let buffer16 = device0.createBuffer({
+  label: '\u8b2c\u0b42\u{1f87b}\uc8da\u9e57\u0560\u02c8\u0878\u4ab3\u{1f6d0}\u{1f837}',
+  size: 3987,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(87), /* required buffer size: 87 */
+{offset: 87, bytesPerRow: 250}, {width: 95, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+document.body.prepend(canvas3);
+let commandEncoder94 = device0.createCommandEncoder({label: '\u81bd\u86d3\u0271\u9451\u0e56\u1f46\ue536\u7cf3\u3f4c\u{1fd7c}'});
+let commandBuffer55 = commandEncoder94.finish({label: '\u720f\u3ec6\u{1fc57}\u25dd\uef64\uc6e0\uee33\u6826\u0b7a\u0cd9\u2007'});
+try {
+renderPassEncoder18.setPipeline(pipeline7);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let commandEncoder95 = device0.createCommandEncoder({label: '\u0cd7\u43ce\u0ed2\uacd6\u0080\u66e2\u09e5\u0d01\ue4fb\u159c\uc71f'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(2999), 30, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer2, 'uint16', 5_978, 5_960);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer10, 1_056, 422);
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(querySet10, 18, 2, buffer5, 512);
+} catch {}
+try {
+renderPassEncoder27.insertDebugMarker('\u{1f819}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 3, depthOrArrayLayers: 39}
+*/
+{
+  source: imageData8,
+  origin: { x: 12, y: 37 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let renderBundle59 = renderBundleEncoder1.finish({label: '\u2c30\u6d96\u0a3c\uf6c8\u7076\u068f\uf6f9\u98ee'});
+try {
+computePassEncoder17.setPipeline(pipeline8);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 3, depthOrArrayLayers: 39}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 1, y: 8 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer56 = commandEncoder95.finish({});
+try {
+computePassEncoder17.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(1);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 108, new DataView(new ArrayBuffer(14689)), 3281, 84);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 5 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u8ae1\u7477\uc1ab\ub646',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle60 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder27.end();
+} catch {}
+let commandEncoder96 = device1.createCommandEncoder({label: '\ud1d3\u0708\u{1f7a4}\u5ffd'});
+try {
+gpuCanvasContext3.configure({device: device1, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let commandEncoder97 = device1.createCommandEncoder({});
+let querySet15 = device1.createQuerySet({
+  label: '\uf761\u0bef\u{1f729}\u4058\u8c5c\uc2a2\u{1fdb9}\u0486\u{1f8ba}\u08c9',
+  type: 'occlusion',
+  count: 327,
+});
+let commandEncoder98 = device1.createCommandEncoder();
+let texture35 = device1.createTexture({
+  label: '\ua3e1\u{1fbb6}\u2329\u{1fc9c}\u{1fc48}\u5a0c\ub9c1\u9a25\uacfa\uee61',
+  size: [41],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device1.queue.submit([commandBuffer54]);
+} catch {}
+try {
+  await promise20;
+} catch {}
+await gc();
+let commandEncoder99 = device0.createCommandEncoder({label: '\u3dd2\u7a28\u024d\u0a47'});
+let texture36 = device0.createTexture({
+  label: '\u{1fc8c}\ub0c0\u0e14\u8390\ufd9b\u1588\u68e2',
+  size: [1440, 28, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView23 = texture31.createView({label: '\uee6b\u0093\u0667\u336e\u{1f7b2}\u66a8\ucb9f\u{1faea}\u0d5c\u5a82\ufff2', baseArrayLayer: 0});
+let computePassEncoder20 = commandEncoder99.beginComputePass({label: '\u97f7\u{1f8b5}\u0029\u2ddf\u801c\u{1fced}\u097a\u003c\ufd03'});
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup1, new Uint32Array(207), 67, 0);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer7, 116, 71);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer10, 1_324, 825);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder100 = device1.createCommandEncoder({});
+await gc();
+let commandBuffer57 = commandEncoder92.finish({});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let commandEncoder101 = device0.createCommandEncoder({label: '\u4bae\u6cf0\ua8ea\ua2b3\u0c8a\u{1fc7a}\ua27e\u8099\u1ddd'});
+let commandBuffer58 = commandEncoder101.finish({label: '\u627f\u5f03\u3627\u07a0\u070c\u{1fa59}\u0b63\u{1f6fc}\u{1f8f4}'});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4_294_967_294, undefined, 1_327_109_177);
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({label: '\u0aec\u{1ff37}\u5dd7'});
+let commandBuffer59 = commandEncoder99.finish({});
+let renderPassEncoder34 = commandEncoder102.beginRenderPass({
+  label: '\u016a\ub004\u7f12\u0baa\u031b\u{1fd9e}',
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 160,
+  clearValue: { r: -394.5, g: 131.0, b: 121.4, a: 395.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer9, 'uint32', 380, 78);
+} catch {}
+let commandEncoder103 = device1.createCommandEncoder({label: '\uf9ae\u0d53\u1526\u02fd\u52c5'});
+let commandBuffer60 = commandEncoder98.finish({label: '\u9f46\u0a6b\u{1fafe}\u{1ffed}\u811f\u{1f678}\u{1f7a6}\uf20f'});
+let renderBundle61 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder13.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer13, 'uint16', 4_528, 2_812);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint16', 1_078, 3_051);
+} catch {}
+let renderBundle62 = renderBundleEncoder8.finish({label: '\u4f8f\u37ec\u{1f980}'});
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer13, 'uint32', 2_668, 347);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup1, new Uint32Array(1083), 76, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer9, 'uint32', 112, 105);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer10);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u61c1');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(192), /* required buffer size: 192 */
+{offset: 192}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout15 = device1.createBindGroupLayout({
+  label: '\u{1fc44}\u00f9\u{1f684}\uef03\u0416',
+  entries: [{binding: 719, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\u4d46\u5d0a\u{1ffc6}\u037b\u05e3\uba0e',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout15],
+});
+let commandEncoder104 = device1.createCommandEncoder({label: '\u{1f914}\u09ce\u024e\u72b2\u0ff3\u92a0\u{1f82b}\u{1fcca}'});
+let commandBuffer61 = commandEncoder97.finish();
+try {
+device1.queue.submit([commandBuffer61, commandBuffer57]);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer5, 1_580);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer13, 'uint32', 12_308, 102);
+} catch {}
+try {
+device0.queue.submit([commandBuffer44]);
+} catch {}
+let bindGroupLayout16 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 389,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 607,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder105 = device1.createCommandEncoder({label: '\u056d\u{1fa1e}\ufdad\u024e\u0733\u02e6'});
+let commandBuffer62 = commandEncoder100.finish();
+let renderBundleEncoder12 = device1.createRenderBundleEncoder({colorFormats: ['r16sint'], stencilReadOnly: true});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let renderBundle63 = renderBundleEncoder12.finish({label: '\u0d7a\u28a2\u{1fad6}\u0b33\u3f01\u{1fdeb}\u3fab'});
+let sampler7 = device1.createSampler({
+  label: '\u28d8\uec4b\u0f80\u0bf3\u{1fcc3}\u54b8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.39,
+  maxAnisotropy: 16,
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer10, 1_932, 544);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4_294_967_294, undefined, 0, 142_722_498);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u77f4');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 272, new Float32Array(21896), 1470, 68);
+} catch {}
+await gc();
+try {
+adapter0.label = '\uf505\u0b2c\u0250\u6f95';
+} catch {}
+let shaderModule4 = device1.createShaderModule({
+  label: '\u{1f7f4}\u8b11\u{1f779}\u0f4f\u0a49\u664f\u0242\u9c4c\uf0c1',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: mat3x4f,
+}
+
+@group(1) @binding(719) var et1: texture_external;
+@group(0) @binding(719) var et0: texture_external;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: i32,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  if bool(textureLoad(et1, vec2u())[1]) {
+    discard;
+  }
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer63 = commandEncoder105.finish({label: '\ua149\u49bb\ucc04\u0700\ucad1\u411f\u088e\u4ceb'});
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let texture37 = gpuCanvasContext0.getCurrentTexture();
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.26,
+  lodMaxClamp: 69.84,
+});
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup3, new Uint32Array(73), 1, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer8, 100, 3_736);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 124, y: 4, z: 9},
+  aspect: 'all',
+}, new ArrayBuffer(110), /* required buffer size: 110 */
+{offset: 110, bytesPerRow: 150}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = await promise19;
+try {
+adapter2.label = '\u0c7f\u9f79\u3f3e\u{1ff39}\u{1faf8}\u5411';
+} catch {}
+let texture38 = device1.createTexture({
+  label: '\ub368\u3c7c\u0fca\ud1d1\ue835\uaa54\u{1f789}',
+  size: {width: 47, height: 30, depthOrArrayLayers: 349},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let commandEncoder106 = device1.createCommandEncoder({label: '\u8e8d\u{1fd99}\u{1f69a}\u92ff\ub1c6\ue793'});
+let pipeline11 = device1.createRenderPipeline({
+  label: '\u{1f99b}\uedb7\u5e76\ub6b1\u30da',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0x2d4d6347},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+});
+try {
+  await promise21;
+} catch {}
+let commandEncoder107 = device1.createCommandEncoder({label: '\u7482\u3303\u240c\u063a\u{1fbd0}'});
+let querySet16 = device1.createQuerySet({label: '\u{1fe38}\u3218\u45dc\ud80d\u{1ffaf}\u1adc\u0253', type: 'occlusion', count: 2959});
+let textureView24 = texture35.createView({});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let texture39 = device0.createTexture({
+  label: '\u{1fa53}\u3e58\u7ee3\u083f\u7325',
+  size: [720],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle64 = renderBundleEncoder10.finish();
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+let textureView25 = texture35.createView({label: '\u{1f721}\u09ad\u33a1\u0fd3', baseMipLevel: 0});
+let renderBundle65 = renderBundleEncoder12.finish({label: '\u2579\ud68b\u09bc\u05ff\u{1fcae}\u2d09\u0877\u40d5\u1758\udb1b'});
+let sampler9 = device1.createSampler({
+  label: '\uf01b\u{1fd9f}\u{1f8d5}\u0b4f\ub9af\u6388\u4154\u066b',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.03,
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u0cff\uc9ad',
+  entries: [
+    {
+      binding: 174,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 221, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 55, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 372,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 187,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 79, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 214,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 474,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 413,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 256,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 124,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 360,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 118,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 15, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 138,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 241,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 21, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {binding: 195, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 181, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 41703570, hasDynamicOffset: false },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 91,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 192, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 64,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 737,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 599,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 383,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 186,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 135,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 170, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {binding: 27, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 152,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 387, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {binding: 0, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 456, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 48, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 273, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 148, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 29,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 95, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 141, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 66, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 238, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 85, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 189, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 166, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 289, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 173,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 211, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 276,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 83, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 357, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 270, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 12, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 350,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 365, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 88, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 163, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 158, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 43, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -112.5, g: 668.6, b: -702.7, a: -55.48, });
+} catch {}
+try {
+renderPassEncoder4.setViewport(915.6143913876801, 12.158899505619278, 420.82305932167833, 3.815170353019344, 0.8941836099728002, 0.9379834291767704);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint16', 1_922, 5_165);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer4, 4_744, 14_141);
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({label: '\u{1ffc6}\u{1fe93}\uec47\ub908\u84f2\u0ba2\uf038\ud337\u{1fd22}\u{1ff1b}'});
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer4, 'uint16', 5_088, 6_333);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u07a7\u7acf',
+  entries: [
+    {
+      binding: 127,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let texture40 = gpuCanvasContext4.getCurrentTexture();
+let renderPassEncoder35 = commandEncoder108.beginRenderPass({
+  label: '\u{1f928}\ufd19\ud35d\u{1f9b1}\u{1fda8}\ud2a4\u{1f8a2}\u{1f740}\ufe36\u60a4\u0714',
+  colorAttachments: [{view: textureView16, depthSlice: 4, loadOp: 'load', storeOp: 'store'}],
+});
+let renderBundle66 = renderBundleEncoder4.finish({label: '\u8a13\u0189\ubc55'});
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer56]);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(5, buffer9);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer9, 'uint16', 678, 393);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 2484, new BigUint64Array(803), 67, 92);
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  label: '\u0756\u{1fb6c}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'invert'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 993738895,
+    stencilWriteMask: 326650995,
+    depthBiasSlopeScale: 305.89314408664796,
+  },
+  vertex: {module: shaderModule1, buffers: []},
+  primitive: {topology: 'triangle-list', cullMode: 'none'},
+});
+let textureView26 = texture15.createView({
+  label: '\u017b\u0075\u{1ffd1}\u26a3\u{1fa2a}\u68f7\u{1fa45}\u{1fe4e}\ubb2c\u{1fc05}',
+  dimension: '1d',
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup1, new Uint32Array(20), 2, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer5, 292);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer9, 'uint32', 136, 93);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4_294_967_295, undefined, 0, 661_922_114);
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  label: '\ud825\u563b\u0962\u5ce8\ud0e9\u6ffb',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {arrayStride: 168, stepMode: 'instance', attributes: []},
+      {arrayStride: 116, stepMode: 'instance', attributes: []},
+      {arrayStride: 68, attributes: []},
+      {arrayStride: 664, stepMode: 'vertex', attributes: []},
+      {arrayStride: 624, attributes: []},
+      {arrayStride: 188, stepMode: 'instance', attributes: []},
+      {arrayStride: 456, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32', offset: 172, shaderLocation: 15},
+          {format: 'sint16x4', offset: 256, shaderLocation: 12},
+          {format: 'sint32x4', offset: 488, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let buffer17 = device0.createBuffer({size: 14976, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let renderBundle67 = renderBundleEncoder9.finish({label: '\u06de\u4250\u02a4\u6ad4\u84b6\u{1f9e4}'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle8, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer4, 'uint32', 1_640, 4_712);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer8, 0, 3_124);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer9, 0, 0);
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder();
+let computePassEncoder21 = commandEncoder64.beginComputePass({label: '\u2f5d\uec9c'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u2a47\u127b\u0bf9\u5ace\u{1ff3d}\u8811\u16d1\uc131\u0eb3\u8d6d',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder109.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1016 */
+  offset: 1016,
+  buffer: buffer5,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder22 = commandEncoder106.beginComputePass({});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({label: '\u467a\u{1f6bc}\udbfb\ud953', colorFormats: ['r16sint'], stencilReadOnly: true});
+let commandEncoder110 = device1.createCommandEncoder({label: '\u3b7c\ue768\u{1f603}'});
+let renderBundle68 = renderBundleEncoder12.finish();
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let bindGroupLayout19 = device1.createBindGroupLayout({
+  label: '\u0a93\u29b3\uf12f\u{1fb4c}\uaa9d\u0bd2\u{1fdef}\u7c3b',
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandBuffer64 = commandEncoder107.finish({label: '\u0c97\uc2be\u{1fc20}\u04b9\u1862\u{1f74c}\u2c4e\u3073\u0c93\u{1ff77}'});
+let renderBundle69 = renderBundleEncoder14.finish({label: '\u3b08\uffe7\ub1f1\u0cf7\u0d78\u0024\u7300'});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout13 = device1.createPipelineLayout({label: '\u{1fac5}\ucc8e', bindGroupLayouts: [bindGroupLayout19, bindGroupLayout15]});
+let commandEncoder111 = device1.createCommandEncoder({label: '\u2dc0\u611a\u{1fb37}\u{1fab7}\u09ff'});
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout({label: '\u01e5\ued6c\u0b92\u7529\u03aa\uf581\uf2e4\u3b88\u8217', bindGroupLayouts: []});
+let commandBuffer65 = commandEncoder104.finish({label: '\u1ee3\u0f93\u0955\u6737\u{1fbe4}\u1cc6\u{1fb12}\u0780'});
+let textureView27 = texture38.createView({label: '\ua318\u{1fb81}\uaf45\u1b6b\u0414\u{1f68c}'});
+try {
+querySet15.destroy();
+} catch {}
+await gc();
+let commandEncoder112 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({
+  size: [360],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup2, new Uint32Array(3480), 928, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(4, buffer10, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer55, commandBuffer59, commandBuffer53]);
+} catch {}
+try {
+commandEncoder110.pushDebugGroup('\u8690');
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({label: '\u1cba\u2446\u64f0\u9bac\u45d8\u728a'});
+let commandBuffer66 = commandEncoder109.finish({label: '\u{1fb67}\u08d1\u{1fe9a}\u74f1\u0a48\ua923\u2fc7\u{1f9e0}\u0b1b\u09fe\u{1fc71}'});
+let computePassEncoder23 = commandEncoder112.beginComputePass({label: '\u0c38\u0c40\uf24b'});
+let renderPassEncoder36 = commandEncoder113.beginRenderPass({
+  label: '\ubcea\u{1f87b}\u791e\u3a90\u01b4',
+  colorAttachments: [{
+  view: textureView6,
+  depthSlice: 14,
+  clearValue: { r: 583.2, g: -551.9, b: 322.9, a: 489.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 72219149,
+});
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(0, buffer4);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup3);
+} catch {}
+let commandEncoder114 = device1.createCommandEncoder({label: '\u0d27\u0f5b\u09c9'});
+let commandBuffer67 = commandEncoder96.finish();
+let computePassEncoder24 = commandEncoder111.beginComputePass({});
+try {
+commandEncoder110.popDebugGroup();
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\u{1fd8e}');
+} catch {}
+let commandEncoder115 = device1.createCommandEncoder();
+try {
+commandEncoder110.pushDebugGroup('\u0354');
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder116 = device1.createCommandEncoder({label: '\ubaa2\u551d\u{1fc48}\u0e3d\uecff\u0f98\uc9fc\u931d\u{1ffc7}'});
+let computePassEncoder25 = commandEncoder103.beginComputePass();
+try {
+device1.queue.submit([commandBuffer63, commandBuffer62]);
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder();
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle54, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer4, 'uint32', 5_436, 332);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer9, 'uint32', 184, 79);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer9, 164, 154);
+} catch {}
+try {
+querySet6.destroy();
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer11, 84, buffer7, 532, 152);
+} catch {}
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 153, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4040 widthInBlocks: 505 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2552 */
+  offset: 2552,
+  buffer: buffer4,
+}, {width: 505, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer66]);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = renderPassEncoder35.label;
+} catch {}
+let commandBuffer68 = commandEncoder117.finish({label: '\u810f\u2285\u0ce9\u{1fc64}\u{1f73a}\u0d11\u3128\u0b31\uf22f'});
+let textureView28 = texture19.createView({label: '\u03c6\ub60d\u413a\u2bc7\ua00f\u929f\ufa7b\u8371\uc95a\u0a23', baseMipLevel: 0});
+let renderBundle70 = renderBundleEncoder13.finish({label: '\u3c5d\u4d5a\u000a\ucbbc\uccde\u0355'});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer2, 'uint16', 2_692, 800);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer4, 6_560, 4_303);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise22;
+} catch {}
+let texture42 = device0.createTexture({
+  label: '\u0222\u7f4c\ufc1d\u2bfe\u11ab',
+  size: [180, 3, 1],
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder30.beginOcclusionQuery(8);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 8 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder118 = device1.createCommandEncoder({label: '\u{1f657}\uc443\u8efb\uffaf\u6231\u{1f804}'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await shaderModule4.getCompilationInfo();
+} catch {}
+let renderBundle71 = renderBundleEncoder12.finish({label: '\ud3a5\u{1f721}\u0ed9\ubb14'});
+let sampler10 = device1.createSampler({
+  label: '\ufcd5\u{1f831}\u13af\u96d1\u0bc1\u9db3\u0472\u70c5\u13b9',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 92.83,
+});
+let promise23 = device1.queue.onSubmittedWorkDone();
+let renderBundle72 = renderBundleEncoder11.finish({label: '\u{1f801}\u7b93\u0ef9\u70d3\u{1ff4d}\u{1fc69}'});
+let sampler11 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.74,
+  lodMaxClamp: 82.31,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup3, new Uint32Array(1058), 121, 0);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer7, 0, 38);
+} catch {}
+let commandEncoder119 = device1.createCommandEncoder({});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({colorFormats: ['r16sint'], stencilReadOnly: true});
+let canvas4 = document.createElement('canvas');
+let textureView29 = texture39.createView({label: '\u{1fe77}\u1884\u87ec\u044a\ub07e\u4e1c\u0e7b\u002d\u46dc\ue326', baseMipLevel: 0});
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 1568, 656);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 31 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder120 = device1.createCommandEncoder({});
+let commandBuffer69 = commandEncoder118.finish();
+let textureView30 = texture35.createView({label: '\uf368\u071a\u073e\u088e', mipLevelCount: 1});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.submit([commandBuffer64, commandBuffer69, commandBuffer60]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext5 = canvas4.getContext('webgpu');
+let texture43 = device0.createTexture({
+  label: '\u{1fd1b}\udeb3\udc09\u09b1\u{1f81e}\u{1f9e0}',
+  size: {width: 360},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder30.setIndexBuffer(buffer9, 'uint32', 1_056, 29);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder121 = device1.createCommandEncoder();
+try {
+querySet16.destroy();
+} catch {}
+try {
+device1.queue.submit([commandBuffer65]);
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+let offscreenCanvas4 = new OffscreenCanvas(76, 204);
+let commandEncoder122 = device1.createCommandEncoder();
+let texture44 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({label: '\u02e1\u2c28\u{1f7a4}\u6044\u8410\u2f03'});
+let commandBuffer70 = commandEncoder123.finish({});
+let texture45 = gpuCanvasContext0.getCurrentTexture();
+let sampler12 = device0.createSampler({
+  label: '\u{1faae}\ua5dc\u{1fb0f}\u0e1d\u0091\u33fd',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 20.80,
+  lodMaxClamp: 80.26,
+});
+try {
+computePassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+let renderBundle73 = renderBundleEncoder1.finish({label: '\u74a0\u165e\u2471\u{1fa19}\u{1ff1c}\u054a\u0f29'});
+let sampler13 = device0.createSampler({
+  label: '\ub007\u{1f8bb}\ue94a\uac20',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 71.79,
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup2, new Uint32Array(3559), 112, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle4, renderBundle55, renderBundle38, renderBundle7, renderBundle15, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(224);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 2504, new Float32Array(41224), 2912, 252);
+} catch {}
+let texture46 = device1.createTexture({
+  label: '\u{1fd87}\ue9f2\u191f\u2786\udfc1',
+  size: [145, 1, 16],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let device2 = await adapter1.requestDevice({
+  label: '\u9121\u0939\uf17b\u9461\u8e2a',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxStorageBuffersPerShaderStage: 8,
+    maxUniformBufferBindingSize: 37929478,
+    maxStorageBufferBindingSize: 141052906,
+    maxInterStageShaderComponents: 64,
+  },
+});
+let sampler14 = device1.createSampler({
+  label: '\u1c84\u874b\u0d00\u01f6\u45f7\u0580\u{1f994}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 97.88,
+  lodMaxClamp: 98.96,
+});
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder115.insertDebugMarker('\u153f');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder124 = device1.createCommandEncoder({label: '\u2a07\ub47f\u{1fd69}\u0beb\u3247\u94c7'});
+let renderBundle74 = renderBundleEncoder12.finish({});
+try {
+renderBundleEncoder15.setVertexBuffer(4_294_967_294, undefined);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder111.insertDebugMarker('\u23b6');
+} catch {}
+let promise25 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(canvas1);
+let commandEncoder125 = device0.createCommandEncoder({label: '\u085d\u62ac\u09a0\ua9d0\u30ba\u0c3f\uaa44\u52d9\u0db0'});
+let texture47 = device0.createTexture({
+  label: '\u0d93\uc396\u006f\uac81\uffa3\u{1f7df}\uef8f\ua075\u08cd\u75b5\u0dce',
+  size: [720, 14, 1],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView31 = texture32.createView({mipLevelCount: 1});
+let computePassEncoder26 = commandEncoder125.beginComputePass({label: '\u0276\u0bab\u2c00\u0a5a'});
+try {
+computePassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle58]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer13, 'uint16', 1_800, 1_532);
+} catch {}
+canvas2.width = 890;
+let computePassEncoder27 = commandEncoder115.beginComputePass({label: '\uc4ac\ucecf'});
+let renderBundle75 = renderBundleEncoder15.finish({label: '\ubd4d\ue651\u0e46\u{1f89d}\u4005'});
+try {
+commandEncoder110.popDebugGroup();
+} catch {}
+try {
+  await promise23;
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture48 = device2.createTexture({
+  label: '\u02e3\uc05d\u0aad\u83d2',
+  size: [8, 6, 1],
+  dimension: '2d',
+  format: 'astc-8x6-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture49 = gpuCanvasContext4.getCurrentTexture();
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise24;
+} catch {}
+let textureView32 = texture49.createView({label: '\u7b79\u{1f9ca}\u07f9\u5d9b\u{1fdd9}\u{1f93f}\u025f\u4236'});
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandBuffer71 = commandEncoder124.finish({label: '\u7ac5\ua664\u{1fb33}\u0f01\u5dfd\u0c5b\ud5b9'});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let renderBundle76 = renderBundleEncoder3.finish({label: '\u{1fe32}\u5bbe\uef4a\u{1f811}\u4282\u07aa\u01be\u62d8\u0ff7\u66ed'});
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4, buffer0, 1_960);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(237), /* required buffer size: 237 */
+{offset: 237}, {width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({label: '\u083d\u0bc8\u3064\u53f4\u559a\u0dd0\udede\ud257'});
+let renderPassEncoder37 = commandEncoder126.beginRenderPass({
+  label: '\u{1fb4c}\uc6fa',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 4,
+  clearValue: { r: 358.0, g: -987.6, b: -490.9, a: 557.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler15 = device0.createSampler({
+  label: '\u834a\u{1fc28}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.93,
+  lodMaxClamp: 74.52,
+});
+try {
+renderPassEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: canvas3,
+  origin: { x: 1, y: 50 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder127 = device1.createCommandEncoder({label: '\u96fe\u{1fe55}\u45a8\u5491\uec22\u2fed'});
+let renderBundle77 = renderBundleEncoder12.finish({label: '\u0ae6\u{1f6eb}\u7d27'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder28 = commandEncoder121.beginComputePass({label: '\u075c\uc597\u6f4b\ue042\u00c6\u{1f768}'});
+let texture50 = device2.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 1},
+  format: 'astc-8x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise26 = device2.queue.onSubmittedWorkDone();
+let commandBuffer72 = commandEncoder119.finish({label: '\ub9ae\u{1fb23}\u{1fba0}\u38e5\u02e7\u{1fd0d}\u7ee6'});
+let computePassEncoder29 = commandEncoder110.beginComputePass({label: '\u037a\u12fe\u09a3\u14cc\u0450\u09c5\u8b4c'});
+let imageData12 = new ImageData(16, 28);
+try {
+window.someLabel = texture35.label;
+} catch {}
+let bindGroup4 = device1.createBindGroup({
+  label: '\u82cb\u{1ffd3}\u{1ff79}\u{1fab1}\u0302\uce01\u23f2\u29ba',
+  layout: bindGroupLayout19,
+  entries: [{binding: 79, resource: sampler10}],
+});
+let texture51 = device1.createTexture({
+  label: '\u6b36\ud82a',
+  size: {width: 290},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView33 = texture35.createView({label: '\u0050\u4a0b\u7e44\u01fc\u0072\u03d9'});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup4, []);
+} catch {}
+let pipeline14 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}],
+},
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {},
+});
+let gpuCanvasContext6 = offscreenCanvas4.getContext('webgpu');
+try {
+  await promise25;
+} catch {}
+document.body.prepend(video2);
+let texture52 = device1.createTexture({
+  label: '\u0d04\u9ee7\u0f6e\u{1f66a}\u81b8\u70d1\u4ec9',
+  size: {width: 20},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+await gc();
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer18 = device1.createBuffer({
+  label: '\u{1f692}\u8200\u7de5\u{1f9bc}\u18df\ue6e4\u7a24\u{1fa2a}\u0607\u8650',
+  size: 13860,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder128 = device1.createCommandEncoder({label: '\u0b04\u01ce\u{1fa5b}\u1599\ub7a1\uce15\u5d1e\uae45'});
+let commandBuffer73 = commandEncoder122.finish({label: '\u82aa\u05fc\u7dc8\uc591\u014a\u00ea\ub646\u1ec3\u83ec'});
+let renderBundle78 = renderBundleEncoder15.finish({label: '\u7c0e\ube06\uaf6d\u5cf1\ua9ab'});
+let pipeline15 = await device1.createRenderPipelineAsync({
+  label: '\u8a5d\u{1fed4}\u13b6\u0589\uaa59',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule4, buffers: []},
+});
+try {
+  await promise26;
+} catch {}
+let commandEncoder129 = device1.createCommandEncoder();
+let sampler16 = device1.createSampler({
+  label: '\u0201\u{1fbb1}\u0361\u{1fd8c}\u{1f803}\u557f',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.329,
+  lodMaxClamp: 23.95,
+});
+try {
+device1.queue.label = '\u0271\u{1f6d8}\udc21\u7a9a\u06df\ub308\u{1f8b4}\u1136\u5e5f\ub113\u4d45';
+} catch {}
+let pipelineLayout15 = device1.createPipelineLayout({label: '\u{1f8d9}\u035c', bindGroupLayouts: []});
+let commandEncoder130 = device1.createCommandEncoder({label: '\u75cc\u36b4\u028b\uddf2\u749c\u{1fb53}\uccbe\u7051\u0180'});
+let textureView34 = texture44.createView({label: '\u09b3\u{1f607}\u0446\u{1f79d}\u{1ffbf}\u07bf'});
+let renderBundle79 = renderBundleEncoder12.finish({label: '\u0df8\u08db'});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let renderBundle80 = renderBundleEncoder5.finish({label: '\u05e1\u0fc4\ub8d1\u496e\u4f6d'});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup3, new Uint32Array(484), 163, 0);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder34.insertDebugMarker('\u2714');
+} catch {}
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+let commandEncoder131 = device1.createCommandEncoder({label: '\u3c32\u0bdf\u{1f966}\u6717\u{1fb3f}\u0aaf\u43f2\u7835\u{1f999}\u8a7a'});
+let texture53 = device1.createTexture({
+  label: '\ue34d\u{1fc15}\u{1f709}\u0f64\ue22c\u042b\u57f9\u0526\u2c8c\u10d4\u5331',
+  size: [41],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler17 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 98.51,
+});
+let promise27 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder132 = device2.createCommandEncoder({label: '\u3c51\u9c5d\ua962\u0f60\udb08\u0326'});
+try {
+commandEncoder132.pushDebugGroup('\u{1fb53}');
+} catch {}
+try {
+commandEncoder132.pushDebugGroup('\u3ea6');
+} catch {}
+let renderBundle81 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder35.setIndexBuffer(buffer4, 'uint32', 17_748, 2_314);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer8, 0, 263);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder133 = device1.createCommandEncoder({label: '\u6cad\ucd56\u{1f690}\ubde6\uce65\u075a'});
+let commandBuffer74 = commandEncoder120.finish();
+try {
+device1.queue.submit([commandBuffer73]);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 3560, new BigUint64Array(3938), 446, 1396);
+} catch {}
+let commandEncoder134 = device1.createCommandEncoder({});
+let commandBuffer75 = commandEncoder131.finish({label: '\u3c18\u0a62\u{1f707}\u8426\u{1ffb3}'});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(572), /* required buffer size: 572 */
+{offset: 572}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData13 = new ImageData(72, 148);
+let videoFrame1 = new VideoFrame(video2, {timestamp: 0});
+let commandEncoder135 = device2.createCommandEncoder({});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let texture54 = device0.createTexture({
+  label: '\u{1fd64}\u2423\u{1fc3d}\ue09f\udae4\uc49d\u784d\uc639\u15dd',
+  size: {width: 360, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture13 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder21.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer9, 'uint32', 0, 133);
+} catch {}
+try {
+texture42.destroy();
+} catch {}
+let renderBundle82 = renderBundleEncoder14.finish({label: '\u1b78\ubdd3\ufd00\u03d7\ub0f1'});
+let externalTexture14 = device1.importExternalTexture({label: '\u0761\u04e9\u1bb0\uaee8\u02cd', source: video2, colorSpace: 'display-p3'});
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 3, y: 4, z: 34},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer67]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer5, 8, 693);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 56 */
+{offset: 56, rowsPerImage: 0}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.submit([commandBuffer75, commandBuffer72]);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder136 = device2.createCommandEncoder({label: '\uf910\uc5a2\u93ae\u0042\u9536\u246d\u2bb4\ub301\u7c18'});
+let commandBuffer76 = commandEncoder136.finish({label: '\u0c6a\ud8d1\u{1f8fd}'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+computePassEncoder28.setBindGroup(3, bindGroup4, new Uint32Array(123), 2, 0);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let commandBuffer77 = commandEncoder135.finish({label: '\ud048\u{1f79e}\u3c87\u{1f7cf}\u{1fd57}\ubab8\ue70b\u0342\u73fa\u8d74'});
+try {
+commandEncoder132.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise28 = device2.queue.onSubmittedWorkDone();
+let commandBuffer78 = commandEncoder130.finish();
+try {
+computePassEncoder25.setBindGroup(1, bindGroup4, new Uint32Array(716), 161, 0);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u0715\uc1cd\u07f4\ue080\u{1fdef}\u0ffe\u093b\u5e79',
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup2, new Uint32Array(2456), 540, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder137 = device1.createCommandEncoder({label: '\u{1f735}\ua694\u0624\u{1fe2f}\ueb87\uadb8\u52c6'});
+let commandBuffer79 = commandEncoder133.finish({label: '\u{1f792}\u374b\uea05\u375a\u3f21'});
+let computePassEncoder30 = commandEncoder134.beginComputePass({label: '\u0898\ubc84\u{1fec2}'});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise27;
+} catch {}
+try {
+device1.queue.submit([commandBuffer71, commandBuffer78]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandBuffer80 = commandEncoder93.finish({label: '\u33a0\u30d9\u6b09\u06cd\u2e71\u0866\u4c7e\u6568'});
+try {
+querySet15.label = '\uc39f\uc2dc\u4e76\u0412\u49a8\u0207\ubf33\u{1f780}\ued1c\u0b83';
+} catch {}
+let bindGroupLayout21 = device1.createBindGroupLayout({
+  label: '\u536b\u0cd6\u06cd\u{1fee8}\u{1f7ef}\ub7c4',
+  entries: [
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 186,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder138 = device1.createCommandEncoder({label: '\u0450\u4918\u{1fa46}\u{1fab9}\ue94d'});
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder139 = device0.createCommandEncoder();
+let texture55 = device0.createTexture({
+  size: {width: 720, height: 14, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder31 = commandEncoder139.beginComputePass({label: '\u{1fc9b}\u0eea'});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup3, new Uint32Array(2208), 24, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+let videoFrame2 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let renderBundle83 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([]);
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+let commandBuffer81 = commandEncoder127.finish({label: '\u{1ff4b}\u{1f88b}'});
+let renderBundle84 = renderBundleEncoder15.finish({label: '\u{1fdcd}\u{1f630}\u10e2\u{1fb81}\u99da\u09c3\u{1ff77}\u{1fb54}\u5387\ud900'});
+let commandBuffer82 = commandEncoder82.finish({label: '\u{1fadf}\u{1fed3}\u0580\u0012\uf731\u072e\u0834\u738d'});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 5688, new DataView(new ArrayBuffer(2033)), 871, 52);
+} catch {}
+try {
+adapter0.label = '\uce89\u48aa\u{1f7fc}\u{1fb89}\u0180\u0c0b';
+} catch {}
+let renderBundle85 = renderBundleEncoder8.finish({label: '\u8474\uf71d\u3d81\u487f\u02b0\u8ca4'});
+try {
+computePassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(231);
+} catch {}
+try {
+renderPassEncoder29.setViewport(430.72115042813755, 12.389551514055364, 345.3838750278115, 7.803374627949119, 0.6035087110555478, 0.7226583530120938);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline7);
+} catch {}
+let imageBitmap3 = await createImageBitmap(canvas2);
+let commandEncoder140 = device1.createCommandEncoder({label: '\u2e43\ubc8c\ue63f\u0206\ue243\u{1f8a5}\ue39c\u0148\u{1f9cb}'});
+let querySet17 = device1.createQuerySet({label: '\u1fdd\u46a9\u{1f6c7}\u0187\uf3d0\u8bec', type: 'occlusion', count: 431});
+let textureView35 = texture38.createView({label: '\u05c3\ud84b'});
+let computePassEncoder32 = commandEncoder128.beginComputePass({label: '\u0c00\u47a5'});
+let renderBundleEncoder16 = device1.createRenderBundleEncoder({
+  label: '\ua693\u{1f973}\u{1f667}\u8f12\u1141\u0de4\u0514',
+  colorFormats: ['r16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder16.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 170},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let renderBundle86 = renderBundleEncoder8.finish({label: '\ue03b\u7796\u20a7\u75f1\uc412\u0f84\u2185\u03f5\u{1fa5e}\u01b1\uc345'});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup0, new Uint32Array(4535), 2696, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer7, 96, 524);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView36 = texture1.createView({label: '\u0b6a\u0f49\ue84f\u8815\uada7\u{1ffcc}\u4ea7\u1312\u5862', baseMipLevel: 2, mipLevelCount: 1});
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer0, 4_172);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let canvas5 = document.createElement('canvas');
+let renderBundle87 = renderBundleEncoder3.finish({label: '\u{1f907}\uc083\u{1ff43}\u0e5b\ue0db\u06bf'});
+try {
+computePassEncoder23.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder25.setViewport(731.2889623705212, 7.77095834907343, 707.2649240377797, 9.120623867039589, 0.2040627945186665, 0.9615888863684489);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder141 = device1.createCommandEncoder({label: '\u07bc\uccf2\u02ed\u04f0\u0561'});
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer18, 0);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas5);
+try {
+window.someLabel = texture50.label;
+} catch {}
+let commandEncoder142 = device2.createCommandEncoder({});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let buffer19 = device0.createBuffer({
+  label: '\u4df8\u02a7\u47aa\u03e6',
+  size: 709,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture56 = gpuCanvasContext2.getCurrentTexture();
+let renderBundle88 = renderBundleEncoder13.finish({label: '\uc99d\ufeef\u0b64\u{1f782}\uf2c6'});
+let externalTexture15 = device0.importExternalTexture({
+  label: '\u5f60\u{1fe2a}\ufa2b\u04e7\u0a24\u04e4\u2785\u{1f806}\u1263\uee48',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder30.setScissorRect(36, 0, 20, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 3, depthOrArrayLayers: 39}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 4, y: 133 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise29;
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(228, 165);
+let commandBuffer83 = commandEncoder142.finish({label: '\u{1fa5f}\ub72e\ueab8\u63ea\uf36a'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext7 = canvas5.getContext('webgpu');
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder143 = device1.createCommandEncoder({});
+let promise30 = device1.queue.onSubmittedWorkDone();
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer58]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(42), /* required buffer size: 42 */
+{offset: 42}, {width: 108, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView37 = texture46.createView({});
+let computePassEncoder33 = commandEncoder129.beginComputePass({label: '\ub3e5\u{1faa0}\u0314\u{1fa74}\u9470\u41f4\u00fe\u0fb7'});
+try {
+renderBundleEncoder16.setIndexBuffer(buffer18, 'uint16', 2_022, 5_749);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer18, 0, 117);
+} catch {}
+let promise31 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext8 = offscreenCanvas5.getContext('webgpu');
+document.body.prepend(video2);
+let imageData14 = new ImageData(12, 64);
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder144 = device2.createCommandEncoder({label: '\u2240\u{1fef4}\u0d79\u51ba'});
+let computePassEncoder34 = commandEncoder132.beginComputePass();
+document.body.prepend(video1);
+let commandBuffer84 = commandEncoder144.finish({label: '\ub545\u275a'});
+let commandEncoder145 = device1.createCommandEncoder({});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup4, new Uint32Array(2244), 176, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup4, new Uint32Array(625), 170, 0);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline14);
+} catch {}
+try {
+device1.queue.submit([commandBuffer74, commandBuffer79]);
+} catch {}
+let bindGroupLayout22 = device1.createBindGroupLayout({
+  label: '\u08fb\ufb64\u0766\u{1fe78}\u03a0\u0cb0\ue809\u2ce0\u52fe\ub704\u076c',
+  entries: [
+    {
+      binding: 285,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 19964484, hasDynamicOffset: false },
+    },
+    {
+      binding: 288,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder146 = device1.createCommandEncoder({label: '\u6188\u{1f719}\ua948\u{1ff1b}'});
+let renderBundle89 = renderBundleEncoder16.finish({label: '\u9afc\ube57\u0bc7\u6222\u955f'});
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 22, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 14, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder147 = device1.createCommandEncoder({});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup4, new Uint32Array(36), 0, 0);
+} catch {}
+let computePassEncoder35 = commandEncoder145.beginComputePass({label: '\u0861\uec49\u064a\u76c2\u2d10\u5659\u0261\u788f'});
+let renderBundle90 = renderBundleEncoder15.finish();
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+await gc();
+let textureView38 = texture18.createView({label: '\u029c\u0455\ubc5b\u0001', mipLevelCount: 1});
+try {
+computePassEncoder26.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle56, renderBundle86, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer9, 236);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 468, new DataView(new ArrayBuffer(5825)), 499, 232);
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+  await promise30;
+} catch {}
+await gc();
+let promise32 = adapter1.requestAdapterInfo();
+let bindGroupLayout23 = device2.createBindGroupLayout({
+  label: '\u2066\u0718\u0197\ua6ad\u04b3\u36d4',
+  entries: [{binding: 349, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }}],
+});
+let commandEncoder148 = device2.createCommandEncoder({label: '\u0f52\ufb5d\u2c0f\u{1fb77}\uefc9\u0b65\ua694\u427e\u71f5\u{1fa5e}\u0cb8'});
+let commandBuffer85 = commandEncoder148.finish({label: '\u{1fc52}\u2a00\u0f53\u9cd8\u{1fe75}\u7549\u64cf'});
+try {
+computePassEncoder34.pushDebugGroup('\u78c1');
+} catch {}
+try {
+computePassEncoder34.popDebugGroup();
+} catch {}
+document.body.prepend(video2);
+await gc();
+let imageData15 = new ImageData(8, 20);
+let pipelineLayout16 = device2.createPipelineLayout({label: '\u0463\u2845\u68fe\u358e', bindGroupLayouts: [bindGroupLayout23]});
+let commandEncoder149 = device2.createCommandEncoder();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise32;
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder();
+let commandBuffer86 = commandEncoder150.finish({label: '\ucc1b\u03d0\u{1fa7a}\u3814\u0679'});
+try {
+renderPassEncoder33.setViewport(1263.328420477592, 2.722709217436936, 165.36186260013548, 14.85237802770203, 0.4678329748005682, 0.7864248389205111);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer9, 0, 864);
+} catch {}
+await gc();
+let commandEncoder151 = device0.createCommandEncoder({label: '\u{1f9d1}\u{1f730}\u{1f94c}\u80df\u{1fbed}\u545c'});
+let commandBuffer87 = commandEncoder151.finish();
+let textureView39 = texture33.createView({});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(2, bindGroup3, new Uint32Array(255), 20, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+let commandEncoder152 = device2.createCommandEncoder({label: '\u0d16\ud763\u3ac2\u0951\u023e\u1c43\u3fa8\u8090'});
+let commandBuffer88 = commandEncoder149.finish({label: '\u5ef1\u8f22\ue775'});
+try {
+device2.queue.submit([commandBuffer85]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(168), /* required buffer size: 168 */
+{offset: 168}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({label: '\u0d40\u4814\u0fa9\u0506\u03b8'});
+let computePassEncoder36 = commandEncoder153.beginComputePass({label: '\u{1fa4d}\u177b\u023b\u{1f634}\u{1fd86}\u{1fe41}\ua48a'});
+try {
+renderPassEncoder18.beginOcclusionQuery(245);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer4, 484, 1_842);
+} catch {}
+try {
+renderPassEncoder19.insertDebugMarker('\u0e99');
+} catch {}
+let commandEncoder154 = device2.createCommandEncoder({label: '\u309d\u8f57\u0363\u{1f9de}\u489d\u0155'});
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(183), /* required buffer size: 183 */
+{offset: 183, bytesPerRow: 83, rowsPerImage: 127}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder155 = device1.createCommandEncoder({label: '\u2735\ub049\u{1f8b0}\u05b9\u{1fee0}\u22bb\u09b1\u{1f9c6}'});
+let renderBundle91 = renderBundleEncoder15.finish({label: '\u0a67\u5a20\u090c\u{1f8cd}\u0046\u1235\u{1faa4}\u2ddb'});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+await gc();
+let commandEncoder156 = device1.createCommandEncoder({label: '\u0a87\uea70\u54d9'});
+let bindGroup5 = device1.createBindGroup({
+  label: '\u90f3\ue52b',
+  layout: bindGroupLayout15,
+  entries: [{binding: 719, resource: externalTexture14}],
+});
+let commandEncoder157 = device1.createCommandEncoder({label: '\u7758\u6bf5\uce67\uab4a'});
+let commandBuffer89 = commandEncoder137.finish({label: '\u2dd5\u0d89\uf3e8\u6903\u54ba\uf299\u0e3b\u{1fede}\ueae0\u3056'});
+try {
+device1.queue.submit([commandBuffer89, commandBuffer81, commandBuffer80]);
+} catch {}
+let texture57 = gpuCanvasContext4.getCurrentTexture();
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+  await promise31;
+} catch {}
+let texture58 = device2.createTexture({
+  label: '\u620f\u54d4\u95de\ufdb3\ue9fb\ud816\u3f30\u0b6a\u0dba\u85ba',
+  size: [298, 1, 20],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+device2.queue.submit([commandBuffer84, commandBuffer76, commandBuffer77, commandBuffer88]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 149, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: imageData6,
+  origin: { x: 13, y: 11 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData16 = new ImageData(76, 8);
+let videoFrame3 = new VideoFrame(canvas0, {timestamp: 0});
+try {
+adapter0.label = '\u0c62\u0680\u03e9\ue35f\u96cd';
+} catch {}
+let commandEncoder158 = device1.createCommandEncoder({});
+let querySet18 = device1.createQuerySet({label: '\u{1ffcc}\u{1fe87}\uec6d\ufa2c\u9edb\u7eab\u0d7a\u18d0', type: 'occlusion', count: 1258});
+let commandBuffer90 = commandEncoder114.finish({label: '\u0614\u03f9\u67fd\u1eb4\uf146\u32a1\u44b3\u020c\u04e9'});
+try {
+device1.queue.submit([commandBuffer90]);
+} catch {}
+let commandEncoder159 = device0.createCommandEncoder({label: '\u0d08\u3f39'});
+let querySet19 = device0.createQuerySet({label: '\u18be\u0ea1\u926c\u025a\u0a1d\u03bb\u0cda', type: 'occlusion', count: 771});
+let texture59 = device0.createTexture({
+  size: {width: 720, height: 14, depthOrArrayLayers: 264},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup3, new Uint32Array(772), 87, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder29.setViewport(327.8153627177353, 24.694691852548893, 914.5095579800019, 2.548643821278344, 0.28660389751071813, 0.8496244182218798);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+adapter0.label = '\u1fb8\ucbde\ud4e4\ua81a\u436a\uc5c4';
+} catch {}
+let pipelineLayout17 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout23]});
+let commandEncoder160 = device2.createCommandEncoder({label: '\u{1ff90}\u1d3f\u1c90\ud82d\uee75\u41a9\u6c47\u55ac\udcc2\u36c8\u0c74'});
+let computePassEncoder37 = commandEncoder160.beginComputePass({label: '\u{1fa02}\ub51b\uf031\u2d30\uee14\u5b58'});
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder161 = device1.createCommandEncoder();
+let textureView40 = texture35.createView({
+  label: '\u1889\u171d\ufc3e\u{1fd3c}\u{1fc10}\u3610\u{1fbf6}\u08c8\u20c3\u7828\u{1fa68}',
+  mipLevelCount: 1,
+});
+let buffer20 = device1.createBuffer({
+  label: '\uf95b\u551f\ue590\u0cc3\u7b57\u{1fa96}\u{1fa0b}\u98a7\u09ed\ud157\uc59e',
+  size: 8328,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder162 = device1.createCommandEncoder();
+try {
+computePassEncoder25.insertDebugMarker('\u09f4');
+} catch {}
+let commandEncoder163 = device2.createCommandEncoder({label: '\u2318\u{1fc44}\u9a15'});
+let commandBuffer91 = commandEncoder152.finish({label: '\u0fad\u0515\uf161\u3951\ud580\u0b35\u6ec7\u0a2e\u0f97\u0c80'});
+let sampler18 = device2.createSampler({
+  label: '\uc05e\u2939',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.08,
+  lodMaxClamp: 56.27,
+  maxAnisotropy: 12,
+});
+let shaderModule5 = device2.createShaderModule({
+  code: `
+enable f16;
+
+struct T0 {
+  f0: mat4x2f,
+}
+
+@group(0) @binding(349) var sam0: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(11) f5: vec4f,
+  @location(6) f6: vec3u,
+  @location(8) f7: vec2i,
+  @location(10) @interpolate(flat, center) f8: vec3i,
+  @location(13) f9: f16,
+  @location(9) f10: vec2u,
+  @location(12) f11: f16,
+  @location(15) @interpolate(flat, centroid) f12: vec4i,
+  @location(7) @interpolate(perspective, sample) f13: vec2h,
+  @location(5) @interpolate(flat, sample) f14: vec2i,
+  @builtin(position) f15: vec4f,
+  @location(2) @interpolate(flat, sample) f16: vec4h,
+  @location(1) @interpolate(flat, sample) f17: vec4u,
+  @location(14) f18: vec3u,
+  @location(3) f19: vec4i,
+  @location(4) f20: f16
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4u,
+  @location(0) @interpolate(flat, centroid) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let computePassEncoder38 = commandEncoder146.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device1, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame1);
+try {
+renderPassEncoder18.setIndexBuffer(buffer13, 'uint16', 30, 7_122);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer10, 584, 1176);
+} catch {}
+let computePassEncoder39 = commandEncoder143.beginComputePass({});
+let sampler19 = device1.createSampler({
+  label: '\u384a\u6e7c\u{1f957}\u3cfe\u379b\uaa42\u0849\u{1fcd1}\ue515\uc1b0\u0156',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.90,
+  lodMaxClamp: 95.83,
+});
+try {
+computePassEncoder39.end();
+} catch {}
+let img1 = await imageWithData(10, 81, '#10101010', '#20202020');
+let commandEncoder164 = device2.createCommandEncoder();
+let commandBuffer92 = commandEncoder154.finish({label: '\ua80c\u5e91\u043b\u0d75\ub6d3\u2dce\ud582\uc94c'});
+let externalTexture16 = device2.importExternalTexture({label: '\u0b86\u{1ff48}\u7181\u0932', source: videoFrame0, colorSpace: 'srgb'});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder165 = device2.createCommandEncoder({label: '\u{1fbcb}\u{1feb1}\u2d57\ufb14\u3725\ubefa\u{1fef6}\u0b51'});
+let commandBuffer93 = commandEncoder165.finish({});
+let sampler20 = device2.createSampler({
+  label: '\u{1fd8e}\u0940\u{1fc11}\u0ebe\ub211\ubec3\u3945\u{1fb85}\u60ae\u4811',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.235,
+  maxAnisotropy: 4,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder40 = commandEncoder147.beginComputePass({label: '\u401f\u073f\ud5a8'});
+let renderBundle92 = renderBundleEncoder12.finish({label: '\u519d\ued27\u{1f957}\u{1fc32}'});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let buffer21 = device0.createBuffer({
+  label: '\u70a5\u1b18\u0f0f',
+  size: 3272,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture60 = device0.createTexture({
+  size: [1440, 28, 120],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder41 = commandEncoder159.beginComputePass({label: '\u6828\udde3\u1231\u{1ffc0}\u04b4\u{1fa58}\u6c03\u0ede'});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup2, new Uint32Array(1364), 25, 0);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(38, 0, 100, 0);
+} catch {}
+try {
+renderPassEncoder29.setViewport(945.6872226149543, 11.507278368994102, 430.13364011890286, 14.660497942017097, 0.6443668762885684, 0.7713791668358814);
+} catch {}
+let texture61 = device1.createTexture({
+  label: '\u{1f609}\u{1fec5}\u02e5\u6ce4',
+  size: [20, 1, 5],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder42 = commandEncoder111.beginComputePass({});
+try {
+commandEncoder140.clearBuffer(buffer20);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle93 = renderBundleEncoder15.finish({label: '\u05ec\u{1fd63}\ud37a\u9a56'});
+try {
+device1.queue.writeBuffer(buffer20, 3560, new BigUint64Array(4606), 317, 80);
+} catch {}
+let imageData17 = new ImageData(12, 52);
+let shaderModule6 = device0.createShaderModule({
+  label: '\u07a3\u{1fae6}\u0e82\u02bf\u0b46',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<mat4x4f>,
+}
+
+@group(0) @binding(202) var st1: texture_storage_2d<r32float, read_write>;
+@group(1) @binding(117) var tex4: texture_3d<f32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  if bool(textureLoad(tex4, vec3i(), 0)[1]) {
+    return;
+  }
+}
+
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat) f0: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+});
+let renderBundle94 = renderBundleEncoder9.finish({label: '\uc9a9\u71b2\u3d49'});
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer4, 0);
+} catch {}
+let textureView41 = texture3.createView({label: '\ub32f\u524b\u{1ffec}\u85e0', mipLevelCount: 1});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder36.setBindGroup(0, bindGroup0, new Uint32Array(9248), 1899, 0);
+} catch {}
+try {
+renderPassEncoder37.setViewport(103.75739809512937, 1.3733947269455435, 60.50270282118661, 2.822942960407251, 0.888437539435061, 0.9306908512061761);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer21, 680, buffer9, 76, 596);
+} catch {}
+try {
+device0.queue.submit([commandBuffer82, commandBuffer87]);
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+let commandBuffer94 = commandEncoder164.finish({label: '\u0c56\u01c7\u0c18\uca24\u{1f713}\u11d0\u02f7\u64cf\u1b42\u{1f95c}\ud6d7'});
+let computePassEncoder43 = commandEncoder132.beginComputePass({});
+let commandEncoder166 = device2.createCommandEncoder({});
+let commandBuffer95 = commandEncoder166.finish();
+try {
+device2.queue.submit([commandBuffer93, commandBuffer83, commandBuffer91]);
+} catch {}
+try {
+  await promise33;
+} catch {}
+canvas4.height = 1651;
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u0d84\u{1fb0d}\u0828\ue093\uf0ae\u8b54\u12ca\uee40', bindGroupLayouts: [bindGroupLayout6]});
+let commandEncoder167 = device0.createCommandEncoder({label: '\u1605\u0c94\u{1f964}'});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+window.someLabel = commandEncoder157.label;
+} catch {}
+let querySet20 = device1.createQuerySet({label: '\u{1faf2}\u{1ff66}\u20b9\uf154', type: 'occlusion', count: 74});
+let commandBuffer96 = commandEncoder155.finish();
+let texture62 = device1.createTexture({
+  label: '\u030a\uc9c2\u{1f62f}\u060d\u{1fc3e}\u5752',
+  size: [82, 1, 74],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({label: '\u0bbe\u{1fa6c}\u7101\u752e\u1b27\u2cf2', colorFormats: ['r16sint']});
+let renderBundle95 = renderBundleEncoder14.finish({label: '\u{1fa46}\u0cf5\uabaf\u043e\u{1fe91}\u9d2a'});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup4, new Uint32Array(54), 29, 0);
+} catch {}
+try {
+commandEncoder121.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 184 */
+  offset: 184,
+  buffer: buffer20,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 676, new Int16Array(1194));
+} catch {}
+await gc();
+let texture63 = device0.createTexture({
+  label: '\u6154\u0caf\ub966\u7f72\ubb4d\u0d91\ub6bd\u{1ff40}\u0192',
+  size: {width: 360, height: 7, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder38 = commandEncoder80.beginRenderPass({
+  label: '\u84f7\ub7d4\ucceb\u04ea\ub561\u2b02\u{1fcf2}',
+  colorAttachments: [{view: textureView28, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 16582927,
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+let querySet21 = device0.createQuerySet({label: '\u{1fd6e}\u6c71\uef07\u7525\u0b74', type: 'occlusion', count: 337});
+try {
+computePassEncoder36.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 18.04, g: 189.6, b: -668.9, a: -325.8, });
+} catch {}
+let commandEncoder168 = device1.createCommandEncoder({label: '\u{1fb63}\u2f6d\u{1f744}\u{1fdaf}\u208e\u04da\u01c5\ubb58\u{1f75e}\u6365'});
+let computePassEncoder44 = commandEncoder158.beginComputePass({});
+let sampler21 = device1.createSampler({
+  label: '\u0015\u0a6f',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 97.08,
+  compare: 'never',
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup4, new Uint32Array(5626), 548, 0);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 52, new DataView(new ArrayBuffer(9843)), 51, 108);
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: []});
+let renderPassEncoder39 = commandEncoder112.beginRenderPass({
+  label: '\u8fd2\u7a37\u{1fc27}',
+  colorAttachments: [{
+  view: textureView14,
+  clearValue: { r: 959.6, g: -492.9, b: 743.2, a: 101.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 141700640,
+});
+let renderBundle96 = renderBundleEncoder8.finish({label: '\u084c\u0399\u1f6a\u{1f93f}\u{1f66c}\u344c\u2aee\u04f6'});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer8);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder167.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 209, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter1.label = '\u07c0\u189f\u043a\u201d\u53b6\u{1f672}\u{1fc4d}';
+} catch {}
+let commandBuffer97 = commandEncoder138.finish();
+let renderBundle97 = renderBundleEncoder12.finish({label: '\u6768\u04f3\u3e39\u3f2d\u00d5\ucaf7\u082e\u2a2b\ud4ca'});
+try {
+renderBundleEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 260, new Int16Array(12407), 2534, 68);
+} catch {}
+let externalTexture17 = device1.importExternalTexture({
+  label: '\u0015\u{1fdd6}\u0103\u736d\u{1f9f7}\u0bcb\u0eb1\u05fe',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup5, new Uint32Array(2613), 249, 0);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer18, 4_700, 300);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 98 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1878 */
+  offset: 1878,
+  buffer: buffer18,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 6844, new Int16Array(23158), 151, 52);
+} catch {}
+let bindGroupLayout24 = device1.createBindGroupLayout({
+  label: '\udb6e\u{1ff99}\ue5a5\u0ab6\u0e42\u177f\u0aef\u{1f965}\u{1f89a}\u{1f9e4}\u9215',
+  entries: [
+    {
+      binding: 76,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 8,
+      visibility: 0,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 275,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 5330220, hasDynamicOffset: true },
+    },
+    {
+      binding: 445,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 257,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 446,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 146,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 55603823, hasDynamicOffset: false },
+    },
+    {
+      binding: 777,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 86,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 233,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 348, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 67,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 244,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 39, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 266,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 296,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 240,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 280,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 19, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 189,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 62, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 335,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 193, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 215, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 259,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {binding: 150, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 75,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 118,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 155, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 1484710, hasDynamicOffset: false },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 341,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 78, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 12,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 30, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 134,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 14, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 165,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 232, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 171,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 178, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 197,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 343, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 37, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 42, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 239, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 199, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 318, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 234,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 91, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 149,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 130,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 11515949, hasDynamicOffset: false },
+    },
+    {
+      binding: 98,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 160,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 111, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 999, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let renderBundle98 = renderBundleEncoder15.finish({label: '\u9677\u06a8\u0da5\u{1f624}\uc5f8\u0e86'});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup5, new Uint32Array(302), 9, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+device2.queue.submit([commandBuffer92, commandBuffer94]);
+} catch {}
+let computePassEncoder45 = commandEncoder167.beginComputePass({label: '\u{1ffb5}\u{1f8ac}\u{1ffe8}\u4055\u{1f845}\u27ab'});
+try {
+computePassEncoder45.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer2, 'uint32', 5_380, 6_031);
+} catch {}
+try {
+texture6.destroy();
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\udc94');
+} catch {}
+let pipeline16 = device0.createComputePipeline({
+  label: '\u7854\u4ba0\u0749\u0c34\u7d82\u0325',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule6, constants: {}},
+});
+let sampler22 = device0.createSampler({
+  label: '\u3e3d\ua0e7\u3083\u7c55\u{1fd9e}\u84c6\u758e\u03a5\u0205',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 62.57,
+  lodMaxClamp: 98.59,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer2, 'uint32', 400, 5_695);
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u37ed');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 188, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(51), /* required buffer size: 51 */
+{offset: 51, bytesPerRow: 289}, {width: 94, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder163.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 74, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 5, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder169 = device2.createCommandEncoder({});
+let commandBuffer98 = commandEncoder169.finish({label: '\u068e\u7b96\u01e8\u{1fe16}\u{1fdd1}\u0b94\ua564\u{1fa4d}'});
+let textureView42 = texture48.createView({label: '\u9a25\u0eed\u9187\u5a16\u01f5\u05b0\u054d\u50dd\ub6ea'});
+let bindGroup6 = device2.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 349, resource: sampler18}]});
+let commandEncoder170 = device2.createCommandEncoder({label: '\u0ce9\u0ae8\u3776\u7caa\u09ee\ud255\u{1faf2}\u495c\u{1f7fb}\u6f11'});
+let commandBuffer99 = commandEncoder170.finish({label: '\u0ea3\u77e6\u{1f9e5}\u{1f69e}\ubfe6\ub9a4\u22d0\u{1ff02}\u07dd\u{1fcd7}'});
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 298, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 14, y: 46 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder171 = device2.createCommandEncoder({label: '\u{1fd27}\uea91\u82eb'});
+try {
+gpuCanvasContext7.configure({device: device2, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = await device2.createRenderPipelineAsync({
+  label: '\u{1fc5f}\ud016',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x3be7fcd8},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  vertex: {module: shaderModule5, constants: {}, buffers: []},
+});
+let img2 = await imageWithData(37, 37, '#10101010', '#20202020');
+let pipelineLayout20 = device0.createPipelineLayout({label: '\u{1f6bf}\u0209\ude2b\ua584\u73c7', bindGroupLayouts: []});
+let sampler23 = device0.createSampler({
+  label: '\u{1fc39}\u{1f89b}\ue721\uc657\u85b6\ub421\u{1fa89}\u488a\u3408\ue405\u{1f81a}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 13.74,
+  lodMaxClamp: 82.06,
+});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(4, buffer0, 0, 704);
+} catch {}
+let commandEncoder172 = device2.createCommandEncoder();
+let renderBundleEncoder18 = device2.createRenderBundleEncoder({
+  colorFormats: ['rg16float', 'rgb10a2unorm', 'r8uint', 'rgba16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle99 = renderBundleEncoder18.finish({label: '\u0945\u0f04\ud54c\u{1fbed}\u859c\u9047\u0fe2'});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup6);
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder({label: '\u{1fb68}\ub350\u{1f891}\u0b97\u{1fa98}'});
+let commandBuffer100 = commandEncoder173.finish();
+try {
+renderPassEncoder30.beginOcclusionQuery(259);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(6, buffer8, 2_104, 670);
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let computePassEncoder46 = commandEncoder168.beginComputePass({label: '\u0fb4\u{1f85c}'});
+try {
+renderBundleEncoder17.setIndexBuffer(buffer18, 'uint16', 2_072, 304);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder157.copyTextureToBuffer({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2508 */
+  offset: 2508,
+  buffer: buffer20,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 908, new Float32Array(5423), 1008, 80);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let bindGroupLayout25 = device1.createBindGroupLayout({
+  label: '\uc89d\u{1fc7c}\u0a54\u0e5c\u{1fe7f}\u7844\ueece\u033e\u6bf1\u{1f6ff}\u{1f99f}',
+  entries: [
+    {
+      binding: 118,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer101 = commandEncoder161.finish({label: '\ub812\u{1f93f}'});
+let renderBundle100 = renderBundleEncoder14.finish({label: '\u243a\u9e9d\u6c11'});
+try {
+device1.queue.writeBuffer(buffer20, 1040, new BigUint64Array(15536), 617, 44);
+} catch {}
+await gc();
+let imageBitmap5 = await createImageBitmap(imageData0);
+let commandBuffer102 = commandEncoder171.finish({label: '\ub51d\u9836\ub6e7\uf462\u2b42\u0165\u{1fc5e}'});
+let computePassEncoder47 = commandEncoder172.beginComputePass();
+try {
+commandEncoder163.insertDebugMarker('\u0fa7');
+} catch {}
+let querySet22 = device2.createQuerySet({type: 'occlusion', count: 826});
+let textureView43 = texture50.createView({label: '\u{1f7d4}\u8f47\u6325\u4dfb\uaf81\udce7'});
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 81, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(45_700), /* required buffer size: 45_700 */
+{offset: 100, bytesPerRow: 76, rowsPerImage: 75}, {width: 3, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let buffer22 = device0.createBuffer({
+  label: '\ucb99\ud89d\u45ea\uebab\u{1fa39}\u845a\u0fd1',
+  size: 43889,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture64 = gpuCanvasContext2.getCurrentTexture();
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup1, new Uint32Array(21), 2, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle26, renderBundle31]);
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({});
+try {
+computePassEncoder41.setPipeline(pipeline9);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder174.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 81, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 168 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 256 */
+  offset: 256,
+  buffer: buffer13,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder175 = device1.createCommandEncoder({label: '\u096c\u18e7\u8d7e\u5e5a\u{1f8cc}\u0fc1\uecce\u{1fc6b}\u78e8\u2d4d'});
+let textureView44 = texture62.createView({label: '\u3e71\u6661\uba60\ud75c\u7f5e\u8459\u0016\u0d27\u7054', baseArrayLayer: 0});
+let sampler24 = device1.createSampler({
+  label: '\u0ace\u02c0\ubfee\u24cd\u11b1\u7ba3\u0457\u6d00\uf4c4\uccf9',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.73,
+  lodMaxClamp: 35.43,
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+  await promise34;
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  label: '\u0ac0\ue5da\u45f8\u5abb\ufb9c\u9068\u0832\u{1f6d1}\u022e\uf754',
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 96,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 109, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 296,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 128,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 112,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 138,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 78, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 785,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 26,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 447,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 395,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 17,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 265, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 213,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 182,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 311,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 199,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 7, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 349, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {binding: 306, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 1, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 84,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 237,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 307,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 4127935, hasDynamicOffset: false },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 290,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 59,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 430,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 10782680, hasDynamicOffset: false },
+    },
+    {binding: 40, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 320,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 139, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {binding: 111, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 322,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 29, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 211,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 215, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 27,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 260, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 339, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 248, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 117,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 798,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 12350728, hasDynamicOffset: false },
+    },
+    {
+      binding: 204,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 66, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 194, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 228,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 420, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 276, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 47, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 196, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 124, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 102, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 160, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 37, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 383, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 110, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 48, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 0, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 63, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 188,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 125, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 105, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 218, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 46, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 364, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 65, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 20, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 82, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 83, visibility: 0, externalTexture: {}},
+    {binding: 100, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 91, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 94, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 234,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 544, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 456, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 324, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 496, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 281, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 64, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 108, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 10, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 512, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 126, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 41, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 22, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 525, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 274,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 143, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 106, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 256, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 300,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 217, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 5, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 16, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 591, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 170, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 32, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView45 = texture34.createView({
+  label: '\u5be8\u078c\u{1fa23}\u7157\u6593\u64d6\ub0ef\u900d\u0b5a',
+  dimension: '1d',
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(149);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer21, 'uint16', 1_250, 263);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 32, new BigUint64Array(15407), 378, 84);
+} catch {}
+await gc();
+let imageData18 = new ImageData(12, 44);
+let commandBuffer103 = commandEncoder174.finish({label: '\u{1fc96}\u0791\u6101\uea53\u0105\u0924\u0d8f'});
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandBuffer104 = commandEncoder163.finish({label: '\u73ba\u53f0\ue598\ud6cd\ub9c0\u{1fe99}\u{1f73e}\uf0c2'});
+let texture65 = device2.createTexture({
+  size: [2384, 1, 11],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+document.body.prepend(video1);
+let commandEncoder176 = device1.createCommandEncoder({label: '\u55d4\uecf4\u02a4\u{1fbe4}\u0207\u{1fb22}\u01ca'});
+let commandBuffer105 = commandEncoder143.finish({});
+let renderPassEncoder40 = commandEncoder116.beginRenderPass({
+  label: '\u0716\ub8af',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 65,
+  clearValue: { r: -868.3, g: -116.5, b: 942.3, a: -797.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 304149149,
+});
+try {
+renderPassEncoder40.executeBundles([renderBundle98]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer18, 'uint32', 4_576, 1_660);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer18);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(625, 380);
+let shaderModule7 = device1.createShaderModule({
+  label: '\u695a\u1504\u04bc\u7503\u0362\u0051\u0b4a',
+  code: `
+enable f16;
+enable f16;
+
+struct T0 {
+  f0: atomic<i32>,
+}
+struct T1 {
+  f0: atomic<u32>,
+  f1: atomic<u32>,
+}
+struct T2 {
+  f0: T1,
+}
+
+@group(1) @binding(719) var et3: texture_external;
+@group(0) @binding(719) var et2: texture_external;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0() {
+}
+
+@vertex
+fn vertex0(@location(4) a0: u32, @location(14) @interpolate(flat, center) a1: vec2u, @builtin(vertex_index) a2: u32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat, sample) f0: vec4i,
+  @location(4) @interpolate(perspective, centroid) f1: f32,
+  @location(7) @interpolate(flat) f2: vec4u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer106 = commandEncoder176.finish({label: '\u0832\u{1fe32}'});
+try {
+renderPassEncoder40.executeBundles([renderBundle79, renderBundle89, renderBundle93, renderBundle68]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+querySet17.destroy();
+} catch {}
+let promise35 = device1.queue.onSubmittedWorkDone();
+let commandEncoder177 = device2.createCommandEncoder({});
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(125), /* required buffer size: 125 */
+{offset: 125, bytesPerRow: 123}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 298, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 5, y: 20 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  label: '\u98a0\u53c5\u{1f79c}\u3167\u{1fbf6}\u5060\u0346\u0c91',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: u32,
+}
+
+@group(0) @binding(294) var sam1: sampler;
+@group(0) @binding(30) var sam7: sampler;
+@group(0) @binding(7) var et7: texture_external;
+@group(0) @binding(149) var tex13: texture_depth_cube_array;
+@group(0) @binding(74) var tex8: texture_3d<u32>;
+@group(0) @binding(44) var<uniform> buffer29: mat3x2f;
+@group(0) @binding(42) var<storage, read_write> buffer32: array<vec3h>;
+@group(0) @binding(110) var sam6: sampler;
+@group(0) @binding(159) var sam11: sampler_comparison;
+@group(0) @binding(10) var sam2: sampler;
+@group(0) @binding(164) var tex14: texture_3d<u32>;
+@group(0) @binding(173) var et4: texture_external;
+@group(0) @binding(48) var<storage, read> buffer24: i32;
+@group(0) @binding(22) var tex19: texture_2d<u32>;
+@group(0) @binding(85) var tex12: texture_multisampled_2d<u32>;
+@group(0) @binding(183) var tex11: texture_cube_array<f32>;
+@group(0) @binding(416) var<uniform> buffer28: mat3x4f;
+@group(0) @binding(29) var<storage, read> buffer30: u32;
+@group(0) @binding(76) var et6: texture_external;
+@group(0) @binding(135) var tex17: texture_2d<f32>;
+@group(0) @binding(483) var<storage, read_write> buffer34: T0;
+@group(0) @binding(9) var sam4: sampler;
+@group(0) @binding(106) var<storage, read_write> buffer27: atomic<u32>;
+@group(0) @binding(101) var st5: texture_storage_1d<r32sint, read_write>;
+@group(0) @binding(129) var et5: texture_external;
+@group(0) @binding(27) var tex15: texture_depth_2d;
+@group(0) @binding(227) var<storage, read> buffer25: mat2x2f;
+@group(0) @binding(268) var<storage, read_write> buffer26: atomic<i32>;
+@group(0) @binding(93) var<uniform> buffer33: mat2x4f;
+@group(0) @binding(64) var<uniform> buffer23: mat3x4h;
+@group(0) @binding(114) var sam10: sampler;
+@group(0) @binding(401) var tex7: texture_3d<i32>;
+@group(0) @binding(146) var sam3: sampler;
+@group(0) @binding(141) var st2: texture_storage_2d_array<rgba8sint, write>;
+@group(0) @binding(255) var st3: texture_storage_2d_array<r32uint, read_write>;
+@group(0) @binding(70) var sam5: sampler;
+@group(0) @binding(2) var st4: texture_storage_3d<rg32uint, read>;
+@group(0) @binding(111) var sam8: sampler;
+@group(0) @binding(77) var tex6: texture_1d<i32>;
+@group(0) @binding(187) var tex9: texture_1d<i32>;
+@group(0) @binding(61) var tex20: texture_3d<i32>;
+@group(0) @binding(137) var tex18: texture_multisampled_2d<i32>;
+@group(0) @binding(20) var tex10: texture_3d<f32>;
+@group(0) @binding(37) var tex5: texture_cube<i32>;
+@group(0) @binding(311) var sam9: sampler;
+@group(0) @binding(116) var tex16: texture_depth_cube_array;
+@group(0) @binding(266) var<storage, read_write> buffer31: atomic<u32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  _ = textureSampleGrad(tex10, sam3, vec3f(), vec3f(), vec3f(), vec3i());
+  _ = buffer31;
+  _ = textureSampleGrad(tex17, sam6, vec2f(), vec2f(), vec2f(), vec2i());
+  _ = textureSampleLevel(tex16, sam5, vec3f(), 0i, 0i);
+  _ = textureSampleLevel(tex11, sam6, vec3f(), 0i, 0.0);
+}
+
+@vertex
+fn vertex0(@location(8) @interpolate(flat, centroid) a0: vec4u) -> @builtin(position) vec4f {
+  var out: vec4f;
+  _ = textureSampleGrad(tex11, sam4, vec3f(), 0i, vec3f(), vec3f());
+  _ = textureSampleLevel(tex17, sam9, vec2f(), 0.0);
+  _ = a0;
+  _ = textureSampleBaseClampToEdge(et4, sam4, vec2f());
+  _ = textureSampleLevel(tex17, sam4, vec2f(), 0.0, vec2i());
+  _ = buffer24;
+  _ = buffer33;
+  _ = textureSampleGrad(tex11, sam2, vec3f(), 0i, vec3f(), vec3f());
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3f,
+  @location(0) @interpolate(flat) f1: vec3f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = textureGather(0, tex17, sam2, vec2f());
+  _ = textureSampleGrad(tex17, sam10, vec2f(), vec2f(), vec2f(), vec2i());
+  _ = textureSample(tex17, sam9, vec2f());
+  _ = textureGather(3, tex19, sam4, vec2f());
+  _ = textureSampleLevel(tex15, sam8, vec2f(), 0i, vec2i());
+  _ = textureSampleLevel(tex13, sam4, vec3f(), 0i, 0i);
+  _ = textureSampleLevel(tex13, sam7, vec3f(), 0i, 0i);
+  _ = textureSample(tex11, sam4, vec3f(), 0i);
+  _ = textureSampleLevel(tex13, sam10, vec3f(), 0i, 0i);
+  _ = textureSampleBias(tex11, sam7, vec3f(), 0i, 0.0);
+  if bool(textureGather(tex13, sam6, vec3f(), 0)[3]) {
+    out.f1 = textureSampleBaseClampToEdge(et4, sam9, vec2f()).rrb;
+  }
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder178 = device0.createCommandEncoder();
+let renderPassEncoder41 = commandEncoder178.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -588.0, g: -317.5, b: 80.32, a: -639.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer4, 400, 2_995);
+} catch {}
+try {
+  await promise35;
+} catch {}
+let imageData19 = new ImageData(48, 12);
+let commandEncoder179 = device2.createCommandEncoder({label: '\u3587\u703b\u0abd\u1eb5\uc77f'});
+let commandBuffer107 = commandEncoder179.finish({});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup6, new Uint32Array(536), 60, 0);
+} catch {}
+let renderBundle101 = renderBundleEncoder3.finish({label: '\udc7d\u{1fe85}\uaafa\u594e'});
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(8);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(3, buffer5, 1_116, 221);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer70, commandBuffer100]);
+} catch {}
+let externalTexture18 = device0.importExternalTexture({
+  label: '\u{1f781}\u00b8\u{1f9e9}\u22d8\u00cd\u82cd\u5214\uf4cd',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle41, renderBundle1, renderBundle29, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer4, 'uint16', 12_504, 701);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture66 = device0.createTexture({
+  label: '\u9c56\u0d3d',
+  size: [1440, 28, 432],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder41.setPipeline(pipeline2);
+} catch {}
+let commandEncoder180 = device0.createCommandEncoder({label: '\u1518\ua5dc\u222d\u025a\u0cb5\ubb90\uf0fc\u{1f970}\u{1fb40}'});
+let renderBundle102 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder36.setPipeline(pipeline3);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder180.copyBufferToBuffer(buffer10, 3172, buffer2, 2020, 344);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: imageData11,
+  origin: { x: 34, y: 7 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 26, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData20 = new ImageData(12, 52);
+try {
+device2.queue.submit([commandBuffer104]);
+} catch {}
+let commandEncoder181 = device2.createCommandEncoder({label: '\u{1fe77}\ud852\u02b4\u94e3\u0250\u{1fab2}\u0c33\u1436\u{1fa99}'});
+let commandBuffer108 = commandEncoder177.finish({label: '\u0f79\u{1f7aa}\u50c9\u0f02\u0d69\ucf18'});
+let computePassEncoder48 = commandEncoder181.beginComputePass();
+let renderBundle103 = renderBundleEncoder18.finish({label: '\u9348\ub656\u97c6\u5f18\u{1f94d}\ua4ca'});
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer21, 'uint32', 188, 730);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder49 = commandEncoder140.beginComputePass({});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({
+  label: '\u28ae\u091a\ucd63\u9375\uba4d',
+  colorFormats: ['r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle104 = renderBundleEncoder12.finish({label: '\u56cb\u0ad4\u66c9\ua9be\u04ac\u{1fe61}\u{1fcb7}\u0098'});
+let sampler25 = device1.createSampler({addressModeU: 'clamp-to-edge', magFilter: 'nearest', lodMinClamp: 56.46, lodMaxClamp: 61.77});
+try {
+renderPassEncoder40.executeBundles([renderBundle93]);
+} catch {}
+try {
+commandEncoder157.copyBufferToBuffer(buffer18, 368, buffer20, 156, 96);
+} catch {}
+try {
+device1.queue.submit([commandBuffer96]);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandBuffer109 = commandEncoder175.finish({label: '\u03b6\u{1fcfe}\u4fe9\ud497\u{1f94e}\u0d21\uc9a8\u94ed\u03ca'});
+let texture67 = device1.createTexture({
+  label: '\uf06c\u5a0f\uada0\u99f2\u9237\u36ab\u0277\u089d\u728e\u32d7',
+  size: {width: 165, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder50 = commandEncoder157.beginComputePass({label: '\u2a02\u92e0\u615b\u0536\ubc9a\uc07a\u{1ff12}'});
+let renderPassEncoder42 = commandEncoder156.beginRenderPass({
+  label: '\u518e\u7507\u5428\uad67\u95af\u0e45\u03d0\u8bf3\u86eb',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 53,
+  clearValue: { r: 346.7, g: 890.9, b: 709.9, a: -242.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 120579296,
+});
+let externalTexture19 = device1.importExternalTexture({
+  label: '\ufa40\u{1ff1b}\u1a4d\uda69\udf93\u{1fe34}\u8194\u2505\u2549\u412e\ue7d0',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder42.beginOcclusionQuery(584);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setViewport(63.589899276888836, 0.7710965790965869, 9.277753609053278, 0.17855444294273976, 0.6311614255752278, 0.9990220583798756);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer18, 'uint16', 3_024, 732);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer18, 0);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer18, 0, 778);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let renderBundle105 = renderBundleEncoder16.finish({label: '\u{1f651}\u41f3\u71b8\u241b\u7ddd\u810e\u0899\u1393\ud648\u27c7\u0695'});
+try {
+renderPassEncoder40.setIndexBuffer(buffer18, 'uint32', 6_176, 736);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer18, 'uint16', 4_758, 1_846);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandBuffer110 = commandEncoder162.finish();
+let renderPassEncoder43 = commandEncoder121.beginRenderPass({
+  label: '\u61bc\u5156\u0e3f\udb8f\u7edc\u{1fa37}\u0a01\u2ab7\u{1f8f8}\u151c\u{1ff5c}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 25,
+  clearValue: { r: 868.7, g: 405.3, b: 575.8, a: -262.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder43.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, undefined, 0);
+} catch {}
+document.body.prepend(video2);
+let commandEncoder182 = device2.createCommandEncoder({label: '\u0451\u{1fb2e}\u6a6d'});
+try {
+gpuCanvasContext8.configure({device: device2, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'opaque'});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 298, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 283,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet23 = device0.createQuerySet({label: '\u1dc4\u6069\u{1fff8}\u0a9d\uf5a7', type: 'occlusion', count: 446});
+try {
+computePassEncoder45.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+commandEncoder180.copyBufferToBuffer(buffer19, 8, buffer15, 1236, 56);
+} catch {}
+try {
+commandEncoder180.clearBuffer(buffer15, 176, 124);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 3, depthOrArrayLayers: 39}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 6, y: 0 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder183 = device2.createCommandEncoder({label: '\u8705\u0f58\u3c88\u{1f6e8}\u0be5\u0baa\u73f5\u07e2\u2c0c\u019c\ucc3f'});
+let textureView46 = texture50.createView({
+  label: '\u{1f6b9}\u37af\u0ea5\ua683\u84cb\u{1fa23}\u{1f757}\u{1fc22}\u{1fe23}\uff6a',
+  baseArrayLayer: 0,
+});
+try {
+commandEncoder183.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder184 = device1.createCommandEncoder();
+let commandBuffer111 = commandEncoder141.finish({label: '\ua901\u09ed\udbf3\u{1fb2b}\u0320\u8e61\u027c'});
+let renderPassEncoder44 = commandEncoder184.beginRenderPass({
+  label: '\u0536\u7db0\ube81\u17cc\uc7ba\uf007\u1e43\ua97c\uf55f',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 72,
+  clearValue: { r: 188.6, g: 529.5, b: -132.0, a: -866.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 133098390,
+});
+let renderBundle106 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup4, new Uint32Array(1486), 49, 0);
+} catch {}
+try {
+renderPassEncoder42.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(0, buffer18, 0, 4_452);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer18, 4_728, 2_853);
+} catch {}
+try {
+device1.queue.submit([commandBuffer110]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let shaderModule9 = device2.createShaderModule({
+  label: '\uce7f\u3ba1',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<array<atomic<i32>, 1>, 1>,
+  f1: array<vec4u>,
+}
+
+@group(0) @binding(349) var sam12: sampler;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(10) @interpolate(flat, centroid) f21: u32,
+  @location(1) @interpolate(flat, sample) f22: u32,
+  @builtin(position) f23: vec4f,
+  @location(14) f24: vec4h
+}
+
+@vertex
+fn vertex0(@location(9) @interpolate(flat, centroid) a0: vec4h, @location(3) @interpolate(linear) a1: vec2f, @location(5) a2: vec2h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(linear) f0: vec3f,
+  @location(1) f1: vec4f,
+  @location(2) @interpolate(flat, center) f2: u32,
+  @location(3) f3: vec4u
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer112 = commandEncoder183.finish({});
+let texture68 = device2.createTexture({
+  label: '\u789e\u0092\u06b9\u0957\u5449\u{1f6eb}',
+  size: [1192],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle107 = renderBundleEncoder18.finish({label: '\ua71d\u82b4\u{1ff95}\u9104\u7727\u08c5'});
+let bindGroupLayout28 = device2.createBindGroupLayout({
+  label: '\u11f7\ue8b7\u0871\ub2b1',
+  entries: [
+    {
+      binding: 100,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer35 = device2.createBuffer({
+  label: '\u0268\u00de\u48a1\u57b9',
+  size: 9176,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandBuffer113 = commandEncoder182.finish({label: '\u{1faf6}\u{1fa72}\u1153\u1924\ub768\u{1f7b8}\u098c\u4516\u83dc'});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder185 = device1.createCommandEncoder({label: '\u06d7\u3d78\ub34b\u0e33'});
+let texture69 = device1.createTexture({
+  size: {width: 47, height: 30, depthOrArrayLayers: 349},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder45 = commandEncoder185.beginRenderPass({
+  label: '\ucf7e\uff91',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 4,
+  clearValue: { r: -936.0, g: -157.2, b: -621.4, a: 186.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+});
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup5, new Uint32Array(438), 194, 0);
+} catch {}
+try {
+renderPassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle90]);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(474, 228);
+let commandBuffer114 = commandEncoder180.finish({label: '\ua6c2\u0f45\u{1fd84}\u9485\u00c4\u{1f8e3}\u019e\u0c56\u0fa7'});
+let textureView47 = texture10.createView({label: '\u32df\u0b8c\u0eab\u{1fc78}\u{1ffbc}\uc6f1\u9566\u{1fd3c}\u81e9\u0556'});
+let renderBundle108 = renderBundleEncoder1.finish();
+let sampler26 = device0.createSampler({
+  label: '\u5f70\u58fa\u01ac\u4fda\u{1f841}\u8b29\u8975\ue0ec\u5e7f\u{1fcad}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.51,
+  lodMaxClamp: 64.84,
+});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup3, new Uint32Array(308), 56, 0);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle64]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderBundle109 = renderBundleEncoder18.finish({label: '\u0d17\u0f44\u053a\ufe69\u016c\u{1f626}\u5d7f\u09ac'});
+let commandEncoder186 = device0.createCommandEncoder();
+let texture70 = device0.createTexture({
+  label: '\u0e51\u{1feee}',
+  size: [720, 14, 48],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder51 = commandEncoder186.beginComputePass({label: '\u1ceb\u{1f900}\u6443\ub512'});
+let sampler27 = device0.createSampler({
+  label: '\u3684\u01bd\u0f6c\u0302\u1985\u0bd3\uaa5e\u0263\u9473',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.20,
+  lodMaxClamp: 91.20,
+});
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+let bindGroupLayout29 = device1.createBindGroupLayout({
+  label: '\ue559\u0e77\u{1fed0}\u240f',
+  entries: [
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 550, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder187 = device1.createCommandEncoder({label: '\u1f38\u{1f83f}\ue590\u08fd\uf1d1\u048a'});
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(150);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+renderPassEncoder20.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let texture71 = gpuCanvasContext5.getCurrentTexture();
+let renderBundle110 = renderBundleEncoder6.finish({label: '\u{1f967}\u7cfa\u0b41\u0d3d\u{1fb85}\u17fd\u7a25\u4010\u9bbb\u{1ff71}\u72ed'});
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+  await buffer17.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter();
+let textureView48 = texture65.createView({
+  label: '\u8dcb\u06fa\u6a78\u285a\u0512\u0023\u{1f7dd}\ueb11\u{1fd23}\u939a',
+  format: 'rgba32float',
+  arrayLayerCount: 3,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let renderBundle111 = renderBundleEncoder18.finish();
+try {
+computePassEncoder43.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(69), /* required buffer size: 69 */
+{offset: 69, bytesPerRow: 46, rowsPerImage: 11}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer36 = device1.createBuffer({
+  label: '\u5178\u0383\u0da2\u{1fe21}\u04df\u74e2\u0b44\u7d68\ub95f\u6932',
+  size: 3668,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder188 = device1.createCommandEncoder({label: '\u1b97\u0fb7\u6c2f\u20a8\u{1f95c}\u187a'});
+let renderPassEncoder46 = commandEncoder188.beginRenderPass({
+  label: '\uebbc\u1aaf\u{1f97b}\u0d4a\u0694\u427f\u0d3e',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 7,
+  clearValue: { r: 210.9, g: 150.5, b: -167.1, a: -342.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet15,
+});
+let sampler28 = device1.createSampler({
+  label: '\ubdaf\u04bf\u1cc2\u0ce1\u96f2\u65d0\u{1f946}\ueb1d\u068e\u{1f7f5}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 98.22,
+});
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer18);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer105]);
+} catch {}
+let video3 = await videoWithData();
+let commandEncoder189 = device1.createCommandEncoder({label: '\u8e38\u7115\uc13c'});
+let computePassEncoder52 = commandEncoder187.beginComputePass();
+let renderPassEncoder47 = commandEncoder189.beginRenderPass({
+  label: '\uee9a\u{1fc04}\u6dc7\u05eb\u098c\u039c\u2a48\u0928\ue3e6\uf28b',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 29,
+  clearValue: { r: 358.6, g: -666.2, b: -7.323, a: 594.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet15,
+});
+let renderBundle112 = renderBundleEncoder14.finish({label: '\u6109\u0274\u7fa0\u0553\u{1fb25}\u8165'});
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(3, buffer18, 0, 633);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5, new Uint32Array(3378), 638, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(336), /* required buffer size: 336 */
+{offset: 336}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter1.label = '\u3b18\udea5\u0ab5';
+} catch {}
+let renderBundle113 = renderBundleEncoder18.finish();
+let gpuCanvasContext9 = offscreenCanvas7.getContext('webgpu');
+let renderBundle114 = renderBundleEncoder15.finish({});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup4, new Uint32Array(1848), 67, 0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup5, new Uint32Array(187), 8, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(8, 0, 10, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer18, 1_196, 241);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let commandEncoder190 = device2.createCommandEncoder({label: '\u0492\u04b5\u0a0e\u3bdc\u0877\u{1f8af}\u8f1a\u{1f9d5}\u9bee\u0639\u59f2'});
+let texture72 = device2.createTexture({
+  label: '\u03d0\u64aa\u{1fc7b}\u0999\uab00\u{1fde6}',
+  size: [1192, 1, 16],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let imageData21 = new ImageData(8, 4);
+let commandBuffer115 = commandEncoder190.finish({label: '\u72b4\ufa8e\u679f\u430d'});
+try {
+computePassEncoder37.insertDebugMarker('\u0439');
+} catch {}
+try {
+device2.queue.submit([commandBuffer112]);
+} catch {}
+let imageData22 = new ImageData(8, 8);
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 932, new BigUint64Array(3872), 66, 200);
+} catch {}
+let commandEncoder191 = device2.createCommandEncoder();
+let computePassEncoder53 = commandEncoder191.beginComputePass({label: '\u02d2\u0461\u7e42\u86eb\u085a\uadc9\uf9a2\u{1ffa1}'});
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 298, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: imageData13,
+  origin: { x: 2, y: 23 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer37 = device0.createBuffer({
+  size: 15600,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+try {
+renderPassEncoder37.setVertexBuffer(3, buffer37);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+  await buffer19.mapAsync(GPUMapMode.WRITE, 0, 40);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 14, depthOrArrayLayers: 216}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture66,
+  mipLevel: 1,
+  origin: {x: 287, y: 2, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle115 = renderBundleEncoder17.finish({label: '\u{1fadf}\u04d9\uf578\u0967\u5f1f\u60d3\u2bd9'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup5, new Uint32Array(96), 16, 0);
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle90]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer18, 396, 557);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer18, 0, 376);
+} catch {}
+try {
+commandEncoder168.resolveQuerySet(querySet16, 125, 38, buffer36, 0);
+} catch {}
+let commandBuffer116 = commandEncoder168.finish({});
+try {
+renderPassEncoder46.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer18, 0, 2_660);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup4, new Uint32Array(949), 328, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer109, commandBuffer97]);
+} catch {}
+let imageData23 = new ImageData(188, 12);
+try {
+adapter0.label = '\u0501\uf5a8\u08bd\u0bcc\u0c4e\u84ef\u{1f924}\u000b\ud407\u{1f964}\u1040';
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  label: '\uee4a\ue218\u{1fbd1}\ub955\ud16f\u{1fe28}',
+  entries: [
+    {
+      binding: 89,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 93, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 99,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 202,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 235,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 245,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 100,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 90,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 350,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 106, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 88, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 378,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 60, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 271,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 210, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 126,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 425, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 424,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 148,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 31,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 79,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 299,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {binding: 356, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 103,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 33639202, hasDynamicOffset: false },
+    },
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 215,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 406,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 370,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 118,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 69, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 151,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 819,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 12,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 443,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 387, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 117, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 22, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 278, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 321,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 54, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 338, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 123, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 171,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 6744500, hasDynamicOffset: false },
+    },
+    {
+      binding: 216,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 16, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 133, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 29, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 266, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 136, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 473,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 124, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {binding: 178, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 57, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 11, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder192 = device0.createCommandEncoder({label: '\u{1f76e}\u{1fd57}\u813c'});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 94});
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup0, new Uint32Array(431), 32, 0);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup3, new Uint32Array(2171), 129, 0);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.insertDebugMarker('\u0b1f');
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\u{1fe6a}\u0f2f\u018d\u200b\ueaa6\u416e',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout13, bindGroupLayout4, bindGroupLayout20],
+});
+let commandEncoder193 = device0.createCommandEncoder({label: '\u38ef\uccf9\u05a8\u7f2e\u{1f6a2}\u2c61\u{1fd99}\u{1fac8}\u{1fe3a}'});
+let commandBuffer117 = commandEncoder192.finish();
+let renderPassEncoder48 = commandEncoder193.beginRenderPass({
+  label: '\u0dbb\u{1fdeb}\u0ff5\u0984\uf229\u0ad9\uc190\u9de8\ube6d',
+  colorAttachments: [{
+  view: textureView6,
+  depthSlice: 6,
+  clearValue: { r: 195.9, g: 824.6, b: 119.7, a: 614.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+renderPassEncoder10.executeBundles([renderBundle2]);
+} catch {}
+let commandEncoder194 = device2.createCommandEncoder({label: '\uac24\u0ef9\u8afc'});
+let querySet25 = device2.createQuerySet({label: '\ubbbb\u{1ff39}\ude53', type: 'occlusion', count: 1082});
+try {
+buffer35.unmap();
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageData4);
+let texture73 = device0.createTexture({
+  size: [180, 3, 73],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle116 = renderBundleEncoder13.finish({label: '\u{1ff1e}\u{1ffd2}\u3817\u7250\u04f3\u0529\u0bd3\u0ab0\u0240\u4897\u884e'});
+try {
+renderPassEncoder23.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline7);
+} catch {}
+await gc();
+let bindGroupLayout31 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup5, new Uint32Array(4157), 315, 0);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer18);
+} catch {}
+let commandBuffer118 = commandEncoder194.finish({label: '\u8dab\u4eed\uf524\u64ca'});
+let renderBundle117 = renderBundleEncoder18.finish();
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+  await shaderModule9.getCompilationInfo();
+} catch {}
+try {
+commandEncoder191.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 496 */
+  offset: 496,
+  buffer: buffer35,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder191.insertDebugMarker('\ubf28');
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let renderBundle118 = renderBundleEncoder14.finish({label: '\u6065\u{1fdab}\u{1f9ec}'});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.draw(67, 527, 203_770_298, 3_942_210_185);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline14);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: imageData12,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 48},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer9, 32);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer86, commandBuffer103]);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas6.getContext('webgpu');
+let querySet26 = device2.createQuerySet({label: '\ua27a\u4ef4\u0f96\u{1f811}\u{1fefe}', type: 'occlusion', count: 1899});
+let textureView49 = texture68.createView({dimension: '1d', arrayLayerCount: 1});
+let renderBundle119 = renderBundleEncoder18.finish({label: '\u5838\ua3e5\u{1fc8a}\u77ac'});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup6, new Uint32Array(3818), 641, 0);
+} catch {}
+try {
+commandEncoder191.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas5.width = 29;
+let commandEncoder195 = device1.createCommandEncoder({});
+let commandBuffer119 = commandEncoder195.finish();
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer36, 'uint16', 300, 303);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 47, height: 30, depthOrArrayLayers: 349}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 173},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder19.draw(145, 8, 536_022_961, 53_202_496);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(34, 390, 15, 726_843_290, 930_101_466);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 5556, new DataView(new ArrayBuffer(279)), 19);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer120 = commandEncoder191.finish({label: '\u4859\u00a8'});
+let textureView50 = texture58.createView({label: '\ubca1\u9744\udc3a', baseMipLevel: 2, mipLevelCount: 1});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder43.insertDebugMarker('\u003e');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer115, commandBuffer99, commandBuffer108, commandBuffer113]);
+} catch {}
+await gc();
+let buffer38 = device2.createBuffer({
+  label: '\u56bb\uffe9\u1d7e',
+  size: 5072,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder196 = device2.createCommandEncoder({label: '\ud657\u{1fda8}\u78b0\u056c\u{1f6e4}\ub135\u251f'});
+try {
+commandEncoder196.copyBufferToTexture({
+  /* bytesInLastRow: 464 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2752 */
+  offset: 2752,
+  buffer: buffer38,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder196.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 167, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder197 = device2.createCommandEncoder({label: '\u0fa6\ucb31\ud4fe\u7dec\ua913\u1242\ua4e1\u{1f919}'});
+let commandBuffer121 = commandEncoder196.finish({label: '\u06bc\udec8'});
+let externalTexture20 = device2.importExternalTexture({source: videoFrame2});
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup7 = device2.createBindGroup({
+  label: '\uf8b5\u6b3d\u{1fd47}\u749c',
+  layout: bindGroupLayout23,
+  entries: [{binding: 349, resource: sampler20}],
+});
+let renderPassEncoder49 = commandEncoder197.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 1,
+  clearValue: { r: 460.4, g: -821.2, b: 491.3, a: -123.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+});
+try {
+renderPassEncoder49.beginOcclusionQuery(285);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder198 = device1.createCommandEncoder();
+let querySet27 = device1.createQuerySet({label: '\u2e92\ubaac', type: 'occlusion', count: 394});
+let renderPassEncoder50 = commandEncoder198.beginRenderPass({
+  label: '\u{1f64d}\u3b7d\u0702\u0c61\ua3ad\u0eed\u0822\u0487',
+  colorAttachments: [{view: textureView44, depthSlice: 34, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 116028500,
+});
+try {
+renderPassEncoder47.executeBundles([renderBundle95, renderBundle91, renderBundle106, renderBundle63, renderBundle114]);
+} catch {}
+try {
+renderBundleEncoder19.draw(87, 30, 459_918_398, 1_039_614_368);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(18, 51, 12, 57_983_861, 188_210_666);
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+adapter0.label = '\u0d3f\ucaef';
+} catch {}
+let commandEncoder199 = device1.createCommandEncoder();
+let renderPassEncoder51 = commandEncoder199.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 39,
+  clearValue: { r: -273.7, g: 180.7, b: -839.5, a: -293.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5, new Uint32Array(2737), 435, 0);
+} catch {}
+try {
+  await shaderModule4.getCompilationInfo();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({label: '\u84bd\u4287\ufb5d\u{1fa05}'});
+let commandBuffer122 = commandEncoder200.finish();
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup0, new Uint32Array(2055), 387, 0);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(0, buffer4, 4_876);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 136, new Float32Array(53429), 3011, 20);
+} catch {}
+let texture74 = gpuCanvasContext8.getCurrentTexture();
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer11, 'uint16', 2_850, 1_372);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(1, buffer9, 0, 34);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let renderBundle120 = renderBundleEncoder18.finish();
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.setScissorRect(7, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(6, buffer38, 36);
+} catch {}
+try {
+device2.queue.submit([commandBuffer120]);
+} catch {}
+let commandEncoder201 = device2.createCommandEncoder();
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\u0fd7\u215f\u0c95\u{1f813}\u{1f697}\u{1ff98}\u0f58\u0573',
+  colorFormats: ['rgba32float'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup7, new Uint32Array(1718), 80, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer38, 'uint32', 504, 372);
+} catch {}
+let promise36 = shaderModule5.getCompilationInfo();
+let imageData24 = new ImageData(12, 44);
+try {
+renderPassEncoder47.executeBundles([renderBundle63]);
+} catch {}
+try {
+renderPassEncoder47.setViewport(28.994567459530373, 0.3638161086771845, 46.59940646314098, 0.03230425279718482, 0.8181115859519731, 0.8634666393989051);
+} catch {}
+try {
+renderBundleEncoder19.draw(26, 30, 388_521_288, 932_987_935);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u19eb\u{1f6a5}\u{1fda3}\u0739\u0288\u8cc0\u88e9\ubbbd\u31ad',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer5);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer10, 0, 325);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u{1ff7c}');
+} catch {}
+try {
+device0.queue.submit([commandBuffer122]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(217, 124);
+let commandEncoder202 = device0.createCommandEncoder({label: '\ud9d3\u{1f633}'});
+let renderBundle121 = renderBundleEncoder10.finish();
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer2, 'uint16', 3_018, 4_511);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer16, 'uint32', 64, 902);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(7, buffer37, 0, 15_459);
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas8.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+  await promise36;
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({label: '\u0fb7\u02f2\u00d3\u89ba'});
+let sampler29 = device0.createSampler({
+  label: '\udc10\u{1fbfd}\u554f\u1c9c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.26,
+});
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer8, 388, 662);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 20, y: 1, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(122_511), /* required buffer size: 122_511 */
+{offset: 183, bytesPerRow: 182, rowsPerImage: 96}, {width: 3, height: 1, depthOrArrayLayers: 8});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup8 = device0.createBindGroup({
+  label: '\u4d50\uebb1\u5245\u5d27\uf673',
+  layout: bindGroupLayout5,
+  entries: [{binding: 109, resource: sampler15}],
+});
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout27, bindGroupLayout13]});
+let commandBuffer123 = commandEncoder203.finish({label: '\u0460\u0f15\u44ab\u2b2f\u9b3f\u{1fd59}\u0a86\u{1ff15}\u8b83\u0c7a'});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({label: '\u05aa\u41ed', colorFormats: ['rgba16sint'], sampleCount: 1, stencilReadOnly: true});
+let externalTexture21 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder36.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer9, 'uint16', 556, 667);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer21, 0, 47);
+} catch {}
+let commandBuffer124 = commandEncoder202.finish();
+try {
+renderBundleEncoder22.setPipeline(pipeline7);
+} catch {}
+document.body.prepend(canvas3);
+let bindGroupLayout32 = device2.createBindGroupLayout({
+  label: '\u3420\u0bd6\u0ffb\u04fc\ub326\u0611\u0760\u0a04\u0559',
+  entries: [
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder204 = device2.createCommandEncoder({label: '\u{1fde2}\u8ff0\u0956\u{1fb3e}\u5433\u{1f838}\u6ccc\u5d17\u{1fcfc}'});
+let renderPassEncoder52 = commandEncoder201.beginRenderPass({colorAttachments: [{view: textureView50, depthSlice: 4, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer35, 'uint32', 1_976, 798);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(1, buffer38, 492, 2_693);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup6, new Uint32Array(523), 203, 0);
+} catch {}
+try {
+commandEncoder204.resolveQuerySet(querySet25, 35, 63, buffer35, 256);
+} catch {}
+canvas5.height = 88;
+let commandEncoder205 = device0.createCommandEncoder({label: '\u{1f9e5}\uf50d'});
+let texture75 = device0.createTexture({
+  label: '\u033e\ud716\u28e6\u055f\u810e\ua8b4',
+  size: {width: 1440},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder53 = commandEncoder205.beginRenderPass({
+  label: '\u0bb4\u{1fe0d}\u90cf',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 14,
+  clearValue: { r: -177.0, g: 294.0, b: -507.4, a: 694.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 39369825,
+});
+try {
+renderPassEncoder39.beginOcclusionQuery(53);
+} catch {}
+try {
+renderPassEncoder39.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 147, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(5_451), /* required buffer size: 5_451 */
+{offset: 115, bytesPerRow: 101, rowsPerImage: 25}, {width: 21, height: 3, depthOrArrayLayers: 3});
+} catch {}
+try {
+renderBundleEncoder19.draw(138, 155, 2_130_143_433, 11_410_977);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(17, 100, 58, 1_711_093_078, 152_293_057);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer18, 32, 1_782);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: canvas4,
+  origin: { x: 12, y: 4 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 80},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder47.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup7, new Uint32Array(740), 44, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer38, 'uint32', 1_596, 220);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline17);
+} catch {}
+try {
+device2.queue.submit([commandBuffer107]);
+} catch {}
+let commandEncoder206 = device2.createCommandEncoder();
+let renderPassEncoder54 = commandEncoder206.beginRenderPass({colorAttachments: [{view: textureView50, depthSlice: 4, loadOp: 'clear', storeOp: 'store'}]});
+let externalTexture22 = device2.importExternalTexture({label: '\uc58e\u51d3\u96ff\u0471\u9c9e\ub7e7\uf870\u011e\u44b5', source: video3, colorSpace: 'srgb'});
+try {
+renderPassEncoder54.setVertexBuffer(7, buffer38, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer38, 'uint16', 680, 834);
+} catch {}
+let commandEncoder207 = device1.createCommandEncoder({label: '\u2e4a\u0041\u3836\u569e\u58e3\u0075\ufb25\u935e\uc3e0\u{1fc82}\u2d8c'});
+let commandBuffer125 = commandEncoder207.finish({label: '\u0948\u1a53\u0008\u282c\u0525\uba31'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup4, new Uint32Array(958), 281, 0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup4, new Uint32Array(1458), 376, 0);
+} catch {}
+try {
+renderBundleEncoder19.draw(267, 67, 163_101_299, 468_047_238);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(73, 0, 15, 943_892_287, 1_019_276_904);
+} catch {}
+try {
+gpuCanvasContext8.configure({device: device1, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+let promise37 = adapter1.requestAdapterInfo();
+let texture76 = device0.createTexture({
+  label: '\uc20f\u5800\u0af2\u{1fb0a}\ub317\u46d0\u8d61\u0786\u25cf\u{1fc45}\u21c2',
+  size: [180, 3, 38],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundle122 = renderBundleEncoder10.finish({label: '\u005d\u001f\u0489\u0dab\ub268\u0caf\ubdca\u{1f969}'});
+try {
+computePassEncoder21.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup8, new Uint32Array(281), 16, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(2, buffer0, 0, 556);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let shaderModule10 = device2.createShaderModule({
+  label: '\u0220\u00c7\u{1f74d}\u5e8d\u00ed\u0fd1\u6592\u05f7',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+
+@group(0) @binding(349) var sam13: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(8) @interpolate(linear, center) f25: vec3f,
+  @builtin(position) f26: vec4f
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4u,
+  @location(0) @interpolate(linear, sample) f1: vec3f,
+  @location(2) f2: vec4u,
+  @builtin(sample_mask) f3: u32,
+  @location(1) f4: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder208 = device2.createCommandEncoder({});
+let commandBuffer126 = commandEncoder160.finish({});
+try {
+renderPassEncoder49.setVertexBuffer(1, buffer38, 4);
+} catch {}
+try {
+commandEncoder204.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 554, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder204.clearBuffer(buffer38);
+} catch {}
+try {
+commandEncoder208.resolveQuerySet(querySet25, 55, 17, buffer35, 1792);
+} catch {}
+try {
+renderBundleEncoder20.insertDebugMarker('\u4130');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 972, new Float32Array(4199), 1857, 196);
+} catch {}
+let pipeline18 = device2.createRenderPipeline({
+  label: '\u9a5c\u0577\u4ef6\uf8af',
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {module: shaderModule5, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder209 = device2.createCommandEncoder({label: '\u{1fa10}\uea12\u368f\u0dd3\u{1fd4b}'});
+let commandBuffer127 = commandEncoder208.finish();
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer35, 2_488);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer38, 'uint32', 460, 963);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(4, buffer38);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder204.copyBufferToBuffer(buffer35, 332, buffer38, 68, 444);
+} catch {}
+let pipeline19 = await device2.createComputePipelineAsync({
+  label: '\u8eac\u{1f7dc}',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let buffer39 = device1.createBuffer({
+  label: '\u0b03\ue524\u86ba\u03de\u329e',
+  size: 1430,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup4, new Uint32Array(288), 60, 0);
+} catch {}
+try {
+renderPassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(438);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, buffer18, 0, 192);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder19.draw(208, 90, 1_339_512_871, 375_394_968);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+let arrayBuffer10 = buffer36.getMappedRange(32);
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let bindGroupLayout33 = device2.createBindGroupLayout({
+  label: '\u0291\u3109\u0418',
+  entries: [{binding: 420, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let buffer40 = device2.createBuffer({
+  label: '\u5998\u{1f65f}\uc6ce\ua4e5\u{1ff6f}\ud0af\uc68f\u1b4b',
+  size: 16622,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandBuffer128 = commandEncoder204.finish({});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder54.setScissorRect(8, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer40, 0, 7_417);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer40, 68);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline17);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup6, new Uint32Array(2343), 254, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer35, 2_812);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(173), /* required buffer size: 173 */
+{offset: 173}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise38 = device2.createRenderPipelineAsync({
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x334cbc26},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 774849838,
+    depthBiasClamp: 720.2247134030164,
+  },
+  vertex: {module: shaderModule5, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list'},
+});
+let commandEncoder210 = device0.createCommandEncoder({});
+let querySet28 = device0.createQuerySet({
+  label: '\u6a3a\u2cf3\ub93b\ud5c7\u06d6\u7079\u0162\u0507\u1cad\u{1ff6e}',
+  type: 'occlusion',
+  count: 340,
+});
+let externalTexture23 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 1968, 1736);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let adapter4 = await promise13;
+let texture77 = device1.createTexture({
+  size: [165, 1, 136],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle123 = renderBundleEncoder15.finish({label: '\u{1f82c}\ua5f1\u305a\u{1f697}\u6611\u605a\u{1ffe8}\u84e4\u0968\u045e\u{1f75f}'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup4, new Uint32Array(5657), 1973, 0);
+} catch {}
+try {
+renderPassEncoder46.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle115, renderBundle95]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer36, 'uint32', 40, 860);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer18, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder({label: '\u8036\u1d0b'});
+let computePassEncoder54 = commandEncoder210.beginComputePass({label: '\u8524\u4c34\u1cc6\u09b0'});
+let externalTexture24 = device0.importExternalTexture({label: '\uaa87\u0598\u853d\u{1f743}', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer37, 'uint32', 13_756);
+} catch {}
+let commandEncoder212 = device2.createCommandEncoder({label: '\u06b7\uc6c5\u0a87\u{1fb76}\u46a0\u{1fcd1}\u80fb\u61b0\u1206\u0718\u0442'});
+let renderPassEncoder55 = commandEncoder209.beginRenderPass({
+  label: '\u38de\u3fb5\u03a6\u3298\u{1fdb8}\u018c',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 4,
+  clearValue: { r: 963.6, g: -166.1, b: -929.6, a: 538.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+});
+try {
+computePassEncoder43.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup7, new Uint32Array(596), 201, 0);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer40, 1_792);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer35, 'uint16', 972, 371);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(1, buffer38);
+} catch {}
+try {
+commandEncoder212.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 720 */
+  offset: 720,
+  rowsPerImage: 58,
+  buffer: buffer40,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise39 = device2.queue.onSubmittedWorkDone();
+try {
+computePassEncoder44.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(2099);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(5, buffer18, 0, 665);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(1, 93, 42, 1_090_651_839, 157_438_891);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(7, buffer18, 2_516, 1_153);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+renderPassEncoder46.insertDebugMarker('\u{1fdd5}');
+} catch {}
+let commandBuffer129 = commandEncoder211.finish({label: '\u0065\u0cfe\u1207'});
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(1, buffer4, 0, 5_349);
+} catch {}
+let arrayBuffer11 = buffer19.getMappedRange(0, 8);
+try {
+device0.queue.submit([commandBuffer117]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(459), /* required buffer size: 459 */
+{offset: 459, bytesPerRow: 367}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 2, y: 2 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 71, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer41 = device1.createBuffer({
+  label: '\u045a\u058c\u0ab8\u0222\ud633\u{1f77f}\u{1fd7f}\u0ff9',
+  size: 9302,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder46.beginOcclusionQuery(10);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup4, new Uint32Array(3809), 1443, 0);
+} catch {}
+try {
+renderBundleEncoder19.draw(115, 519, 838_811_405, 2_138_289_984);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(14, 28, 12, 241_110_303, 661_896_314);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer18, 'uint32', 5_384, 1_229);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(21, 392, 46, 408_212_980, 1_109_848_265);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer36, 'uint32', 3_668);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer18, 760, 1_946);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 320, new Int16Array(42778), 31525, 20);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter2.label = '\uc3c8\u0a8e\u023d\u7597';
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(3, buffer4, 0, 2_429);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint16', 2_220, 3_031);
+} catch {}
+try {
+computePassEncoder41.insertDebugMarker('\u8aed');
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(4_294_967_295, undefined, 438_349_942, 98_847_136);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup4, new Uint32Array(7133), 360, 0);
+} catch {}
+try {
+renderBundleEncoder19.draw(295, 82, 498_169_231, 684_413_345);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(0, 288, 0, 101_694_165, 484_148_243);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline14);
+} catch {}
+let promise40 = device1.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder50.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer18, 3_520, 5);
+} catch {}
+try {
+computePassEncoder32.insertDebugMarker('\u{1f809}');
+} catch {}
+try {
+device1.queue.submit([commandBuffer106, commandBuffer119]);
+} catch {}
+try {
+renderBundleEncoder19.draw(224, 3, 437_626_384, 157_946_077);
+} catch {}
+try {
+computePassEncoder29.pushDebugGroup('\u{1f9cb}');
+} catch {}
+try {
+computePassEncoder29.popDebugGroup();
+} catch {}
+try {
+  await promise40;
+} catch {}
+let commandEncoder213 = device1.createCommandEncoder();
+let computePassEncoder55 = commandEncoder213.beginComputePass({label: '\u9b04\u2bec\u7c69\u20f1\ue384\ud1f6'});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(3, bindGroup4, new Uint32Array(1693), 68, 0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder19.draw(70, 417, 1_045_319_763, 77_132_324);
+} catch {}
+let promise41 = device1.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+await gc();
+try {
+externalTexture9.label = '\u0876\u{1ff53}\u940b\u9d49\u27b6\u076f\u0727\u0f4d\u{1fb4e}\u0c5c';
+} catch {}
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 81.30,
+  lodMaxClamp: 85.78,
+});
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await promise41;
+} catch {}
+let adapter5 = await promise7;
+let commandEncoder214 = device2.createCommandEncoder({label: '\uba5e\ubbf2\u9393'});
+let renderPassEncoder56 = commandEncoder214.beginRenderPass({
+  label: '\u98a0\u5f9d\u{1f722}\u832a\u2198\u079e\u136b\u0042',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 2,
+  clearValue: { r: -223.6, g: -887.8, b: 378.3, a: -192.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+  maxDrawCount: 1086599392,
+});
+try {
+computePassEncoder47.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder52.setScissorRect(0, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder54.setStencilReference(1984);
+} catch {}
+try {
+renderPassEncoder49.draw(23, 60, 1_250_958_646, 227_749_632);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 1_016);
+} catch {}
+try {
+renderBundleEncoder20.draw(88, 215, 1_859_147_050, 1_701_364_847);
+} catch {}
+try {
+commandEncoder212.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3728 */
+  offset: 3728,
+  bytesPerRow: 256,
+  buffer: buffer40,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise39;
+} catch {}
+let videoFrame4 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({
+  label: '\u051d\ue7c2\u0f1c\u0706\u5cdb\u2380',
+  colorFormats: ['rg16float', 'rgb10a2unorm', 'r8uint', 'rgba16uint'],
+});
+let renderBundle124 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder43.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 172);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(0, buffer40, 8_204, 1_943);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder20.draw(60, 458, 68_950_503, 199_414_323);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(1, 29, 29, 585_540_401, 885_253_830);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer35, 72);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer35, 1_124);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(288_289), /* required buffer size: 288_289 */
+{offset: 29, bytesPerRow: 994, rowsPerImage: 145}, {width: 56, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder215 = device1.createCommandEncoder({label: '\u2d56\u{1fcd2}\u{1f9fd}\u455b\u16b1\u{1fa0f}'});
+let texture78 = device1.createTexture({
+  label: '\u{1fa98}\u0df1\u0aef\u0b67\u{1fb7b}\u{1f7f5}\u7256\u5ada',
+  size: {width: 82, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer18, 'uint32', 1_140, 1_051);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.draw(405, 249, 20_892_951, 1_532_125_786);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer18);
+} catch {}
+try {
+commandEncoder215.resolveQuerySet(querySet15, 38, 177, buffer36, 256);
+} catch {}
+try {
+renderPassEncoder45.insertDebugMarker('\u{1fe8b}');
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder56 = commandEncoder212.beginComputePass();
+try {
+computePassEncoder47.dispatchWorkgroupsIndirect(buffer35, 840);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder56.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.draw(5, 88, 2_274_632_390, 1_991_083_895);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 5_344);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder20.draw(6, 157, 348_657_243, 142_661_689);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer40, 5_956);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer35, 3_556);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+computePassEncoder43.pushDebugGroup('\uf0f6');
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup3, new Uint32Array(1489), 67, 0);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(72);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer124]);
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(19, 4, 435, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer16, 'uint16', 396, 280);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint16', 4_952, 7_146);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder({label: '\u026b\u715b\u37fe\ucc86\u4583\u572a\u{1fdcc}\u{1fe13}\u01e2\ud791'});
+let commandBuffer130 = commandEncoder216.finish({label: '\u6299\u0076'});
+let renderBundle125 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder51.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder53.setScissorRect(4, 0, 6, 0);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(5, buffer9, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer5);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+await gc();
+try {
+computePassEncoder43.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder20.draw(215, 106, 421_202_384, 3_695_352_957);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer35, 'uint32', 132, 1_841);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer40);
+} catch {}
+let promise43 = device2.queue.onSubmittedWorkDone();
+let imageBitmap7 = await createImageBitmap(imageBitmap0);
+try {
+computePassEncoder43.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.draw(21, 59, 656_915_876, 358_449_542);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer35, 'uint16', 1_546, 437);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder20.draw(236, 246, 185_516_706, 117_548_309);
+} catch {}
+let commandEncoder217 = device1.createCommandEncoder({label: '\u83a9\u4db4\uc29a\u0e6d'});
+let textureView51 = texture53.createView({});
+let renderPassEncoder57 = commandEncoder215.beginRenderPass({
+  label: '\u23d2\u0c79\u0300\u0b9f\u202f\u2c9d\u0adb\u56dc',
+  colorAttachments: [{view: textureView44, depthSlice: 15, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 158757407,
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder46.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup4, new Uint32Array(5164), 515, 0);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer18, 'uint16', 1_512, 1_850);
+} catch {}
+try {
+commandEncoder217.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer125]);
+} catch {}
+let commandEncoder218 = device2.createCommandEncoder({});
+let commandBuffer131 = commandEncoder218.finish({label: '\u679f\u3c1f\u0fab\ub430\u051e\u9927\ub87e\u0cb2'});
+let renderBundle126 = renderBundleEncoder23.finish({label: '\u5bb1\u0a9f\u007d\uc104\u15a9\u07e5\ub72c\u{1f663}\u0e6b\u662a'});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(22, 21, 45, 538_854_475, 67_916_463);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer40, 1_144);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer35, 1_572);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(4, buffer40);
+} catch {}
+try {
+commandEncoder181.clearBuffer(buffer40, 2360, 4800);
+} catch {}
+try {
+device2.queue.submit([commandBuffer95, commandBuffer127, commandBuffer128]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(22), /* required buffer size: 22 */
+{offset: 22}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView52 = texture72.createView({label: '\u{1faaf}\uac72\u{1fd29}\uc3df', baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder58 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 1,
+  clearValue: { r: 736.7, g: -847.9, b: -900.0, a: 198.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet26,
+});
+try {
+computePassEncoder47.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder56.end();
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(14, 143, 28, 689_039_066, 437_060_158);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(30, 317, 2, 50_139_341, 176_956_704);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer35, 1_016);
+} catch {}
+try {
+computePassEncoder43.popDebugGroup();
+} catch {}
+let renderPassEncoder59 = commandEncoder217.beginRenderPass({
+  label: '\u0f4f\u{1f723}\u0e4e\u6841\u{1f6ed}\uc7bd\ufb72\u06ae\ub32b\u9fcc\u{1fdbc}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 24,
+  clearValue: { r: -641.2, g: -979.6, b: -414.3, a: -678.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet20,
+});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup4, new Uint32Array(1985), 12, 0);
+} catch {}
+try {
+renderPassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle74]);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(7, buffer18, 3_084, 159);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+  await promise42;
+} catch {}
+document.body.prepend(img1);
+let externalTexture25 = device0.importExternalTexture({source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.setViewport(521.51802418593, 19.241284531614237, 636.2883373090153, 4.198563602857963, 0.4304870881399375, 0.5161822972286279);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  label: '\u{1f917}\u0af8\u{1f8ea}\u0ee7\u110a\u053e\u2fce\u7514\ueba8\u6322\u2615',
+  layout: bindGroupLayout12,
+  entries: [{binding: 16, resource: {buffer: buffer21, offset: 256, size: 1932}}],
+});
+let querySet29 = device0.createQuerySet({label: '\u{1fb73}\u1151\u1243', type: 'occlusion', count: 585});
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder({label: '\u0223\u0527\u5dc8\u{1fe6b}\u{1fe3d}\u04df\uafca\u{1f8f6}\u073c'});
+let textureView53 = texture16.createView({label: '\u708e\ud02e\u{1f6a5}\u0bef\u4530\u4a71\ub191\u3705\u{1f8d5}', mipLevelCount: 1});
+let computePassEncoder57 = commandEncoder219.beginComputePass();
+let renderBundle127 = renderBundleEncoder11.finish({label: '\u5f99\u{1f965}\u0aba\u14f6'});
+try {
+computePassEncoder26.setPipeline(pipeline9);
+} catch {}
+let arrayBuffer12 = buffer1.getMappedRange(1968, 92);
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+canvas4.width = 725;
+let commandEncoder220 = device1.createCommandEncoder({});
+let renderPassEncoder60 = commandEncoder220.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 41,
+  clearValue: { r: 100.6, g: 597.7, b: -524.9, a: 258.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 46903624,
+});
+let renderBundle128 = renderBundleEncoder12.finish({label: '\u{1fab8}\u0576'});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer18, 1_708, 4_909);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer36, 'uint32', 952, 48);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+let commandEncoder221 = device1.createCommandEncoder({});
+let renderBundle129 = renderBundleEncoder15.finish({label: '\u2a35\u09ed\u0d41\u0ea3\u074f\u0b57\ue48e\ubaa3\u{1f77d}\uf980'});
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder57.end();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(2, buffer18, 1_848, 2_345);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer36, 'uint16', 40, 989);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise43;
+} catch {}
+let pipelineLayout23 = device2.createPipelineLayout({
+  label: '\u9d4a\u{1fe90}\ud1d4\u{1fcf8}\u{1fb73}',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout28, bindGroupLayout33],
+});
+try {
+computePassEncoder47.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(57, 67, 24, 7_205_430, 1_247_419_704);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer35, 432);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 496);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline17);
+} catch {}
+document.body.prepend(video1);
+let commandEncoder222 = device1.createCommandEncoder({label: '\u053b\uff76\u01c3\u535f\uff9b'});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup5, new Uint32Array(2172), 1557, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 6800, new Int16Array(7070), 485, 16);
+} catch {}
+video2.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder223 = device2.createCommandEncoder({});
+let texture79 = device2.createTexture({
+  size: [1192, 1, 9],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView54 = texture79.createView({format: 'rgba16uint', baseMipLevel: 2});
+let renderBundle130 = renderBundleEncoder20.finish();
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder49.draw(61, 46, 1_044_676_001, 92_167_616);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(5, 306, 46, 359_357_859, 345_871_566);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 5_404);
+} catch {}
+try {
+commandEncoder223.clearBuffer(buffer40, 1048, 908);
+} catch {}
+let commandBuffer132 = commandEncoder212.finish({label: '\ud9e6\u52a4\u05fd\u73a6'});
+try {
+computePassEncoder47.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.draw(65, 350, 1_772_122_179, 1_568_123_341);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(40, 19, 49, -1_443_709_072, 265_597_076);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 149, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: imageData12,
+  origin: { x: 7, y: 0 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder224 = device2.createCommandEncoder({});
+let computePassEncoder58 = commandEncoder223.beginComputePass({label: '\u{1f695}\u0cc4\u{1f9ce}\u02cb\u0e22'});
+let renderBundle131 = renderBundleEncoder20.finish();
+try {
+renderPassEncoder49.drawIndexed(22, 141, 18, -2_103_311_142, 62_963_201);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 476);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder224.copyBufferToBuffer(buffer38, 1988, buffer40, 4676, 56);
+} catch {}
+try {
+commandEncoder224.resolveQuerySet(querySet25, 8, 155, buffer40, 0);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 724, new Float32Array(6062), 2210, 880);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let textureView55 = texture70.createView({aspect: 'all'});
+try {
+renderPassEncoder48.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint16', 5_856, 2_732);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandBuffer98.label = '\u{1f6a3}\uf475\u{1fe77}\u081b\u93f0\u3b48\u0587\u0524';
+} catch {}
+let commandEncoder225 = device2.createCommandEncoder({label: '\u{1f941}\uf743\u0056\u0c73\u279c\u{1f7fe}\u{1fbe4}\u{1fba4}\u{1fb02}'});
+let computePassEncoder59 = commandEncoder224.beginComputePass({label: '\u8ffe\u67f8'});
+document.body.prepend(canvas3);
+let commandEncoder226 = device2.createCommandEncoder({label: '\uab1d\u0eb8\u7156'});
+let renderPassEncoder61 = commandEncoder226.beginRenderPass({
+  label: '\u2867\u014c\u0f22\ue7ee\u05a5\u2b0a\u8d24\u0861',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 4,
+  clearValue: { r: 295.1, g: -795.1, b: -23.39, a: -983.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 554024254,
+});
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup6, new Uint32Array(2181), 198, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 844);
+} catch {}
+try {
+device2.queue.submit([commandBuffer98, commandBuffer132]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 248, new DataView(new ArrayBuffer(7232)), 1468, 108);
+} catch {}
+let commandEncoder227 = device0.createCommandEncoder();
+let renderPassEncoder62 = commandEncoder227.beginRenderPass({
+  label: '\u{1f764}\ua73b\u0741\u028d\u0402',
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -190.2, g: 256.2, b: -758.4, a: 458.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup3, new Uint32Array(1875), 355, 0);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer4, 0, 7_997);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+let arrayBuffer13 = buffer37.getMappedRange(4104, 1684);
+let renderBundle132 = renderBundleEncoder4.finish({label: '\u2ed7\u069d\ucd46\u2278\u89ee\u01c4\u0e73\uc992\uce83'});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(3, buffer10, 0, 656);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup8);
+} catch {}
+let commandEncoder228 = device1.createCommandEncoder({label: '\u395f\uf291\u{1f62f}\ue725'});
+let querySet30 = device1.createQuerySet({
+  label: '\u{1ff75}\u2ef6\u80a5\ub6bc\u52e9\u{1fe0a}\u67ba\u07d3\u0364\u{1fab3}',
+  type: 'occlusion',
+  count: 163,
+});
+let renderBundle133 = renderBundleEncoder16.finish();
+try {
+computePassEncoder27.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder222.clearBuffer(buffer20);
+} catch {}
+await gc();
+let commandEncoder229 = device2.createCommandEncoder({label: '\u{1fb85}\ubd68\u8bf8\u9efe\u4684\u0cce\u055d\u9fda\u0d6f'});
+let commandBuffer133 = commandEncoder225.finish({label: '\u84b4\u98fd\uc2d0\u9beb\ue5ed\u6d9c\u{1fc96}\ue125\u0727'});
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer35, 1_264);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 1_224);
+} catch {}
+try {
+device2.queue.submit([commandBuffer118]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 74, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: canvas4,
+  origin: { x: 27, y: 287 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer134 = commandEncoder229.finish({label: '\u01f1\u0b01\u3208'});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder49.draw(90, 11, 224_859_222, 274_165_539);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(39, 185, 29, 312_768_281, 479_967_180);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 2_740);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline18);
+} catch {}
+try {
+device2.queue.submit([commandBuffer126, commandBuffer131]);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(0, buffer8, 700, 5_622);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 7, depthOrArrayLayers: 108}
+*/
+{
+  source: imageData2,
+  origin: { x: 16, y: 12 },
+  flipY: true,
+}, {
+  texture: texture66,
+  mipLevel: 2,
+  origin: {x: 4, y: 3, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder230 = device0.createCommandEncoder({label: '\ue637\u51a5\u55eb\ue6b8\u{1fe69}\u{1fba5}\ua672\u7a77\u3380\uae5e\u24a1'});
+let commandBuffer135 = commandEncoder230.finish({label: '\u{1fb70}\ueef5\u{1fd9c}\u{1fed3}\u8f22\u391e'});
+let renderBundle134 = renderBundleEncoder10.finish({label: '\ufd1e\u{1fb12}\u36dd\u7ad0\u{1fe7f}'});
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer8, 0, 1_592);
+} catch {}
+try {
+device0.queue.submit([commandBuffer129]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 964, new Int16Array(9906), 1927, 700);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder231 = device0.createCommandEncoder({label: '\ud37d\u{1fe84}\u0316\u5613\ufe1c\u{1fab3}\u4d42\u2702'});
+let computePassEncoder60 = commandEncoder231.beginComputePass({label: '\u9134\u0347\u{1fb91}\ub215\ub8dd\u5fea\u{1fb21}'});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup1, new Uint32Array(753), 90, 0);
+} catch {}
+try {
+renderPassEncoder38.setBlendConstant({ r: -641.3, g: 543.9, b: 140.0, a: -730.6, });
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(2, buffer8, 472, 28);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer9, 'uint16', 738, 33);
+} catch {}
+try {
+device0.queue.submit([commandBuffer130]);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(4_294_967_295, undefined, 653_480_797);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer0, 'uint32', 3_356, 6_689);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant({ r: 856.1, g: -557.5, b: -174.2, a: -466.5, });
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer21, 'uint32', 1_396, 388);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer37, 0, 694);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1776, new Int16Array(3005), 1084, 528);
+} catch {}
+let commandEncoder232 = device2.createCommandEncoder({label: '\uea51\ud9d9\ud0a2\ufb41\u2f95'});
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(1, 197, 18, 65_247_606, 201_560_369);
+} catch {}
+let commandBuffer136 = commandEncoder228.finish({label: '\uc99b\u0138\u494c\u0d2c'});
+let texture80 = device1.createTexture({
+  label: '\u9845\u{1fab7}',
+  size: [1160, 1, 1],
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder61 = commandEncoder106.beginComputePass({label: '\ueff9\u0b1d\u{1fde9}\u9478\u02f2\u{1fdad}\u303f'});
+try {
+renderPassEncoder40.setIndexBuffer(buffer18, 'uint16', 4_614, 2_594);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(4, buffer18, 376);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer18, 516, 7_391);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer136]);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let commandEncoder233 = device1.createCommandEncoder({label: '\u02a7\ue97c\u454e'});
+let commandBuffer137 = commandEncoder222.finish({label: '\ufaf1\u{1fa42}\u2b16\uf8de\u{1fc06}\u9998\u{1f90d}\ue1e5'});
+let renderPassEncoder63 = commandEncoder221.beginRenderPass({
+  label: '\ud38f\u8b31\u0900',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 12,
+  clearValue: { r: -941.5, g: 328.1, b: -638.1, a: -453.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder46.executeBundles([renderBundle75]);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let pipeline20 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule4, constants: {}, buffers: []},
+});
+try {
+window.someLabel = computePassEncoder38.label;
+} catch {}
+let commandBuffer138 = commandEncoder233.finish();
+let renderPassEncoder64 = commandEncoder110.beginRenderPass({
+  label: '\uee87\u8f69\u8fe7\u0d43\u8ff7\u4238\uddaa',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 55,
+  clearValue: { r: -983.1, g: -74.15, b: -628.8, a: -742.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet20,
+});
+let renderBundle135 = renderBundleEncoder15.finish({label: '\u8375\u0d93'});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup4, new Uint32Array(1700), 36, 0);
+} catch {}
+try {
+renderPassEncoder60.setBlendConstant({ r: -780.5, g: 161.9, b: -436.2, a: -522.3, });
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer36, 'uint32', 1_260, 25);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(16, 48, 19, 170_071_970, 1_690_396_536);
+} catch {}
+let pipeline21 = await device1.createComputePipelineAsync({
+  label: '\u2754\u07d6\u4d63\u{1f88f}\u80bc\u{1f80f}',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule4, constants: {}},
+});
+let buffer42 = device0.createBuffer({
+  label: '\u0068\u0887\u01ad\uf3fe\ub6b3\u0045\ud6c2\u0d89\ub4a3',
+  size: 5100,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder234 = device0.createCommandEncoder({label: '\u{1f8cb}\u{1f920}\ueb53\u9f9f\u{1f9f9}\ufc70\u08f3\u0dd8\u22c1\u5861\u09c2'});
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup0, new Uint32Array(1839), 399, 0);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer4, 'uint16', 5_228, 20_922);
+} catch {}
+try {
+commandEncoder234.copyBufferToBuffer(buffer21, 624, buffer2, 9280, 16);
+} catch {}
+try {
+device0.queue.submit([commandBuffer135]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1440, height: 28, depthOrArrayLayers: 432}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 223, y: 2, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder235 = device0.createCommandEncoder();
+try {
+renderPassEncoder17.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer11, 'uint32', 668, 2_213);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+adapter5.label = '\u0827\u08ee\udf9a\u08ed\u3520\u04c0\u{1fe5a}\u044f\u2cbd\u1f1b\u0544';
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder64.setViewport(45.07858909130657, 0.8383655105465397, 27.276403012033303, 0.052470296398795295, 0.30580407498070084, 0.6970457933188807);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(0, buffer18);
+} catch {}
+try {
+renderBundleEncoder19.draw(136, 32, 717_631_486, 1_736_267_767);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer36, 'uint32', 780, 23);
+} catch {}
+try {
+device1.queue.submit([commandBuffer138]);
+} catch {}
+let imageData25 = new ImageData(24, 4);
+let renderBundle136 = renderBundleEncoder18.finish({label: '\u{1f8b5}\u{1fccb}\u08d5'});
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup6, new Uint32Array(2486), 985, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(35, 22, 4, -2_068_020_678, 271_136_838);
+} catch {}
+try {
+device2.queue.submit([commandBuffer121]);
+} catch {}
+document.body.prepend(canvas2);
+let pipelineLayout24 = device1.createPipelineLayout({label: '\uf924\ub667\u3e13\uf2ac\u6b3c\u00fb\u{1f709}\u{1fb33}\u{1f719}', bindGroupLayouts: []});
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer18, 'uint32', 1_392, 1_545);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5, new Uint32Array(1541), 26, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 57},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 38},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let pipelineLayout25 = device1.createPipelineLayout({label: '\u03fc\u{1fedf}\u069e', bindGroupLayouts: [bindGroupLayout16, bindGroupLayout31]});
+let commandEncoder236 = device1.createCommandEncoder({label: '\u4bf2\u56d4\u{1fc6c}\u08bc\u0456\u0d59\u6a5d\u5143\uc20f\ubf5b'});
+let commandBuffer139 = commandEncoder158.finish();
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(1, 85, 0, 665_786_038, 78_892_342);
+} catch {}
+try {
+commandEncoder236.insertDebugMarker('\u0a13');
+} catch {}
+let promise44 = device1.queue.onSubmittedWorkDone();
+let commandEncoder237 = device1.createCommandEncoder({label: '\uefd6\u0e76\u3b5a\u{1f927}\u0666\u0dd5\ufaea\u17fe\u{1ff72}\u52c3\ube4f'});
+let commandBuffer140 = commandEncoder237.finish({label: '\u3d83\u541c\u{1fd5d}\u056e\ub7c5\u{1f7c6}\u09c5\u{1fdab}\ued1b\ube6a'});
+try {
+renderPassEncoder45.beginOcclusionQuery(261);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle115]);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline14);
+} catch {}
+try {
+  await promise44;
+} catch {}
+let commandEncoder238 = device2.createCommandEncoder({});
+let renderBundle137 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder49.beginOcclusionQuery(277);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer40, 76);
+} catch {}
+try {
+renderPassEncoder54.drawIndirect(buffer35, 624);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 149, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: imageData23,
+  origin: { x: 5, y: 1 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture22.label;
+} catch {}
+try {
+renderPassEncoder61.end();
+} catch {}
+try {
+renderPassEncoder54.draw(85, 4, 159_893_505, 91_261_331);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder172.copyBufferToBuffer(buffer38, 852, buffer40, 2832, 124);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(23), /* required buffer size: 23 */
+{offset: 23}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline22 = device2.createRenderPipeline({
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x45417403},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+  },
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'r8uint', writeMask: 0}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule10, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let renderBundle138 = renderBundleEncoder9.finish({label: '\u0777\u07f7\u9739\udd1a\ud309\u0f61\ub6ba\u3e30'});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer7, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+commandEncoder167.copyBufferToTexture({
+  /* bytesInLastRow: 192 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 400 */
+  offset: 400,
+  rowsPerImage: 218,
+  buffer: buffer0,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 228, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder239 = device2.createCommandEncoder({label: '\u6bc4\u{1fcf5}\u0906\u02dd\u0ff0\u{1f64f}\u{1fbb8}\u{1ffda}'});
+let textureView56 = texture58.createView({label: '\u5bb4\u09da\u{1f727}\u0782\uf965\u09a9\u29db\u{1fcb1}\u927b', mipLevelCount: 1});
+let renderBundleEncoder24 = device2.createRenderBundleEncoder({label: '\u0af3\u0a7b\u1a25\u0c64', colorFormats: ['rgba32float'], sampleCount: 4, depthReadOnly: true});
+try {
+renderPassEncoder54.draw(476, 163, 447_517_666, 1_435_320_619);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(86, 298, 7, 3_118_195, 218_451_598);
+} catch {}
+try {
+renderPassEncoder54.drawIndirect(buffer35, 2_236);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer38, 260);
+} catch {}
+try {
+commandEncoder172.clearBuffer(buffer38);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder240 = device0.createCommandEncoder({label: '\u{1fa7b}\u6e94\u0b40\uea6c\ude0c\uba3c\u68d5\ub4f8'});
+try {
+renderPassEncoder19.insertDebugMarker('\u0af7');
+} catch {}
+let texture81 = device1.createTexture({
+  label: '\ue490\ucc4b\u9ffd\u20a2\u1ea3\u3d17\u0698\u0cbb\ubc40\u12e0',
+  size: {width: 23},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder65 = commandEncoder236.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 38,
+  clearValue: { r: 757.4, g: -408.8, b: 513.6, a: -595.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 169937475,
+});
+try {
+renderBundleEncoder19.draw(276, 525, 244_266_096, 366_712_305);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(0, 326, 0, 260_321_305, 1_432_171_517);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline15);
+} catch {}
+let pipelineLayout26 = device1.createPipelineLayout({label: '\ue5a6\u31de\ud2b9\u3573\u0b74', bindGroupLayouts: []});
+let commandEncoder241 = device1.createCommandEncoder({label: '\u0ebd\u0153\u020b\u590a\u{1fdb0}\ua8c1'});
+let commandBuffer141 = commandEncoder241.finish();
+let renderBundle139 = renderBundleEncoder15.finish({label: '\ua8ad\ua914\u{1f75e}\u4647\uec95\u6d74\u6dfb'});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup4, new Uint32Array(2902), 1172, 0);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle90]);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder19.draw(70, 403, 427_353_003, 241_506_094);
+} catch {}
+try {
+device1.queue.submit([commandBuffer140]);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+video0.height = 14;
+let pipelineLayout27 = device0.createPipelineLayout({label: '\u0892\u087b\ud4b5\u0f28\u6d04\u7522\u762a\u31f1\u{1fb36}', bindGroupLayouts: []});
+let commandEncoder242 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  label: '\uc919\u{1f9cc}',
+  size: {width: 180},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView57 = texture66.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder66 = commandEncoder240.beginRenderPass({
+  label: '\u{1f675}\u0d2a\uca4e\uaff4\u4f74',
+  colorAttachments: [{view: textureView57, depthSlice: 81, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 176428033,
+});
+let externalTexture26 = device0.importExternalTexture({label: '\u6cf3\u4b78\u082c\u5491\u0a64', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup3, new Uint32Array(5538), 944, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle16, renderBundle55, renderBundle87, renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup3, new Uint32Array(972), 118, 0);
+} catch {}
+try {
+commandEncoder234.copyBufferToTexture({
+  /* bytesInLastRow: 724 widthInBlocks: 181 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3996 */
+  offset: 3996,
+  buffer: buffer10,
+}, {
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 507, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 181, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer142 = commandEncoder239.finish({label: '\u{1f90c}\u{1fdd1}\u{1f9a5}\ufe31\u05db\u{1fd50}\u09ef\u4669'});
+let computePassEncoder62 = commandEncoder232.beginComputePass();
+try {
+computePassEncoder62.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer35, 2_388);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer38, 'uint16', 370, 1_453);
+} catch {}
+try {
+commandEncoder238.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 229, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 437, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 52, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let texture83 = device1.createTexture({
+  label: '\uddcd\u137a',
+  size: [1160],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup5, new Uint32Array(2616), 366, 0);
+} catch {}
+try {
+renderPassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder19.drawIndexed(2, 357, 0, 88_126_708, 320_717_015);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let commandEncoder243 = device1.createCommandEncoder({label: '\uf14f\u{1fc03}\u035c'});
+let querySet31 = device1.createQuerySet({label: '\u{1f98c}\uce04\ue8d4\ud7e7', type: 'occlusion', count: 122});
+let commandBuffer143 = commandEncoder243.finish({label: '\u5997\u{1f757}\u1b15\u0839\u0818\uc0cd\u{1f644}\ua944\ua86f'});
+let renderBundle140 = renderBundleEncoder16.finish({label: '\u0c03\u83ad\u0ee7'});
+try {
+computePassEncoder27.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(0, buffer18, 0);
+} catch {}
+try {
+renderBundleEncoder19.draw(63, 43, 453_254_370, 828_132_359);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 92, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(11), /* required buffer size: 11 */
+{offset: 11}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder67 = commandEncoder235.beginRenderPass({
+  label: '\u067b\u3f55\u8063\u{1fb8b}',
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -417.4, g: 561.0, b: -906.9, a: -86.36, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 78827750,
+});
+let renderBundle141 = renderBundleEncoder2.finish({label: '\u{1f697}\u{1fc99}\u0b06\u{1fbef}\u0826\ueb71\u{1fe67}\u30f5\uc1d4\u1ddc\ubc11'});
+try {
+renderPassEncoder67.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setViewport(86.00847218198564, 0.6895389365317428, 2.6564631128326868, 0.27055646130447947, 0.6882258248001731, 0.733829410911208);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer11, 'uint16', 6_750, 1_719);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer0);
+} catch {}
+let commandEncoder244 = device1.createCommandEncoder();
+let commandBuffer144 = commandEncoder244.finish();
+let renderBundle142 = renderBundleEncoder19.finish();
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder146.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1246 */
+  offset: 1246,
+  buffer: buffer18,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.draw(211, 254, 332_122_865, 283_768_880);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer40, 6_704);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(6, buffer38);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer35, 'uint16', 956, 772);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let imageData26 = new ImageData(136, 4);
+let commandEncoder245 = device2.createCommandEncoder();
+let querySet32 = device2.createQuerySet({label: '\uc8e9\u{1fc1d}\u0db2\u0c6c\ub1c7\u29a6\u0c15\ua54e', type: 'occlusion', count: 90});
+let renderBundle143 = renderBundleEncoder18.finish({label: '\ub047\u{1f754}'});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup7, new Uint32Array(3087), 344, 0);
+} catch {}
+try {
+computePassEncoder43.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup7, new Uint32Array(1021), 202, 0);
+} catch {}
+try {
+renderPassEncoder55.draw(190, 74, 951_687_941, 1_225_670_286);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer35, 2_508);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(5, buffer38, 1_468, 57);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder24.drawIndexed(30, 53, 19, 148_385_005, 759_680_594);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(4, buffer38, 0, 3_514);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  label: '\u0d35\u6e28\ua78f\u5ffb\u06ae\u1139\u48fd\ube06\u0210\u0b61',
+  entries: [
+    {
+      binding: 164,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 38014823, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder246 = device1.createCommandEncoder({label: '\uaa20\u4c05\u{1fa67}\u0af5\u0174\uc46b\u95ea'});
+let commandBuffer145 = commandEncoder146.finish({label: '\u7c93\u238d\u{1fda2}\u2a93\u0992\u{1f6af}\u86a5'});
+let renderPassEncoder68 = commandEncoder246.beginRenderPass({colorAttachments: [{view: textureView44, depthSlice: 47, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundle144 = renderBundleEncoder14.finish({label: '\u3b15\u08c4'});
+try {
+computePassEncoder40.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(4, buffer18);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder247 = device2.createCommandEncoder({label: '\uabd0\u5c25\u4b01\u6246'});
+let commandBuffer146 = commandEncoder172.finish({});
+let renderPassEncoder69 = commandEncoder245.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 2,
+  clearValue: { r: -564.8, g: 673.6, b: -487.2, a: -902.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle145 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder43.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder54.draw(44, 240, 171_038_150, 739_834_974);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(153, 199, 10, 1_517_695_209, 1_023_705_725);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer40, 32);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 9_160);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer35, 'uint32', 6_948, 267);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline18);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder238.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1920 */
+  offset: 1920,
+  buffer: buffer38,
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 980, new Float32Array(10061), 1025, 124);
+} catch {}
+let commandBuffer147 = commandEncoder242.finish({label: '\u0895\u03e3\u987e\ua311\u0a76\ub257\u{1f75f}\ufcf0\u1a6b'});
+let textureView58 = texture36.createView({label: '\u0fa8\uc06e\u828b\u0b8a\uc549', dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder63 = commandEncoder234.beginComputePass({label: '\u0b8f\u{1ff8e}\u04a3\u3f1f\u{1fca9}\u{1f991}\ub6d8\u07f8\u0856\u0dea\u1f02'});
+let renderBundle146 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder51.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer11, 'uint32', 388, 7_961);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer21, 'uint16', 34, 5);
+} catch {}
+let pipelineLayout28 = device2.createPipelineLayout({
+  label: '\u0127\u2366\u049e\u0f21\u57aa\u077a\ud421',
+  bindGroupLayouts: [bindGroupLayout33, bindGroupLayout32, bindGroupLayout28, bindGroupLayout28],
+});
+let renderBundle147 = renderBundleEncoder24.finish({label: '\u0a51\uaaee\u2837\u7a83\u9129\u085a\u0e33\u0ec4\ue1cf\u51cc'});
+try {
+computePassEncoder62.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 4_860);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer35, 'uint16', 1_238, 576);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(6, buffer38, 0);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer133, commandBuffer146]);
+} catch {}
+let commandEncoder248 = device0.createCommandEncoder({label: '\u07f8\u4452\u7ff0'});
+let commandBuffer148 = commandEncoder167.finish();
+let renderPassEncoder70 = commandEncoder248.beginRenderPass({
+  label: '\ufb49\u{1f79d}\u0da4\u09c4\u717a\ucbc8\u0e67\u{1fecb}\uf5d5',
+  colorAttachments: [{view: textureView28, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 224854545,
+});
+let sampler31 = device0.createSampler({
+  label: '\u7bdc\u8a23\u827b\u0398\u{1fe01}\ua8dd\u5d8b',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 53.67,
+  lodMaxClamp: 72.32,
+});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 296, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2296 widthInBlocks: 287 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 928 */
+  offset: 928,
+  rowsPerImage: 11,
+  buffer: buffer4,
+}, {width: 287, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder125.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 75, y: 1, z: 1},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 14, depthOrArrayLayers: 216}
+*/
+{
+  source: imageData23,
+  origin: { x: 2, y: 3 },
+  flipY: true,
+}, {
+  texture: texture66,
+  mipLevel: 1,
+  origin: {x: 3, y: 10, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder249 = device1.createCommandEncoder({});
+let renderPassEncoder71 = commandEncoder249.beginRenderPass({
+  label: '\u{1f60d}\u39de\ue668\u0e18\u4b5a\u008a\ud819\ub482\u{1fac5}',
+  colorAttachments: [{view: textureView44, depthSlice: 65, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 185036468,
+});
+let renderBundle148 = renderBundleEncoder17.finish({label: '\u{1ffad}\u42fd\ubd14\ub8de'});
+try {
+computePassEncoder33.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder68.setViewport(38.77356364182784, 0.11171682176595243, 28.12753929816152, 0.8779981225590695, 0.22415909290307867, 0.9078935825019974);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(5, buffer18, 0, 322);
+} catch {}
+try {
+device1.queue.submit([commandBuffer139]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas3);
+try {
+renderPassEncoder65.end();
+} catch {}
+try {
+renderPassEncoder68.setBlendConstant({ r: 393.9, g: -712.4, b: 307.0, a: 295.0, });
+} catch {}
+let pipelineLayout29 = device2.createPipelineLayout({label: '\u136f\ue2b0\u{1fd34}\u{1fc4d}\ue7cf', bindGroupLayouts: []});
+let commandEncoder250 = device2.createCommandEncoder();
+let computePassEncoder64 = commandEncoder247.beginComputePass({label: '\u{1fc7c}\u{1ffa0}\u036c\uf270\u{1fbc0}\u05c6\ubd9c\u884e\u48e0\ue7cb\u0388'});
+try {
+computePassEncoder64.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder58.setViewport(61.286415154685244, 0.09422777880820266, 4.466142673614727, 0.14904690897543188, 0.45597545638040593, 0.9834558008447623);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer35, 156);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer40, 13_996);
+} catch {}
+try {
+commandEncoder238.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 441, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+},
+{width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 260, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(163), /* required buffer size: 163 */
+{offset: 163, bytesPerRow: 10917}, {width: 679, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let imageData27 = new ImageData(32, 72);
+let commandEncoder251 = device2.createCommandEncoder({label: '\u7218\u{1f93d}\uca1c\u65b7\u239d\uea6e\u{1fd05}\ud0cc\u{1f960}\uf34a\u6645'});
+let texture84 = gpuCanvasContext8.getCurrentTexture();
+let renderPassEncoder72 = commandEncoder251.beginRenderPass({
+  label: '\u0771\u0fb2\ud27b\u01ca',
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 11,
+  clearValue: { r: -780.6, g: 108.0, b: -572.7, a: -500.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(80, 46, 64, 270_893_284, 508_170_940);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer35, 1_308);
+} catch {}
+try {
+renderPassEncoder69.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder250.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 128 */
+  offset: 128,
+  buffer: buffer38,
+}, {
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise45 = device2.queue.onSubmittedWorkDone();
+try {
+window.someLabel = device2.label;
+} catch {}
+let commandEncoder252 = device2.createCommandEncoder({});
+let texture85 = gpuCanvasContext6.getCurrentTexture();
+try {
+computePassEncoder58.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer40, 1_860);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer35, 3_824);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer35, 'uint32', 1_268, 650);
+} catch {}
+let promise46 = device2.queue.onSubmittedWorkDone();
+let commandEncoder253 = device2.createCommandEncoder({label: '\u0d43\u64a5'});
+let commandBuffer149 = commandEncoder250.finish({label: '\u{1fa5d}\u05c8\u0d19\u0886\u2164\u6ff7\u08bd\u0cb5\u{1f828}'});
+let computePassEncoder65 = commandEncoder238.beginComputePass();
+try {
+computePassEncoder59.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(111, 258, 31, 231_228_670, 1_270_845_197);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer40, 16);
+} catch {}
+try {
+commandEncoder252.copyBufferToTexture({
+  /* bytesInLastRow: 360 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3080 */
+  offset: 3080,
+  buffer: buffer38,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 280, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 90, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.submit([commandBuffer142, commandBuffer134]);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let textureView59 = texture50.createView({label: '\uc08e\u5204\u{1fa63}\u8f44\ubfb2\u8496'});
+let renderPassEncoder73 = commandEncoder252.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 0,
+  clearValue: { r: 845.8, g: -296.0, b: 325.0, a: -374.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let externalTexture27 = device2.importExternalTexture({label: '\u{1f92f}\u3dd2\u880d\u2c1c\u0df9\u043e', source: video1});
+try {
+computePassEncoder65.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer40, 2_752);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(2, buffer38, 16, 768);
+} catch {}
+try {
+commandEncoder253.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 576 */
+  offset: 576,
+  bytesPerRow: 256,
+  buffer: buffer40,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder253.clearBuffer(buffer40, 552, 2320);
+} catch {}
+try {
+renderPassEncoder58.insertDebugMarker('\u8148');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 149, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: imageData6,
+  origin: { x: 3, y: 3 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder254 = device0.createCommandEncoder({label: '\u4c80\u01a5\u22bb\u6561\u7fdc\u0a21\u0d8c\u20ef\u0411'});
+let renderPassEncoder74 = commandEncoder254.beginRenderPass({
+  label: '\u067d\u{1f915}\u{1fa9c}\u05d2\uc42a\u01df\u53c5\uf9cd\u{1fae8}\u0c87',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 209,
+  clearValue: { r: -241.6, g: -9.271, b: -197.0, a: 72.78, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup9, new Uint32Array(2029), 274, 0);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(2, buffer0, 7_284, 3_369);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 2804, new Float32Array(15893), 659, 120);
+} catch {}
+let commandEncoder255 = device2.createCommandEncoder({label: '\u{1f836}\u{1f914}\u5332\u{1fe49}\u605d\u8852\u27e0\u0766\ufdce\u{1f7d7}\u0d47'});
+let renderBundleEncoder25 = device2.createRenderBundleEncoder({label: '\u066e\u04ae\u2292', colorFormats: ['rg16float', 'rgb10a2unorm', 'r8uint', 'rgba16uint']});
+try {
+computePassEncoder64.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.draw(240, 90, 1_327_343_389, 115_290_340);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer35, 124);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer35, 'uint32', 1_376, 2_230);
+} catch {}
+let img3 = await imageWithData(11, 165, '#10101010', '#20202020');
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.draw(530, 30, 92_571_413, 335_883_781);
+} catch {}
+try {
+renderPassEncoder55.drawIndexed(11, 227, 109, 162_829_927, 1_393_219_397);
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter();
+let commandEncoder256 = device0.createCommandEncoder({label: '\u{1f7cc}\ua378\u{1faf6}'});
+let commandBuffer150 = commandEncoder256.finish({label: '\u0c5d\u0cf7\u536c\u064b\u318b'});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer18, 'uint16', 978, 2_368);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(4, buffer18, 0, 238);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let commandEncoder257 = device2.createCommandEncoder({label: '\u9ab9\ud66b\u0216\u{1fcb7}\u7959'});
+let computePassEncoder66 = commandEncoder255.beginComputePass({label: '\u4691\u940e\ub130\u8f57\uc1d0\u6093\u84db\u9e89\u064c'});
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder49.draw(64, 11, 145_176_959, 146_740_397);
+} catch {}
+try {
+renderPassEncoder54.drawIndirect(buffer35, 364);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1648 */
+  offset: 1648,
+  rowsPerImage: 3,
+  buffer: buffer38,
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: canvas0,
+  origin: { x: 96, y: 7 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet33 = device0.createQuerySet({label: '\u09fc\u0dbe\u08ff\ubcd9\u{1fce0}\u144f\u6252\u1bab', type: 'occlusion', count: 473});
+let renderPassEncoder75 = commandEncoder125.beginRenderPass({
+  label: '\u0580\ubf96\u{1fea7}\ucbdc\u409d\u{1f62d}\u14ca\u14e9\u{1f681}',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 298,
+  clearValue: { r: -867.4, g: 29.20, b: -143.3, a: -431.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle149 = renderBundleEncoder9.finish();
+try {
+renderPassEncoder70.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandBuffer151 = commandEncoder253.finish({label: '\u9ad4\u{1faf8}\u0723\u71d9\ud2f3\uc68f\u{1fde7}'});
+let texture86 = device2.createTexture({
+  label: '\u01ca\u1dec\u{1fbfc}\uf174\u{1ffb0}\u2fe2',
+  size: {width: 596, height: 1, depthOrArrayLayers: 23},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder62.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.draw(130, 172, 1_101_760_367, 68_080_344);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer38, 'uint32', 752, 556);
+} catch {}
+try {
+querySet22.destroy();
+} catch {}
+try {
+commandEncoder257.resolveQuerySet(querySet25, 73, 126, buffer40, 2816);
+} catch {}
+let commandEncoder258 = device0.createCommandEncoder({label: '\u0538\u5542\u{1fd96}\u04a3'});
+let commandBuffer152 = commandEncoder258.finish({label: '\u8f43\ud58f\u9621\u0977\u{1ffa3}\u{1f6a2}\u12fc'});
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup0, new Uint32Array(885), 113, 0);
+} catch {}
+try {
+renderPassEncoder38.beginOcclusionQuery(597);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup3, new Uint32Array(466), 9, 0);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer11, 760, buffer12, 404, 4284);
+} catch {}
+let renderPassEncoder76 = commandEncoder153.beginRenderPass({
+  label: '\u{1fd89}\u3e1a\u{1fcd1}',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 126,
+  clearValue: { r: -106.8, g: -551.4, b: -912.4, a: 701.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder39.setIndexBuffer(buffer37, 'uint32', 2_288, 1_205);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer16, 'uint16', 944, 881);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer37, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer0, 'uint32', 984, 11_873);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device0.queue.submit([commandBuffer123, commandBuffer147]);
+} catch {}
+let commandEncoder259 = device1.createCommandEncoder({label: '\u0747\u{1fd1d}\u00c9\u9bf1\u2f00'});
+let renderPassEncoder77 = commandEncoder259.beginRenderPass({
+  label: '\u5cf0\u5dbe',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 49,
+  clearValue: { r: -81.89, g: 611.9, b: -209.2, a: 475.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder61.setPipeline(pipeline21);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+computePassEncoder54.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+  await buffer17.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandBuffer153 = commandEncoder257.finish({label: '\u8140\uc171\u{1fad4}\u{1f940}\u03a9'});
+try {
+renderPassEncoder49.drawIndirect(buffer40, 7_796);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer38, 'uint32', 544, 2_517);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer38);
+} catch {}
+try {
+buffer35.destroy();
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer38, 1444, buffer40, 356, 640);
+} catch {}
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 134, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 352 */
+  offset: 352,
+  buffer: buffer38,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device2.createComputePipeline({layout: pipelineLayout17, compute: {module: shaderModule10}});
+let bindGroupLayout35 = device2.createBindGroupLayout({label: '\u{1fa1c}\u{1f872}\ua6fe\u8371\u68de\u0fa4', entries: []});
+let renderPassEncoder78 = commandEncoder132.beginRenderPass({
+  label: '\u{1f952}\ua5cc\u1b7e\u78e1\u{1faeb}\u7d2a\u1a63\u0104\ue09d\u0dc0',
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 0,
+  clearValue: { r: -985.3, g: 123.7, b: 629.4, a: -531.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle150 = renderBundleEncoder18.finish({label: '\u0748\u{1fa88}\ud76c'});
+try {
+renderPassEncoder78.end();
+} catch {}
+try {
+renderPassEncoder55.drawIndexed(20, 84, 23, -2_002_266_056, 1_873_688_462);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer35, 2_144);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 1_236);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+renderPassEncoder54.draw(823, 567, 16_179_481, 1_381_051_512);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(1, buffer40, 268);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer35, 'uint16', 2_074, 182);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 1172, new BigUint64Array(5558), 114, 0);
+} catch {}
+let img4 = await imageWithData(5, 19, '#10101010', '#20202020');
+let promise47 = adapter0.requestAdapterInfo();
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.draw(29, 6, 1_791_222_195, 1_166_211_320);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer35, 420);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline24 = device2.createRenderPipeline({
+  label: '\ub23b\ud160\u3790\ubd12\u66e7\u05db\u45f1\ud2fd\u14b8\u8346',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule5, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+renderPassEncoder50.setPipeline(pipeline15);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+video0.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+try {
+adapter2.label = '\u8c32\u033f\u0780\u{1f9c9}\u17f6\ufdd5\u{1f78c}\u0080\u0141\u0780';
+} catch {}
+let bindGroup10 = device1.createBindGroup({
+  label: '\u0430\u{1ffef}\u0736\u{1f6b5}\u5343\u9392\uf5cb\u14af',
+  layout: bindGroupLayout19,
+  entries: [{binding: 79, resource: sampler19}],
+});
+let commandEncoder260 = device1.createCommandEncoder({});
+try {
+renderPassEncoder77.setBlendConstant({ r: -290.9, g: -247.1, b: 488.8, a: -66.53, });
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer18, 'uint16', 2_232, 1_957);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline15);
+} catch {}
+try {
+texture81.destroy();
+} catch {}
+let commandEncoder261 = device1.createCommandEncoder();
+let commandBuffer154 = commandEncoder261.finish();
+let computePassEncoder67 = commandEncoder260.beginComputePass({label: '\ucf11\u{1f94f}\u0bc5\u0ba5\u092e\u1fc6\uf688\u53bd\u43ee\u{1f928}'});
+try {
+computePassEncoder50.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer18, 'uint32', 4_996, 159);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(3, buffer18, 0, 50);
+} catch {}
+let promise48 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise47;
+} catch {}
+let commandEncoder262 = device2.createCommandEncoder();
+let computePassEncoder68 = commandEncoder262.beginComputePass({label: '\u0f8e\u0800\u8529\u5742\u6054\u0af9'});
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer40, 7_948);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 2_088);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+device2.queue.submit([commandBuffer149, commandBuffer102]);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+textureView42.label = '\u29a7\u0e25\ue7c4\u32cd\u2123\u4d01\u{1f8eb}';
+} catch {}
+let commandEncoder263 = device2.createCommandEncoder({label: '\uca13\u{1f9b9}\u0e26\u01a0\u{1fc7b}\u0b3a\u{1fb3c}\u8544'});
+try {
+renderPassEncoder55.setScissorRect(10, 0, 4, 0);
+} catch {}
+try {
+renderPassEncoder54.draw(75, 77, 492_496_737, 902_406_794);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(5, buffer40, 244, 2_865);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer35, 'uint32', 428, 230);
+} catch {}
+let commandEncoder264 = device1.createCommandEncoder({label: '\u00c2\u0f9a\u4e58\u20f6\u8964\u{1fa49}\u0a64\u4489\u04a2\u{1f813}'});
+let commandBuffer155 = commandEncoder264.finish({label: '\uaaee\u34cc\u84c6\u0bef'});
+try {
+computePassEncoder35.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer18);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(274), /* required buffer size: 274 */
+{offset: 274}, {width: 195, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder265 = device0.createCommandEncoder({label: '\u{1fedb}\ud8bf\u6fb6\u0679\u06d8'});
+let renderPassEncoder79 = commandEncoder265.beginRenderPass({
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -587.1, g: -163.8, b: -876.2, a: 209.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 276847231,
+});
+let renderBundle151 = renderBundleEncoder22.finish({label: '\u{1f734}\u096f\u{1f9df}\u275a\u4a07\u2818\u0372\ud61e\u0329'});
+try {
+renderPassEncoder36.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(7, buffer0, 0, 6_346);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer13, 'uint32', 1_736, 4_559);
+} catch {}
+let commandEncoder266 = device2.createCommandEncoder({label: '\u{1ff20}\u0373'});
+let renderBundle152 = renderBundleEncoder20.finish();
+try {
+computePassEncoder62.dispatchWorkgroups(1, 4);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.draw(115, 742, 806_014_852, 345_308_526);
+} catch {}
+try {
+renderPassEncoder54.drawIndexed(15, 279, 73, 61_805_043, 631_979_512);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 2_508);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer35, 'uint16', 1_446, 345);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer35, 'uint16', 1_802, 1_353);
+} catch {}
+try {
+  await promise46;
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline15);
+} catch {}
+let commandEncoder267 = device2.createCommandEncoder();
+let renderBundle153 = renderBundleEncoder24.finish({label: '\u0aa4\u88b2\udffc\u06f8\u847c\u0b1d\u7e61\u{1fb94}'});
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(7, 312, 7, 119_753_530, 634_831_434);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline24);
+} catch {}
+let pipelineLayout30 = device2.createPipelineLayout({
+  label: '\u{1fc35}\u08f6\u4a8d\u0bb6\u35b1\u719f\u0916\u{1f920}\u7f9a\u42e9\u9b82',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout23],
+});
+let commandEncoder268 = device2.createCommandEncoder({});
+let commandBuffer156 = commandEncoder268.finish({label: '\u1385\u31e4\u{1f661}\ued72\ub522\u09b8\u27e4\u348d\uf83a\u23df'});
+let texture87 = gpuCanvasContext6.getCurrentTexture();
+let textureView60 = texture86.createView({label: '\u{1f648}\ue31e\u0ead\u077a\u0816\u01b7', format: 'r8uint', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder65.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder55.draw(23, 47, 147_423_523, 200_435_937);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(13, 206, 49, 339_485_586, 1_278_665_002);
+} catch {}
+try {
+renderPassEncoder54.drawIndirect(buffer35, 9_160);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer156, commandBuffer153]);
+} catch {}
+let commandEncoder269 = device0.createCommandEncoder({label: '\uab69\u0561\u{1fdbe}\ufc54\u{1f85d}\u84c0\u{1f9e2}'});
+let commandBuffer157 = commandEncoder269.finish({label: '\u5b30\u1d8c\u028e\u07d9'});
+let computePassEncoder69 = commandEncoder231.beginComputePass();
+try {
+computePassEncoder57.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.pushDebugGroup('\ub3a8');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 120, new DataView(new ArrayBuffer(13334)), 2322, 204);
+} catch {}
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let querySet34 = device0.createQuerySet({
+  label: '\u9f1a\uf92c\u{1f933}\u02f6\u{1f963}\u8c64\ub3df\u0c11\u{1f8c7}\u004c\u{1fd20}',
+  type: 'occlusion',
+  count: 1129,
+});
+let externalTexture28 = device0.importExternalTexture({source: video3, colorSpace: 'display-p3'});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup9, new Uint32Array(3188), 1166, 0);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer152]);
+} catch {}
+let sampler32 = device0.createSampler({
+  label: '\u7a4c\u637b\u0a21\u88ee\u{1fd06}\u3d15\ub803',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.72,
+  lodMaxClamp: 58.82,
+});
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer4, 10_620, 1_657);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroupLayout36 = device1.createBindGroupLayout({
+  label: '\uc15d\u48ce\u{1fa22}\uaf7b\u{1f657}',
+  entries: [
+    {
+      binding: 470,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 219,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 305,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 286,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 69,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 17892829, hasDynamicOffset: false },
+    },
+    {binding: 89, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 501, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 122,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 156,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 289, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 938,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 272,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 357,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 124,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 195,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 11,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 155, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 39,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 225,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 181,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 843,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 320, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 188,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 47, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 38,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 999, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 45,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 473,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 33, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 130,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 79, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 275, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 8, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 109, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 202, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 36, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 61,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 618, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 474,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 513,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 139,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 166,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 28, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 178, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 118, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 55, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 128, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 42, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 22, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 77, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 264,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 423, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 433, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 19,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 172, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 129, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 512,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 274, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 59, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 321, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let buffer43 = device1.createBuffer({
+  label: '\u0278\u475d\uf0a6\u7480\u025d\uf2f6\uf67e',
+  size: 4664,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandEncoder270 = device1.createCommandEncoder();
+let renderPassEncoder80 = commandEncoder270.beginRenderPass({
+  label: '\u4eda\u{1fd92}\u{1fede}\u{1fcef}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 34,
+  clearValue: { r: -691.2, g: -971.9, b: -505.0, a: 846.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({
+  label: '\u7da0\u{1fd26}\u76b2\u{1ffa1}\u008c\u{1fc83}\u31d1\u21ce\u45b2\u0c53\u3b39',
+  colorFormats: ['r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline14);
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.READ, 192, 4);
+} catch {}
+try {
+device1.queue.submit([commandBuffer101, commandBuffer154]);
+} catch {}
+let pipeline25 = device1.createRenderPipeline({
+  label: '\u734c\u{1fe6c}\u4286',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 84, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 28, attributes: []},
+      {arrayStride: 504, attributes: []},
+      {arrayStride: 224, stepMode: 'instance', attributes: []},
+      {arrayStride: 120, attributes: []},
+      {arrayStride: 60, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 384,
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 4},
+          {format: 'uint16x4', offset: 72, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip'},
+});
+let texture88 = gpuCanvasContext8.getCurrentTexture();
+let textureView61 = texture61.createView({label: '\u{1fe72}\u7ed9\u3168', mipLevelCount: 1});
+try {
+renderPassEncoder46.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder63.setBlendConstant({ r: -421.3, g: -651.8, b: 500.4, a: -517.1, });
+} catch {}
+try {
+renderPassEncoder60.setViewport(40.45488440905903, 0.6727457600991994, 5.99449235611639, 0.2554879838170835, 0.41180997314512124, 0.6655932680587735);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer36, 'uint16', 236, 444);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder26.insertDebugMarker('\u86aa');
+} catch {}
+await gc();
+let commandEncoder271 = device0.createCommandEncoder({label: '\u0e0b\u7f9a\u0d67'});
+let renderPassEncoder81 = commandEncoder271.beginRenderPass({
+  label: '\u4858\ud5fe\uf0d4\u{1fbde}\u4bf3\u7a97',
+  colorAttachments: [{view: textureView6, depthSlice: 3, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 160275377,
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup3, new Uint32Array(374), 59, 0);
+} catch {}
+try {
+renderPassEncoder38.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer21, 'uint32', 360, 1_920);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+let buffer44 = device0.createBuffer({
+  label: '\u5ed5\u60d4\u0533\u08e0\u0e38\u3ded\u0254\u9e4b\u{1f77e}',
+  size: 3513,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle154 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder31.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(3, buffer4, 0, 12_593);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let commandEncoder272 = device0.createCommandEncoder();
+let renderPassEncoder82 = commandEncoder272.beginRenderPass({
+  label: '\u299d\u9e15\u77a7\u32c2\u480e\ud850\u3e8b\u{1fed4}',
+  colorAttachments: [{view: textureView28, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet5,
+});
+let renderBundle155 = renderBundleEncoder8.finish({label: '\u{1ff92}\ue019\u89d5\u{1fae9}\u664f\u2610\u9208\u620a\u00a4'});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([]);
+} catch {}
+let commandEncoder273 = device2.createCommandEncoder();
+let commandBuffer158 = commandEncoder267.finish({label: '\u{1ff42}\u0606'});
+let textureView62 = texture65.createView({
+  label: '\ufa60\u{1f899}\ue453\u{1f75e}\u{1febf}\ufa8f\u{1f6da}\ua3ab',
+  baseArrayLayer: 1,
+  arrayLayerCount: 2,
+});
+let renderPassEncoder83 = commandEncoder263.beginRenderPass({
+  label: '\u0997\u841b\ubbff\ub44e\u6bd9\ud456\u4507\uc394\u36e9\u0324',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 0,
+  clearValue: { r: 620.5, g: 882.8, b: 318.3, a: 958.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet32,
+});
+try {
+renderPassEncoder55.drawIndirect(buffer40, 6_448);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder266.insertDebugMarker('\u36ff');
+} catch {}
+let bindGroupLayout37 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+try {
+computePassEncoder68.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder83.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.draw(35, 330, 189_283_877, 236_616_828);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer40, 6_512);
+} catch {}
+try {
+renderPassEncoder54.drawIndirect(buffer35, 3_364);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer38, 'uint16', 1_894, 163);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer35, 'uint16', 344, 1_623);
+} catch {}
+try {
+commandEncoder266.clearBuffer(buffer40, 1088, 1996);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup11 = device2.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 349, resource: sampler18}]});
+let commandBuffer159 = commandEncoder266.finish({label: '\u058c\u72a9\u310e\ua964\u0e74\uf4f1\u{1fc1c}\u047e\uab1d\u0ad0\u743d'});
+let texture89 = device2.createTexture({
+  label: '\u{1f960}\u{1fdf4}\u{1f899}\u2a5c\u60b1\u0b7e',
+  size: [596],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView63 = texture85.createView({label: '\u{1f7ee}\u0af2\u0244', aspect: 'all'});
+try {
+renderPassEncoder55.draw(113, 118, 1_636_438_386, 122_019_913);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer40, 12_928);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(4, buffer40, 720);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer38, 'uint16', 272, 14);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 7400, new Int16Array(1887), 609, 152);
+} catch {}
+let imageData28 = new ImageData(28, 16);
+let commandEncoder274 = device0.createCommandEncoder({label: '\u0e2f\u{1f63d}\u371a\ube9a\u{1fbee}\u1a12\ua038'});
+let texture90 = device0.createTexture({
+  label: '\u4dc3\u7000\u0657\ub5df\ub197\u{1fc6e}\u0ed8',
+  size: [360],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder84 = commandEncoder274.beginRenderPass({
+  label: '\ub6bf\u{1fa41}\u1d6c\u04e2\u015b\u06a9\ua460\u{1ffc4}\u{1fb1d}',
+  colorAttachments: [{view: textureView57, depthSlice: 60, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet19,
+});
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer9, 'uint32', 8, 361);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup8, new Uint32Array(2080), 493, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer37, 'uint16', 1_130, 1_240);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer5, 0);
+} catch {}
+let texture91 = device0.createTexture({
+  label: '\u058b\u092c\u31a2\u0c0e\ufb05\u36eb',
+  size: {width: 1440},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer0, 'uint32', 420, 6_540);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer44, 388, 2_521);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer45 = device0.createBuffer({
+  label: '\u{1f9ca}\u07d0\u01f3\u9cfe\u00e6\u0640\u850c',
+  size: 1072,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer44, 'uint16', 152, 452);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(4, buffer21, 0, 43);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder23.popDebugGroup();
+} catch {}
+try {
+  await promise48;
+} catch {}
+let buffer46 = device2.createBuffer({
+  label: '\u9333\u{1fbec}\u{1f6d4}\ue0d0\u{1f8fc}\ue4df\u1085\u0ad2\u2c5c',
+  size: 9443,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder85 = commandEncoder273.beginRenderPass({
+  label: '\u10cf\u1e7c\u7896\u8a9f\u913e',
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 0,
+  clearValue: { r: 820.4, g: -355.6, b: 173.8, a: -519.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet32,
+  maxDrawCount: 497470956,
+});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder49.draw(162, 124, 366_693_706, 4_748_423);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(40, 257, 16, 277_701_938, 430_992_494);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 5_888);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4, buffer40, 3_864, 333);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let textureView64 = texture58.createView({label: '\ucbf7\u{1fa6e}\u8043', dimension: '3d', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle156 = renderBundleEncoder20.finish({label: '\u8ed3\u5f7b\u4836'});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer35, 'uint32', 116, 829);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder73.insertDebugMarker('\u85de');
+} catch {}
+document.body.prepend(img0);
+let renderBundle157 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup3, new Uint32Array(1680), 53, 0);
+} catch {}
+try {
+renderPassEncoder76.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(41);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1124, new BigUint64Array(14568), 206, 8);
+} catch {}
+let texture92 = device2.createTexture({
+  label: '\u{1ff92}\u0191\u4852\u{1f9ef}\u{1fcf3}\u{1f96a}\u190e',
+  size: [596, 1, 1328],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle158 = renderBundleEncoder23.finish({label: '\udef7\u2c7e\u5baa'});
+try {
+computePassEncoder62.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer35, 'uint32', 1_660, 280);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer38);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.draw(99, 67, 968_649_252, 247_362_629);
+} catch {}
+try {
+renderPassEncoder55.drawIndexed(52, 497, 32, 152_769_129, 95_889_539);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer40, 0, 2_236);
+} catch {}
+try {
+computePassEncoder59.insertDebugMarker('\u7d57');
+} catch {}
+let texture93 = gpuCanvasContext9.getCurrentTexture();
+let renderBundle159 = renderBundleEncoder23.finish({label: '\u6cec\uec46\u00e9\uf24f\u{1fdc3}\u67e1\uda6e'});
+try {
+computePassEncoder66.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder52.end();
+} catch {}
+try {
+renderPassEncoder83.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer46, 3_404);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer38, 'uint32', 1_532, 393);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder85.pushDebugGroup('\udbfe');
+} catch {}
+let gpuCanvasContext12 = canvas6.getContext('webgpu');
+try {
+computePassEncoder21.setBindGroup(1, bindGroup3, new Uint32Array(2122), 201, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer4, 'uint16', 2_854, 807);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer9);
+} catch {}
+let img5 = await imageWithData(31, 162, '#10101010', '#20202020');
+let commandEncoder275 = device1.createCommandEncoder({label: '\u{1f6a5}\u0b9a\u{1fb4a}\u034c\ua9bf\u0904'});
+let renderPassEncoder86 = commandEncoder275.beginRenderPass({
+  label: '\u{1f86d}\ua5e8\u5457\u{1f90b}\ufd3a\uc54c',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 71,
+  clearValue: { r: -662.7, g: 500.0, b: -297.3, a: -803.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder60.executeBundles([renderBundle69, renderBundle133]);
+} catch {}
+try {
+renderPassEncoder46.setViewport(19.23974932822855, 0.7581985398225906, 58.45725727847063, 0.060647458142598566, 0.8835750684451075, 0.9954463708876079);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer36, 'uint32', 268, 182);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(1, buffer18);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let commandEncoder276 = device2.createCommandEncoder();
+try {
+computePassEncoder62.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup7, new Uint32Array(441), 34, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer35, 'uint16', 402, 1_608);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(0, buffer40, 0);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(0, buffer46);
+} catch {}
+try {
+commandEncoder276.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 301, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2000 widthInBlocks: 125 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1600 */
+  offset: 1600,
+  bytesPerRow: 2048,
+  buffer: buffer40,
+}, {width: 125, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+window.someLabel = bindGroup4.label;
+} catch {}
+let renderBundle160 = renderBundleEncoder19.finish();
+let externalTexture29 = device1.importExternalTexture({label: '\u7a4d\u{1fa65}\u09d1\u0c75\u052a', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder32.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline15);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let imageData29 = new ImageData(60, 140);
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({label: '\u660e\u00da\u03c2', colorFormats: ['rgba16sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder74.setIndexBuffer(buffer2, 'uint32', 1_200, 15_473);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup0, new Uint32Array(3627), 726, 0);
+} catch {}
+let arrayBuffer14 = buffer19.getMappedRange(8, 4);
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let commandEncoder277 = device0.createCommandEncoder();
+let commandBuffer160 = commandEncoder277.finish();
+try {
+computePassEncoder31.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer13, 'uint16', 4_908, 66);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder278 = device2.createCommandEncoder({label: '\ub7c3\u0a27'});
+let textureView65 = texture93.createView({label: '\ub6bc\u5e5c\u9363\u7be4\u{1f9ae}\u032f\u0f22\u{1fcfa}\u0135\u1cc3'});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder54.draw(137, 91, 968_559_100, 850_974_391);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(283, 399, 46, 21_920_344, 438_859_326);
+} catch {}
+let commandEncoder279 = device1.createCommandEncoder({label: '\u9795\u{1f646}\u904d\ub003'});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(3, bindGroup4, new Uint32Array(606), 172, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline15);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 30, y: 19 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder280 = device1.createCommandEncoder({label: '\u259a\uff13\u125b\u05dd\uc63e\u2d5a\u9d65\u1d4f\u9623'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline25);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder51.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1036, new Int16Array(11724), 316, 44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(288), /* required buffer size: 288 */
+{offset: 288, bytesPerRow: 196}, {width: 47, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup9, new Uint32Array(1219), 109, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder82.setVertexBuffer(7, buffer21, 404, 492);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.submit([commandBuffer150, commandBuffer157]);
+} catch {}
+let commandEncoder281 = device0.createCommandEncoder({label: '\u6c2f\u6cb1\u2587\ua32d\uc6b8\u163f\u04bc\ud61c\u{1ffea}\u3407\u218f'});
+let commandBuffer161 = commandEncoder281.finish({label: '\u0489\u07da\u{1f964}\u09a2\u256a\u8a85'});
+try {
+renderPassEncoder62.setBindGroup(3, bindGroup3, new Uint32Array(1133), 267, 0);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(314);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer160]);
+} catch {}
+let promise49 = adapter3.requestAdapterInfo();
+let renderBundle161 = renderBundleEncoder1.finish({label: '\uad4e\ud21a\ue5d3\u1419\u0ada\u5d0f\u8731'});
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer7, 52, 73);
+} catch {}
+let commandEncoder282 = device0.createCommandEncoder();
+let textureView66 = texture12.createView({label: '\u0ef3\u{1ff77}\ued2b\u0fe6\u0499\u{1f851}\u1a77\u0718\u0cc6\ue570\u5e6f'});
+try {
+computePassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup2, new Uint32Array(1133), 148, 0);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer45, 108, 332);
+} catch {}
+try {
+commandEncoder282.copyBufferToBuffer(buffer44, 264, buffer3, 932, 328);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 40, y: 1, z: 11},
+  aspect: 'all',
+}, new ArrayBuffer(99), /* required buffer size: 99 */
+{offset: 99}, {width: 37, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let video4 = await videoWithData();
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 62, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let commandBuffer162 = commandEncoder282.finish({label: '\u871a\u{1f909}\u210a'});
+let renderBundle162 = renderBundleEncoder13.finish({label: '\ud638\u1f68\u{1ff49}\u6935\u{1f932}'});
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, buffer8, 0, 2_599);
+} catch {}
+try {
+device0.queue.submit([commandBuffer148]);
+} catch {}
+let texture94 = device0.createTexture({
+  label: '\u087d\u0dcf\u06a9',
+  size: {width: 720, height: 14, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true});
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer10, 0, 1_757);
+} catch {}
+let commandEncoder283 = device0.createCommandEncoder();
+let renderPassEncoder87 = commandEncoder283.beginRenderPass({
+  label: '\u{1f7f6}\uc125\u2faa\u0088\u6e41\u{1fcdc}\u0afd\udca2\u689f',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 66,
+  clearValue: { r: 87.23, g: -225.3, b: -575.9, a: 669.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 585765029,
+});
+let renderBundle163 = renderBundleEncoder10.finish({label: '\u30c9\u1316\uc7ab\u09f7\u{1ffc3}'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup8, new Uint32Array(1977), 7, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer16, 'uint32', 3_592, 234);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+let commandBuffer163 = commandEncoder280.finish({label: '\u07ac\ud804'});
+let renderPassEncoder88 = commandEncoder279.beginRenderPass({
+  label: '\u0016\ue5f9\u7e1d',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 46,
+  clearValue: { r: 194.0, g: -465.3, b: 41.71, a: 3.802, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet17,
+});
+try {
+renderPassEncoder77.setBindGroup(3, bindGroup4, new Uint32Array(1094), 138, 0);
+} catch {}
+try {
+renderPassEncoder86.executeBundles([renderBundle160]);
+} catch {}
+try {
+renderPassEncoder68.setBlendConstant({ r: -545.6, g: -942.4, b: 414.3, a: 130.1, });
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer18, 960, 221);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer36, 824, new Float32Array(13940), 1681, 52);
+} catch {}
+let promise50 = device1.queue.onSubmittedWorkDone();
+try {
+device1.label = '\u0559\uf288\u01e1\u{1f959}\u47d3\ufa78\u{1fb69}\u02d1\u03a6';
+} catch {}
+let commandEncoder284 = device1.createCommandEncoder({label: '\ua0dc\u3880\u{1fa69}\u{1ffb5}\u07b7\u{1fce9}\u{1fa96}\u0046\uae6e'});
+let renderPassEncoder89 = commandEncoder284.beginRenderPass({
+  label: '\u8d79\u229e\ue9c9\u0425\u{1f87c}\u13a0',
+  colorAttachments: [{view: textureView44, depthSlice: 14, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet30,
+  maxDrawCount: 206937092,
+});
+let renderBundle164 = renderBundleEncoder19.finish({label: '\u8d50\u041b\ubc25\u0a32\u{1f9aa}\ufaea'});
+let externalTexture30 = device1.importExternalTexture({label: '\u24d9\u6180\u0068\u302f\u0bb6\u471d\u9a9f', source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup10, new Uint32Array(4323), 1326, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(0, bindGroup5, new Uint32Array(432), 9, 0);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline15);
+} catch {}
+try {
+device1.queue.submit([commandBuffer155, commandBuffer137, commandBuffer145, commandBuffer141]);
+} catch {}
+try {
+  await promise50;
+} catch {}
+await gc();
+let pipelineLayout31 = device1.createPipelineLayout({label: '\u6d73\u08be\uef80', bindGroupLayouts: [bindGroupLayout19, bindGroupLayout34]});
+let commandEncoder285 = device1.createCommandEncoder({label: '\u0f3d\u0b7c\ua62b\u3b21\u0175\u1c66\u{1f730}\u205e\u0efb\u055f'});
+let renderPassEncoder90 = commandEncoder285.beginRenderPass({
+  label: '\u{1ff8f}\ufc67\u{1f69c}\u0140\ubf43\uc421\uc72c\uc11d\u{1f725}\uc9a7\u{1f757}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 1,
+  clearValue: { r: 900.1, g: -380.9, b: -246.0, a: -647.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet30,
+});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup10, new Uint32Array(35), 8, 0);
+} catch {}
+try {
+renderPassEncoder90.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer36, 'uint16', 1_002, 1_321);
+} catch {}
+try {
+renderPassEncoder86.setVertexBuffer(7, buffer18, 0, 3_521);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline20);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let commandEncoder286 = device2.createCommandEncoder();
+let computePassEncoder70 = commandEncoder276.beginComputePass({label: '\u{1f617}\u439f\u3014\u012d\u28be\u9e78\u0230\ub4ec\u8f41\u07ac'});
+let externalTexture31 = device2.importExternalTexture({
+  label: '\u{1fe61}\u4973\u0818\u07be\u3d52\u{1f775}\u4a19',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(0, bindGroup7, new Uint32Array(1793), 4, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(2, bindGroup11, new Uint32Array(78), 10, 0);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise49;
+} catch {}
+let img6 = await imageWithData(33, 53, '#10101010', '#20202020');
+let commandEncoder287 = device0.createCommandEncoder({label: '\u{1f8e4}\uacd2\u{1ff40}\ue8a6'});
+let renderPassEncoder91 = commandEncoder287.beginRenderPass({
+  label: '\u{1fa1c}\uaf2c\u0dc8\u8bf9\uf804\u6889',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 14,
+  clearValue: { r: -384.4, g: 991.3, b: 430.9, a: -704.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(3, bindGroup1, new Uint32Array(2885), 175, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder91.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder87.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 412, new DataView(new ArrayBuffer(15116)), 4405, 1356);
+} catch {}
+try {
+  await promise45;
+} catch {}
+let commandEncoder288 = device0.createCommandEncoder({label: '\u{1f92d}\u01a8\u72dc\u529a\uac33\u{1f6ec}\u004f\u{1f932}\u{1f6ad}'});
+let textureView67 = texture18.createView({label: '\u1572\uee03\ufa42\u08e9\u{1f716}\u0c86\u{1fd01}\u0875', aspect: 'all', baseMipLevel: 1});
+let computePassEncoder71 = commandEncoder288.beginComputePass({label: '\u4368\u2fdc\u4635\u21ff\u4c81\u067c\u99ca\u{1ffd7}\u336a\u15d1\u0b8c'});
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup0, new Uint32Array(1779), 267, 0);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+let commandEncoder289 = device0.createCommandEncoder();
+let commandBuffer164 = commandEncoder289.finish({label: '\u{1fd78}\u0e5c\u51ce\uba36\u00ef\u963a\u011e\u0a7a\udf1c'});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer2, 'uint16', 1_470, 384);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 264, new Int16Array(430), 84, 52);
+} catch {}
+let commandEncoder290 = device2.createCommandEncoder({label: '\ube54\u0237\u525b\u020d\u525b\u0df9\ud5bb\u0b67\ud55b\u{1facf}'});
+let renderBundle165 = renderBundleEncoder25.finish();
+let sampler33 = device2.createSampler({
+  label: '\ud911\u4bb7\u9d70\u6e87\u{1f7d1}\u{1f6dd}\u{1f71e}\u0523',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.99,
+  lodMaxClamp: 98.26,
+});
+try {
+computePassEncoder65.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder55.draw(203, 92, 2_316_918_853, 49_397_491);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(58, 11, 111, -2_063_502_642, 2_607_447_792);
+} catch {}
+try {
+renderPassEncoder72.drawIndirect(buffer46, 984);
+} catch {}
+try {
+commandEncoder286.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1600 */
+  offset: 1600,
+  buffer: buffer38,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle166 = renderBundleEncoder12.finish({label: '\u06e6\u{1f77f}\u34e7\u{1f749}\u{1f742}\uce86\u{1f757}\u071b\u1477'});
+try {
+renderPassEncoder77.executeBundles([renderBundle123, renderBundle129, renderBundle98, renderBundle91]);
+} catch {}
+try {
+renderPassEncoder46.setBlendConstant({ r: -353.2, g: 29.86, b: -924.7, a: 390.9, });
+} catch {}
+try {
+renderPassEncoder77.setViewport(23.37226486389149, 0.6052572086975044, 0.7143691864079248, 0.22687238375476587, 0.2937534358951541, 0.8634461151625724);
+} catch {}
+try {
+renderPassEncoder90.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(1, buffer18, 1_304, 295);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer18, 0, 649);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(169), /* required buffer size: 169 */
+{offset: 169}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer47 = device2.createBuffer({
+  label: '\u5dc9\u3be8\u{1f77b}\uc6f0\u62bc',
+  size: 4337,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer165 = commandEncoder286.finish({label: '\u{1f890}\u{1fd71}\u0011\u0362\u{1f943}\u9977'});
+try {
+renderPassEncoder69.drawIndexed(93, 157, 11, 61_006_584, 1_694_893_164);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer40, 10_472);
+} catch {}
+try {
+commandEncoder290.resolveQuerySet(querySet32, 4, 3, buffer35, 1024);
+} catch {}
+let commandEncoder291 = device1.createCommandEncoder({label: '\u91d6\u{1f87f}\ud811\u{1f81d}\ue9dc\u558e'});
+let externalTexture32 = device1.importExternalTexture({label: '\u{1f99a}\u446c\u1360\ue97f\u{1f782}\u60c5', source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup10, new Uint32Array(4074), 359, 0);
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(0, bindGroup5, new Uint32Array(82), 1, 0);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle160, renderBundle84]);
+} catch {}
+try {
+renderPassEncoder51.setViewport(2.8621474145452366, 0.6065566538239908, 45.90703003727612, 0.21871075754693708, 0.8056006293654505, 0.9906605213331346);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer36, 'uint32', 1_812, 313);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(5, buffer18, 1_088, 2_546);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline25);
+} catch {}
+try {
+commandEncoder291.clearBuffer(buffer20);
+} catch {}
+try {
+device1.queue.submit([commandBuffer111, commandBuffer144]);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer9, 0, 54);
+} catch {}
+try {
+device0.queue.submit([commandBuffer161]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 3, depthOrArrayLayers: 39}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 2, y: 2 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder292 = device1.createCommandEncoder({label: '\u3a1a\u4282\u5985\u2989'});
+let renderPassEncoder92 = commandEncoder291.beginRenderPass({
+  label: '\uee5a\u02bb\u0928\uf2a5',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 20,
+  clearValue: { r: -714.0, g: -207.9, b: -137.9, a: -383.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder32.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(1, bindGroup5, new Uint32Array(2020), 161, 0);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer43, 'uint32', 736, 356);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer43, 'uint16', 96, 770);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(2, buffer18);
+} catch {}
+try {
+commandEncoder292.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4756 */
+  offset: 4756,
+  buffer: buffer18,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 204, new BigUint64Array(4012), 132, 28);
+} catch {}
+let video5 = await videoWithData();
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder62.setViewport(220.3140172408897, 3.947461047637189, 13.4264767771803, 1.6720105725424244, 0.8960738319671213, 0.9170241455394794);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup8, new Uint32Array(1125), 394, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let commandEncoder293 = device0.createCommandEncoder({label: '\u02eb\u1b72\u{1ffa1}\u7eb8\u489a\u2845'});
+let querySet35 = device0.createQuerySet({label: '\u{1f99a}\u0117\u0ffb\u4583\ud5fd', type: 'occlusion', count: 302});
+let textureView68 = texture34.createView({
+  label: '\u{1fbb7}\uae94\u3aa7\u4a25\u0a3b\uaa66\u041a\u{1f8c4}\ufaf6\uadd4\u{1fe64}',
+  mipLevelCount: 1,
+});
+let renderPassEncoder93 = commandEncoder231.beginRenderPass({
+  label: '\u0776\uadd6\u{1fd8d}\u6ced\u{1fb06}\u{1fc36}\u0d59\u3e16\u7f1b',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 68,
+  clearValue: { r: 719.4, g: 163.6, b: -276.5, a: -612.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder62.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+commandEncoder293.copyBufferToBuffer(buffer42, 200, buffer5, 740, 2740);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let pipelineLayout32 = device0.createPipelineLayout({
+  label: '\u1fd2\u{1f6f4}\ufc0c\u3ea7\u4d59\ua065',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout8, bindGroupLayout18],
+});
+let commandBuffer166 = commandEncoder293.finish({label: '\u{1fb57}\u{1ff74}\u0afd\ud52e\ue01a\u0222\u4d2f\u0cc2\u58a0\u075e\u7b01'});
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder93.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer45);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 61, y: 1, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(105_651), /* required buffer size: 105_651 */
+{offset: 55, bytesPerRow: 476, rowsPerImage: 17}, {width: 50, height: 1, depthOrArrayLayers: 14});
+} catch {}
+try {
+computePassEncoder70.setBindGroup(2, bindGroup7, new Uint32Array(1736), 72, 0);
+} catch {}
+try {
+computePassEncoder66.dispatchWorkgroups(2, 1, 1);
+} catch {}
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup6, new Uint32Array(1125), 120, 0);
+} catch {}
+try {
+renderPassEncoder69.setStencilReference(543);
+} catch {}
+try {
+renderPassEncoder54.draw(32, 104, 346_980_758, 276_275_016);
+} catch {}
+try {
+renderPassEncoder54.drawIndexed(33, 11, 36, 1_559_268_073, 2_007_083_808);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer46, 120);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(1, buffer47);
+} catch {}
+try {
+commandEncoder238.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 17},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder278.clearBuffer(buffer38);
+} catch {}
+try {
+device2.queue.submit([commandBuffer151]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 2864, new DataView(new ArrayBuffer(12004)), 1252, 360);
+} catch {}
+let buffer48 = device2.createBuffer({
+  label: '\u06b0\u080e\u041c\u6a29\u5fee\u07a9',
+  size: 14024,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandEncoder294 = device2.createCommandEncoder({});
+let texture95 = device2.createTexture({
+  label: '\ue3b6\u4bfa\ud4fe\u5394\u0a4c\u0d63\u63a3\ud1c2\u3055\u0d46\u0489',
+  size: [596, 1, 1],
+  mipLevelCount: 5,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle167 = renderBundleEncoder25.finish({label: '\ue539\u03b3\ue524\u{1f96f}\u{1fce6}\u06e8\u0c51\u0de5'});
+try {
+computePassEncoder62.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder54.draw(6, 151, 336_288_698, 860_016_467);
+} catch {}
+try {
+renderPassEncoder69.drawIndexed(36, 362, 4, 409_616_934, 603_795_198);
+} catch {}
+try {
+renderPassEncoder72.drawIndirect(buffer48, 5_368);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder238.resolveQuerySet(querySet32, 0, 23, buffer40, 2304);
+} catch {}
+try {
+gpuCanvasContext8.configure({device: device2, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+let renderPassEncoder94 = commandEncoder159.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 867.4, g: 110.5, b: -768.3, a: -478.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle168 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup1, new Uint32Array(207), 16, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle125, renderBundle14]);
+} catch {}
+let renderBundle169 = renderBundleEncoder22.finish({label: '\ud993\ubccb\u{1f7a9}\u0ef3\u3076\ue27c\u0614'});
+try {
+renderPassEncoder4.setViewport(1305.587384782957, 17.771553775099957, 59.978069327366036, 1.6346834808477513, 0.6126474494363565, 0.7185608459711279);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer7);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await buffer42.mapAsync(GPUMapMode.WRITE, 568);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer164]);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandBuffer167 = commandEncoder278.finish({label: '\u82fb\u{1f998}\u9614'});
+try {
+device2.queue.submit([commandBuffer165]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 74, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData12,
+  origin: { x: 2, y: 6 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture96 = device0.createTexture({
+  size: [720, 14, 56],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+document.body.prepend(img0);
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+let renderPassEncoder95 = commandEncoder64.beginRenderPass({
+  label: '\uf9e1\u0f46\uc3d6\udfd5\ud13d\uaf37\u73fa\uc1bc',
+  colorAttachments: [{
+  view: textureView28,
+  clearValue: { r: -24.43, g: -303.5, b: 816.7, a: 293.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder75.setVertexBuffer(3, buffer4, 8_140, 718);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint32', 3_032, 1_764);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer8);
+} catch {}
+video4.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let videoFrame5 = new VideoFrame(videoFrame2, {timestamp: 0});
+let commandEncoder295 = device2.createCommandEncoder({label: '\u7028\u99bf\u19f4\u368a\u0fcf\u{1fdd9}\u45e1\uf1f0\u3074\u{1f9af}\u0f53'});
+let renderPassEncoder96 = commandEncoder295.beginRenderPass({
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 6,
+  clearValue: { r: -723.8, g: -777.6, b: 437.4, a: 762.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+});
+let renderBundle170 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup6, new Uint32Array(1182), 8, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(149, 624, 308, 1_863_590_420, 79_862_842);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer46, 272);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline24);
+} catch {}
+let promise51 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise51;
+} catch {}
+let commandEncoder296 = device2.createCommandEncoder({});
+let commandBuffer168 = commandEncoder238.finish({label: '\ua236\u0d4f\uebf6\u{1f9b9}\ufa6b\u5e79'});
+let texture97 = device2.createTexture({
+  label: '\u{1fd56}\u082c\u5028\u00a5\u0a41\ue788\u{1fe83}\u03a4\u08ae\u{1fd3d}\ue0e8',
+  size: [1192, 1, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder72 = commandEncoder290.beginComputePass({label: '\udcc0\u005c\ud230\u7475\u9a39\u604c\u{1f80f}\u{1fa76}'});
+let renderBundle171 = renderBundleEncoder18.finish();
+try {
+computePassEncoder59.setBindGroup(0, bindGroup11, new Uint32Array(1916), 621, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder54.draw(77, 25, 1_683_368_734, 1_288_042_502);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer48, 324);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder296.copyBufferToBuffer(buffer35, 2192, buffer38, 224, 216);
+} catch {}
+let promise52 = device2.queue.onSubmittedWorkDone();
+let commandEncoder297 = device0.createCommandEncoder({label: '\u1792\u3b23\u{1ffe6}\u603f\u5171'});
+let renderPassEncoder97 = commandEncoder297.beginRenderPass({
+  label: '\u0e16\u41bf\u9704\u{1ff7d}\ub900\u0863\u03ba\u2fd3\u0e9d\u2431\u{1fbb0}',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 65,
+  clearValue: { r: -108.7, g: -922.4, b: -509.0, a: -518.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 78446978,
+});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder34.setIndexBuffer(buffer21, 'uint16', 408, 841);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer45, 0, 55);
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u2988');
+} catch {}
+await gc();
+let commandBuffer169 = commandEncoder292.finish({label: '\u{1f861}\uc505\u026a\u36f4'});
+let textureView69 = texture38.createView({aspect: 'all'});
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder89.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(7, buffer18, 3_260);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup4, new Uint32Array(366), 7, 0);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline20);
+} catch {}
+let promise53 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 7, depthOrArrayLayers: 87}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 88, y: 173 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 36},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle172 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder94.setViewport(129.2000620072816, 4.946459185262935, 1269.0581837433383, 22.86102328351574, 0.8627680696331513, 0.9923259972044086);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer0, 'uint16', 4_330, 10_941);
+} catch {}
+try {
+renderPassEncoder97.setVertexBuffer(1, buffer45, 1_068);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder298 = device0.createCommandEncoder();
+let commandBuffer170 = commandEncoder298.finish({});
+try {
+renderPassEncoder39.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder87.setIndexBuffer(buffer44, 'uint16', 206, 365);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer10, 124, 2_333);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let bindGroupLayout39 = device1.createBindGroupLayout({
+  label: '\u0b94\uc6d6\u0ff6\u2b43',
+  entries: [
+    {
+      binding: 197,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 212,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(7, buffer18, 500, 1_625);
+} catch {}
+let commandEncoder299 = device0.createCommandEncoder({label: '\u{1fe16}\u00c3\uf031\u4835\u9a3d\u601f\u{1f648}'});
+let commandBuffer171 = commandEncoder299.finish({label: '\u{1f8be}\u{1fa99}\u9c48\ub783\u3ced\u0686\ucba9\u{1fb68}\u49d5\u5358'});
+let texture98 = gpuCanvasContext9.getCurrentTexture();
+let textureView70 = texture3.createView({label: '\ufc53\u075a\uc77d\u6da5\u44a5\ue91d\u9597\u04c4', dimension: '2d-array', baseMipLevel: 1});
+try {
+renderPassEncoder39.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer9, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+video1.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let texture99 = gpuCanvasContext4.getCurrentTexture();
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\uc290\u8523\u{1fa8d}\u1a8e\uea97\u15d2\uf897\u{1f7f6}',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true,
+});
+let renderBundle173 = renderBundleEncoder28.finish({label: '\u783e\u4047\u{1fcd4}\u7e07\u0769\uf4f3'});
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.86,
+});
+try {
+computePassEncoder51.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer0, 'uint32', 2_848, 154);
+} catch {}
+let device3 = await adapter4.requestDevice({
+  label: '\ufc2e\ud1ed\u{1f85a}\u099e\udaa3\u9254\u0fba',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 62470111, maxStorageBufferBindingSize: 135881193},
+});
+try {
+renderPassEncoder69.drawIndexed(34, 402, 12, -1_255_234_938, 1_641_811_249);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer35, 'uint16', 1_188, 1_516);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder296.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 35, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 400 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16 */
+  offset: 16,
+  bytesPerRow: 512,
+  rowsPerImage: 2,
+  buffer: buffer38,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder85.popDebugGroup();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 37, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video1.height = 72;
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let sampler35 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder61.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer36, 'uint32', 392, 2_283);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer36, 'uint16', 30, 6);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline25);
+} catch {}
+let imageData30 = new ImageData(4, 20);
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({
+  label: '\u{1ff2d}\u1ebc\u41f6\u{1fe84}\u{1fe7f}\u69b7\u00cd\u{1f8f6}\u0c53',
+  colorFormats: ['r16sint'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder90.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder90.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer36, 'uint32', 252, 204);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: imageData21,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 2, y: 2, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder300 = device2.createCommandEncoder();
+let commandBuffer172 = commandEncoder294.finish({label: '\u0d30\u038d\u3d42\u0d45\u89b3'});
+let computePassEncoder73 = commandEncoder296.beginComputePass();
+let renderPassEncoder98 = commandEncoder300.beginRenderPass({
+  label: '\uabf5\u0943\u{1ffdd}\ubcba\u0fec\u86a9\u08ef\u7a31',
+  colorAttachments: [{
+  view: textureView56,
+  depthSlice: 17,
+  clearValue: { r: -78.98, g: -349.9, b: 255.1, a: 544.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup7, new Uint32Array(287), 26, 0);
+} catch {}
+try {
+renderPassEncoder69.drawIndirect(buffer35, 224);
+} catch {}
+try {
+renderPassEncoder98.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(0, buffer38, 0, 354);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let commandEncoder301 = device1.createCommandEncoder({});
+try {
+renderPassEncoder90.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder59.setStencilReference(381);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+externalTexture30.label = '\u04ed\u0456\u0852\udade\u{1fba5}\u0cc3\ue396\uedb9\u3548\u00f0\u0398';
+} catch {}
+let commandEncoder302 = device1.createCommandEncoder({label: '\u0e82\u70f6'});
+let texture100 = device1.createTexture({
+  size: [47, 30, 349],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  label: '\u1b8f\u0e2b\uc92c\u0a50\ued40\u{1f7b5}\udbee\u8062\u{1f97e}\u1b8d\u{1fc11}',
+  colorFormats: ['r16sint'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder45.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder88.setVertexBuffer(0, buffer18, 0);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+await gc();
+let texture101 = device2.createTexture({
+  label: '\u1808\u{1fd3d}\u03ec\uc862\ucef7\u061d\ub53b\u8e42\u074a',
+  size: {width: 298, height: 1, depthOrArrayLayers: 3},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder72.setBindGroup(2, bindGroup11, new Uint32Array(40), 11, 0);
+} catch {}
+try {
+computePassEncoder62.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+querySet22.destroy();
+} catch {}
+let commandEncoder303 = device3.createCommandEncoder({});
+let commandBuffer173 = commandEncoder303.finish();
+try {
+gpuCanvasContext3.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let computePassEncoder74 = commandEncoder302.beginComputePass({label: '\u895f\u07dd\u80c4\udb38\u94e8\u080f\u585b'});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder30.insertDebugMarker('\u08cb');
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 12, y: 1, z: 74},
+  aspect: 'all',
+}, new ArrayBuffer(53_339), /* required buffer size: 53_339 */
+{offset: 147, bytesPerRow: 104, rowsPerImage: 14}, {width: 3, height: 8, depthOrArrayLayers: 37});
+} catch {}
+await gc();
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\u3fc7\u{1f709}\udc2c\u8641\ueeb8',
+  entries: [
+    {
+      binding: 15,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+try {
+renderPassEncoder97.setVertexBuffer(1, buffer8, 0, 768);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer0, 'uint16', 694, 3_337);
+} catch {}
+try {
+device0.queue.submit([commandBuffer170]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 360, height: 7, depthOrArrayLayers: 108}
+*/
+{
+  source: imageData25,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture66,
+  mipLevel: 2,
+  origin: {x: 130, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer48, 2_468);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder96.setVertexBuffer(3, buffer46);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+let texture102 = gpuCanvasContext9.getCurrentTexture();
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder72.draw(163, 292, 703_397_401, 189_938_824);
+} catch {}
+try {
+renderPassEncoder54.drawIndexed(1, 65, 15, 329_053_930, 1_027_123_271);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer48, 1_396);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(2, buffer38, 124, 517);
+} catch {}
+try {
+device2.queue.submit([commandBuffer158, commandBuffer172]);
+} catch {}
+let commandEncoder304 = device2.createCommandEncoder({});
+let computePassEncoder75 = commandEncoder304.beginComputePass({label: '\u{1f9e0}\u4f96'});
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder69.setBlendConstant({ r: 967.9, g: -26.91, b: -187.6, a: 947.4, });
+} catch {}
+try {
+renderPassEncoder54.draw(86, 275, 594_359_936, 764_305_154);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer48, 448);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline18);
+} catch {}
+let commandBuffer174 = commandEncoder301.finish({});
+try {
+renderPassEncoder80.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder88.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(3, buffer18, 644);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+device1.queue.submit([commandBuffer169, commandBuffer174, commandBuffer163]);
+} catch {}
+await gc();
+let pipelineLayout33 = device1.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup5, new Uint32Array(2295), 160, 0);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle104]);
+} catch {}
+let imageData31 = new ImageData(12, 60);
+let buffer49 = device2.createBuffer({
+  label: '\u0e76\u0329\u{1ff6c}\uf1aa',
+  size: 9685,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle174 = renderBundleEncoder20.finish();
+try {
+computePassEncoder62.setBindGroup(0, bindGroup11, new Uint32Array(2486), 866, 0);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.draw(66, 529, 1_422_667_347, 1_159_015_341);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer48, 884);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(6, buffer40, 10_252);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 149, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 3, y: 120 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData32 = new ImageData(44, 12);
+try {
+computePassEncoder73.setBindGroup(2, bindGroup7, new Uint32Array(1390), 179, 0);
+} catch {}
+try {
+computePassEncoder58.dispatchWorkgroupsIndirect(buffer48, 1_680);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder54.draw(73, 244, 131_304_434, 60_808_681);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(62, 583, 9, -1_818_979_209, 363_451_160);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer48, 736);
+} catch {}
+try {
+renderPassEncoder72.drawIndirect(buffer48, 776);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline18);
+} catch {}
+let externalTexture34 = device1.importExternalTexture({label: '\ubfa2\u8b72\u69dd\u3668\ubc03\u0dc8', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder68.setBlendConstant({ r: -97.22, g: 866.4, b: -833.1, a: 994.1, });
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer36, 'uint16', 410, 338);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 680, new DataView(new ArrayBuffer(3760)), 2262, 60);
+} catch {}
+let commandEncoder305 = device0.createCommandEncoder({});
+let computePassEncoder76 = commandEncoder305.beginComputePass();
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup8, new Uint32Array(104), 9, 0);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise53;
+} catch {}
+let commandEncoder306 = device2.createCommandEncoder();
+let commandBuffer175 = commandEncoder306.finish({label: '\u9a58\u0208\uc0ed'});
+let texture103 = device2.createTexture({
+  label: '\u{1f62d}\uf0da\u9993\u7529\u{1f7d1}\u{1fb2c}\u20ff',
+  size: {width: 596},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder98.end();
+} catch {}
+try {
+renderPassEncoder69.setBlendConstant({ r: 714.9, g: 994.4, b: -167.5, a: 156.5, });
+} catch {}
+try {
+renderPassEncoder55.drawIndexed(52, 48, 37, 1_312_559_922, 684_074_100);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 3_512);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 6432, new DataView(new ArrayBuffer(9096)), 2178, 344);
+} catch {}
+let commandEncoder307 = device1.createCommandEncoder({label: '\u{1fa86}\u{1faf2}'});
+let renderPassEncoder99 = commandEncoder307.beginRenderPass({
+  label: '\u208d\ue5c0\u04f7\u0498\uc391\u9642\u7ce4\u4782\u0a0f',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 64,
+  clearValue: { r: 223.4, g: -258.9, b: -472.4, a: -398.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet27,
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup10, new Uint32Array(239), 17, 0);
+} catch {}
+try {
+renderPassEncoder88.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder80.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline25);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(13), /* required buffer size: 13 */
+{offset: 13}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle175 = renderBundleEncoder23.finish();
+try {
+computePassEncoder70.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.draw(20, 206, 395_724_456, 30_559_120);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(34, 35, 26, 579_913_859, 1_040_877_273);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer49, 1736, new DataView(new ArrayBuffer(19567)), 2798, 1156);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder308 = device2.createCommandEncoder({label: '\u{1fd1a}\u{1fd5f}\u{1fc80}\u767b\u0f12\u7833\u{1fb81}\u{1fd24}\u{1fc24}\u0fe1'});
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer38, 'uint16', 2_728, 95);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline18);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+let renderBundle176 = renderBundleEncoder10.finish();
+try {
+renderPassEncoder32.executeBundles([renderBundle163, renderBundle122, renderBundle122]);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer13, 'uint16', 3_366, 2_221);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer0, 0, 2_826);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+try {
+  await promise52;
+} catch {}
+let commandEncoder309 = device0.createCommandEncoder({label: '\ub068\ua04e\u860c\u792d\u0be5\u0c47\u{1fd13}\u4646\u6552\ud940\u02f8'});
+let texture104 = device0.createTexture({
+  label: '\ude35\u69f4\ua841\ue74b\ua680\u0919',
+  size: [180, 3, 1],
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder93.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup3, new Uint32Array(686), 474, 0);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\ubbc3');
+} catch {}
+video3.width = 96;
+try {
+gpuCanvasContext8.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipelineLayout34 = device1.createPipelineLayout({
+  label: '\u0a38\u07a8\ub882\u{1fa0f}\u9428\u0bdc',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout34, bindGroupLayout16],
+});
+try {
+renderPassEncoder89.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder86.setVertexBuffer(5, buffer18);
+} catch {}
+try {
+computePassEncoder62.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder72.draw(313, 32, 556_472, 1_728_042_747);
+} catch {}
+try {
+commandEncoder308.copyTextureToBuffer({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 376 */
+  offset: 376,
+  rowsPerImage: 8,
+  buffer: buffer47,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\u0c71\ufb27\u0652\u{1f747}\ufb27\u04b8\ua9f2\u{1f6a1}\u00c3\u2d57\u0ffc',
+  layout: bindGroupLayout20,
+  entries: [{binding: 106, resource: {buffer: buffer9, offset: 0, size: 68}}],
+});
+try {
+renderPassEncoder48.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder91.setIndexBuffer(buffer4, 'uint16', 290, 197);
+} catch {}
+try {
+renderPassEncoder82.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer4, 'uint32', 8_712, 1_847);
+} catch {}
+let arrayBuffer15 = buffer3.getMappedRange(344, 16);
+try {
+commandEncoder309.copyBufferToTexture({
+  /* bytesInLastRow: 560 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2392 */
+  offset: 2392,
+  buffer: buffer6,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder309.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 1,
+  origin: {x: 83, y: 1, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 151, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder310 = device3.createCommandEncoder({label: '\u35f4\uba62\u0fcd'});
+let commandBuffer176 = commandEncoder310.finish();
+let computePassEncoder77 = commandEncoder308.beginComputePass({label: '\u{1f7e1}\u0112\u0268\u0221\u0429\u5b09'});
+try {
+computePassEncoder70.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer40, 2_392);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer38, 'uint16', 1_372, 97);
+} catch {}
+try {
+renderPassEncoder85.setPipeline(pipeline24);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder311 = device0.createCommandEncoder({});
+let textureView71 = texture41.createView({label: '\u014a\u0d74\u6f75\ufb40\ubb4b\ufe9a', format: 'rg16float'});
+try {
+renderPassEncoder79.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder93.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder62.pushDebugGroup('\u202b');
+} catch {}
+await gc();
+try {
+adapter2.label = '\u0254\uc0dc\u84cb\ud3a1\u0811\u5cc0\u62a5\u6566\u{1fd63}\u0365';
+} catch {}
+let texture105 = device1.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder88.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(1, buffer18);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(6, buffer18, 240, 2_516);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(221), /* required buffer size: 221 */
+{offset: 221}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder68.setBindGroup(0, bindGroup7, new Uint32Array(161), 18, 0);
+} catch {}
+try {
+renderPassEncoder85.end();
+} catch {}
+try {
+renderPassEncoder49.draw(343, 89, 1_467_229_464, 1_447_105_440);
+} catch {}
+let pipelineLayout35 = device2.createPipelineLayout({label: '\u1da3\u0f56\u72a0\u{1f626}\u119c\u01f0', bindGroupLayouts: [bindGroupLayout23]});
+let buffer50 = device2.createBuffer({
+  label: '\u0e07\u{1fa9d}\u{1f81e}\u{1f7af}\u{1fa60}\u{1fb22}\u41f0\u1168\u{1f7ac}\ud07e\u07f8',
+  size: 4323,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder312 = device2.createCommandEncoder({label: '\u070a\ub090\uf803\u0b4a\u02c1'});
+let commandBuffer177 = commandEncoder312.finish();
+let renderBundleEncoder32 = device2.createRenderBundleEncoder({label: '\ua4ee\u{1f756}\u7ae0', colorFormats: ['rgba32float'], sampleCount: 4});
+let externalTexture35 = device2.importExternalTexture({
+  label: '\ua701\u0c1b\u{1fd42}\u{1f93a}\u{1f79f}\ub1d4\u0fec',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup6, new Uint32Array(1873), 418, 0);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(4, buffer40, 0);
+} catch {}
+try {
+querySet26.destroy();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 298, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: imageData31,
+  origin: { x: 1, y: 12 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(7, buffer40, 0);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+renderPassEncoder54.pushDebugGroup('\ubffb');
+} catch {}
+try {
+renderPassEncoder54.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup7, new Uint32Array(784), 145, 0);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(163, 247, 222, 88_270_543, 2_239_208_086);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer48, 560);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer48, 'uint16', 2_036, 820);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(4, buffer46, 8_968, 0);
+} catch {}
+let imageData33 = new ImageData(24, 68);
+try {
+device3.queue.submit([commandBuffer173]);
+} catch {}
+document.body.prepend(img2);
+let bindGroupLayout41 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 130, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder313 = device3.createCommandEncoder({label: '\u51fb\u{1f69e}\uca83\uc2ce\u{1fe77}\u02c6\ucda0\u2c36\u0dc9'});
+let commandBuffer178 = commandEncoder313.finish({});
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder72.drawIndexedIndirect(buffer35, 1_744);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer35, 404);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer35, 'uint32', 512, 4_825);
+} catch {}
+try {
+device2.queue.submit([commandBuffer168, commandBuffer159]);
+} catch {}
+let renderBundle177 = renderBundleEncoder1.finish({label: '\u639d\uec13\u{1fc57}\u0ee9\u24b3\u{1fd8d}'});
+try {
+renderBundleEncoder27.setIndexBuffer(buffer11, 'uint16', 2_470, 9_969);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder311.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8928 widthInBlocks: 1116 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 9816 */
+  offset: 9816,
+  buffer: buffer6,
+}, {width: 1116, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder62.popDebugGroup();
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = texture24.label;
+} catch {}
+let commandEncoder314 = device0.createCommandEncoder({label: '\u07c3\uf322\u{1f6b4}\u0398\u{1f728}'});
+let renderPassEncoder100 = commandEncoder311.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 10,
+  clearValue: { r: -538.4, g: 590.4, b: 60.15, a: 698.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 221252940,
+});
+try {
+renderBundleEncoder21.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 3576, new DataView(new ArrayBuffer(8922)), 932, 788);
+} catch {}
+await gc();
+let renderBundle178 = renderBundleEncoder25.finish({label: '\u03b7\u86f4\u0a08\ub205\u7b32'});
+try {
+renderPassEncoder69.drawIndexedIndirect(buffer46, 152);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer47, 'uint32', 1_400, 312);
+} catch {}
+let promise54 = device2.queue.onSubmittedWorkDone();
+let commandEncoder315 = device1.createCommandEncoder({label: '\u{1ff4d}\u0304\ua55d\u0638\u0c80\u06ec'});
+let commandBuffer179 = commandEncoder315.finish({label: '\u01a6\uf11d\u3c61\u0954\ue46a\u0ac7\uf049\u05c6\ud977\uebc0'});
+let texture106 = gpuCanvasContext4.getCurrentTexture();
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup10, new Uint32Array(3504), 3, 0);
+} catch {}
+try {
+renderPassEncoder92.executeBundles([renderBundle69]);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint16', 560, 67);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline20);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let renderBundle179 = renderBundleEncoder20.finish();
+try {
+computePassEncoder75.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer47, 'uint16', 1_476, 689);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(5, buffer40, 0);
+} catch {}
+try {
+buffer47.destroy();
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise54;
+} catch {}
+let commandEncoder316 = device1.createCommandEncoder({label: '\u4a34\u936a\u0181\ua4ec\u{1ffcb}\u0b50\u0746\u{1ff69}\u277c'});
+let computePassEncoder78 = commandEncoder316.beginComputePass();
+try {
+computePassEncoder27.setBindGroup(0, bindGroup5, new Uint32Array(109), 28, 0);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(0, buffer18, 0, 662);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer36, 'uint16', 288, 1_074);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline14);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 23, height: 15, depthOrArrayLayers: 174}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 7, y: 9 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 6, y: 5, z: 63},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  label: '\u02b5\u5124\u8847\u08a1\u085f\u{1fb6c}\u{1fc61}',
+  entries: [
+    {
+      binding: 89,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandBuffer180 = commandEncoder314.finish();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 14, depthOrArrayLayers: 216}
+*/
+{
+  source: canvas1,
+  origin: { x: 72, y: 0 },
+  flipY: false,
+}, {
+  texture: texture66,
+  mipLevel: 1,
+  origin: {x: 35, y: 3, z: 109},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img5);
+let pipelineLayout36 = device3.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder317 = device3.createCommandEncoder();
+document.body.prepend(canvas2);
+try {
+window.someLabel = externalTexture21.label;
+} catch {}
+let renderPassEncoder101 = commandEncoder309.beginRenderPass({
+  label: '\u913f\u8dcc\u{1f7a5}\u{1f993}',
+  colorAttachments: [{
+  view: textureView41,
+  clearValue: { r: -132.9, g: -95.42, b: -782.9, a: -220.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle180 = renderBundleEncoder8.finish({label: '\u0b25\u0409\u{1fedb}\u129c\u045f\u1b8c\u{1fcce}\u{1fb68}\u{1fd24}\u361b'});
+try {
+renderPassEncoder84.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder93.setIndexBuffer(buffer0, 'uint32', 3_756, 1_278);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer11, 'uint32', 2_928, 152);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let imageData34 = new ImageData(12, 76);
+let bindGroupLayout43 = device3.createBindGroupLayout({
+  label: '\ucc20\u6541\u0bb8\u{1fecc}\u{1fe93}\ua135\u0945\ub250\u3b55\ud76f\u145b',
+  entries: [
+    {
+      binding: 262,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer181 = commandEncoder317.finish();
+let device4 = await adapter3.requestDevice({
+  label: '\u8937\u699f\u0218',
+  defaultQueue: {label: '\u{1fa19}\u4981\ubff7\ubeb3\u080d\u0606'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 107255943, maxStorageBufferBindingSize: 145510227},
+});
+let offscreenCanvas9 = new OffscreenCanvas(177, 27);
+let bindGroupLayout44 = device1.createBindGroupLayout({
+  label: '\uc562\u03b0\u0f73\u91c3',
+  entries: [
+    {binding: 43, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 379,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup10, new Uint32Array(1351), 53, 0);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer18, 'uint16', 2_498, 1_572);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, buffer18, 0, 322);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint32', 364, 289);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline15);
+} catch {}
+let promise55 = device1.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+let texture107 = device4.createTexture({
+  label: '\u0a27\uf4fc\u059d\uccac\u0564\u046a\u{1f741}\u2eec\u000f\u01b1',
+  size: {width: 2838, height: 1, depthOrArrayLayers: 16},
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let video6 = await videoWithData();
+try {
+adapter5.label = '\u{1f672}\u0c0d\u{1f97f}\ude49\u0a39\u{1f7d8}';
+} catch {}
+let pipelineLayout37 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout28]});
+try {
+renderPassEncoder49.setViewport(55.90185092950236, 0.9828945455145331, 6.333718691513265, 0.013359771510717555, 0.9508176819602533, 0.9717390537534004);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(3, buffer40, 908);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(176), /* required buffer size: 176 */
+{offset: 176, bytesPerRow: 2560}, {width: 314, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let offscreenCanvas10 = new OffscreenCanvas(270, 64);
+let commandEncoder318 = device0.createCommandEncoder();
+try {
+renderPassEncoder76.insertDebugMarker('\u0888');
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device4, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 2838, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: video5,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 109, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder319 = device1.createCommandEncoder({label: '\u0e86\u{1fca2}\u5083\uca2d\u7499\u1e8e'});
+let renderPassEncoder102 = commandEncoder319.beginRenderPass({
+  label: '\u{1fa78}\u{1fb8c}\u08c5\u{1fc19}\u69f3\u0eed\ueb6e\u99bb',
+  colorAttachments: [{view: textureView44, depthSlice: 32, loadOp: 'clear', storeOp: 'discard'}],
+});
+try {
+renderPassEncoder86.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle164, renderBundle74]);
+} catch {}
+try {
+renderPassEncoder99.setIndexBuffer(buffer43, 'uint32', 696, 407);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint32', 112, 580);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline14);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer179]);
+} catch {}
+try {
+window.someLabel = texture107.label;
+} catch {}
+let buffer51 = device4.createBuffer({
+  label: '\u{1fe4a}\uf07b\u0d2b\u0577',
+  size: 11490,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder320 = device4.createCommandEncoder({label: '\u81ac\u{1fbce}\ube43\u0105\u9263\u714c\ud544\u{1fb16}\u52c4\u0ee5\u0121'});
+let commandEncoder321 = device0.createCommandEncoder({label: '\u07af\u{1f6b2}\u974e\uf224\u{1f80c}\u{1fc49}\u41ab'});
+try {
+renderPassEncoder91.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle101, renderBundle53]);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup3, new Uint32Array(477), 20, 0);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer21, 140);
+} catch {}
+try {
+commandEncoder318.copyBufferToBuffer(buffer42, 680, buffer2, 19616, 1036);
+} catch {}
+let querySet36 = device3.createQuerySet({label: '\u086a\u25d8\u0ccb\uec4b\u45b1', type: 'occlusion', count: 761});
+let sampler36 = device3.createSampler({
+  label: '\u5bd2\uf3fc\ubacc\u9ba8\u6585\u077a\u67e9\u539a',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.54,
+});
+try {
+gpuCanvasContext9.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let commandEncoder322 = device1.createCommandEncoder({label: '\u079d\u6ec4\u{1fdfb}\u{1ff14}\u{1f887}\u0a03\u8453\u{1fe0a}'});
+let computePassEncoder79 = commandEncoder322.beginComputePass({label: '\uc716\u32e6\u64e4\u{1f620}\u6f18\u0830\u08f1\u7a9f\u0e9b\u048a\u{1feb8}'});
+try {
+computePassEncoder49.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer18, 0, 969);
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.READ, 0, 148);
+} catch {}
+try {
+renderBundleEncoder30.insertDebugMarker('\u3e53');
+} catch {}
+let promise56 = device1.queue.onSubmittedWorkDone();
+let buffer52 = device4.createBuffer({
+  size: 8903,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder323 = device4.createCommandEncoder({});
+let querySet37 = device4.createQuerySet({label: '\u{1faff}\u05b2\u0abb\u095c\u22ae\u0183\uf3da\u4387', type: 'occlusion', count: 915});
+let commandBuffer182 = commandEncoder320.finish({label: '\u{1fb88}\u041d\u87a2\uf7b4\u9be4\ue369\u{1f6ed}'});
+let sampler37 = device4.createSampler({
+  label: '\uc7a5\u40cc\u0597\u{1f609}\u0820\u6983\ue4fb\u{1f8c5}\u2cd5\u66c9\u0600',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.56,
+  lodMaxClamp: 49.17,
+  compare: 'equal',
+});
+try {
+device4.pushErrorScope('out-of-memory');
+} catch {}
+let imageData35 = new ImageData(28, 100);
+let renderBundle181 = renderBundleEncoder3.finish({label: '\u{1fb17}\u4594\u4216\u0e55\u0eb8\u{1fc26}\u0bd6\ue853'});
+let externalTexture36 = device0.importExternalTexture({label: '\u3ef8\u0e3a\u5fbe\u0038\uaaa7\ud00b', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder48.beginOcclusionQuery(49);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle151, renderBundle2, renderBundle7]);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer11, 'uint16', 966, 4_741);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer44);
+} catch {}
+let pipelineLayout38 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout32, bindGroupLayout35]});
+let commandEncoder324 = device2.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder324.beginComputePass({label: '\u0d3e\u{1f8b1}\u{1fa33}\u096a\u0bc9\u5006'});
+let renderBundle182 = renderBundleEncoder25.finish({label: '\uc93a\u{1f90d}\u4761\u{1fa92}\u0122\u{1f961}\u506c\u0ff3\u1010'});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(0, bindGroup11, new Uint32Array(3317), 1294, 0);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer46, 2_236);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+device2.queue.submit([commandBuffer167, commandBuffer177]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let pipelineLayout39 = device2.createPipelineLayout({
+  label: '\ucd6b\u{1ff0e}\u5dab\u079b\u06db\u871a',
+  bindGroupLayouts: [bindGroupLayout33, bindGroupLayout33, bindGroupLayout33],
+});
+let buffer53 = device2.createBuffer({
+  label: '\u0b9c\u0b8c\u2824\ufe7c',
+  size: 9806,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder325 = device2.createCommandEncoder({label: '\u{1f878}\u081d\ue4b6\u{1f616}\u7a72\u{1fea2}\u{1f981}\u0ca2'});
+let commandBuffer183 = commandEncoder325.finish();
+let textureView72 = texture101.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle183 = renderBundleEncoder24.finish({label: '\u4447\udd07\u1c8b\ub606\u4360'});
+try {
+renderPassEncoder73.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 288);
+} catch {}
+try {
+renderPassEncoder96.setIndexBuffer(buffer35, 'uint16', 1_176, 189);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer35, 'uint16', 758, 982);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+offscreenCanvas10.width = 889;
+await gc();
+try {
+computePassEncoder62.setBindGroup(0, bindGroup6, new Uint32Array(209), 30, 0);
+} catch {}
+try {
+renderPassEncoder69.end();
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(6, buffer50, 0);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer35, 'uint16', 6_682, 339);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+device2.queue.submit([commandBuffer175]);
+} catch {}
+await gc();
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup11, new Uint32Array(62), 11, 0);
+} catch {}
+try {
+computePassEncoder62.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder83.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder72.drawIndirect(buffer40, 3_196);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer38, 'uint32', 1_520, 359);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(6, buffer50, 64);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 472, new DataView(new ArrayBuffer(5754)), 72, 1964);
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas10.getContext('webgpu');
+let promise57 = navigator.gpu.requestAdapter();
+let commandEncoder326 = device3.createCommandEncoder({label: '\u30c2\uc653\u04ad\u{1fa87}\u{1fdcc}\u{1fbcb}\u{1fff3}\u5c69\uf064\u0b35'});
+let bindGroup13 = device2.createBindGroup({
+  label: '\u09ed\u0b3b\u01c8\u{1f821}\u{1f9ee}\u6bde\u0bf5\uad6d\u910e',
+  layout: bindGroupLayout33,
+  entries: [{binding: 420, resource: externalTexture31}],
+});
+let texture108 = device2.createTexture({
+  size: [298, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder72.drawIndexedIndirect(buffer46, 776);
+} catch {}
+try {
+renderPassEncoder72.drawIndirect(buffer48, 160);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer38, 'uint16', 472, 186);
+} catch {}
+let commandEncoder327 = device1.createCommandEncoder({label: '\ud69f\u{1f743}\u{1f6f6}\uccb3\ue4a0\u{1faf7}\u5cbe\u39f8\u{1fca8}\u1549\u{1f685}'});
+try {
+renderPassEncoder90.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder102.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder45.pushDebugGroup('\uc520');
+} catch {}
+let commandEncoder328 = device2.createCommandEncoder({label: '\ua245\uebde\u4651\ufddc\u6802\u4ea3\u7feb\u0b24'});
+try {
+renderPassEncoder73.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.drawIndirect(buffer46, 5_256);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(0, buffer46);
+} catch {}
+try {
+  await buffer49.mapAsync(GPUMapMode.READ, 0, 2360);
+} catch {}
+try {
+commandEncoder328.copyBufferToTexture({
+  /* bytesInLastRow: 74 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1536 */
+  offset: 1536,
+  buffer: buffer35,
+}, {
+  texture: texture95,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 74, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer184 = commandEncoder318.finish({label: '\u7d86\uf181\u0fb8\u1e72\u06ac\ud261\ue4ea\ufcfc'});
+let renderPassEncoder103 = commandEncoder321.beginRenderPass({
+  label: '\u3563\u0362',
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 18,
+  clearValue: { r: 460.8, g: -926.0, b: 305.3, a: -215.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup2, new Uint32Array(1548), 423, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder97.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer37, 'uint32', 9_452, 770);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer21, 'uint32', 700, 344);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 1272, new BigUint64Array(28721), 2860, 36);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1440, height: 28, depthOrArrayLayers: 432}
+*/
+{
+  source: video5,
+  origin: { x: 1, y: 7 },
+  flipY: false,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 659, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline26 = device0.createRenderPipeline({
+  label: '\u023e\u4dd3\u3031',
+  layout: pipelineLayout2,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 368, stepMode: 'vertex', attributes: []},
+      {arrayStride: 132, stepMode: 'instance', attributes: []},
+      {arrayStride: 244, attributes: []},
+      {arrayStride: 316, attributes: []},
+      {arrayStride: 912, stepMode: 'instance', attributes: []},
+      {arrayStride: 44, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint16x4', offset: 104, shaderLocation: 15},
+          {format: 'sint8x4', offset: 64, shaderLocation: 12},
+          {format: 'sint8x4', offset: 676, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer18, 5_380, 1_480);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer18);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+device1.queue.submit([commandBuffer143]);
+} catch {}
+try {
+  await promise56;
+} catch {}
+try {
+externalTexture27.label = '\u{1fc05}\u{1f9ff}\u0592\u0701';
+} catch {}
+let commandEncoder329 = device2.createCommandEncoder({});
+let texture109 = gpuCanvasContext5.getCurrentTexture();
+let computePassEncoder81 = commandEncoder328.beginComputePass({label: '\u0c75\u{1fe0a}\u5e35\u68ac\u1ff1\u{1fbbf}\u77cd\u052a\uf3eb'});
+let renderBundle184 = renderBundleEncoder18.finish();
+try {
+renderPassEncoder55.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup13, new Uint32Array(364), 173, 0);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(1, buffer46, 96);
+} catch {}
+try {
+renderBundleEncoder32.drawIndexedIndirect(buffer40, 792);
+} catch {}
+try {
+renderBundleEncoder32.drawIndirect(buffer48, 8_412);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(0, buffer46, 0);
+} catch {}
+let commandEncoder330 = device0.createCommandEncoder({label: '\ud40a\u7184\u80d6\u7e27\u{1fc97}\uff01\u04e1\ucff1\u14e6\u06b2'});
+let renderPassEncoder104 = commandEncoder330.beginRenderPass({
+  label: '\uc456\u0650\u2c41\u{1f7e9}\u98d4\uf5f6\u890d\ud522\u1983\udfad',
+  colorAttachments: [{view: textureView5, depthSlice: 264, loadOp: 'load', storeOp: 'discard'}],
+});
+let renderBundle185 = renderBundleEncoder4.finish({label: '\u0d52\u{1f8ca}\u0c6c\u{1fae5}\u4587\u06e5\u6f4e\u0864\u0af1\u0563'});
+try {
+renderBundleEncoder21.setIndexBuffer(buffer9, 'uint32', 88, 14);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer5, 0, 2_404);
+} catch {}
+let commandEncoder331 = device0.createCommandEncoder({});
+let textureView73 = texture16.createView({
+  label: '\ud0bd\ud8a8\u4bc5\u0863\u{1f732}\u697a\u0f01\u{1f842}\ub970\u1984\u{1fcd9}',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder27.setVertexBuffer(2, buffer4, 0);
+} catch {}
+let bindGroupLayout45 = device1.createBindGroupLayout({
+  label: '\u0bae\ua862\u7f47',
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder332 = device1.createCommandEncoder({label: '\u{1f808}\u78aa\u{1f96b}\u{1fa66}\u4f0e\u3bd1\u0622\u296e\u946b'});
+let commandBuffer185 = commandEncoder332.finish({});
+try {
+commandEncoder327.copyBufferToTexture({
+  /* bytesInLastRow: 672 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1088 */
+  offset: 1088,
+  buffer: buffer18,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 118, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let imageData36 = new ImageData(40, 8);
+let promise58 = adapter0.requestAdapterInfo();
+let renderBundle186 = renderBundleEncoder27.finish({label: '\u0328\u31cf\udaae'});
+try {
+renderPassEncoder79.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder333 = device0.createCommandEncoder({label: '\u0445\u7b8c\u02be\u7ccb\ufe02\u{1f93f}\u{1fcf6}\u0ddb\u5135'});
+let commandBuffer186 = commandEncoder331.finish({});
+let renderPassEncoder105 = commandEncoder333.beginRenderPass({
+  label: '\u{1f648}\u5a2d\u{1f75c}\u13c8\u{1f7c9}',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 42,
+  clearValue: { r: -368.3, g: -778.0, b: 777.2, a: -729.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 297672976,
+});
+try {
+computePassEncoder51.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(4, buffer8, 776, 616);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(30_750), /* required buffer size: 30_750 */
+{offset: 90, bytesPerRow: 73, rowsPerImage: 20}, {width: 17, height: 0, depthOrArrayLayers: 22});
+} catch {}
+let commandBuffer187 = commandEncoder323.finish({label: '\ubda2\u3bd8\ud12b\u0968\u{1f70c}\ucd64\u0482\u5a37'});
+let commandBuffer188 = commandEncoder326.finish({label: '\u6f05\ufc7d\u58d1\u3dc2\u26f8\u{1f7cc}\u8d40'});
+try {
+externalTexture35.label = '\ud734\ub086';
+} catch {}
+let commandBuffer189 = commandEncoder329.finish({label: '\u{1f885}\u00cc\u0fb7\u1230\u{1f908}\u{1fbf9}'});
+let texture110 = device2.createTexture({
+  label: '\uecff\udf22\u{1f6e5}\u8863\udb5e\u06c7',
+  size: [298],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder33 = device2.createRenderBundleEncoder({
+  label: '\u{1f656}\u{1fea9}\u002c\u{1fb4d}',
+  colorFormats: ['rgba32float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderPassEncoder96.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer35, 1_588);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder32.draw(445, 82, 365_167_459, 216_559_251);
+} catch {}
+try {
+renderBundleEncoder32.drawIndexedIndirect(buffer46, 1_932);
+} catch {}
+try {
+renderBundleEncoder32.drawIndirect(buffer40, 3_308);
+} catch {}
+try {
+  await promise55;
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let commandEncoder334 = device1.createCommandEncoder({label: '\u0138\ud9d9\u0248\u0632\u0227\u6231\ub248\uaca2\uc1eb\u1bde'});
+let commandBuffer190 = commandEncoder334.finish({label: '\u8912\u4d22'});
+let renderPassEncoder106 = commandEncoder327.beginRenderPass({
+  label: '\u9829\ud846\u{1f8b7}\u59e4\u06d5\u4f03\u{1fc8b}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 65,
+  clearValue: { r: -53.22, g: 85.60, b: 611.1, a: 236.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder92.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder88.executeBundles([renderBundle128]);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder102.setVertexBuffer(5, buffer18, 0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(1, buffer18, 0, 132);
+} catch {}
+await gc();
+let shaderModule11 = device0.createShaderModule({
+  label: '\u{1fb11}\u0e65\u{1f7d6}\u{1fb7a}\u03f7\u3441\u0648',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+struct T1 {
+  f0: array<atomic<u32>>,
+}
+struct T2 {
+  f0: array<atomic<i32>>,
+}
+
+@group(2) @binding(117) var tex21: texture_cube_array<i32>;
+@group(0) @binding(114) var st6: texture_storage_2d<r32uint, write>;
+@group(3) @binding(16) var<storage, read_write> buffer54: array<atomic<u32>>;
+@group(1) @binding(202) var st7: texture_storage_3d<r32uint, read_write>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(5) f27: vec2h,
+  @location(14) f28: vec2u,
+  @builtin(position) f29: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2f,
+  @location(5) @interpolate(perspective, center) f1: vec3f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder51.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle40, renderBundle177, renderBundle22, renderBundle38]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 95, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(104), /* required buffer size: 104 */
+{offset: 104, bytesPerRow: 831}, {width: 101, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise58;
+} catch {}
+let commandEncoder335 = device4.createCommandEncoder({});
+let commandBuffer191 = commandEncoder335.finish({});
+document.body.prepend(img4);
+let imageData37 = new ImageData(4, 40);
+let canvas7 = document.createElement('canvas');
+try {
+canvas7.getContext('2d');
+} catch {}
+let externalTexture37 = device0.importExternalTexture({label: '\u8d2d\ufbb1', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder97.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup0, new Uint32Array(601), 76, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 20 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+querySet37.destroy();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 2838, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 7, y: 0 },
+  flipY: false,
+}, {
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 902, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout46 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let pipelineLayout40 = device4.createPipelineLayout({bindGroupLayouts: [bindGroupLayout46]});
+try {
+gpuCanvasContext3.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device4.queue.submit([commandBuffer191]);
+} catch {}
+let commandEncoder336 = device0.createCommandEncoder({label: '\u54c5\u6974\u97f0'});
+try {
+renderPassEncoder101.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder94.setVertexBuffer(3, buffer8);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder336.copyBufferToTexture({
+  /* bytesInLastRow: 528 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8008 */
+  offset: 8008,
+  buffer: buffer15,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder337 = device3.createCommandEncoder({label: '\u{1fc27}\u2cb4\ud1ed\u{1fc4a}\u0201\u{1ffe3}\uccd0\u0bfa'});
+let shaderModule12 = device4.createShaderModule({
+  code: `
+enable f16;
+
+struct T0 {
+  f0: mat4x3h,
+}
+
+@group(0) @binding(68) var st8: texture_storage_2d_array<rgba8unorm, write>;
+@group(0) @binding(210) var tex22: texture_2d<u32>;
+@group(0) @binding(30) var sam14: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(6) f30: vec3i,
+  @location(9) f31: vec4h,
+  @location(0) f32: vec4h,
+  @location(13) f33: vec3u,
+  @builtin(position) f34: vec4f,
+  @location(12) f35: vec4i,
+  @location(14) f36: f32,
+  @location(2) f37: f16,
+  @location(8) f38: vec3f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+@fragment
+fn fragment0(@location(14) a0: f32) {
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+buffer51.unmap();
+} catch {}
+let commandEncoder338 = device3.createCommandEncoder({label: '\ub868\u08f6\u217d\ue057\u114e\u6e6b\ue1d7'});
+try {
+device3.pushErrorScope('validation');
+} catch {}
+try {
+device3.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let texture111 = device4.createTexture({
+  label: '\ub803\u0ec8\ub30d\u{1feab}\ud6dc\ud9b2\u{1fa02}\u0e01\ue078\ua3ab',
+  size: {width: 8, height: 8, depthOrArrayLayers: 1},
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer55 = device4.createBuffer({label: '\u0c59\u5529\u4357\u0b0d\u0c7f', size: 4540, usage: GPUBufferUsage.MAP_WRITE});
+let textureView74 = texture111.createView({
+  label: '\ud19d\u{1fdb6}\u46a8\u0b23\u0281\u{1fc0f}\u{1f865}',
+  dimension: '2d',
+  format: 'astc-8x8-unorm',
+});
+await gc();
+let commandEncoder339 = device2.createCommandEncoder({label: '\u0f90\u92cc\u3783\uc03a\u0cc1\u{1fec0}\u0eb6\u0fd2\u0a9e\u7ff5'});
+let computePassEncoder82 = commandEncoder339.beginComputePass({label: '\u{1fa76}\u90dd\u{1f7a7}\u14d9\u04c2\u81b6'});
+let renderBundle187 = renderBundleEncoder32.finish({label: '\u0811\u00b7\ub377\ud90c'});
+try {
+computePassEncoder75.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder54.draw(72, 84, 921_054_439, 104_233_678);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer35, 8);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer46);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+let bindGroupLayout47 = device3.createBindGroupLayout({
+  label: '\u194c\u0275\u6aef\ue11f',
+  entries: [
+    {
+      binding: 284,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+try {
+commandEncoder338.pushDebugGroup('\u0cc7');
+} catch {}
+await gc();
+let pipelineLayout41 = device1.createPipelineLayout({label: '\udeca\u5c64\uee53\u0d14\u{1f9b6}\u11e8\ubc92', bindGroupLayouts: []});
+let renderBundle188 = renderBundleEncoder15.finish({label: '\u7362\u0510'});
+try {
+computePassEncoder67.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle164, renderBundle129, renderBundle123, renderBundle123]);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint16', 92, 462);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer18, 596, 317);
+} catch {}
+try {
+device1.queue.submit([commandBuffer185]);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder72.draw(158, 167, 1_194_557_693, 274_299_497);
+} catch {}
+try {
+renderPassEncoder55.drawIndexed(60, 31, 81, 243_647_200, 97_856_078);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(6, buffer50, 304);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline17);
+} catch {}
+let bindGroupLayout48 = device3.createBindGroupLayout({
+  label: '\u03bc\u0a22\uce55\u05da\u58da',
+  entries: [
+    {
+      binding: 218,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 76, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder340 = device3.createCommandEncoder();
+document.body.prepend(video6);
+let buffer56 = device2.createBuffer({
+  label: '\u80da\u{1f7bd}\u581a',
+  size: 7568,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder341 = device2.createCommandEncoder({label: '\u{1f85b}\ubf3b\u01af\u0d0d\u02db\ue27b\u{1f687}\ub249'});
+let externalTexture38 = device2.importExternalTexture({label: '\uebd2\ub6c0\uf03e\u23be\u644d\u0e56', source: video2});
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(16, 287, 1, -2_079_872_664, 444_721_460);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let commandBuffer192 = commandEncoder341.finish({label: '\u{1fb75}\u{1fcc1}\u0aad\uc627\u6643\u0e77'});
+let renderBundle189 = renderBundleEncoder32.finish({});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(0, bindGroup7, new Uint32Array(535), 205, 0);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.draw(87, 78, 1_692_773_807, 1_277_994_554);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer53, 'uint32', 5_344, 429);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer38, 1_448, 186);
+} catch {}
+video5.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let computePassEncoder83 = commandEncoder340.beginComputePass();
+await gc();
+let textureView75 = texture83.createView({label: '\u26b5\u77d3\u0076\u{1fc82}\ub836\u0a8f'});
+try {
+renderPassEncoder50.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup5);
+} catch {}
+let commandEncoder342 = device1.createCommandEncoder({label: '\u8c0c\u7764\ua890\u04ef\u2ef8\u0b21'});
+let commandBuffer193 = commandEncoder342.finish({label: '\u{1fed0}\uf509\u06c0\ue27d\u0c3a'});
+let renderBundle190 = renderBundleEncoder16.finish({label: '\u2a9f\u{1fc58}\u48b6'});
+try {
+computePassEncoder78.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle164, renderBundle144]);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer36, 'uint32', 576, 0);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline25);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(224), /* required buffer size: 224 */
+{offset: 224}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let texture112 = device1.createTexture({
+  label: '\u07f5\u0ae8\u9e10\u3f61\u59d8\u1c4d\u73ef',
+  size: {width: 290},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder34 = device1.createRenderBundleEncoder({
+  label: '\u0d39\u62e2\uc34a\u0a2c\u19c4\u0d05\u1b5c\u8dbc\ubcba\u20df',
+  colorFormats: ['r16sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer36, 'uint32', 1_788, 71);
+} catch {}
+try {
+device1.queue.submit([commandBuffer193]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 7, depthOrArrayLayers: 87}
+*/
+{
+  source: imageData0,
+  origin: { x: 34, y: 0 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(video6, {timestamp: 0});
+let buffer57 = device3.createBuffer({
+  label: '\u054a\ud31a\u0743\u0aa3',
+  size: 26647,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder343 = device3.createCommandEncoder({label: '\u{1ffc0}\u0fc3\u0419\u50c4\u9f96\ube61\uf6af\u{1fab5}'});
+try {
+commandEncoder343.pushDebugGroup('\u00cb');
+} catch {}
+let adapter8 = await promise57;
+try {
+commandEncoder161.label = '\u0f1d\u04d3\u0524\u{1fdeb}\u06cb';
+} catch {}
+let commandEncoder344 = device1.createCommandEncoder({label: '\u{1fa55}\u23dd\uc21b\u0760'});
+let commandBuffer194 = commandEncoder344.finish({label: '\u{1fa66}\u{1f6c9}\u{1faa8}\u{1f8ff}'});
+let renderBundle191 = renderBundleEncoder17.finish();
+try {
+computePassEncoder25.setBindGroup(1, bindGroup10, new Uint32Array(1403), 404, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder80.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder77.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup10, new Uint32Array(1125), 56, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer36, 'uint32', 1_296, 17);
+} catch {}
+try {
+  await buffer41.mapAsync(GPUMapMode.READ, 2328, 1812);
+} catch {}
+try {
+device1.queue.submit([commandBuffer194]);
+} catch {}
+let textureView76 = texture49.createView({dimension: '2d-array'});
+try {
+computePassEncoder66.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder72.drawIndexedIndirect(buffer48, 204);
+} catch {}
+try {
+renderPassEncoder83.drawIndirect(buffer48, 1_280);
+} catch {}
+let commandEncoder345 = device3.createCommandEncoder({label: '\u{1fc85}\u0cd8\uf1dd'});
+let texture113 = device3.createTexture({
+  label: '\ua8d0\ud6ff\u4be5\ub6c4\udab2\u4365\ud539\u0697\u{1fb94}\u81fc',
+  size: {width: 276, height: 1, depthOrArrayLayers: 4},
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let promise59 = device3.queue.onSubmittedWorkDone();
+try {
+device4.queue.submit([commandBuffer182, commandBuffer187]);
+} catch {}
+try {
+  await promise59;
+} catch {}
+let computePassEncoder84 = commandEncoder337.beginComputePass({label: '\u0444\ub2b7\u1800\u4daf\u0a30\u03ce\u{1faba}\u0c6e\u04ac\uf1f7\u2efb'});
+let externalTexture39 = device3.importExternalTexture({
+  label: '\ua550\uc378\ue8bd\u8337\u{1f653}\u0074\ubfa3\u0189\u8b40\u{1fab8}',
+  source: video3,
+  colorSpace: 'srgb',
+});
+video5.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let querySet38 = device4.createQuerySet({label: '\u3702\u66f2', type: 'occlusion', count: 208});
+let promise60 = device4.queue.onSubmittedWorkDone();
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+adapter4.label = '\u8ac8\u0bf6\u{1f6c1}\u{1f7ca}\u085f\ue9b0\uc746';
+} catch {}
+let commandBuffer195 = commandEncoder345.finish({label: '\u0ea5\u{1f9a8}\u569a\u29a3\u0aac\u0ba8\uc8f3\u05cf\u1ec0\u0814\u0b5c'});
+try {
+gpuCanvasContext11.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline27 = device4.createRenderPipeline({
+  label: '\u09f8\ue304',
+  layout: pipelineLayout40,
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: [undefined]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 2091040600,
+    stencilWriteMask: 46089057,
+    depthBiasClamp: 79.18532088931155,
+  },
+  vertex: {module: shaderModule12, buffers: []},
+  primitive: {frontFace: 'cw'},
+});
+let commandEncoder346 = device4.createCommandEncoder({label: '\u5517\u3125'});
+let computePassEncoder85 = commandEncoder346.beginComputePass({});
+try {
+computePassEncoder85.insertDebugMarker('\u7bec');
+} catch {}
+let commandEncoder347 = device4.createCommandEncoder({label: '\u483a\u0f88\u9d06\u012c\u{1faaf}\ub7e7\u3926\u0de3\u{1f753}\ube43'});
+let commandBuffer196 = commandEncoder347.finish({label: '\u0e80\ue8fd\u72b3\u2d6c\u{1f709}\u67be\u{1fbf2}\u055f\u01f4\u0397'});
+try {
+device4.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 139, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(395_463), /* required buffer size: 395_463 */
+{offset: 243, bytesPerRow: 4705, rowsPerImage: 21}, {width: 1161, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+adapter7.label = '\u4c17\u2ed2\u72d9\ucf4f\u043c\u{1f9fb}\u75df\uc740\u{1f9cc}\uf253';
+} catch {}
+let shaderModule13 = device4.createShaderModule({
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<atomic<u32>>,
+}
+
+@group(0) @binding(210) var tex23: texture_cube<i32>;
+@group(0) @binding(30) var sam15: sampler;
+@group(0) @binding(68) var st9: texture_storage_1d<r32sint, write>;
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @location(13) f39: vec2u,
+  @location(7) @interpolate(linear, centroid) f40: f32,
+  @builtin(position) f41: vec4f
+}
+
+@vertex
+fn vertex0(@location(2) @interpolate(flat) a0: f16, @location(3) a1: vec3f, @location(7) @interpolate(flat, center) a2: vec4u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(5) f0: u32
+}
+
+@fragment
+fn fragment0(@location(13) @interpolate(flat, center) a0: vec2u, @location(7) a1: f32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+device4.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 1478, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(67), /* required buffer size: 67 */
+{offset: 67, rowsPerImage: 28}, {width: 135, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let buffer58 = device4.createBuffer({
+  size: 1230,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder348 = device4.createCommandEncoder({label: '\u140f\u0aba\u0f72\u9d1e\u{1f6f8}\ue7fe\u98e4\u6ac3\u9398\u{1fbd5}'});
+document.body.prepend(img3);
+try {
+computePassEncoder30.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder89.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(5, buffer18, 9_208, 956);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer36, 'uint16', 8, 237);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(172), /* required buffer size: 172 */
+{offset: 172}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView77 = texture105.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder77.executeBundles([renderBundle118, renderBundle84]);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup4, new Uint32Array(5921), 891, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer36, 'uint16', 382, 14);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer18, 0, 13_860);
+} catch {}
+let imageData38 = new ImageData(24, 24);
+try {
+commandEncoder348.resolveQuerySet(querySet38, 1, 12, buffer52, 0);
+} catch {}
+document.body.prepend(canvas7);
+let imageData39 = new ImageData(12, 72);
+let texture114 = device0.createTexture({
+  label: '\u0167\uc49a\u06e9\u4f6a\u{1f764}\ub171',
+  size: {width: 360, height: 7, depthOrArrayLayers: 783},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView78 = texture9.createView({label: '\ubf72\u0059\u12a2\u3157\u0920\u143a\u3613'});
+let renderPassEncoder107 = commandEncoder336.beginRenderPass({
+  label: '\u0272\u99ac\u2e95',
+  colorAttachments: [{view: textureView28, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+});
+let sampler38 = device0.createSampler({
+  label: '\u1008\u8ecb\ub292\u0405\u02d9\u8d39\u31f8\u0e35\ub997\u0fae',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.03,
+  lodMaxClamp: 73.57,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(3, bindGroup1, new Uint32Array(338), 5, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder104.setPipeline(pipeline6);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u0e60\u0462\u0ba0',
+  layout: bindGroupLayout12,
+  entries: [{binding: 16, resource: {buffer: buffer9, offset: 256, size: 56}}],
+});
+try {
+computePassEncoder63.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer5, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+renderPassEncoder66.insertDebugMarker('\u1703');
+} catch {}
+try {
+renderBundleEncoder29.insertDebugMarker('\u00ad');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle192 = renderBundleEncoder32.finish({label: '\u{1fc6f}\u9053'});
+try {
+renderPassEncoder83.draw(183, 82, 1_200_358_493, 529_771_062);
+} catch {}
+try {
+renderPassEncoder72.drawIndexedIndirect(buffer40, 1_624);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+offscreenCanvas8.height = 240;
+await gc();
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let commandEncoder349 = device3.createCommandEncoder({label: '\u0630\ue309\u{1f6da}\u1ec1\ucf4f'});
+let commandBuffer197 = commandEncoder349.finish({label: '\u9a15\u{1fd3a}\u{1f7be}\u{1fa6a}\udd44'});
+try {
+gpuCanvasContext12.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder350 = device4.createCommandEncoder({});
+let commandBuffer198 = commandEncoder350.finish({label: '\u15f0\udb75\u23aa\u0faf'});
+let renderBundleEncoder35 = device4.createRenderBundleEncoder({
+  label: '\u053c\u0b47\u0829\u599b\u94e5\u8c41\u0bdd\u9aff\ud651\u{1fb70}',
+  colorFormats: [undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder35.setIndexBuffer(buffer58, 'uint16', 136, 29);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+commandEncoder348.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1728 */
+  offset: 1728,
+  buffer: buffer51,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder49.draw(61, 56, 507_917_248, 319_455_513);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer35, 2_536);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4, buffer38, 0, 348);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(93), /* required buffer size: 93 */
+{offset: 93}, {width: 620, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline28 = device2.createComputePipeline({
+  label: '\ua817\u0b3e\u01e9\u{1f912}\u9d3f\u00a7\uf1a7\u{1ff80}',
+  layout: pipelineLayout35,
+  compute: {module: shaderModule5, constants: {}},
+});
+let texture115 = device0.createTexture({
+  size: [180, 3, 527],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder67.executeBundles([]);
+} catch {}
+let promise61 = shaderModule8.getCompilationInfo();
+try {
+buffer17.unmap();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let pipelineLayout42 = device4.createPipelineLayout({
+  label: '\u{1f75c}\uc86c\u0a6a\u869e\ub8cc\u33e0\u6c7b\u{1fdf1}\u762e\u04e6',
+  bindGroupLayouts: [bindGroupLayout46, bindGroupLayout46, bindGroupLayout46, bindGroupLayout46],
+});
+let texture116 = device4.createTexture({
+  label: '\u005b\u7ad7\u62bf\uc85b\ub281\u446d\u57c8\u{1fdd7}\u8f69',
+  size: {width: 1419, height: 1, depthOrArrayLayers: 44},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder35.setIndexBuffer(buffer52, 'uint16', 4_438, 1_329);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(160), /* required buffer size: 160 */
+{offset: 160}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle193 = renderBundleEncoder33.finish({label: '\u{1f638}\u0dd0\u063e\u054d\ub4ff\u{1fe39}\u015a\u{1f793}'});
+let externalTexture40 = device2.importExternalTexture({label: '\u539f\uc670', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup7, new Uint32Array(646), 64, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.drawIndexedIndirect(buffer48, 2_832);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let sampler39 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 97.31,
+  lodMaxClamp: 99.22,
+});
+try {
+renderPassEncoder35.setVertexBuffer(0, buffer4, 2_040, 542);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup0, new Uint32Array(2561), 179, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint16', 6_564, 289);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline26);
+} catch {}
+let arrayBuffer16 = buffer37.getMappedRange(0, 2104);
+let commandEncoder351 = device3.createCommandEncoder({label: '\u{1f603}\u0473\u{1fd88}\u20ed'});
+let textureView79 = texture113.createView({label: '\u0e8b\u0006'});
+let bindGroupLayout49 = device3.createBindGroupLayout({label: '\u{1fbb5}\u0cc4', entries: []});
+let commandBuffer199 = commandEncoder351.finish({label: '\ub796\u0d67\u477f\ua35c\u{1f8ad}\u{1f8fd}\u6a0d'});
+let texture117 = device3.createTexture({
+  label: '\ud1ed\u0b28\u{1fedc}\u{1f772}\u23d2',
+  size: {width: 138},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder108 = commandEncoder338.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 0,
+  clearValue: { r: 340.6, g: 533.9, b: -184.8, a: -409.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder108.setVertexBuffer(5, buffer57, 2_332, 5_292);
+} catch {}
+try {
+commandEncoder343.copyTextureToBuffer({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1988 */
+  offset: 1988,
+  bytesPerRow: 256,
+  buffer: buffer57,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas6);
+await gc();
+let commandEncoder352 = device1.createCommandEncoder({label: '\u03a5\u0453\u5323\u0f7a\u07ba\ud8ba\u{1f6f3}'});
+let computePassEncoder86 = commandEncoder352.beginComputePass({label: '\u{1f817}\u{1f91a}\ud15a\u1190\u042c\u{1f612}'});
+try {
+renderPassEncoder89.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer36, 'uint32', 248, 374);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline15);
+} catch {}
+let arrayBuffer17 = buffer41.getMappedRange(2328, 660);
+let commandEncoder353 = device1.createCommandEncoder();
+let renderPassEncoder109 = commandEncoder353.beginRenderPass({
+  label: '\u5f55\u{1fb56}\uee1c',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 15,
+  clearValue: { r: 585.0, g: 757.3, b: -201.8, a: 409.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler40 = device1.createSampler({
+  label: '\u06b2\u{1f66e}\u03f9\u04bd\u9434\u{1fffa}\u{1f67e}\ue3df',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.99,
+  lodMaxClamp: 92.19,
+  compare: 'never',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder102.setVertexBuffer(3, buffer18);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let renderBundleEncoder36 = device4.createRenderBundleEncoder({label: '\ua9bc\uaf1e\u7d35', colorFormats: [undefined], depthReadOnly: true, stencilReadOnly: true});
+offscreenCanvas5.width = 963;
+let commandEncoder354 = device2.createCommandEncoder();
+try {
+renderPassEncoder96.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.drawIndexed(24, 96, 35, 64_168_951, 265_602_583);
+} catch {}
+try {
+device2.queue.submit([commandBuffer183]);
+} catch {}
+try {
+  await promise60;
+} catch {}
+let computePassEncoder87 = commandEncoder343.beginComputePass();
+try {
+renderPassEncoder108.setBlendConstant({ r: -465.5, g: -714.2, b: -861.3, a: -520.1, });
+} catch {}
+let querySet39 = device2.createQuerySet({label: '\u{1f9fe}\ue931', type: 'occlusion', count: 47});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder55.draw(87, 29, 35_484_884, 391_881_605);
+} catch {}
+try {
+renderPassEncoder72.drawIndexedIndirect(buffer46, 824);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer48, 692);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer53, 'uint32', 1_288, 298);
+} catch {}
+try {
+  await promise61;
+} catch {}
+try {
+texture107.label = '\u2e75\u7d08';
+} catch {}
+let commandEncoder355 = device4.createCommandEncoder({label: '\u1f18\uf642\uff13\u0667\u{1ffc4}\u{1ffb8}\u{1fd27}\u07d9\u02eb\u0260'});
+let commandBuffer200 = commandEncoder355.finish();
+let texture118 = device4.createTexture({
+  label: '\u0c9d\u9cc5\u3c7d\u1e1e\u7da3\u9160\uf465',
+  size: [1800, 12, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'astc-5x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle194 = renderBundleEncoder36.finish();
+try {
+renderBundleEncoder35.setIndexBuffer(buffer58, 'uint32', 176, 120);
+} catch {}
+document.body.prepend(img2);
+let textureView80 = texture101.createView({label: '\u{1ffd6}\u393f', dimension: '2d', mipLevelCount: 1});
+let renderBundle195 = renderBundleEncoder23.finish({label: '\u0574\u060d\ud316\u2936\u0f68\u4b53\u09fa\uc023\u{1f857}'});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup6, new Uint32Array(82), 0, 0);
+} catch {}
+try {
+computePassEncoder66.dispatchWorkgroupsIndirect(buffer46, 1_956);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder83.drawIndexedIndirect(buffer46, 1_036);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder354.copyBufferToTexture({
+  /* bytesInLastRow: 664 widthInBlocks: 166 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4912 */
+  offset: 4912,
+  rowsPerImage: 28,
+  buffer: buffer35,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 385, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 166, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 144, new Int16Array(34021), 14447, 304);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(107), /* required buffer size: 107 */
+{offset: 107}, {width: 120, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout50 = device3.createBindGroupLayout({
+  label: '\u168b\u0cc6\u8750',
+  entries: [
+    {
+      binding: 263,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView81 = texture117.createView({
+  label: '\u5a3c\u{1fab8}\u0026\uf1bd\ud856\u0c4c\u0a71\u1ee6\u4c61',
+  format: 'rgba8unorm-srgb',
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder108.setIndexBuffer(buffer57, 'uint16', 2_490, 3_859);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer57, 8356, new Float32Array(8766), 1680, 2588);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let commandBuffer201 = commandEncoder354.finish({});
+let renderBundle196 = renderBundleEncoder24.finish();
+try {
+computePassEncoder62.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(315);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(0, undefined, 105_009_989, 401_041_283);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 516, new BigUint64Array(380));
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 16 */
+{offset: 16, rowsPerImage: 9}, {width: 274, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandBuffer202 = commandEncoder223.finish();
+try {
+computePassEncoder82.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder96.setIndexBuffer(buffer38, 'uint32', 200, 2_541);
+} catch {}
+await gc();
+let commandEncoder356 = device0.createCommandEncoder({label: '\ucbc1\u16e6\u73e3\u08a7\u{1f681}'});
+let commandBuffer203 = commandEncoder356.finish({});
+try {
+renderPassEncoder104.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder97.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder93.setVertexBuffer(6, buffer44, 556);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer9, 'uint16', 854, 539);
+} catch {}
+let commandEncoder357 = device2.createCommandEncoder({label: '\u01ed\u55c0\u5fa5\u{1fefb}\u{1fec8}'});
+let commandBuffer204 = commandEncoder357.finish();
+try {
+renderPassEncoder55.drawIndexed(104, 71, 7, 89_925_306, 2_111_172_515);
+} catch {}
+try {
+renderPassEncoder49.drawIndexedIndirect(buffer48, 964);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer46, 2_080);
+} catch {}
+let commandEncoder358 = device0.createCommandEncoder({label: '\u91b6\u3471\u{1fff7}\u{1feb7}\u307b\u{1f9d2}\u9050\u{1f7d7}\u{1f7e1}\ua7ca\ub535'});
+let commandBuffer205 = commandEncoder358.finish();
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder96.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer38, 'uint32', 244, 232);
+} catch {}
+try {
+renderPassEncoder96.pushDebugGroup('\u957d');
+} catch {}
+try {
+renderPassEncoder96.popDebugGroup();
+} catch {}
+let commandEncoder359 = device3.createCommandEncoder();
+let commandBuffer206 = commandEncoder359.finish({});
+try {
+renderPassEncoder108.setIndexBuffer(buffer57, 'uint32', 3_064, 420);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder360 = device3.createCommandEncoder();
+let commandBuffer207 = commandEncoder360.finish({label: '\u696c\u{1f731}\u4dee\u8ecd\u{1fa67}'});
+try {
+renderPassEncoder108.end();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let commandEncoder361 = device3.createCommandEncoder({label: '\u{1fc5c}\u0140\uc533'});
+let renderPassEncoder110 = commandEncoder361.beginRenderPass({
+  label: '\ubbef\u0471\u0b03\u{1fb95}\u145e\uaeee\u{1f843}\u3c9e',
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 3,
+  clearValue: { r: 752.6, g: -756.5, b: 174.8, a: -642.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet36,
+});
+let renderBundleEncoder37 = device3.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb']});
+try {
+computePassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle13, renderBundle172, renderBundle16, renderBundle125]);
+} catch {}
+try {
+renderPassEncoder94.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(3, buffer5, 0, 774);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer13, 'uint16', 2_134, 2_463);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 408, new BigUint64Array(16048), 767, 156);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline21);
+} catch {}
+let bindGroupLayout51 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 586,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+try {
+renderPassEncoder81.setBindGroup(1, bindGroup12, new Uint32Array(2537), 140, 0);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder105.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer13, 'uint32', 940, 2_045);
+} catch {}
+let renderBundle197 = renderBundleEncoder29.finish({label: '\u0e59\ud3b0\u0f7d\u059b\ubebd\u{1f75a}\u02ba\uf44e\ucab3\u06ef\u{1feac}'});
+try {
+renderPassEncoder95.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint32', 2_684, 3_165);
+} catch {}
+document.body.prepend(canvas4);
+let commandBuffer208 = commandEncoder348.finish({label: '\ub64f\u37f5\u{1fa07}\u0d24\u043c\u{1feed}\ubf8b\u{1fd3b}'});
+let renderBundle198 = renderBundleEncoder36.finish({label: '\u89d2\u{1fe92}\u0878\u01ff\u130b\uebe6\u0002'});
+try {
+renderPassEncoder110.end();
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer57, 'uint32', 17_160, 3_181);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(0, buffer57);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise62 = device3.queue.onSubmittedWorkDone();
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle191]);
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer18, 'uint16', 1_150, 8_710);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 2208, new Float32Array(6891), 576, 308);
+} catch {}
+let commandEncoder362 = device1.createCommandEncoder({label: '\u09d6\u{1f81e}'});
+let querySet40 = device1.createQuerySet({label: '\u{1f697}\u0031\u828b', type: 'occlusion', count: 64});
+let commandBuffer209 = commandEncoder111.finish({label: '\u769d\ud499\uac3b\u{1fa24}\u5551\u2cb2\u{1f93c}\u3148\u03b9\u{1fb28}'});
+let renderPassEncoder111 = commandEncoder362.beginRenderPass({
+  label: '\uf766\u292c\u{1fb31}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 10,
+  clearValue: { r: 674.8, g: 44.29, b: -164.8, a: 5.310, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 67920013,
+});
+try {
+renderPassEncoder106.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder92.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(4, buffer18, 0);
+} catch {}
+let texture119 = device1.createTexture({
+  label: '\u{1fdc4}\ubb78\u0858\u0afa\ubf1c\u0b5b\u7d59\u0944\udef8\u422f',
+  size: {width: 165},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder88.setVertexBuffer(7, buffer18, 0, 14);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline15);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let commandEncoder363 = device2.createCommandEncoder({});
+let texture120 = device2.createTexture({
+  size: {width: 298, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder88 = commandEncoder363.beginComputePass({label: '\ud2b1\u3df2\ud9a5\ud743\u{1fb77}\ucd2d\u8b61'});
+let renderBundle199 = renderBundleEncoder23.finish({label: '\u046d\u{1f93c}\u{1f63d}\u02a4\ue395\u024d\u0682\u07d2\u0e7f'});
+try {
+renderPassEncoder73.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.setViewport(33.17734100650044, 0.08908694991864308, 25.480389780097457, 0.9009254328538651, 0.30842617128194216, 0.5636522421786738);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer47, 'uint16', 116, 205);
+} catch {}
+try {
+renderPassEncoder96.setPipeline(pipeline18);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 1692, new DataView(new ArrayBuffer(6932)), 2098, 180);
+} catch {}
+let commandEncoder364 = device4.createCommandEncoder({label: '\u0546\u646c\u0937\u7d05\u08ab\u8b96\u0885\ud96b\u{1f9ef}'});
+let texture121 = gpuCanvasContext5.getCurrentTexture();
+try {
+buffer51.unmap();
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+let pipelineLayout43 = device0.createPipelineLayout({
+  label: '\u13b4\u9f08\u{1fdf1}\u5e9f\u90b5\u{1ff2f}\u0771\u0863',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout13],
+});
+let commandEncoder365 = device0.createCommandEncoder({label: '\u1960\u83b8\u1ffe'});
+let querySet41 = device0.createQuerySet({label: '\u{1fc0b}\u{1f83e}\uabd6\u1509\ueb76\u06c9', type: 'occlusion', count: 492});
+let renderBundle200 = renderBundleEncoder3.finish({label: '\u10ed\u{1f926}\u5c6b\u7a09\u{1fba7}\uab82\u80e3\u{1fd93}\ub367'});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup14, new Uint32Array(1077), 249, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(4, buffer0, 44, 5_899);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer2, 'uint32', 16_540, 2_402);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer4);
+} catch {}
+let arrayBuffer18 = buffer42.getMappedRange(584, 8);
+try {
+commandEncoder365.copyTextureToBuffer({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 118, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2232 widthInBlocks: 279 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1176 */
+  offset: 1176,
+  bytesPerRow: 2304,
+  buffer: buffer9,
+}, {width: 279, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\ub454');
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder366 = device2.createCommandEncoder();
+let renderPassEncoder112 = commandEncoder366.beginRenderPass({
+  label: '\ub745\u076e',
+  colorAttachments: [{
+  view: textureView64,
+  depthSlice: 4,
+  clearValue: { r: 652.9, g: -743.1, b: 212.6, a: 693.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder55.drawIndexed(4, 236, 0, -2_048_199_731, 160_250_828);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer48, 344);
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(7, buffer38, 0, 151);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(92), /* required buffer size: 92 */
+{offset: 92}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder367 = device3.createCommandEncoder({label: '\u5398\u5fdf\u{1fedd}\u0349\uc7e3\ucd90\uf440\u{1fa63}'});
+let texture122 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle201 = renderBundleEncoder37.finish({label: '\u{1f82e}\u0f94\u{1fd12}\u004f\u0e47\u7936\u10eb\u1d7b\u0567\u0af6\u07dc'});
+try {
+commandEncoder367.copyTextureToBuffer({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 652 */
+  offset: 652,
+  buffer: buffer57,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData40 = new ImageData(36, 96);
+let commandEncoder368 = device0.createCommandEncoder({label: '\u660d\u049b'});
+let computePassEncoder89 = commandEncoder365.beginComputePass();
+let renderPassEncoder113 = commandEncoder368.beginRenderPass({
+  label: '\uac44\u088f\u5d32\u0653\u1eef',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 22,
+  clearValue: { r: 986.1, g: -895.3, b: 980.3, a: -774.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder75.setVertexBuffer(2, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer0, 244);
+} catch {}
+let commandEncoder369 = device3.createCommandEncoder();
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let commandEncoder370 = device1.createCommandEncoder({label: '\u4488\u22ad\u{1f8b9}\u028c\u17f4\u1d66\u62a8\u0969\u{1ff9b}'});
+let computePassEncoder90 = commandEncoder370.beginComputePass();
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 7, depthOrArrayLayers: 87}
+*/
+{
+  source: imageData19,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter2.label = '\u4542\u67c5';
+} catch {}
+let commandEncoder371 = device2.createCommandEncoder({label: '\u0075\u8651\u28b5\u0145\u532f\ud0c2\u{1f86d}\u5f6d\u1c37'});
+let textureView82 = texture68.createView({label: '\u4644\u3b05\u9f9b\u0f60\u3537\u0b40\u0178\u025f'});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup6, new Uint32Array(1919), 495, 0);
+} catch {}
+try {
+computePassEncoder66.dispatchWorkgroupsIndirect(buffer46, 4_980);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup7, new Uint32Array(3156), 577, 0);
+} catch {}
+try {
+renderPassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder112.setScissorRect(22, 0, 57, 0);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(34, 138, 1, 23_503_543, 180_889_051);
+} catch {}
+try {
+renderPassEncoder55.drawIndirect(buffer48, 5_080);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline18);
+} catch {}
+try {
+device2.queue.submit([commandBuffer202]);
+} catch {}
+let buffer59 = device2.createBuffer({
+  size: 43744,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder372 = device2.createCommandEncoder();
+let computePassEncoder91 = commandEncoder372.beginComputePass({label: '\u29a5\u043c'});
+let renderPassEncoder114 = commandEncoder371.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 4,
+  clearValue: { r: 64.80, g: -31.51, b: -46.07, a: -547.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle202 = renderBundleEncoder33.finish({label: '\u3e1a\u{1fd04}\u127f\u0a01'});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup6, new Uint32Array(1944), 874, 0);
+} catch {}
+try {
+renderPassEncoder112.end();
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer47, 'uint16', 1_426, 431);
+} catch {}
+document.body.prepend(canvas0);
+let buffer60 = device0.createBuffer({
+  label: '\u{1fb30}\uf557',
+  size: 17784,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder373 = device0.createCommandEncoder({});
+let renderPassEncoder115 = commandEncoder373.beginRenderPass({
+  label: '\u{1fb3b}\ucae0\u068e\udcae\u{1fabb}\uc59c\u4959\u46d5',
+  colorAttachments: [{
+  view: textureView57,
+  depthSlice: 5,
+  clearValue: { r: -262.7, g: 974.4, b: 703.8, a: -836.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 1234567890,
+});
+let renderBundle203 = renderBundleEncoder0.finish({label: '\u8634\uab1a\u2df3\u{1f8a1}\u{1f858}\u{1fefc}\u019d\u0896\u03ce'});
+try {
+renderPassEncoder103.beginOcclusionQuery(448);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder103.setIndexBuffer(buffer37, 'uint16', 1_774, 5_802);
+} catch {}
+try {
+renderPassEncoder100.setVertexBuffer(3, buffer45, 84, 235);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup8, new Uint32Array(666), 204, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer60, 'uint32', 7_132, 1_163);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline26);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 720, height: 14, depthOrArrayLayers: 216}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 15, y: 23 },
+  flipY: false,
+}, {
+  texture: texture66,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+video6.requestVideoFrameCallback((now, metadata) => { metadata.length = now; });
+let commandEncoder374 = device3.createCommandEncoder({label: '\u0e77\uafda\u016c\u{1fe01}\ub942\u000f\u6f15'});
+let texture123 = device2.createTexture({
+  label: '\u{1f67e}\ua343\u9e90\u0a07\u0d51\u69bf',
+  size: {width: 596, height: 1, depthOrArrayLayers: 95},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture124 = gpuCanvasContext10.getCurrentTexture();
+let renderBundleEncoder38 = device2.createRenderBundleEncoder({
+  label: '\u0485\u5b6b\u083c\u{1f7ca}\u9e4c\u0e1f\u0270',
+  colorFormats: ['rg16float', 'rgb10a2unorm', 'r8uint', 'rgba16uint'],
+});
+try {
+renderPassEncoder83.drawIndexed(29, 542, 20, 868_719_232, 2_181_124_611);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup6);
+} catch {}
+document.body.prepend(video3);
+let commandEncoder375 = device0.createCommandEncoder();
+let computePassEncoder92 = commandEncoder375.beginComputePass({});
+let renderBundle204 = renderBundleEncoder10.finish({label: '\u{1f92d}\u0764\u8cc4\u{1f7e0}\u{1fc36}\u023d\ueb83'});
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer10, 380, 6_825);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let commandBuffer210 = commandEncoder187.finish({label: '\u{1fd3e}\uc236\u69cd\u{1fcd2}\uacd0\ub7e3\u0acf\u{1fdd6}\u784d\u10ad'});
+let texture125 = gpuCanvasContext4.getCurrentTexture();
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer18, 'uint32', 1_388, 538);
+} catch {}
+try {
+device1.queue.submit([commandBuffer190, commandBuffer210]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 115, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(425), /* required buffer size: 425 */
+{offset: 425}, {width: 653, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video5);
+let commandBuffer211 = commandEncoder364.finish({});
+try {
+gpuCanvasContext7.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(3, bindGroup13, new Uint32Array(502), 119, 0);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+querySet39.destroy();
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+renderPassEncoder114.insertDebugMarker('\u345a');
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder376 = device0.createCommandEncoder({label: '\u67ab\u9a45\u{1fa63}\u{1ff92}\u{1fc54}\u4b95\u9a4f\ud4bf\u18c5\u0111'});
+let renderBundle205 = renderBundleEncoder9.finish({label: '\uf7fc\u{1ffad}\u273d\u27d6\u040f\u2bd7\u0382\u{1f831}\udfc1\u{1fb2b}'});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup0, new Uint32Array(1162), 186, 0);
+} catch {}
+try {
+renderPassEncoder103.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer44, 'uint32', 180, 495);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer4, 0, 1_831);
+} catch {}
+try {
+querySet35.destroy();
+} catch {}
+try {
+commandEncoder376.insertDebugMarker('\u{1ffc1}');
+} catch {}
+let commandEncoder377 = device2.createCommandEncoder({label: '\u{1ffa3}\u0386\ue003\u0fd4\u45d1'});
+let texture126 = gpuCanvasContext6.getCurrentTexture();
+let computePassEncoder93 = commandEncoder377.beginComputePass();
+try {
+computePassEncoder70.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder54.draw(246, 5, 29_135_651, 91_426_408);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer47, 'uint16', 394, 117);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup13, new Uint32Array(2903), 679, 0);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer38, 'uint16', 2_180, 608);
+} catch {}
+try {
+device2.queue.submit([commandBuffer192]);
+} catch {}
+try {
+commandEncoder317.label = '\u{1ff56}\ubabc\u8067\u128c';
+} catch {}
+let commandEncoder378 = device3.createCommandEncoder();
+let computePassEncoder94 = commandEncoder378.beginComputePass();
+let renderPassEncoder116 = commandEncoder369.beginRenderPass({
+  label: '\uc2b3\u7d63\u{1f9ba}\u0c9d\u{1fae3}\u420b',
+  colorAttachments: [{view: textureView79, depthSlice: 2, loadOp: 'clear', storeOp: 'store'}],
+});
+video6.height = 38;
+let promise63 = adapter6.requestAdapterInfo();
+let computePassEncoder95 = commandEncoder374.beginComputePass({label: '\u0601\uab15\u03c4\u9628\u{1f82f}\ub126\u068f'});
+try {
+commandEncoder367.copyBufferToTexture({
+  /* bytesInLastRow: 264 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2012 */
+  offset: 2012,
+  buffer: buffer57,
+}, {
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.submit([commandBuffer188, commandBuffer206]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+let imageData41 = new ImageData(24, 136);
+let renderBundle206 = renderBundleEncoder16.finish({label: '\u086a\u520b\u52c2\u0dab\u0ac9\u0fae\ubd6d\uac61\u{1f633}\u743c\ua8df'});
+try {
+renderPassEncoder77.end();
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(1, buffer18, 3_540);
+} catch {}
+let commandEncoder379 = device1.createCommandEncoder({label: '\u{1fab0}\u3580\u0174'});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup5, new Uint32Array(2186), 266, 0);
+} catch {}
+try {
+commandEncoder379.copyBufferToBuffer(buffer18, 1316, buffer39, 180, 4);
+} catch {}
+try {
+commandEncoder379.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 84 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 358 */
+  offset: 358,
+  rowsPerImage: 45,
+  buffer: buffer18,
+}, {
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 84, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(129), /* required buffer size: 129 */
+{offset: 129}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer212 = commandEncoder367.finish({label: '\u{1f785}\u05bb\ud787\u727b\u{1fee7}\u{1fe01}\u076f'});
+let renderBundleEncoder39 = device3.createRenderBundleEncoder({
+  label: '\ua0be\u{1f6c3}\u83b2\u0bd4\u4ac3\u6580\u18f6\u0e49\u5a69\u37d0',
+  colorFormats: ['rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+device3.queue.submit([commandBuffer212, commandBuffer207, commandBuffer199, commandBuffer176, commandBuffer197]);
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\u{1fee6}\u{1fe5d}\u{1fbe6}\u311e\u6962\ufd9d\u{1f9fd}\u8368\u1f75\u351d',
+  code: `
+enable f16;
+enable f16;
+
+struct T0 {
+  f0: array<atomic<i32>>,
+}
+
+@group(3) @binding(16) var<storage, read_write> buffer61: array<mat3x2f>;
+@group(1) @binding(202) var st11: texture_storage_1d<r32uint, read_write>;
+@group(0) @binding(114) var st10: texture_storage_2d_array<rgba32uint, write>;
+@group(2) @binding(117) var tex24: texture_1d<f32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0() {
+}
+
+struct S0 {
+  @location(11) @interpolate(flat) f0: vec3u,
+  @builtin(vertex_index) f1: u32
+}
+
+@vertex
+fn vertex0(@location(14) @interpolate(flat) a0: vec3h, a1: S0, @location(8) a2: vec2h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4i
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = buffer61;
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView83 = texture1.createView({label: '\u{1ff73}\u0271', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder96 = commandEncoder376.beginComputePass({label: '\u02c4\u2185\u0197\u{1fea5}\u3928'});
+let commandEncoder380 = device3.createCommandEncoder({label: '\ue4fb\u{1f6e8}'});
+let renderPassEncoder117 = commandEncoder380.beginRenderPass({
+  label: '\u7a6f\u{1f7cc}\u0fbc\u{1ff4f}\u{1ff5f}\uae5a',
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 1,
+  clearValue: { r: 691.6, g: 547.8, b: 126.9, a: -44.74, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet36,
+  maxDrawCount: 148058534,
+});
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb']});
+try {
+renderPassEncoder117.end();
+} catch {}
+try {
+renderPassEncoder116.executeBundles([renderBundle201]);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(6, buffer57, 0);
+} catch {}
+try {
+device3.queue.submit([commandBuffer178, commandBuffer181]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(172), /* required buffer size: 172 */
+{offset: 172}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let computePassEncoder97 = commandEncoder379.beginComputePass({label: '\u{1f65b}\u06af'});
+let renderBundle207 = renderBundleEncoder15.finish({label: '\ub25e\u250b\u{1f78f}\ua1ae\u{1fe07}\u{1ff9d}\u0204\u2bcd\u8385\ua02f\u0643'});
+try {
+renderPassEncoder109.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline20);
+} catch {}
+let externalTexture41 = device2.importExternalTexture({
+  label: '\u030a\u0488\u63c9\u{1fb99}\u0bd8\u7fa6\ub2fc\u0201\u4a11',
+  source: video5,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder62.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder96.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder55.draw(80, 101, 736_156_163, 280_472_559);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer48, 596);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer38, 'uint32', 176, 85);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(147), /* required buffer size: 147 */
+{offset: 147, bytesPerRow: 399}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder381 = device2.createCommandEncoder({label: '\u0aff\uac72\udcab\u1e52\ue944\u05fa\u{1f722}\u05ea\uca80\u4822'});
+let commandBuffer213 = commandEncoder381.finish();
+let texture127 = device2.createTexture({
+  label: '\u87b3\u098c\ue804\u0974\u{1ff31}\u17d9\u08e2\u070d\u055f',
+  size: [1192],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle208 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder73.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder54.draw(57, 307, 2_437_832_108, 1_787_536_321);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer46, 348);
+} catch {}
+try {
+renderPassEncoder49.drawIndirect(buffer40, 772);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup6, new Uint32Array(3028), 791, 0);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle123]);
+} catch {}
+try {
+renderPassEncoder71.setViewport(65.90341898822068, 0.022141698147769784, 2.10811278581742, 0.876762832770178, 0.37446338024351633, 0.521115276385187);
+} catch {}
+try {
+renderPassEncoder90.setVertexBuffer(2, buffer18, 0, 6_396);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder30.draw(281, 64, 292_373_831, 2_225_024_651);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(47, 67, 58, -2_106_909_790, 589_226_040);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer43, 'uint32', 1_160, 592);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline25);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let img7 = await imageWithData(11, 106, '#10101010', '#20202020');
+let pipelineLayout44 = device1.createPipelineLayout({
+  label: '\udea0\u069d\u004e\u0d25\u0cda',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout22, bindGroupLayout29, bindGroupLayout19],
+});
+let commandEncoder382 = device1.createCommandEncoder({});
+let renderPassEncoder118 = commandEncoder382.beginRenderPass({
+  label: '\u078e\u0498\u0265\u7098',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 62,
+  clearValue: { r: 948.3, g: -3.430, b: -389.5, a: -508.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder89.setIndexBuffer(buffer18, 'uint16', 7_644, 471);
+} catch {}
+try {
+renderPassEncoder109.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder30.draw(202, 119, 1_156_874_483, 498_083_033);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+let imageData42 = new ImageData(88, 16);
+let renderBundle209 = renderBundleEncoder21.finish({label: '\ub080\u0b79\ud793\u0e1c\ua7e7\ud23d\u0984\u{1f7d2}\uf514'});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup8, new Uint32Array(559), 374, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer44, 'uint32', 684, 261);
+} catch {}
+try {
+renderPassEncoder84.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(149), /* required buffer size: 149 */
+{offset: 149, bytesPerRow: 916}, {width: 107, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder102.setBindGroup(0, bindGroup10, new Uint32Array(37), 0, 0);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer43, 2_576);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline25);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer52, 'uint16', 272, 3_360);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData43 = new ImageData(24, 52);
+let commandEncoder383 = device3.createCommandEncoder({label: '\ufc06\u034f\u8599\u0503\u{1fe98}\u{1faba}\u0181\u0362\u0b17\u06ba\u740c'});
+let textureView84 = texture117.createView({label: '\u0f4e\u08f2\u0625\u{1fb9b}\u9829\u02e0\u0058\u{1f76c}'});
+let renderPassEncoder119 = commandEncoder383.beginRenderPass({
+  label: '\u2b14\u2267\u00a7',
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 1,
+  clearValue: { r: 647.9, g: -254.4, b: -802.3, a: 416.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder41 = device3.createRenderBundleEncoder({label: '\u6550\u03f0', colorFormats: ['rgba8unorm-srgb'], stencilReadOnly: false});
+try {
+computePassEncoder84.end();
+} catch {}
+let texture128 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle210 = renderBundleEncoder31.finish({label: '\u13e9\u0a1b\u058c\uf931\ucf0e\u6ed7\u68a7\u0cb1\u{1ff37}'});
+try {
+computePassEncoder35.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup5, new Uint32Array(1625), 26, 0);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer43, 200);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline14);
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker('\u4b94');
+} catch {}
+try {
+renderPassEncoder92.insertDebugMarker('\uc1e1');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise64 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise64;
+} catch {}
+let videoFrame7 = new VideoFrame(img2, {timestamp: 0});
+try {
+computePassEncoder92.setBindGroup(3, bindGroup0, new Uint32Array(1086), 51, 0);
+} catch {}
+try {
+renderPassEncoder94.setVertexBuffer(3, buffer0, 2_260, 1_405);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(30), /* required buffer size: 30 */
+{offset: 30}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder38.beginOcclusionQuery(39);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer0, 'uint32', 2_020, 910);
+} catch {}
+try {
+renderPassEncoder103.setVertexBuffer(1, buffer8, 172, 937);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer186, commandBuffer203]);
+} catch {}
+let commandEncoder384 = device1.createCommandEncoder({label: '\u9090\u{1fd7b}\u0309\u0006\u07dd\u6690\u206f\u{1fd28}\u2247\u3bce\u9b15'});
+let commandBuffer214 = commandEncoder384.finish({label: '\u0a7a\u{1ff01}'});
+try {
+renderPassEncoder45.setIndexBuffer(buffer18, 'uint16', 3_284, 2_233);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(8, 80, 10, 70_869_816, 238_384_554);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer43, 340);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer43, 264);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise63;
+} catch {}
+let commandEncoder385 = device4.createCommandEncoder({label: '\udf23\u{1f7bb}\ubbd2\u7248\u1d60\u{1f8b2}\u0689\u028e\u0c0c\u64a9\u9ed8'});
+let commandBuffer215 = commandEncoder385.finish({label: '\u5f66\u{1ff3d}\u80a6\ub95b\u{1f964}\u90e9\u6e65'});
+let renderBundle211 = renderBundleEncoder36.finish({});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+  await shaderModule12.getCompilationInfo();
+} catch {}
+try {
+device4.queue.submit([commandBuffer198, commandBuffer208]);
+} catch {}
+let promise65 = device4.createComputePipelineAsync({
+  label: '\u03b5\u3fc9\u{1f648}\u705a\u{1fa19}\u34d8\u{1f6b2}\ud8ce\u97f1\u{1fbb6}',
+  layout: pipelineLayout40,
+  compute: {module: shaderModule12},
+});
+video5.height = 29;
+try {
+renderPassEncoder68.end();
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle118, renderBundle105, renderBundle210, renderBundle160, renderBundle144, renderBundle207, renderBundle164, renderBundle140]);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer43, 12);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer43, 804);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer43, 'uint16', 140, 193);
+} catch {}
+try {
+renderPassEncoder111.setVertexBuffer(1, buffer18, 1_780, 1_537);
+} catch {}
+try {
+renderPassEncoder59.insertDebugMarker('\u{1f9f7}');
+} catch {}
+let commandEncoder386 = device0.createCommandEncoder({label: '\u0c8b\uaeda'});
+let renderPassEncoder120 = commandEncoder386.beginRenderPass({
+  label: '\u0d78\u04e6\u0165\ud34c',
+  colorAttachments: [{view: textureView16, depthSlice: 12, loadOp: 'load', storeOp: 'discard'}],
+});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder38.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder104.setIndexBuffer(buffer60, 'uint32', 4_844, 1_286);
+} catch {}
+try {
+renderPassEncoder120.setVertexBuffer(7, buffer10, 408, 25);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(1, undefined);
+} catch {}
+try {
+  await promise62;
+} catch {}
+let commandEncoder387 = device1.createCommandEncoder({label: '\u0dc2\u353e\u0cdc\u9dc1\u{1fb76}\u{1faa8}\u6045\u{1f735}\u{1f82e}'});
+let querySet42 = device1.createQuerySet({label: '\u8633\u0fa7\u{1fe90}\u7825\ue90a', type: 'occlusion', count: 359});
+let commandBuffer216 = commandEncoder387.finish({label: '\u0063\u{1fc40}\uaf0d\ua85d\u42c6\u13c4\uad49\u9c87\u0051\u8cef'});
+let texture129 = device1.createTexture({
+  label: '\u9d39\u6530\uab9a',
+  size: {width: 11, height: 7, depthOrArrayLayers: 162},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderBundleEncoder30.drawIndirect(buffer43, 508);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer18, 'uint16', 752, 153);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer0, 'uint16', 3_272, 11_899);
+} catch {}
+try {
+renderPassEncoder104.setVertexBuffer(4_294_967_295, undefined);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await buffer19.mapAsync(GPUMapMode.WRITE, 0, 28);
+} catch {}
+let renderBundle212 = renderBundleEncoder4.finish();
+try {
+computePassEncoder57.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 796, new Int16Array(6362), 12, 88);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder32.setBindGroup(2, bindGroup10, new Uint32Array(1078), 285, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+computePassEncoder62.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder114.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder54.draw(112, 102, 50_720_723, 1_072_895_359);
+} catch {}
+try {
+renderPassEncoder83.drawIndexedIndirect(buffer35, 228);
+} catch {}
+try {
+renderPassEncoder96.setVertexBuffer(3, undefined, 0, 1_577_190_884);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(1, bindGroup7);
+} catch {}
+let textureView85 = texture35.createView({format: 'r16sint', mipLevelCount: 1});
+try {
+computePassEncoder74.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder106.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup4, new Uint32Array(7463), 1988, 0);
+} catch {}
+try {
+renderBundleEncoder30.draw(88, 26, 1_536_251_778, 426_694_722);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer43, 788);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer43, 232);
+} catch {}
+let texture130 = device2.createTexture({
+  label: '\u{1ff19}\u0ef2\uc264\u{1f70f}\u{1f9b1}',
+  size: [1192, 1, 24],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle213 = renderBundleEncoder23.finish({label: '\u1ed5\u063f'});
+try {
+computePassEncoder66.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder54.drawIndexed(12, 459, 95, 494_051_161, 699_030_833);
+} catch {}
+try {
+renderPassEncoder54.drawIndexedIndirect(buffer40, 12_888);
+} catch {}
+try {
+renderPassEncoder83.drawIndirect(buffer40, 448);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer47, 'uint32', 656, 546);
+} catch {}
+let imageData44 = new ImageData(72, 132);
+let bindGroup15 = device3.createBindGroup({
+  layout: bindGroupLayout43,
+  entries: [{binding: 262, resource: {buffer: buffer57, offset: 7168, size: 3600}}],
+});
+let pipelineLayout45 = device3.createPipelineLayout({label: '\u{1f828}\ud7dd', bindGroupLayouts: [bindGroupLayout48]});
+let commandEncoder388 = device3.createCommandEncoder();
+let commandBuffer217 = commandEncoder337.finish();
+let computePassEncoder98 = commandEncoder388.beginComputePass({label: '\u{1ff87}\u33c3\ucff3\ud071\u706e\u1f40\u946d\u302a\u{1fa1d}'});
+try {
+renderBundleEncoder39.pushDebugGroup('\u{1ff52}');
+} catch {}
+try {
+adapter1.label = '\u{1fb54}\u037b\uc0f1\uaf4b\ua84a\u1198\u61b6\uc314';
+} catch {}
+let bindGroupLayout52 = device2.createBindGroupLayout({
+  label: '\uf195\u{1fe8c}\u{1f8c2}\u{1f9b3}\u5eef\u05b7\u{1fadc}\u0833',
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder389 = device2.createCommandEncoder({label: '\u9d0c\u{1ff48}\u7671\u386f\u{1fbba}'});
+try {
+renderPassEncoder114.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(7, buffer40);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let commandEncoder390 = device0.createCommandEncoder();
+let textureView86 = texture90.createView({});
+let renderPassEncoder121 = commandEncoder390.beginRenderPass({
+  label: '\u0652\u042a\u639d\u7ade\u{1f6bd}\u7c0e\ud392\uf35b\u04ca\u7d8c\u{1fe9f}',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 92,
+  clearValue: { r: 198.2, g: -346.6, b: -10.10, a: -803.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle214 = renderBundleEncoder27.finish({});
+try {
+buffer9.unmap();
+} catch {}
+let computePassEncoder99 = commandEncoder389.beginComputePass({label: '\u07de\u6e78\u7901\u012f\u{1fc47}\u{1f7b5}\u31a5\u{1fcdc}\u{1fd0b}\u3ed8\u20b0'});
+try {
+computePassEncoder68.dispatchWorkgroupsIndirect(buffer40, 2_336);
+} catch {}
+try {
+renderPassEncoder83.draw(148, 173, 141_675_223, 159_374_706);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer53, 'uint32', 1_368, 305);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer53, 'uint32', 920, 1_621);
+} catch {}
+try {
+device2.queue.submit([commandBuffer213]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(108), /* required buffer size: 108 */
+{offset: 108, bytesPerRow: 322, rowsPerImage: 14}, {width: 298, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 74, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData32,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+document.body.prepend(canvas0);
+let externalTexture42 = device4.importExternalTexture({label: '\u0c21\u49fa\u72ed\u35de', source: videoFrame5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder35.setIndexBuffer(buffer58, 'uint32', 200, 12);
+} catch {}
+try {
+computePassEncoder85.pushDebugGroup('\u0628');
+} catch {}
+try {
+computePassEncoder85.insertDebugMarker('\u0ce3');
+} catch {}
+let texture131 = device4.createTexture({
+  size: [1419, 1, 264],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView87 = texture111.createView({
+  label: '\u7985\u09b8\u3a03\uf828\u8c90\u0063\u0de8\u105a\uf338\u{1fcc2}\ua0e5',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+let promise66 = adapter8.requestAdapterInfo();
+try {
+renderBundleEncoder35.setIndexBuffer(buffer52, 'uint32', 496, 4_138);
+} catch {}
+try {
+renderPassEncoder97.end();
+} catch {}
+try {
+renderPassEncoder101.setPipeline(pipeline7);
+} catch {}
+let gpuCanvasContext14 = canvas8.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+  await promise66;
+} catch {}
+let commandEncoder391 = device4.createCommandEncoder({label: '\u0ee5\u4a4d\u05b3\u{1fe72}'});
+try {
+renderBundleEncoder35.setVertexBuffer(2, undefined, 0, 105_255_638);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.submit([commandBuffer200, commandBuffer196, commandBuffer211]);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 646, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(12_431), /* required buffer size: 12_431 */
+{offset: 251, bytesPerRow: 812, rowsPerImage: 15}, {width: 203, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let texture132 = device3.createTexture({
+  label: '\u0ae3\u0e3d\u07ec\u3ce7\u0cf5\u3f5f',
+  size: [6, 40, 34],
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+querySet36.destroy();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(361), /* required buffer size: 361 */
+{offset: 361}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder111.setBindGroup(3, bindGroup10, new Uint32Array(9315), 551, 0);
+} catch {}
+try {
+renderPassEncoder99.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder26.draw(85, 42, 1_553_767_354, 3_495_957_894);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer43, 384);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer18, 0, 1_585);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer216]);
+} catch {}
+let commandEncoder392 = device1.createCommandEncoder({label: '\u02c7\u{1f6d1}\u6834\u{1f6b8}\u6f85\u0268'});
+let texture133 = device1.createTexture({
+  label: '\u3fbf\u527d\u{1fe0a}\ubf9d\u6eb6\ub876\u0269\u{1fe2e}\u7543\uf160\u656f',
+  size: {width: 580, height: 1, depthOrArrayLayers: 20},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder100 = commandEncoder392.beginComputePass();
+let externalTexture43 = device1.importExternalTexture({label: '\u{1f9ed}\u3fc4\udc8c\u0ef9\u0c61', source: video2, colorSpace: 'srgb'});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder88.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder46.setBlendConstant({ r: -874.3, g: 322.7, b: 253.6, a: 715.8, });
+} catch {}
+try {
+renderPassEncoder109.setVertexBuffer(6, buffer18, 232);
+} catch {}
+try {
+renderBundleEncoder26.draw(29, 238, 1_405_348_055, 904_968_577);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer43, 1_256);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline14);
+} catch {}
+try {
+device1.queue.submit([commandBuffer209]);
+} catch {}
+let imageData45 = new ImageData(16, 148);
+let commandEncoder393 = device1.createCommandEncoder({label: '\u0c44\u{1f93f}\u0330'});
+let texture134 = device1.createTexture({size: {width: 41}, sampleCount: 1, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder101 = commandEncoder393.beginComputePass();
+let renderBundle215 = renderBundleEncoder14.finish({label: '\u{1f600}\uf3e3\uc696\u15f0\ueb40\uf6cf\u3664\ua99d\u091a'});
+try {
+renderPassEncoder89.beginOcclusionQuery(2);
+} catch {}
+try {
+renderBundleEncoder26.draw(1, 108, 204_852_910, 419_408_681);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(8, 581, 16, -1_885_542_565, 311_243_693);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer36, 'uint16', 3_668);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+renderPassEncoder45.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder91.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer10, 1_684, 7);
+} catch {}
+try {
+computePassEncoder76.insertDebugMarker('\u4d13');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(3_592), /* required buffer size: 3_592 */
+{offset: 407, bytesPerRow: 91, rowsPerImage: 35}, {width: 17, height: 0, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(img4);
+let renderBundle216 = renderBundleEncoder9.finish();
+try {
+computePassEncoder96.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer37, 'uint32', 392, 682);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let promise67 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video4);
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({label: '\u{1f60e}\u8cd3\u70d7', colorFormats: ['r16sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder55.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder71.end();
+} catch {}
+try {
+renderPassEncoder88.beginOcclusionQuery(40);
+} catch {}
+try {
+renderBundleEncoder26.draw(407, 98, 342_319_698, 765_553_802);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(0, 162, 0, 163_002_501, 1_074_244_767);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer43, 416);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(1, buffer18);
+} catch {}
+try {
+renderPassEncoder119.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder119.setViewport(22.4415415133993, 0.792003718687646, 165.92185886421754, 0.1635657241434071, 0.3131754577875414, 0.7965165205517628);
+} catch {}
+try {
+renderPassEncoder116.setVertexBuffer(2, buffer57, 0, 1_881);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(4, buffer57, 0, 1_997);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+computePassEncoder50.setBindGroup(1, bindGroup4, new Uint32Array(516), 187, 0);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder106.setVertexBuffer(3, buffer18);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(5, buffer18, 2_896);
+} catch {}
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3104 */
+  offset: 3104,
+  bytesPerRow: 256,
+  rowsPerImage: 110,
+  buffer: buffer18,
+}, {
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 3, y: 2, z: 12},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule15 = device2.createShaderModule({
+  label: '\u0d55\u00e7\u03ce\u02fd',
+  code: `
+enable f16;
+enable f16;
+
+struct T0 {
+  f0: array<array<mat3x2h, 1>, 1>,
+  f1: atomic<i32>,
+}
+
+@group(0) @binding(349) var sam16: sampler;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f42: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(5) @interpolate(flat, sample) f0: u32,
+  @location(1) @interpolate(linear) f1: vec4f,
+  @location(3) @interpolate(flat) f2: vec4u,
+  @location(2) @interpolate(flat, center) f3: vec2u,
+  @location(0) f4: vec3f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f4 = vec3f(0.03335, 0.1406, 0.2583);
+  return out;
+}
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder54.draw(11, 270, 228_461_886, 136_096_367);
+} catch {}
+try {
+renderPassEncoder49.drawIndexed(0, 115, 4, 198_865_626, 918_810_214);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer47, 'uint16', 2_728, 323);
+} catch {}
+try {
+renderPassEncoder116.setVertexBuffer(2, buffer57);
+} catch {}
+let bindGroupLayout53 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 162, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 51,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 328,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder394 = device0.createCommandEncoder();
+let commandBuffer218 = commandEncoder394.finish({label: '\uc746\ua490\u8a0c\u7326\ue3ff\ueb6a\uaefc\ue48f'});
+let renderBundle217 = renderBundleEncoder8.finish({label: '\u0170\u{1f8df}\u{1ffda}\u0d46\u3ca2\u{1fd75}\u6378\u5ffc\uea63'});
+try {
+renderPassEncoder87.setPipeline(pipeline13);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let bindGroupLayout54 = device0.createBindGroupLayout({
+  label: '\u{1ff73}\u9b82\u23a3\ue4fa\ua7b2\u{1ff5e}\u0ff9\u530e',
+  entries: [{binding: 282, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let buffer62 = device0.createBuffer({
+  label: '\u3281\u0dba\u{1fc5c}',
+  size: 11830,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder395 = device0.createCommandEncoder({});
+let renderBundle218 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder57.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle209]);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer2, 'uint32', 4_664, 13_053);
+} catch {}
+let device5 = await adapter8.requestDevice({
+  label: '\u4e8d\u05c5\u0738\u0427\u5a93\u7a60',
+  defaultQueue: {label: '\u{1fbd6}\u07ac'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 12597774, maxStorageBufferBindingSize: 164960875},
+});
+try {
+window.someLabel = computePassEncoder97.label;
+} catch {}
+let commandBuffer219 = commandEncoder115.finish({label: '\u8115\ud0f0\u62a3\uf3f6\ufaf6\u4db9\u0be7\u0333\u{1f691}'});
+try {
+computePassEncoder49.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder106.setBindGroup(1, bindGroup4, new Uint32Array(2857), 367, 0);
+} catch {}
+try {
+renderPassEncoder88.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer43, 668);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer43, 20);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer36, 'uint16', 1_162, 1_083);
+} catch {}
+let bindGroupLayout55 = device4.createBindGroupLayout({
+  label: '\u0cb4\uaa88\u1475\ufc9c\u8417\ud6c5',
+  entries: [
+    {binding: 234, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 260,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 27,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 568,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 483, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 778, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 50,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 115,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 109, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 336,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 86, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 182,
+      visibility: 0,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 413,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 117, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 140, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 82,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 105, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 126,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {binding: 94, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 4, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 220,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 723,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 361, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 338,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 159,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 316, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 20059151, hasDynamicOffset: false },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 9, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 999,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 213,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 107, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 566,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let pipelineLayout46 = device4.createPipelineLayout({label: '\u0064\u39c6\ud0c9\u089c', bindGroupLayouts: [bindGroupLayout55]});
+try {
+  await buffer55.mapAsync(GPUMapMode.WRITE, 624);
+} catch {}
+let commandEncoder396 = device1.createCommandEncoder({label: '\u9f96\uf5e5\u044d\u{1f783}\ue148\u{1f7e2}\ua88f'});
+let renderPassEncoder122 = commandEncoder396.beginRenderPass({
+  label: '\ua991\u79ad\u{1fae3}\u{1fefa}\ud65d\u1bca\u723f\u17f1\u840b\u{1ff9e}',
+  colorAttachments: [{
+  view: textureView44,
+  depthSlice: 39,
+  clearValue: { r: 960.9, g: 150.0, b: 171.1, a: -150.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder89.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer18, 'uint16', 2_710, 1_046);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(0, 90, 0, -2_131_376_529, 433_532_360);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer43, 2_296);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer43, 280);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let commandEncoder397 = device2.createCommandEncoder({label: '\u70ad\uda83\u85cd\u0f56\ue045\u0b63\u1ee9\uee31\u0790\u{1fa0c}'});
+let commandBuffer220 = commandEncoder397.finish({label: '\u{1f7b4}\u2842\u42e3\u0f05'});
+let renderBundle219 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder68.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder54.draw(17, 328, 354_484_285, 384_375_590);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer47, 'uint16', 300, 286);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer53, 'uint32', 1_348, 591);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let promise68 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise67;
+} catch {}
+let bindGroupLayout56 = device5.createBindGroupLayout({
+  label: '\u9da4\u0326\u7388\u5783',
+  entries: [
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout47 = device5.createPipelineLayout({bindGroupLayouts: [bindGroupLayout56, bindGroupLayout56]});
+let buffer63 = device5.createBuffer({
+  label: '\u1ede\uf10f\u6f1a\u063d\u99e0\ueaba\u3da8\uee4d\u7dbb\u66f7\u2a9c',
+  size: 3917,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder398 = device5.createCommandEncoder({label: '\ud2bd\u6d6c'});
+let commandBuffer221 = commandEncoder398.finish({});
+let texture135 = device5.createTexture({
+  size: {width: 990, height: 20, depthOrArrayLayers: 1},
+  format: 'astc-10x10-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+device5.pushErrorScope('internal');
+} catch {}
+document.body.prepend(canvas3);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder49.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder90.end();
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(4, buffer18);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer43, 1_220);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer36, 'uint16', 1_118, 686);
+} catch {}
+let commandEncoder399 = device1.createCommandEncoder({label: '\u2e6d\ubb15\u0b6c\u38a6\u0447\u0e6f\u36a5\u{1fb9f}\u{1f759}\u08c5'});
+let commandBuffer222 = commandEncoder399.finish({label: '\u0d08\u438e\u{1fbb9}\u4a4e\u0ffb\uc558\u069e\u6fda\ua495\u3bfa'});
+let renderBundle220 = renderBundleEncoder17.finish({label: '\u51ce\u{1f901}\u0c03\u78ad\u{1fcc1}\u{1f6c1}\uc08c\u0642\u0577\u16d8\u519d'});
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup5, new Uint32Array(784), 105, 0);
+} catch {}
+try {
+renderPassEncoder106.setVertexBuffer(7, buffer18, 1_104);
+} catch {}
+try {
+renderBundleEncoder26.draw(94, 3, 272_823_031, 910_877_401);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer43, 316);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(2, buffer18, 2_880, 2_295);
+} catch {}
+document.body.prepend(canvas1);
+let commandBuffer223 = commandEncoder391.finish({label: '\u71b0\u73e1\uf23e\u0536\u2726\ua8ef\u06b2\uea2b'});
+let externalTexture44 = device4.importExternalTexture({
+  label: '\u7a4d\u90a0\u8eff\u0acc\u724d\u{1fe76}\u01a6\ude04\ud987\u1344\u14e9',
+  source: video1,
+  colorSpace: 'srgb',
+});
+let promise69 = device4.queue.onSubmittedWorkDone();
+let shaderModule16 = device5.createShaderModule({
+  label: '\u037a\u{1fcb9}\ubdf9\uadc9\uddd1\u041e\u0c82',
+  code: `
+enable f16;
+
+struct T0 {
+  f0: array<vec2i>,
+}
+struct T1 {
+  f0: T0,
+}
+
+@group(0) @binding(58) var<uniform> buffer64: array<mat3x2h, 1>;
+@group(1) @binding(58) var<uniform> buffer65: vec3u;
+
+@compute @workgroup_size(1, 3, 2)
+fn compute0() {
+}
+
+struct VertexOutput0 {
+  @builtin(position) f43: vec4f
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  _ = buffer65;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(4) @interpolate(flat) f0: vec4f,
+  @location(0) f1: vec4f
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  return out;
+}
+`,
+  hints: {},
+});
+let commandEncoder400 = device5.createCommandEncoder({});
+let renderBundleEncoder43 = device5.createRenderBundleEncoder({
+  label: '\u0498\u{1f967}\u9f3c\u7ece\u{1f818}\u6323\u490e',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle221 = renderBundleEncoder37.finish();
+try {
+renderPassEncoder119.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer57, 6412, new Float32Array(24217), 7922, 64);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 270daeeb394a9b84814b54364333dfd19a310e39
<pre>
[WebGPU] Validation error in RenderBundleEncoder::drawIndexed
<a href="https://bugs.webkit.org/show_bug.cgi?id=278049">https://bugs.webkit.org/show_bug.cgi?id=278049</a>
<a href="https://rdar.apple.com/133788434">rdar://133788434</a>

Reviewed by Dan Glastonbury.

Index buffer size must be &gt;= indexCount * indexSize + indexOffsetInBytes.

* LayoutTests/fast/webgpu/nocrash/fuzz-278049-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-278049.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::drawIndexed):

Canonical link: <a href="https://commits.webkit.org/282594@main">https://commits.webkit.org/282594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4862fd1edd87d396db4c7ed1759dc4dfa6b1b8f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14184 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51195 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9814 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13056 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69293 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12324 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55133 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6276 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38753 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->