### PR TITLE
Migrate NSURLProtectionSpace serialization from WKKeyedCoder

### DIFF
--- a/Source/WebCore/platform/network/ProtectionSpaceBase.cpp
+++ b/Source/WebCore/platform/network/ProtectionSpaceBase.cpp
@@ -66,13 +66,20 @@ bool ProtectionSpaceBase::isPasswordBased() const
     case AuthenticationScheme::NTLM:
     case AuthenticationScheme::Negotiate:
     case AuthenticationScheme::OAuth:
+#if PLATFORM(COCOA)
+    case AuthenticationScheme::XMobileMeAuthToken:
+    case AuthenticationScheme::PrivateAccessToken:
+    case AuthenticationScheme::OAuthBearerToken:
+#endif
 #if USE(GLIB)
     case AuthenticationScheme::ClientCertificatePINRequested:
 #endif
         return true;
     case AuthenticationScheme::ClientCertificateRequested:
     case AuthenticationScheme::ServerTrustEvaluationRequested:
+#if !PLATFORM(COCOA)
     case AuthenticationScheme::Unknown:
+#endif
         return false;
     }
 

--- a/Source/WebCore/platform/network/ProtectionSpaceBase.h
+++ b/Source/WebCore/platform/network/ProtectionSpaceBase.h
@@ -30,35 +30,47 @@
 namespace WebCore {
 
 class ProtectionSpace;
+
+enum class ProtectionSpaceBaseServerType : uint8_t {
+    HTTP = 1, // NOLINT
+    HTTPS, // NOLINT
+    FTP, // NOLINT
+    FTPS, // NOLINT
+    ProxyHTTP,
+    ProxyHTTPS,
+    ProxyFTP,
+    ProxySOCKS
+};
+
+enum class ProtectionSpaceBaseAuthenticationScheme : uint8_t {
+    Default = 1,
+    HTTPBasic,
+    HTTPDigest,
+    HTMLForm,
+    NTLM, // NOLINT
+    Negotiate,
+    ClientCertificateRequested,
+    ServerTrustEvaluationRequested,
+#if PLATFORM(COCOA)
+    XMobileMeAuthToken,
+#endif
+    OAuth,
+#if PLATFORM(COCOA)
+    PrivateAccessToken,
+    OAuthBearerToken,
+#endif
+#if USE(GLIB)
+    ClientCertificatePINRequested,
+#endif
+#if !PLATFORM(COCOA)
+    Unknown = 100
+#endif
+};
   
 class ProtectionSpaceBase {
 public:
-    enum class ServerType : uint8_t {
-        HTTP = 1,
-        HTTPS = 2,
-        FTP = 3,
-        FTPS = 4,
-        ProxyHTTP = 5,
-        ProxyHTTPS = 6,
-        ProxyFTP = 7,
-        ProxySOCKS = 8
-    };
-
-    enum class AuthenticationScheme : uint8_t {
-        Default = 1,
-        HTTPBasic = 2,
-        HTTPDigest = 3,
-        HTMLForm = 4,
-        NTLM = 5,
-        Negotiate = 6,
-        ClientCertificateRequested = 7,
-        ServerTrustEvaluationRequested = 8,
-        OAuth = 9,
-#if USE(GLIB)
-        ClientCertificatePINRequested = 10,
-#endif
-        Unknown = 100
-    };
+    using ServerType = ProtectionSpaceBaseServerType;
+    using AuthenticationScheme = ProtectionSpaceBaseAuthenticationScheme;
 
     bool isHashTableDeletedValue() const { return m_isHashTableDeletedValue; }
     

--- a/Source/WebCore/platform/network/ProtectionSpaceBase.serialization.in
+++ b/Source/WebCore/platform/network/ProtectionSpaceBase.serialization.in
@@ -20,7 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[Nested] enum class WebCore::ProtectionSpace::ServerType : uint8_t {
+webkit_platform_headers: <WebCore/ProtectionSpaceBase.h>
+
+header: <WebCore/ProtectionSpaceBase.h>
+[CustomHeader, WebKitPlatform] enum class WebCore::ProtectionSpaceBaseServerType : uint8_t {
     HTTP,
     HTTPS,
     FTP,
@@ -30,8 +33,10 @@
     ProxyFTP,
     ProxySOCKS,
 };
+using WebCore::ProtectionSpace::ServerType = WebCore::ProtectionSpaceBaseServerType;
 
-[Nested] enum class WebCore::ProtectionSpace::AuthenticationScheme : uint8_t {
+header: <WebCore/ProtectionSpaceBase.h>
+[CustomHeader, WebKitPlatform] enum class WebCore::ProtectionSpaceBaseAuthenticationScheme : uint8_t {
     Default,
     HTTPBasic,
     HTTPDigest,
@@ -40,9 +45,19 @@
     Negotiate,
     ClientCertificateRequested,
     ServerTrustEvaluationRequested,
+#if PLATFORM(COCOA)
+    XMobileMeAuthToken,
+#endif
     OAuth,
+#if PLATFORM(COCOA)
+    PrivateAccessToken,
+    OAuthBearerToken,
+#endif
 #if USE(GLIB)
     ClientCertificatePINRequested,
 #endif
-    Unknown,
+#if !PLATFORM(COCOA)
+    Unknown
+#endif
 };
+using WebCore::ProtectionSpace::AuthenticationScheme = WebCore::ProtectionSpaceBaseAuthenticationScheme;

--- a/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
@@ -87,7 +87,7 @@ static ProtectionSpace::AuthenticationScheme scheme(NSURLProtectionSpace *space)
         return ProtectionSpace::AuthenticationScheme::OAuth;
 
     ASSERT_NOT_REACHED();
-    return ProtectionSpace::AuthenticationScheme::Unknown;
+    return ProtectionSpace::AuthenticationScheme::Default;
 }
 
 ProtectionSpace::ProtectionSpace(NSURLProtectionSpace *space)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.mm
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCNSURLProtectionSpace.h"
+
+#import "ArgumentCoders.h"
+
+#if PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLPROTECTIONSPACE)
+
+@interface NSURLProtectionSpace (WKSecureCoding)
+- (NSDictionary *)_webKitPropertyListData;
+- (instancetype)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+@end
+
+namespace WebKit {
+
+#define SET_OBJECT(NAME, CLASS, WRAPPER)    \
+    id NAME = dict[@#NAME];                 \
+    if ([NAME isKindOfClass:CLASS.class]) { \
+        auto var = WRAPPER(NAME);           \
+        m_data.NAME = WTFMove(var);         \
+    }
+
+CoreIPCNSURLProtectionSpace::CoreIPCNSURLProtectionSpace(NSURLProtectionSpace *ps)
+{
+    auto dict = [ps _webKitPropertyListData];
+
+    SET_OBJECT(host, NSString, CoreIPCString);
+
+    id port = dict[@"port"];
+    if ([port isKindOfClass:NSNumber.class])
+        m_data.port = [port unsignedShortValue];
+
+    id type = dict[@"type"];
+    if ([type isKindOfClass:NSNumber.class]) {
+        auto val = [type unsignedCharValue];
+        if (isValidEnum<WebCore::ProtectionSpaceBaseServerType>(val))
+            m_data.type = static_cast<WebCore::ProtectionSpaceBaseServerType>(val);
+    }
+
+    SET_OBJECT(realm, NSString, CoreIPCString);
+
+    id scheme = dict[@"scheme"];
+    if ([scheme isKindOfClass:NSNumber.class]) {
+        auto val = [scheme unsignedCharValue];
+        if (isValidEnum<WebCore::ProtectionSpaceBaseAuthenticationScheme>(val))
+            m_data.scheme = static_cast<WebCore::ProtectionSpaceBaseAuthenticationScheme>(val);
+    }
+
+    id trust = dict[@"trust"];
+    if (trust && CFGetTypeID((CFTypeRef)trust) == SecTrustGetTypeID())
+        m_data.trust = { CoreIPCSecTrust((SecTrustRef)trust) };
+
+    NSArray *distnames = dict[@"distnames"];
+    if ([distnames isKindOfClass:NSArray.class]) {
+        bool allElementsValid = true;
+        Vector<WebKit::CoreIPCData> data;
+        data.reserveInitialCapacity(distnames.count);
+        for (NSData *d in distnames) {
+            if (![d isKindOfClass:NSData.class]) {
+                allElementsValid = false;
+                break;
+            }
+            data.append(d);
+        }
+        if (allElementsValid)
+            m_data.distnames = WTFMove(data);
+    }
+}
+
+CoreIPCNSURLProtectionSpace::CoreIPCNSURLProtectionSpace(CoreIPCNSURLProtectionSpaceData&& data)
+    : m_data(WTFMove(data)) { }
+
+CoreIPCNSURLProtectionSpace::CoreIPCNSURLProtectionSpace(const RetainPtr<NSURLProtectionSpace>& ps)
+    : CoreIPCNSURLProtectionSpace(ps.get()) { }
+
+RetainPtr<id> CoreIPCNSURLProtectionSpace::toID() const
+{
+    auto dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:7]); // Initialized with the count of members in CoreIPCNSURLProtectionSpaceData
+
+    if (m_data.host)
+        [dict setObject:m_data.host->toID().get() forKey:@"host"];
+
+    [dict setObject:[NSNumber numberWithUnsignedShort:m_data.port] forKey:@"port"];
+    [dict setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(m_data.type)] forKey:@"type"];
+
+    if (m_data.realm)
+        [dict setObject:m_data.realm->toID().get() forKey:@"realm"];
+
+    [dict setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(m_data.scheme)] forKey:@"scheme"];
+
+    if (m_data.trust)
+        [dict setObject:(id)m_data.trust->createSecTrust().get() forKey:@"trust"];
+
+    if (m_data.distnames) {
+        auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data.distnames->size()]);
+        for (auto& value : *m_data.distnames)
+            [array addObject:value.toID().get()];
+        [dict setObject:array.get() forKey:@"distnames"];
+    }
+    return adoptNS([[NSURLProtectionSpace alloc] _initWithWebKitPropertyListData:dict.get()]);
+}
+
+#undef SET_OBJECT
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.serialization.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && !HAVE(WK_SECURE_CODING_NSURLPROTECTIONSPACE)
 
 [WebKitSecureCodingClass=NSURLProtectionSpace.class, SupportWKKeyedCoder] webkit_secure_coding NSURLProtectionSpace {
     __nsurlprotectionspace_proto_plist: Dictionary?
@@ -34,3 +34,24 @@
 }
 
 #endif // PLATFORM(COCOA)
+
+#if PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLPROTECTIONSPACE)
+
+webkit_platform_headers: "CoreIPCNSURLProtectionSpace.h" "CoreIPCSecTrust.h" "CoreIPCData.h"
+
+header: "CoreIPCNSURLProtectionSpace.h"
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCNSURLProtectionSpaceData {
+    std::optional<WebKit::CoreIPCString> host;
+    uint16_t port;
+    WebCore::ProtectionSpaceBaseServerType type;
+    std::optional<WebKit::CoreIPCString> realm;
+    WebCore::ProtectionSpace::AuthenticationScheme scheme;
+    std::optional<WebKit::CoreIPCSecTrust> trust;
+    std::optional<Vector<WebKit::CoreIPCData>> distnames;
+}
+
+[WebKitPlatform] class WebKit::CoreIPCNSURLProtectionSpace {
+    WebKit::CoreIPCNSURLProtectionSpaceData m_data
+}
+
+#endif // PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLPROTECTIONSPACE)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2547,6 +2547,8 @@
 		F4660BC225DEF08100E86598 /* PasteboardAccessIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = F4660BC125DEF08100E86598 /* PasteboardAccessIntent.h */; };
 		F468770B2C6402650068A20C /* CocoaWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = F468770A2C6402650068A20C /* CocoaWindow.h */; };
 		F47AA6CA2B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47AA6C92B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift */; };
+		F48523B62C76962C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm in Sources */ = {isa = PBXBuildFile; fileRef = F48523B52C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm */; };
+		F48523B72C769D8700C71FC2 /* CoreIPCNSURLProtectionSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = F48523B42C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.h */; };
 		F48570A32644BEC500C05F71 /* Timeout.h in Headers */ = {isa = PBXBuildFile; fileRef = F48570A22644BEC400C05F71 /* Timeout.h */; };
 		F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */ = {isa = PBXBuildFile; fileRef = F48C81E32AE0BA6E00073850 /* CoreIPCData.h */; };
 		F48D2A8521583A7E00C6752B /* AppKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F48D2A8421583A0200C6752B /* AppKitSPI.h */; };
@@ -8187,6 +8189,8 @@
 		F468770A2C6402650068A20C /* CocoaWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CocoaWindow.h; sourceTree = "<group>"; };
 		F476894628D2B5CD00073641 /* LayerTreeContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = LayerTreeContext.serialization.in; sourceTree = "<group>"; };
 		F47AA6C92B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WKWebView+TextExtraction.swift"; path = "TextExtraction/WKWebView+TextExtraction.swift"; sourceTree = "<group>"; };
+		F48523B42C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSURLProtectionSpace.h; sourceTree = "<group>"; };
+		F48523B52C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSURLProtectionSpace.mm; sourceTree = "<group>"; };
 		F48570A22644BEC400C05F71 /* Timeout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timeout.h; sourceTree = "<group>"; };
 		F488B90F2ACFC67A00792C16 /* RemoteWorkerInitializationData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWorkerInitializationData.serialization.in; sourceTree = "<group>"; };
 		F488B9142AD09C9C00792C16 /* DocumentEditingContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = DocumentEditingContext.serialization.in; sourceTree = "<group>"; };
@@ -11855,6 +11859,8 @@
 				FABBDE9D2B85550000EFAFC4 /* CoreIPCNSURLCredential.h */,
 				FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */,
 				FA4368C62B811BA3001B993D /* CoreIPCNSURLCredential.serialization.in */,
+				F48523B42C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.h */,
+				F48523B52C76961C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm */,
 				F42FC8702B7ADA5800BAF8D6 /* CoreIPCNSURLProtectionSpace.serialization.in */,
 				F4EE982F2C41C0FB00989568 /* CoreIPCNSURLRequest.h */,
 				F4EE98302C41C0FB00989568 /* CoreIPCNSURLRequest.mm */,
@@ -16334,6 +16340,7 @@
 				F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */,
 				5197FAE42AFD33CF009180C5 /* CoreIPCNSCFObject.h in Headers */,
 				4486A15C2B730D0000E48068 /* CoreIPCNSShadow.h in Headers */,
+				F48523B72C769D8700C71FC2 /* CoreIPCNSURLProtectionSpace.h in Headers */,
 				F4F12C942C41CEE700BC1254 /* CoreIPCNSURLRequest.h in Headers */,
 				51ACFFDF2B048821001331A2 /* CoreIPCNSValue.h in Headers */,
 				FAB955FB2B75E43D0060829C /* CoreIPCNull.h in Headers */,
@@ -19448,6 +19455,7 @@
 				5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */,
 				4486A15D2B730D0900E48068 /* CoreIPCNSShadow.mm in Sources */,
 				FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */,
+				F48523B62C76962C00C71FC2 /* CoreIPCNSURLProtectionSpace.mm in Sources */,
 				F4F12C932C41CED500BC1254 /* CoreIPCNSURLRequest.mm in Sources */,
 				51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */,
 				FA4FE2662B75EB290016E671 /* CoreIPCNull.mm in Sources */,

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -382,7 +382,11 @@ static ProtectionSpace::AuthenticationScheme authenticationSchemeFromAuthenticat
     if (CFEqual(method, kCFHTTPAuthenticationSchemeNegotiate))
         return ProtectionSpace::AuthenticationScheme::Negotiate;
     ASSERT_NOT_REACHED();
+#if PLATFORM(COCOA)
+    return ProtectionSpace::AuthenticationScheme::Default;
+#else
     return ProtectionSpace::AuthenticationScheme::Unknown;
+#endif
 }
     
 static void setCONNECTProxyAuthorizationForStream(CFReadStreamRef stream, CFStringRef proxyAuthorizationString)

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -549,8 +549,10 @@ static BOOL wkDDActionContext_isEqual(WKDDActionContext *a, SEL, WKDDActionConte
 
 static bool wkNSURLProtectionSpace_isEqual(NSURLProtectionSpace *a, SEL, NSURLProtectionSpace* b)
 {
-    if (![a.host isEqual: b.host])
-        return false;
+    if (![a.host isEqual: b.host]) {
+        if (!(a.host == nil && b.host == nil))
+            return false;
+    }
     if (!(a.port == b.port))
         return false;
     if (![a.protocol isEqual:b.protocol])
@@ -1310,6 +1312,12 @@ TEST(IPCSerialization, Basic)
     [protectionSpace2.get() _setServerTrust:trustRef];
     [protectionSpace2.get() _setDistinguishedNames:distinguishedNames];
     runTestNS({ protectionSpace2.get() });
+
+    NSString* nilString = nil;
+    RetainPtr<NSURLProtectionSpace> protectionSpace3 = adoptNS([[NSURLProtectionSpace alloc] initWithHost:nilString port:443 protocol:NSURLProtectionSpaceHTTPS realm:nil authenticationMethod:NSURLAuthenticationMethodServerTrust]);
+    [protectionSpace3.get() _setServerTrust:nil];
+    [protectionSpace3.get() _setDistinguishedNames:nil];
+    runTestNS({ protectionSpace3.get() });
 
     runTestNS({ [NSURLCredential credentialForTrust:trust.get()] });
 #if HAVE(DICTIONARY_SERIALIZABLE_NSURLCREDENTIAL)


### PR DESCRIPTION
#### d6df66d73ecc084b401ad4b6f3ce29f14277151a
<pre>
Migrate NSURLProtectionSpace serialization from WKKeyedCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=278484">https://bugs.webkit.org/show_bug.cgi?id=278484</a>
<a href="https://rdar.apple.com/134452219">rdar://134452219</a>

Reviewed by Alex Christensen and Sihui Liu.

* Source/WebCore/platform/network/ProtectionSpaceBase.cpp:
(WebCore::ProtectionSpaceBase::isPasswordBased const):
* Source/WebCore/platform/network/ProtectionSpaceBase.h:
* Source/WebCore/platform/network/ProtectionSpaceBase.serialization.in:
* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::scheme):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCString.h.
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.mm: Added.
(WebKit::CoreIPCNSURLProtectionSpace::CoreIPCNSURLProtectionSpace):
(WebKit::CoreIPCNSURLProtectionSpace::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCString.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp:
(WebCore::authenticationSchemeFromAuthenticationMethod):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(wkNSURLProtectionSpace_isEqual):
(TEST(IPCSerialization, Basic)):

Canonical link: <a href="https://commits.webkit.org/283373@main">https://commits.webkit.org/283373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/343bf58403cb5bf8ff3c330c1671c34666df5f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53048 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11629 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10047 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60658 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1941 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->