### PR TITLE
text-spacing: text-autospace: integrate ideogram-alpha for Simple path (WidthIterator)

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -629,10 +629,6 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
     if (s_codePath != CodePath::Auto)
         return s_codePath;
 
-    // FIXME: add support for text-autospace on simple path (rdar://133319627).
-    if (textAutospace().hasIdeographAlpha())
-        return CodePath::Complex;
-
 #if !USE(FREETYPE)
     // FIXME: Use the fast code path once it handles partial runs with kerning and ligatures. See http://webkit.org/b/100050
     if ((enableKerning() || requiresShaping()) && (from.value_or(0) || to.value_or(run.length()) != run.length()))

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -164,6 +164,16 @@ public:
         setWidth(lastAdvance, WebCore::width(lastAdvance) + width);
     }
 
+    void expandAdvanceToLogicalRight(unsigned index, float width)
+    {
+        if (index >= size()) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+        setWidth(m_advances[index], WebCore::width(m_advances[index]) + width);
+        setX(m_origins[index], x(m_origins[index]) + width);
+    }
+
     void expandLastAdvance(GlyphBufferAdvance expansion)
     {
         ASSERT(!isEmpty());

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -28,6 +28,7 @@
 #include "GlyphBuffer.h"
 #include "Latin1TextIterator.h"
 #include "SurrogatePairAwareTextIterator.h"
+#include "TextSpacing.h"
 #include <algorithm>
 #include <wtf/MathExtras.h>
 #include <wtf/text/CharacterProperties.h>
@@ -182,7 +183,7 @@ void WidthIterator::applyInitialAdvance(GlyphBuffer& glyphBuffer, GlyphBufferAdv
 
 bool WidthIterator::hasExtraSpacing() const
 {
-    return (m_font->letterSpacing() || m_font->wordSpacing() || m_expansion) && !m_run->spacingDisabled();
+    return (m_font->letterSpacing() || m_font->wordSpacing() || m_expansion || !m_font->textAutospace().isNoAutospace()) && !m_run->spacingDisabled();
 }
 
 static void resetGlyphBuffer(GlyphBuffer& glyphBuffer, GlyphBufferStringOffset index)
@@ -609,7 +610,9 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
         }
     }
 
+    auto previousCharacterClass = m_run->textSpacingState().lastCharacterClassFromPreviousRun;
     float position = m_run->xPos() + startingRunWidth;
+    const auto& textAutospace = m_font->textAutospace();
     for (auto i = characterStartIndex; i < characterDestinationIndex; ++i) {
         auto& glyphIndexRange = characterIndexToGlyphIndexRange[i];
         if (!glyphIndexRange)
@@ -617,6 +620,18 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
 
         auto width = calculateAdditionalWidth(glyphBuffer, i, glyphIndexRange->leadingGlyphIndex, glyphIndexRange->trailingGlyphIndex, position);
         applyAdditionalWidth(glyphBuffer, glyphIndexRange.value(), width.left, width.right, width.leftExpansion, width.rightExpansion);
+
+        auto textAutospaceSpacing = 0.f;
+        auto characterClass = TextSpacing::CharacterClass::Undefined;
+        if (!textAutospace.isNoAutospace()) {
+            characterClass = TextSpacing::characterClass(m_run.get()[i]);
+            if (textAutospace.shouldApplySpacing(characterClass, previousCharacterClass)) {
+                textAutospaceSpacing = TextAutospace::textAutospaceSize(glyphBuffer.fontAt(glyphIndexRange->leadingGlyphIndex));
+                glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange->leadingGlyphIndex, textAutospaceSpacing);
+                m_runWidthSoFar += textAutospaceSpacing;
+            }
+        }
+        previousCharacterClass = characterClass;
 
         m_isAfterExpansion = (ltr() && width.rightExpansion) || (rtl() && width.leftExpansion);
 


### PR DESCRIPTION
#### 18ad7252511a13c7560f140806684ae789e60c7f
<pre>
text-spacing: text-autospace: integrate ideogram-alpha for Simple path (WidthIterator)
<a href="https://bugs.webkit.org/show_bug.cgi?id=278541">https://bugs.webkit.org/show_bug.cgi?id=278541</a>
<a href="https://rdar.apple.com/133319627">rdar://133319627</a>

Reviewed by Brent Fulgham.

We have two paths for producing GlyphBuffer&apos;s required for layout and painting.
WidthIterator is taken for CodePath::Simple. ComplexTextController is taken for
CodePath::Complex. Up to now, we would switch to the complex path in the presence
of &quot;text-autospace&quot;, since its processing is currently only covered by ComplexTextController.

After this patch we no longer need to switch to the CodePath::Complex path in the presence of
text-autospace. This change is analogous to the changes to ComplexTextController from [1].

The text-autospace specification [2] requires certain classes of characters to have an extra
spacing added in between them. Our approach is to add a leading spacing to the current
glyph&apos;s advance (which affects layout). We also move the current glyph&apos;s origin by the same
spacing amount such that the spacing is always added as a leading spacing.

For example, if two characters &quot;水&quot; and &quot;e&quot; are adjacent and the spec requuires an
extra spacing between them, we adjust the correspondent glyph&apos;s advance and origin
while processing &quot;e&quot; in relation to the previous character &quot;水&quot;.

[1] <a href="https://commits.webkit.org/282511@main">https://commits.webkit.org/282511@main</a>
[2] <a href="https://www.w3.org/TR/css-text-4/#text-autospace-property">https://www.w3.org/TR/css-text-4/#text-autospace-property</a>

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::codePath const):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::expandAdvanceToLogicalRight):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::hasExtraSpacing const):
(WebCore::WidthIterator::applyExtraSpacingAfterShaping):

Canonical link: <a href="https://commits.webkit.org/282821@main">https://commits.webkit.org/282821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/915ae2ec39ee2ff00f934f4e093df860af5323e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15244 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70078 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12910 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55777 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6865 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39533 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->