### PR TITLE
WebExtensionContext should track runtime errors separate from WebExtension errors.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
@@ -240,7 +240,11 @@ using namespace WebKit;
 - (LocalizationDictionary *)_localizationDictionaryForWebExtension:(WebExtension&)webExtension withLocale:(NSString *)localeString
 {
     auto *path = [NSString stringWithFormat:pathToJSONFile, localeString];
-    auto *data = [NSData dataWithData:webExtension.resourceDataForPath(path, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)];
+
+    NSError *error;
+    NSData *data = [NSData dataWithData:webExtension.resourceDataForPath(path, &error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)];
+    webExtension.recordErrorIfNeeded(error);
+
     return parseJSON(data);
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
@@ -63,10 +63,6 @@ typedef NS_ERROR_ENUM(WKWebExtensionErrorDomain, WKWebExtensionError) {
     WKWebExtensionErrorInvalidBackgroundPersistence,
 } NS_SWIFT_NAME(WKWebExtension.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-/*! @abstract This notification is sent whenever a ``WKWebExtension`` has new errors or errors were cleared. */
-WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_EXTERN NSNotificationName const WKWebExtensionErrorsWereUpdatedNotification NS_SWIFT_NAME(WKWebExtension.errorsWereUpdatedNotification) NS_SWIFT_NONISOLATED;
-
 /*!
  @abstract A ``WKWebExtension`` object encapsulates a web extension’s resources that are defined by a `manifest.json`` file.
  @discussion This class handles the reading and parsing of the manifest file along with the supporting resources like icons and localizations.
@@ -92,8 +88,11 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 + (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
- @abstract The active errors for the extension.
- @discussion Provides an array of error objects if there are any errors, or an empty array if there are no errors.
+ @abstract An array of all errors that occurred during the processing of the extension.
+ @discussion Provides an array of all parse-time errors for the extension, with repeat errors consolidated into a single entry for the original
+ occurrence only. If no errors occurred, an empty array is returned.
+ @note Once the extension is loaded, use the ``errors`` property on an extension context to monitor any runtime errors, as they can occur
+ after the extension is loaded.
  */
 @property (nonatomic, readonly, copy) NSArray<NSError *> *errors;
 
@@ -199,7 +198,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 /*!
  @abstract A Boolean value indicating whether the extension has script or stylesheet content that can be injected into webpages.
  @discussion If this property is `YES`, the extension has content that can be injected by matching against the extension's requested match patterns.
- @note Once the extension is loaded, use the ``hasInjectedContent`` property on the extension context, as the injectable content can change after the extension is loaded.
+ @note Once the extension is loaded, use the ``hasInjectedContent`` property on an extension context, as the injectable content can change after the extension is loaded.
  */
 @property (nonatomic, readonly) BOOL hasInjectedContent;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -36,7 +36,6 @@
 #import "WebExtension.h"
 
 NSErrorDomain const WKWebExtensionErrorDomain = @"WKWebExtensionErrorDomain";
-NSNotificationName const WKWebExtensionErrorsWereUpdatedNotification = @"WKWebExtensionErrorsWereUpdated";
 
 @implementation WKWebExtension
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h
@@ -68,6 +68,10 @@ typedef NS_ERROR_ENUM(WKWebExtensionContextErrorDomain, WKWebExtensionContextErr
     WKWebExtensionContextErrorBackgroundContentFailedToLoad,
 } NS_SWIFT_NAME(WKWebExtensionContext.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+/*! @abstract This notification is sent whenever a ``WKWebExtensionContext`` has new errors or errors were cleared. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_EXTERN NSNotificationName const WKWebExtensionContextErrorsDidUpdateNotification NS_SWIFT_NAME(WKWebExtensionContext.errorsDidUpdateNotification) NS_SWIFT_NONISOLATED;
+
 /*!
  @abstract Constants used to indicate permission status in ``WKWebExtensionContext``.
  @constant WKWebExtensionContextPermissionStatusDeniedExplicitly  Indicates that the permission was explicitly denied.
@@ -166,6 +170,13 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*! @abstract A Boolean value indicating if this context is loaded in an extension controller. */
 @property (nonatomic, readonly, getter=isLoaded) BOOL loaded;
+
+/*!
+ @abstract All errors that occurred in the extension context.
+ @discussion Provides an array of all parse-time and runtime errors for the extension and extension context, with repeat errors
+ consolidated into a single entry for the original occurrence. If no errors occurred, an empty array is returned.
+ */
+@property (nonatomic, readonly, copy) NSArray<NSError *> *errors;
 
 /*!
  @abstract The base URL the context uses for loading extension resources or injecting content into webpages.
@@ -529,7 +540,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
 
 /*!
  @abstract Loads the background content if needed for the extension.
- @param completionHandler A block to be called upon completion of the loading process, with an optional error object.
+ @param completionHandler A block to be called upon completion of the loading process, with an optional error.
  @discussion This method forces the loading of the background content for the extension that will otherwise be loaded on-demand during specific events.
  It is useful when the app requires the background content to be loaded for other reasons. If the background content is already loaded, the completion handler
  will be called immediately. An error will occur if the extension does not have any background content to load or loading fails.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -47,6 +47,7 @@
 #import <wtf/cocoa/VectorCocoa.h>
 
 NSErrorDomain const WKWebExtensionContextErrorDomain = @"WKWebExtensionContextErrorDomain";
+NSNotificationName const WKWebExtensionContextErrorsDidUpdateNotification = @"WKWebExtensionContextErrorsDidUpdate";
 
 NSNotificationName const WKWebExtensionContextPermissionsWereGrantedNotification = @"WKWebExtensionContextPermissionsWereGranted";
 NSNotificationName const WKWebExtensionContextPermissionsWereDeniedNotification = @"WKWebExtensionContextPermissionsWereDenied";
@@ -105,6 +106,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 - (BOOL)isLoaded
 {
     return _webExtensionContext->isLoaded();
+}
+
+-(NSArray<NSError *> *)errors
+{
+    return _webExtensionContext->errors();
 }
 
 - (NSURL *)baseURL
@@ -873,6 +879,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWeb
 - (BOOL)isLoaded
 {
     return NO;
+}
+
+-(NSArray<NSError *> *)errors
+{
+    return nil;
 }
 
 - (NSURL *)baseURL

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
@@ -157,7 +157,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context within which the web extension is running.
  @param completionHandler A block to be called once the popup display operation is completed.
  @discussion This method is called in response to the extension's scripts or when invoking ``performActionForTab:`` if the action has a popup.
- The associated tab, if applicable, can be located through the ``associatedTab`` property of the `action` parameter. This delegate method is
+ The associated tab, if applicable, can be located through the ``associatedTab`` property of the ``action`` parameter. This delegate method is
  called when the web view for the popup is fully loaded and ready to display. Implementing this method is needed if the app intends to support
  programmatically showing the popup by the extension, although it is recommended for handling both programmatic and user-initiated cases.
  */
@@ -182,8 +182,8 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param controller The web extension controller that is managing the extension.
  @param extensionContext The context in which the web extension is running.
  @param port A port object for handling the message exchange.
- @param completionHandler A block to be called when the connection is ready to use, taking an optional error object
- as a parameter. If the connection is successfully established, the error parameter should be \c nil.
+ @param completionHandler A block to be called when the connection is ready to use, taking an optional error.
+ If the connection is successfully established, the error should be \c nil.
  @discussion This method should be implemented by the app to handle establishing connections to applications.
  The provided ``WKWebExtensionPort`` object can be used to handle message sending, receiving, and disconnection.
  You should retain the port object for as long as the connection remains active. Releasing the port will disconnect it.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
@@ -64,13 +64,13 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MessagePort)
 
 /*!
  @abstract The block to be executed when a message is received from the web extension.
- @discussion The block takes two parameters: the message and an optional error object in case of an error.
+ @discussion An optional block to be invoked when a message is received, taking two parameters: the message and an optional error.
  */
 @property (nonatomic, copy, nullable) void (^messageHandler)(id _Nullable message, NSError * _Nullable error);
 
 /*!
  @abstract The block to be executed when the port disconnects.
- @discussion This block has one parameter: an optional error object in case an error caused the disconnection.
+ @discussion An optional block to be invoked when the port disconnects, taking an optional error that indicates if the disconnection was caused by an error.
  */
 @property (nonatomic, copy, nullable) void (^disconnectHandler)(NSError * _Nullable error);
 
@@ -80,7 +80,7 @@ WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.MessagePort)
 /*!
  @abstract Sends a message to the connected web extension.
  @param message The JSON-serializable message to be sent.
- @param completionHandler An optional block to be invoked after the message is sent, taking an optional error object.
+ @param completionHandler An optional block to be invoked after the message is sent, taking an optional error.
  @note The message must be JSON-serializable according to ``NSJSONSerialization``.
  */
 - (void)sendMessage:(nullable id)message completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(sendMessage(_:completionHandler:));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -49,7 +49,7 @@
 
 NSErrorDomain const _WKWebExtensionErrorDomain = @"WKWebExtensionErrorDomain";
 
-NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"WKWebExtensionErrorsWereUpdated";
+NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"WKWebExtensionContextErrorsDidUpdate";
 
 #undef _WKWebExtension
 @implementation _WKWebExtension

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -589,14 +589,14 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
             scriptData = SourcePair { parameters.code.value(), URL { } };
         else {
             NSString *filePath = parameters.files.value().first();
-            scriptData = sourcePairForResource(filePath, m_extension);
+            scriptData = sourcePairForResource(filePath, *this);
             if (!scriptData) {
                 completionHandler(toWebExtensionError(apiName, nil, @"Invalid resource: %@", filePath));
                 return;
             }
         }
 
-        auto scriptPairs = getSourcePairsForParameters(parameters, m_extension);
+        auto scriptPairs = getSourcePairsForParameters(parameters, *this);
         executeScript(scriptPairs, webView, *m_contentScriptWorld, *tab, parameters, *this, [completionHandler = WTFMove(completionHandler)](InjectionResults&& injectionResults) mutable {
             completionHandler(WTFMove(injectionResults));
         });
@@ -628,7 +628,7 @@ void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdent
         // FIXME: <https://webkit.org/b/262491> There is currently no way to inject CSS in specific frames based on ID's. If 'frameIds' is passed, default to the main frame.
         auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
-        auto styleSheetPairs = getSourcePairsForParameters(parameters, m_extension);
+        auto styleSheetPairs = getSourcePairsForParameters(parameters, *this);
         injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, parameters.styleLevel, injectedFrames, *this);
 
         completionHandler({ });
@@ -657,7 +657,7 @@ void WebExtensionContext::tabsRemoveCSS(WebPageProxyIdentifier webPageProxyIdent
     // FIXME: <https://webkit.org/b/262491> There is currently no way to inject CSS in specific frames based on ID's. If 'frameIds' is passed, default to the main frame.
     auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
-    auto styleSheetPairs = getSourcePairsForParameters(parameters, m_extension);
+    auto styleSheetPairs = getSourcePairsForParameters(parameters, *this);
     removeStyleSheets(styleSheetPairs, webView, injectedFrames, *this);
 
     completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -646,8 +646,11 @@ CocoaImage *WebExtensionAction::icon(CGSize idealSize)
         return nil;
 
     if (m_customIcons) {
-        if (CocoaImage *result = extensionContext()->extension().bestImageInIconsDictionary(m_customIcons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height))
+        NSError *error;
+        if (CocoaImage *result = extensionContext()->extension().bestImageInIconsDictionary(m_customIcons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height, &error))
             return result;
+
+        extensionContext()->recordErrorIfNeeded(error);
 
         // If custom icons fail, fallback to the default icons.
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -331,7 +331,11 @@ CocoaImage *WebExtensionMenuItem::icon(CGSize idealSize) const
 {
     ASSERT(extensionContext());
 
-    return extensionContext()->extension().bestImageInIconsDictionary(m_icons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height);
+    NSError *error;
+    auto *result = extensionContext()->extension().bestImageInIconsDictionary(m_icons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height, &error);
+    extensionContext()->recordErrorIfNeeded(error);
+
+    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -104,8 +104,10 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
             loadingExtensionMainFrame = true;
         }
 
-        auto *fileData = extensionContext->extension().resourceDataForPath(requestURL.path().toString());
+        NSError *error;
+        auto *fileData = extensionContext->extension().resourceDataForPath(requestURL.path().toString(), &error);
         if (!fileData) {
+            extensionContext->recordError(error);
             task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil]);
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -82,7 +82,6 @@ public:
     ~WebExtension() { }
 
     enum class CacheResult : bool { No, Yes };
-    enum class SuppressNotification : bool { No, Yes };
     enum class SuppressNotFoundErrors : bool { No, Yes };
 
     enum class Error : uint8_t {
@@ -209,12 +208,10 @@ public:
 
     bool isWebAccessibleResource(const URL& resourceURL, const URL& pageURL);
 
-    NSURL *resourceFileURLForPath(NSString *);
-
     UTType *resourceTypeForPath(NSString *);
 
-    NSString *resourceStringForPath(NSString *, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
-    NSData *resourceDataForPath(NSString *, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
+    NSString *resourceStringForPath(NSString *, NSError **, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
+    NSData *resourceDataForPath(NSString *, NSError **, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
 
     _WKWebExtensionLocalization *localization();
     NSLocale *defaultLocale();
@@ -243,10 +240,10 @@ public:
     NSString *sidebarTitle();
 #endif
 
-    CocoaImage *imageForPath(NSString *);
+    CocoaImage *imageForPath(NSString *, NSError **);
 
     NSString *pathForBestImageInIconsDictionary(NSDictionary *, size_t idealPixelSize);
-    CocoaImage *bestImageInIconsDictionary(NSDictionary *, size_t idealPointSize);
+    CocoaImage *bestImageInIconsDictionary(NSDictionary *, size_t idealPointSize, NSError **);
     CocoaImage *bestImageForIconsDictionaryManifestKey(NSDictionary *, NSString *manifestKey, CGSize idealSize, RetainPtr<CocoaImage>& cacheLocation, Error, NSString *customLocalizedDescription);
 
     bool hasBackgroundContent();
@@ -297,11 +294,8 @@ public:
     MatchPatternSet allRequestedMatchPatterns();
 
     NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
-
-    // If an error can't be synchronously determined by one of the populate methods in the errors() getter,
-    // then the caller of recordError() should pass SuppressNotification::No.
-    void recordError(NSError *, SuppressNotification = SuppressNotification::Yes);
-    void removeError(Error, SuppressNotification = SuppressNotification::No);
+    void recordErrorIfNeeded(NSError *error) { if (error) recordError(error); }
+    void recordError(NSError *);
 
     NSArray *errors();
 
@@ -329,6 +323,8 @@ private:
     void populateSidebarActionProperties(RetainPtr<NSDictionary>);
     void populateSidePanelProperties(RetainPtr<NSDictionary>);
 #endif
+
+    NSURL *resourceFileURLForPath(NSString *);
 
     std::optional<WebExtension::DeclarativeNetRequestRulesetData> parseDeclarativeNetRequestRulesetDictionary(NSDictionary *, NSError **);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -272,6 +272,11 @@ public:
     bool operator==(const WebExtensionContext& other) const { return (this == &other); }
 
     NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
+    void recordErrorIfNeeded(NSError *error) { if (error) recordError(error); }
+    void recordError(NSError *);
+    void clearError(Error);
+
+    NSArray *errors();
 
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     const String& storageDirectory() const { return m_storageDirectory; }
@@ -898,6 +903,7 @@ private:
     String m_storageDirectory;
 
     RetainPtr<NSMutableDictionary> m_state;
+    RetainPtr<NSMutableArray> m_errors;
 
     RefPtr<WebExtension> m_extension;
     WeakPtr<WebExtensionController> m_extensionController;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -105,8 +105,8 @@ private:
     void removeUserScripts(const String& identifier);
 };
 
-std::optional<SourcePair> sourcePairForResource(String path, RefPtr<WebExtension>);
-SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParameters&, RefPtr<WebExtension>);
+std::optional<SourcePair> sourcePairForResource(String path, WebExtensionContext&);
+SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParameters&, WebExtensionContext&);
 Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *, std::optional<Vector<WebExtensionFrameIdentifier>>);
 
 void executeScript(const SourcePairs&, WKWebView *, API::ContentWorld&, WebExtensionTab&, const WebExtensionScriptInjectionParameters&, WebExtensionContext&, CompletionHandler<void(InjectionResults&&)>&&);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
@@ -64,6 +64,12 @@
             ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--gtest_filter=WKWebExtensionContext.LoadNonExistentImage"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
#### abd52ae8bb5205b6dac4fcdeb5f28b21b18f9b40
<pre>
WebExtensionContext should track runtime errors separate from WebExtension errors.
<a href="https://webkit.org/b/270580">https://webkit.org/b/270580</a>
<a href="https://rdar.apple.com/problem/124147806">rdar://problem/124147806</a>

Reviewed by Jeff Miller.

Track runtime errors at the context level to account for varying conditions across multiple
extension contexts. Extension errors now exclusively reflect manifest and parse-time issues,
ensuring they remain consistent regardless of runtime behavior.

This change moves the existing WKWebExtension errors update notification to WKWebExtensionContext,
where it now fires for context objects. The dynamic errors for resource loading now get returned
to the caller to record, so it can be recorded on the correct object (context or extension).

Make the errors property KVO compliant as well.

* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm:
(-[_WKWebExtensionLocalization _localizationDictionaryForWebExtension:withLocale:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext errors]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript):
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::scriptingRemoveCSS):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::icon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::manifest):
(WebKit::WebExtension::resourceStringForPath):
(WebKit::WebExtension::resourceDataForPath):
(WebKit::WebExtension::recordError):
(WebKit::WebExtension::errors):
(WebKit::WebExtension::populateActionPropertiesIfNeeded):
(WebKit::WebExtension::imageForPath):
(WebKit::WebExtension::bestImageInIconsDictionary):
(WebKit::WebExtension::bestImageForIconsDictionaryManifestKey):
(WebKit::WebExtension::removeError): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::recordError): Added.
(WebKit::WebExtensionContext::clearError): Added.
(WebKit::WebExtensionContext::errors): Added.
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::didFailNavigation):
(WebKit::WebExtensionContext::addInjectedContent):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::sourcePairForResource):
(WebKit::WebExtensionDynamicScripts::getSourcePairsForParameters):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::icon const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::recordErrorIfNeeded): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::recordErrorIfNeeded): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, CommandsParsing)): Use errors on the context.
(TestWebKitAPI::TEST(WKWebExtensionContext, LoadNonExistentImage)): Added.

Canonical link: <a href="https://commits.webkit.org/282755@main">https://commits.webkit.org/282755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c869e6054fa248437e088f9d15b333b7633109f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63715 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14323 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51331 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9901 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66784 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39922 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31963 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36603 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.sharedworker.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58607 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58823 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6368 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9712 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38892 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->