### PR TITLE
Reduce use of TestRunner.installStatisticsDidScanDataRecordsCallback

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-mixed-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-mixed-statistics.html
@@ -34,9 +34,8 @@
             testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin2);
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-sub-frame-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-sub-frame-under-top-frame-origins.html
@@ -34,9 +34,8 @@
             testRunner.setStatisticsSubframeUnderTopFrameOrigin(statisticsUrl, topFrameOrigin2);
             testRunner.setStatisticsSubframeUnderTopFrameOrigin(statisticsUrl, topFrameOrigin3);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-under-top-frame-origins.html
@@ -32,9 +32,8 @@
             testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin1);
             testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin2);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-unique-redirects-to.html
@@ -32,9 +32,8 @@
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin2);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-mixed-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-mixed-statistics.html
@@ -43,9 +43,8 @@
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-sub-frame-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-sub-frame-under-top-frame-origins.html
@@ -38,9 +38,8 @@
             testRunner.setStatisticsSubframeUnderTopFrameOrigin(statisticsUrl, topFrameOrigin3);
             testRunner.setStatisticsSubframeUnderTopFrameOrigin(statisticsUrl, topFrameOrigin4);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-to-prevalent.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-to-prevalent.html
@@ -29,8 +29,8 @@
         testRunner.setStatisticsPrevalentResource(topFrameOrigin1, true, async function() {
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-under-top-frame-origins.html
@@ -38,9 +38,8 @@
             testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin3);
             testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin4);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-unique-redirects-to.html
@@ -38,9 +38,8 @@
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin4);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-to-prevalent.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-to-prevalent.html
@@ -29,8 +29,8 @@
         testRunner.setStatisticsPrevalentResource(topFrameOrigin1, true, async function() {
             testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-unique-redirects-to.html
@@ -34,9 +34,8 @@
         testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
         testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin4);
 
-        testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        completeTest();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-very-prevalent-based-on-mixed-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-very-prevalent-based-on-mixed-statistics.html
@@ -50,8 +50,8 @@
                 i += 3;
             }
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            completeTest();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html
@@ -48,9 +48,8 @@
         testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
         testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin3);
 
-        testRunner.installStatisticsDidScanDataRecordsCallback(testStep2);
-
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        testStep2();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html
@@ -48,9 +48,8 @@
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
             testRunner.setStatisticsSubresourceUnderTopFrameOrigin(statisticsUrl, topFrameOrigin3);
 
-            testRunner.installStatisticsDidScanDataRecordsCallback(testStep2);
-
             await testRunner.statisticsProcessStatisticsAndDataRecords();
+            testStep2();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-import-in-worker.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-import-in-worker.html
@@ -20,6 +20,7 @@
             testFailed(event.data.replace("FAIL ", ""));
 
         await testRunner.statisticsNotifyObserver();
+        finishTest();
     }
 
     function runTest() {
@@ -28,7 +29,6 @@
                 if (window.testRunner && window.internals) {
                     testRunner.waitUntilDone();
                     setEnableFeature(true, function() {
-                        testRunner.installStatisticsDidScanDataRecordsCallback(finishTest);
                         document.location.hash = "LoadWorker";
                         runTest();
                     });

--- a/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-loads.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-loads.html
@@ -24,7 +24,6 @@
                 if (window.testRunner && window.internals) {
                     testRunner.waitUntilDone();
                     setEnableFeature(true, function() {
-                        testRunner.installStatisticsDidScanDataRecordsCallback(finishTest);
                         document.location.hash = "step1";
                         runTest();
                     });
@@ -39,6 +38,7 @@
                 break;
             case "#step2":
                 await testRunner.statisticsNotifyObserver();
+                finishTest()
                 break;
         }
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html
@@ -24,7 +24,6 @@
                 if (window.testRunner && window.internals) {
                     testRunner.waitUntilDone();
                     setEnableFeature(true, function() {
-                        testRunner.installStatisticsDidScanDataRecordsCallback(finishTest);
                         document.location.hash = "step1";
                         runTest();
                     });
@@ -39,6 +38,7 @@
                 break;
             case "#step2":
                 await testRunner.statisticsNotifyObserver();
+                finishTest();
                 break;
         }
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html
@@ -58,9 +58,8 @@
         // Set the cookie again to reset its SameSite status.
         document.cookie = "clientSideCookie=1";
 
-        testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        completeTest();
     }
 
     async function runTest() {
@@ -82,9 +81,8 @@
 
         setMultipleTopFrameUniqueRedirectTo(statisticsUrl);
 
-        testRunner.installStatisticsDidScanDataRecordsCallback(secondStep);
-
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        secondStep();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html
@@ -216,8 +216,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html
@@ -216,8 +216,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion-database.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion-database.html
@@ -216,8 +216,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion.html
@@ -216,8 +216,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/grandfathering.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/grandfathering.html
@@ -26,10 +26,8 @@
     }
 
     async function fireDataModificationHandlerAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(function() {
-            runTest();
-        });
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        runTest();
     }
 
     function clearInMemoryAndPersistentStoreAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/many-inserts-only-insert-once.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/many-inserts-only-insert-once.html
@@ -50,8 +50,8 @@
 
     async function setUpStatisticsAndContinue() {
         insertManyTimes(subframeUrl);
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkClassificationAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkClassificationAndContinue();
     }
 
     function checkCountStatistics(result) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html
@@ -34,19 +34,18 @@
                     if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get logged for user interaction.");
 
-                    testRunner.installStatisticsDidScanDataRecordsCallback(function() {
-                        if (document.cookie === cookie)
-                            testPassed("Cookie not deleted.");
-                        else
-                            testFailed("Cookie deleted or document.cookie contains other cookies: " + document.cookie);
-
-                        setEnableFeature(false, function() {
-                            testRunner.notifyDone();
-                        });
-                    });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
                     await testRunner.statisticsProcessStatisticsAndDataRecords();
+
+                    if (document.cookie === cookie)
+                        testPassed("Cookie not deleted.");
+                    else
+                        testFailed("Cookie deleted or document.cookie contains other cookies: " + document.cookie);
+
+                    setEnableFeature(false, function() {
+                        testRunner.notifyDone();
+                    });
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-without-user-interaction.html
@@ -34,19 +34,18 @@
                     if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get cleared of user interaction.");
 
-                    testRunner.installStatisticsDidScanDataRecordsCallback(function() {
-                        if (document.cookie === cookie)
-                            testPassed("Cookie not deleted.");
-                        else
-                            testFailed("Cookie deleted or document.cookie contains other cookies: " + document.cookie);
-
-                        setEnableFeature(false, function() {
-                            testRunner.notifyDone();
-                        });
-                    });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
                     await testRunner.statisticsProcessStatisticsAndDataRecords();
+
+                    if (document.cookie === cookie)
+                        testPassed("Cookie not deleted.");
+                    else
+                        testFailed("Cookie deleted or document.cookie contains other cookies: " + document.cookie);
+
+                    setEnableFeature(false, function() {
+                        testRunner.notifyDone();
+                    });
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -25,8 +25,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {
@@ -40,9 +42,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -25,8 +25,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {
@@ -40,9 +42,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -25,8 +25,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {
@@ -40,9 +42,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -25,8 +25,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {
@@ -40,9 +42,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -25,8 +25,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {
@@ -40,9 +42,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -25,8 +25,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {
@@ -40,9 +42,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html
@@ -215,8 +215,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html
@@ -215,8 +215,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html
@@ -215,8 +215,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/remove-website-data-for-origin-deletes-third-party-script-loads.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/remove-website-data-for-origin-deletes-third-party-script-loads.html
@@ -26,7 +26,6 @@
                 if (window.testRunner && window.internals) {
                     testRunner.waitUntilDone();
                     setEnableFeature(true, function() {
-                        testRunner.installStatisticsDidScanDataRecordsCallback(finishTest);
                         document.location.hash = "step1";
                         runTest();
                     });
@@ -41,6 +40,7 @@
                 break;
             case "#step2":
                 await testRunner.statisticsNotifyObserver();
+                finishTest();
                 break;
         }
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -13,9 +13,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
 
         var lastPageInRedirectChainLoaded = false;
@@ -31,8 +29,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -13,9 +13,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
 
         var lastPageInRedirectChainLoaded = false;
@@ -31,8 +29,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -13,9 +13,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
 
         var lastPageInRedirectChainLoaded = false;
@@ -31,8 +29,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -13,9 +13,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
 
         var lastPageInRedirectChainLoaded = false;
@@ -31,8 +29,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -13,9 +13,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
 
         var lastPageInRedirectChainLoaded = false;
@@ -31,8 +29,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -13,9 +13,7 @@
         }
 
         if (testRunner) {
-            setEnableFeature(true, function() {
-                testRunner.installStatisticsDidScanDataRecordsCallback(checkStats);
-            });
+            setEnableFeature(true, function() { });
         }
 
         var lastPageInRedirectChainLoaded = false;
@@ -31,8 +29,10 @@
             lastPageInRedirectChainLoaded = true;
             if (statsChecked)
                 finishTest();
-            else
+            else {
                 await testRunner.statisticsNotifyObserver();
+                checkStats();
+            }
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html
@@ -217,8 +217,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html
@@ -248,8 +248,8 @@
 
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html
@@ -248,8 +248,8 @@
 
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-before-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-before-short-deletion.html
@@ -248,8 +248,8 @@
 
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html
@@ -220,8 +220,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html
@@ -248,8 +248,8 @@
 
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html
@@ -248,8 +248,8 @@
 
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html
@@ -248,8 +248,8 @@
 
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function setPrevalentDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html
@@ -216,8 +216,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html
@@ -220,8 +220,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html
@@ -235,8 +235,8 @@
     }
 
     async function processWebsiteDataAndContinue() {
-        testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
         await testRunner.statisticsProcessStatisticsAndDataRecords();
+        checkWebsiteDataAndContinue();
     }
 
     function checkWebsiteDataAndContinue() {


### PR DESCRIPTION
#### c2e4b673742acda4d321dbfa88437ae52fcda2ab
<pre>
Reduce use of TestRunner.installStatisticsDidScanDataRecordsCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=278491">https://bugs.webkit.org/show_bug.cgi?id=278491</a>
<a href="https://rdar.apple.com/134446932">rdar://134446932</a>

Reviewed by Pascoe.

We need to remove TestRunner.installStatisticsDidScanDataRecordsCallback to make the tests
work with site isolation because they store state in the injected bundle part of WebKitTestRunner.
Most of its use can be replaced by just calling the callback after an existing await,
which executes the code at an equivalent time.  In a followup PR I&apos;ll remove the more involved use
of TestRunner.installStatisticsDidScanDataRecordsCallback and remove it.

* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-mixed-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-sub-frame-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-mixed-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-sub-frame-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-to-prevalent.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-to-prevalent.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-very-prevalent-based-on-mixed-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html:
* LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html:
* LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-import-in-worker.html:
* LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-loads.html:
* LayoutTests/http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html:
* LayoutTests/http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion-database.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/grandfathering.html:
* LayoutTests/http/tests/resourceLoadStatistics/many-inserts-only-insert-once.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-without-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html:
* LayoutTests/http/tests/resourceLoadStatistics/remove-website-data-for-origin-deletes-third-party-script-loads.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-before-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html:

Canonical link: <a href="https://commits.webkit.org/282597@main">https://commits.webkit.org/282597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c2d34ee7fd83d78fb24f71aea3706038b3a7f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51200 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9820 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69307 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12335 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55155 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6283 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9623 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->