### PR TITLE
Improve sidePanel API test coverage.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -98,6 +98,7 @@ private:
     std::optional<RetainPtr<NSDictionary>> m_iconsOverride;
     std::optional<String> m_titleOverride;
     std::optional<String> m_sidebarPathOverride;
+    std::optional<bool> m_isEnabled;
 
     WeakPtr<WebExtensionContext> m_extensionContext;
     const std::optional<Ref<WebExtensionTab>> m_tab;
@@ -106,7 +107,6 @@ private:
     bool m_isOpen { false };
     bool m_opensSidebarWhenReady { false };
     bool m_sidebarOpened { false };
-    bool m_isEnabled { false };
     const IsDefault m_isDefault { IsDefault::No };
 
     RetainPtr<WKWebView> m_webView;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
@@ -75,15 +75,13 @@ static ParseResult parseWindowIdentifier(NSDictionary *options)
 
 static NSDictionary<NSString *, id> *serializeSidebarParameters(WebExtensionSidebarParameters const& parameters)
 {
-    NSDictionary *serializedParameters = @{
-        @"enabled": @(parameters.enabled),
-        @"path": parameters.panelPath,
-    };
+    NSMutableDictionary *serializedParameters = [NSMutableDictionary new];
 
-    if (parameters.tabIdentifier) {
-        NSNumber *tabIdNum = [NSNumber numberWithUnsignedLongLong:parameters.tabIdentifier->toUInt64()];
-        [serializedParameters setValue:tabIdNum forKey:@"tabId"];
-    }
+    serializedParameters[@"enabled"] = @(parameters.enabled);
+    serializedParameters[@"path"] = parameters.panelPath;
+
+    if (parameters.tabIdentifier)
+        serializedParameters[@"tabId"] = @(toWebAPI(parameters.tabIdentifier.value()));
 
     return serializedParameters;
 }


### PR DESCRIPTION
#### 944ca61fed7730e59a563e890753bc5ec8bf4e16
<pre>
Improve sidePanel API test coverage.
<a href="https://webkit.org/b/278485">https://webkit.org/b/278485</a>
<a href="https://rdar.apple.com/134444173">rdar://134444173</a>

Reviewed by Timothy Hatcher.

This patch adds tests which exercise the sidePanel API, especially as
pertaining to the url and enable &quot;properties.&quot; Additionally, this patch
also contains several fixes for bugs which I found while writing these
tests.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(WebKit::WebExtensionSidebar::icon): Lazily evaluate retrieving the
extension&apos;s action icon when no sidebar icon is present
(WebKit::WebExtensionSidebar::title const): Lazily evaluate retrieving
the current sidebar&apos;s parent&apos;s title when the current sidebar has no
title override
(WebKit::WebExtensionSidebar::isEnabled const): Add code to defer to the
current sidebar&apos;s parent&apos;s enablement state rather than assuming every
sidebar will have an enablement state
(WebKit::WebExtensionSidebar::sidebarPath const): Lazily evaluate
retrieving the current sidebar&apos;s parent&apos;s path when the current sidebar
has no path override
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Change type
  of m_isEnabled from bool to std::optional&lt;bool&gt;
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::serializeSidebarParameters): Fix serialization of tab
identifier
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPIGlobalPathPersists)):
Test which ensures that the globally configured sidebar path persists
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPITabPathPersists)):
Test which ensures that per-tab sidebar paths persist
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPIGlobalEnablePersists)):
Test which ensures that the global enablement state persists
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPITabEnablePersists)):
Test which ensure that the per-tab enablement state persists
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPIModifyGlobalPath)):
Test which ensures that the global sidebar path can be modified
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelAPIModifyTabPath)):
Test which ensures that tab-specific sidebar paths can be modified
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelModifyGlobalEnable)):
Test which ensures that the global enablement state can be modified
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelModifyTabEnable)):
Test which ensures that the per-tab enablement state can be modified

Canonical link: <a href="https://commits.webkit.org/282606@main">https://commits.webkit.org/282606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6481bcc0f56256f87ed2cbda345134da14d35a0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51203 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9821 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55159 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58739 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6286 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9628 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38769 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->