### PR TITLE
[WebProcess] Use convenience method for NSBitmapImageRep

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -333,7 +333,7 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
     }
 
 #if USE(APPKIT)
-    auto *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];
+    auto *imageRep = [NSBitmapImageRep imageWithCGImage:cgImage];
     CGImageRelease(cgImage);
 
     auto *pngData = [imageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];


### PR DESCRIPTION
<pre>[WebProcess] Use convenience method for NSBitmapImageRep
https://bugs.webkit.org/show_bug.cgi?id=278505

Reviewed by NOBODY (OOPS!).

iOS does it, and so should macOS.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
  (WebKit::dataURLFromImageData): Use convenience initializer.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a359dc4645153c92e2b05742adf95a7338428047

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42993 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16234 "Hash a359dc46 for PR 32569 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/14245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50681 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14525 "Hash a359dc46 for PR 32569 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/14245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39888 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/16234 "Hash a359dc46 for PR 32569 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/16234 "Hash a359dc46 for PR 32569 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13118 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/16234 "Hash a359dc46 for PR 32569 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7584 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/14525 "Hash a359dc46 for PR 32569 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7617 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/16234 "Hash a359dc46 for PR 32569 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6315 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->