### PR TITLE
[css-masonry] Update masonry-gap-002-ref.html to align with test case behavior

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1694,8 +1694,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/baseline/masonry-
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-002.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002.html [ ImageOnlyFailure ]
-
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002-expected.html
@@ -4,17 +4,18 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <html><head>
-  <meta charset="utf-8">
-  <title>Reference: Masonry layout with definite `gap` in both axes</title>
-  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-  <style>
+<meta charset="utf-8">
+<title>Reference: Masonry layout with normal `gap` in both axes</title>
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+<link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
+<style>
 html,body {
   color:black; background-color:white; font:25px/1 "Courier New", monospace; padding:0; margin:0;
 }
 
 grid {
   display: inline-grid;
-  gap: 10px 20px;
+  gap: 0;
   grid-template-columns: auto min-content repeat(2,auto);
   color: #444;
   border: 1px solid;
@@ -29,6 +30,7 @@ item {
   border: 5px solid blue;
   place-self: start;
   grid-row: span 2;
+  display: block;
 }
 </style>
 </head>
@@ -41,3 +43,35 @@ item {
   <item>4</item>
   <item style="padding:0; grid-column: 2; grid-row: 2">5</item>
 </grid>
+
+<grid>
+  <item>1</item>
+  <item style="padding:0; grid-row: span 1">2</item>
+  <item>3</item>
+  <item>4</item>
+  <item style="padding:0; grid-column: 2; grid-row: 2">5</item>
+</grid>
+
+<grid>
+  <div style="columns: 3; column-gap: 1em;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+  <div style="columns: 3; column-gap: 1em; visibility: hidden;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+  <div style="columns: 3; column-gap: 1em; visibility: hidden;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+  <div style="columns: 3; column-gap: 1em; visibility: hidden;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+</grid>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002-ref.html
@@ -4,11 +4,11 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <html><head>
-  <meta charset="utf-8">
-  <title>Reference: Masonry layout with normal `gap` in both axes</title>
-  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-  <link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
-  <style>
+<meta charset="utf-8">
+<title>Reference: Masonry layout with normal `gap` in both axes</title>
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+<link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
+<style>
 html,body {
   color:black; background-color:white; font:25px/1 "Courier New", monospace; padding:0; margin:0;
 }
@@ -54,6 +54,21 @@ item {
 
 <grid>
   <div style="columns: 3; column-gap: 1em;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+  <div style="columns: 3; column-gap: 1em; visibility: hidden;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+  <div style="columns: 3; column-gap: 1em; visibility: hidden;">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </div>
+  <div style="columns: 3; column-gap: 1em; visibility: hidden;">
     <item>1</item>
     <item>2</item>
     <item>3</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002.html
@@ -4,18 +4,19 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <html><head>
-  <meta charset="utf-8">
-  <title>CSS Grid Test: Masonry layout with normal `gap` in both axes</title>
-  <meta name="assert"
-        content="Test passes if a 'normal' gap is the initial value,
-                 is resolved to zero,
-                 does not allow margin collapsing,
-                 and inherits as 'normal' in masonry layout">
-  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-  <link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
-  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#alignment">
-  <link rel="match" href="masonry-gap-001-ref.html">
-  <style>
+<meta charset="utf-8">
+<title>CSS Grid Test: Masonry layout with normal `gap` in both axes</title>
+<meta name="assert"
+      content="Test passes if a 'normal' gap is the initial value,
+               is resolved to zero,
+               does not allow margin collapsing,
+               and inherits as 'normal' in masonry layout">
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+<link rel="author" title="Elika J. Etemad" href="https://fantasai.inkedblade.net/contact">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3/#alignment">
+<link rel="match" href="masonry-gap-002-ref.html">
+
+<style>
 html,body {
   color:black; background-color:white; font:25px/1 "Courier New", monospace; padding:0; margin:0;
 }
@@ -37,7 +38,6 @@ item {
   border: 5px solid blue;
   display: block;
 }
-
 </style>
 </head>
 <body>
@@ -62,7 +62,7 @@ item {
 
 <!-- test inheritance of normal as keyword -->
 
-<grid style="gap: 10px; gap: normal">
+<grid style="gap: 10px; gap: normal;">
   <div style="columns: 3; gap: inherit;">
     <item>1</item>
     <item>2</item>


### PR DESCRIPTION
#### cef8bd5564edda53b9f18e81c3f730a1764db824
<pre>
[css-masonry] Update masonry-gap-002-ref.html to align with test case behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=278489">https://bugs.webkit.org/show_bug.cgi?id=278489</a>
<a href="https://rdar.apple.com/problem/134446346">rdar://problem/134446346</a>

Reviewed by Sammy Gill.

gap-002 was creating 4 columns of &apos;auto&apos;, which in masonry would set all the &apos;auto&apos; tracks to the same size.
We can address this by creating hidden elements in the expected test to emulate this.

-expected test case did not match the -ref test case, so that has been corrected.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-002.html:

Canonical link: <a href="https://commits.webkit.org/282614@main">https://commits.webkit.org/282614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abcbdffe4d9c04ea8179d78cc053248a75ddd79a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14217 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51270 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9835 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69326 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6305 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38786 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39865 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->