### PR TITLE
Fix PlayStation build following 282580@main

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
@@ -103,7 +103,7 @@ enum class NumericIdentity : uint8_t {
     DPCM
 };
 
-constexpr uint8_t numberOfNumericIdentityTypes = std::to_underlying(NumericIdentity::DPCM) + 1;
+constexpr uint8_t numberOfNumericIdentityTypes = static_cast<uint8_t>(NumericIdentity::DPCM) + 1;
 
 constexpr NumericIdentity toNumericIdentity(const Number&)
 {

--- a/Source/WebCore/css/calc/CSSCalcType.h
+++ b/Source/WebCore/css/calc/CSSCalcType.h
@@ -67,12 +67,12 @@ struct Type {
     private:
         enum class InternalValue : uint8_t {
             None = 0,
-            Length = std::to_underlying(PercentHint::Length),
-            Angle = std::to_underlying(PercentHint::Angle),
-            Time = std::to_underlying(PercentHint::Time),
-            Frequency = std::to_underlying(PercentHint::Frequency),
-            Resolution = std::to_underlying(PercentHint::Resolution),
-            Flex = std::to_underlying(PercentHint::Flex)
+            Length = static_cast<uint8_t>(PercentHint::Length),
+            Angle = static_cast<uint8_t>(PercentHint::Angle),
+            Time = static_cast<uint8_t>(PercentHint::Time),
+            Frequency = static_cast<uint8_t>(PercentHint::Frequency),
+            Resolution = static_cast<uint8_t>(PercentHint::Resolution),
+            Flex = static_cast<uint8_t>(PercentHint::Flex)
         };
 
     public:


### PR DESCRIPTION
#### baaae40b9bf25c5b292c1c0bda83a74977c34715
<pre>
Fix PlayStation build following 282580@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=278506">https://bugs.webkit.org/show_bug.cgi?id=278506</a>

Unreviewed build fix.

std::to_underlying is a C++23 feature; unless we plan to implement this in WTF, we can just use static_cast&lt;uint8_t&gt;.

* Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplifyForMinMax):
(WebCore::CSSCalc::simplify):
* Source/WebCore/css/calc/CSSCalcType.h:

Canonical link: <a href="https://commits.webkit.org/282601@main">https://commits.webkit.org/282601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf4f2268f2e24088773f867a28efd5d45e6a553f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55104 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/31917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36574 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/12483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13125 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7591 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55197 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6321 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->