### PR TITLE
[Navigation] Reject intercepted navigations with the correct caught exception

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: TypeError: a message
 
 Harness Error (FAIL), message = TypeError: a message
 
-FAIL event.intercept() should abort if the handler throws assert_true: expected true got false
+PASS event.intercept() should abort if the handler throws
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6969,7 +6969,7 @@ sub GenerateCallbackImplementationContent
                 push(@$contentRef, "        UNUSED_PARAM(lexicalGlobalObject);\n");
                 push(@$contentRef, "        reportException(m_data->callback()->globalObject(), returnedException);\n");
             }
-            push(@$contentRef, "        return CallbackResultType::ExceptionThrown;\n");
+            push(@$contentRef, "        return returnedException.get();\n");
             push(@$contentRef, "     }\n\n");
 
             if ($operation->type->name eq "undefined") {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -73,7 +73,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -73,7 +73,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
@@ -76,7 +76,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     if (returnedException) {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwException(&lexicalGlobalObject, throwScope, returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -77,7 +77,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunction
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -78,7 +78,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunction
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -74,7 +74,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -210,7 +210,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };
@@ -238,7 +238,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };
@@ -267,7 +267,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };
@@ -295,7 +295,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };
@@ -323,7 +323,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };
@@ -352,7 +352,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };
@@ -379,7 +379,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -411,7 +411,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwException(&lexicalGlobalObject, throwScope, returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -443,7 +443,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterfac
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -79,7 +79,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunc
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -90,7 +90,7 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunc
     if (returnedException) {
         UNUSED_PARAM(lexicalGlobalObject);
         reportException(m_data->callback()->globalObject(), returnedException);
-        return CallbackResultType::ExceptionThrown;
+        return returnedException.get();
      }
 
     return { };

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -816,9 +816,8 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
             if (callbackResult.type() == CallbackResultType::Success)
                 promiseList.append(callbackResult.releaseReturnValue());
             else if (callbackResult.type() == CallbackResultType::ExceptionThrown) {
-                // FIXME: We need to keep around the failure reason but the generated handleEvent() catches and consumes it.
                 auto promiseAndWrapper = createPromiseAndWrapper(*document);
-                promiseAndWrapper.second->reject(ExceptionCode::TypeError);
+                promiseAndWrapper.second->reject<IDLAny>(callbackResult.exceptionObject().value());
                 promiseList.append(WTFMove(promiseAndWrapper.first));
             }
         }


### PR DESCRIPTION
#### 6319cfbc35ff0f71679fc01f0846cbfeea3b009d
<pre>
[Navigation] Reject intercepted navigations with the correct caught exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=278486">https://bugs.webkit.org/show_bug.cgi?id=278486</a>

Reviewed by NOBODY (OOPS!).

We store the exception from JS so it now has the correct type and information
such as lineno.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
(WebCore::JSTestCallbackFunction::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
(WebCore::JSTestCallbackFunctionGenerateIsReachable::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp:
(WebCore::JSTestCallbackFunctionRethrow::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
(WebCore::JSTestCallbackFunctionWithThisObject::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
(WebCore::JSTestCallbackFunctionWithTypedefs::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
(WebCore::JSTestCallbackFunctionWithVariadic::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::JSTestCallbackInterface::callbackWithNoParam):
(WebCore::JSTestCallbackInterface::callbackWithArrayParam):
(WebCore::JSTestCallbackInterface::callbackWithSerializedScriptValueParam):
(WebCore::JSTestCallbackInterface::callbackWithStringList):
(WebCore::JSTestCallbackInterface::callbackWithBoolean):
(WebCore::JSTestCallbackInterface::callbackRequiresThisToPass):
(WebCore::JSTestCallbackInterface::callbackWithAReturnValue):
(WebCore::JSTestCallbackInterface::callbackThatRethrowsExceptions):
(WebCore::JSTestCallbackInterface::callbackWithThisObject):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
(WebCore::JSTestCallbackWithFunctionOrDict::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
(WebCore::JSTestVoidCallbackFunction::handleEvent):
* Source/WebCore/dom/CallbackResult.h:
(WebCore::CallbackResult&lt;ReturnType&gt;::CallbackResult):
(WebCore::CallbackResult&lt;ReturnType&gt;::exceptionObject const):
(WebCore::CallbackResult&lt;void&gt;::CallbackResult):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6319cfbc35ff0f71679fc01f0846cbfeea3b009d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52403 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10962 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13836 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59775 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14176 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59731 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56526 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60006 "Found 10 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hypertext/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/action/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/basic-hierarchy, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/table/basic (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14379 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1265 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40405 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->