### PR TITLE
[Grid] Rename min/maxContentForGridItem and minSizeForGridItem in GridTrackSizingAlgorithm.

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -355,9 +355,9 @@ private:
 class GridTrackSizingAlgorithmStrategy {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    virtual LayoutUnit minContentForGridItem(RenderBox&, GridLayoutState&) const;
-    LayoutUnit maxContentForGridItem(RenderBox&, GridLayoutState&) const;
-    LayoutUnit minSizeForGridItem(RenderBox&, GridLayoutState&) const;
+    virtual LayoutUnit minContentContributionForGridItem(RenderBox&, GridLayoutState&) const;
+    LayoutUnit maxContentContributionForGridItem(RenderBox&, GridLayoutState&) const;
+    LayoutUnit minContributionForGridItem(RenderBox&, GridLayoutState&) const;
 
     virtual ~GridTrackSizingAlgorithmStrategy() = default;
 


### PR DESCRIPTION
#### 51781e32c383b3de02ab11c1e274249a471e73f0
<pre>
[Grid] Rename min/maxContentForGridItem and minSizeForGridItem in GridTrackSizingAlgorithm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278499">https://bugs.webkit.org/show_bug.cgi?id=278499</a>
<a href="https://rdar.apple.com/134451435">rdar://134451435</a>

Reviewed by Vitor Roriz.

During the grid track sizing algorithm, the spec will use different
types of grid item sizes as part of the process. In particular, it
may use the min content contribution, max content contribution, or
minimum contribution of a grid item.

The GridTrackSizingAlgorithm code has minContentForGridItem,
maxContentForGridItem, and minSizeForGridItem to try to capture these
ideas. These current names are misleading because the first two have
their own spec terms/definitions which are not the same. For example
the min/max content size of a box does not take into consideration the
min/max size properties of the box whereas the later does. The last one
can just be better named to match the spec.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem):
(WebCore::GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentContributionForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContributionForGridItem const):
(WebCore::IndefiniteSizeStrategy::accumulateFlexFraction const):
(WebCore::DefiniteSizeStrategy::minContentContributionForGridItem const):
(WebCore::GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry):
(WebCore::GridTrackSizingAlgorithmStrategy::minContentForGridItem const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentForGridItem const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::minSizeForGridItem const): Deleted.
(WebCore::DefiniteSizeStrategy::minContentForGridItem const): Deleted.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/282643@main">https://commits.webkit.org/282643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c199dc63a17efaf9cdd476318a7175b11856e713

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51283 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12460 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69334 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12358 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58543 "Found 1 new test failure: fast/forms/search/search-size-with-decorations.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58765 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6302 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38794 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->