### PR TITLE
[Sonoma wk2] fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html is a flaky failure

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border.html
@@ -38,8 +38,9 @@
             testRunner.waitUntilDone();
 
         window.addEventListener('load', async () => {
-            await UIHelper.renderingUpdate();
-            testRunner.notifyDone();
+            await UIHelper.waitForPDFFadeIn();
+            if (window.testRunner)
+                testRunner.notifyDone();
         }, false);
     </script>
 </head>

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed-with-root-page-zoom.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed-with-root-page-zoom.html
@@ -16,7 +16,7 @@
         }
         window.addEventListener('load', async () => {
             await UIHelper.zoomToScale(1.3);
-            await UIHelper.ensureStablePresentationUpdate();
+            await UIHelper.waitForPDFFadeIn();
             const layers = document.getElementById('layers');
             layers.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS);
             testRunner.notifyDone();

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed.html
@@ -14,7 +14,7 @@
             testRunner.dumpAsText();
         }
         window.addEventListener('load', async () => {
-            await UIHelper.renderingUpdate();
+            await UIHelper.waitForPDFFadeIn();
             
             const layers = document.getElementById('layers');
             layers.textContent = internals.layerTreeAsText(document);

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed.html
@@ -18,7 +18,7 @@
             testRunner.dumpAsText();
         }
         window.addEventListener('load', async () => {
-            await UIHelper.renderingUpdate();
+            await UIHelper.waitForPDFFadeIn();
             
             const layers = document.getElementById('layers');
             layers.textContent = internals.layerTreeAsText(document);

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html
@@ -14,7 +14,7 @@
             testRunner.dumpAsText();
         }
         window.addEventListener('load', async () => {
-            await UIHelper.renderingUpdate();
+            await UIHelper.waitForPDFFadeIn();
 
             if (window.internals)
                 document.getElementById('scrollingtree').textContent = internals.scrollingStateTreeAsText();

--- a/LayoutTests/fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html
+++ b/LayoutTests/fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html
@@ -1,2 +1,19 @@
-<!-- webkit-test-runner [ PluginsEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body onload="runTest()">
 <embed src="resources/image.pdf" style="margin:2px"></embed>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function runTest()
+{
+    await UIHelper.waitForPDFFadeIn();
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>

--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-50">
+    <script src="/js-test-resources/ui-helper.js"></script>
     <style>
         iframe {
             width: 700px;
@@ -13,19 +14,15 @@
         if (window.testRunner)
             testRunner.waitUntilDone();
         
-        function testComplete()
+        async function runTest()
         {
-            const pdfFadeInDelay = 250;
-            requestAnimationFrame(() => {
-                setTimeout(() => {
-                    if (window.testRunner)
-                        testRunner.notifyDone();
-                }, pdfFadeInDelay);
-            });
+            await UIHelper.waitForPDFFadeIn();
+            if (window.testRunner)
+                testRunner.notifyDone();
         }
     </script>
 </head>
 <body>
-    <iframe onload="testComplete()" src="/resources/network-simulator.py?test=pdf-load&path=/pdf/resources/linearized.pdf&chunksize=1024&chunkdelay=16"></iframe>
+    <iframe onload="runTest()" src="/resources/network-simulator.py?test=pdf-load&path=/pdf/resources/linearized.pdf&chunksize=1024&chunkdelay=16"></iframe>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1840,7 +1840,3 @@ imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss [ Pass Failur
 
 # webkit.org/b/278365 REGRESSION (279617@main): [ macOS wk2 ] imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-active.https.html is a flaky faliure
 imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-active.https.html [ Pass Failure ]
-
-# webkit.org/b/278429 [Sonoma wk2] fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html is a flaky failure
-[ Sonoma+ ] fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html [ Pass Failure ]
-

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2193,6 +2193,13 @@ window.UIHelper = class UIHelper {
             testRunner.runUIScript("uiController.resetVisibilityAdjustments(result => uiController.uiScriptComplete(result));", resolve);
         });
     }
+
+    static async waitForPDFFadeIn()
+    {
+        const pdfFadeInDelay = 250;
+        await new Promise(resolve => setTimeout(resolve, pdfFadeInDelay));
+        await new Promise(requestAnimationFrame);
+    }
 }
 
 UIHelper.EventStreamBuilder = class {


### PR DESCRIPTION
#### 932af5b1166d073e4d51829adff52c9db7ab8fbd
<pre>
[Sonoma wk2] fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=278429">https://bugs.webkit.org/show_bug.cgi?id=278429</a>
<a href="https://rdar.apple.com/134377511">rdar://134377511</a>

Reviewed by Wenson Hsieh.

PDFKit performs an animated fade-in of the PDF document to render, and
as such it looks like the &lt;embed&gt; just never loads. We work around this
issue by rAF-ing after a timeout of 250ms, which we&apos;ve previously
determined to be enough time for the PDF fade-in animation to pass.

Instead of adjusting the single failing test, though, we introduce a new
utility UIHelper.waitForPDFFadeIn, and adopt that in other relevant
tests.

Also, we get rid of the PluginsEnabled test preference, since we removed
support for that key in 274917@main.

* LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border.html:
* LayoutTests/compositing/plugins/pdf/pdf-in-embed-with-root-page-zoom.html:
* LayoutTests/compositing/plugins/pdf/pdf-in-embed.html:
* LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed.html:
* LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html:
* LayoutTests/fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html:
* LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async waitForPDFFadeIn):
(window.UIHelper):

Canonical link: <a href="https://commits.webkit.org/282638@main">https://commits.webkit.org/282638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c84e71bdce7673664c92ae801098457bad88e2ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63786 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/43143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16383 "Failed to checkout and rebase branch from PR 32554") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/14394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/50833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/14674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/14394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/50833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/16383 "Failed to checkout and rebase branch from PR 32554") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/50833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/16383 "Failed to checkout and rebase branch from PR 32554") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/13267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/50833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/16383 "Failed to checkout and rebase branch from PR 32554") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/7733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/14674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/7766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/16383 "Failed to checkout and rebase branch from PR 32554") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9643 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->