### PR TITLE
Use BorderShape for rounded clips in background painting, and for content area clipping

### DIFF
--- a/LayoutTests/fast/borders/border-radius-clip-iframe-content-expected.html
+++ b/LayoutTests/fast/borders/border-radius-clip-iframe-content-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .clipping {
+            margin: 50px;
+            width: 300px;
+            height: 200px;
+            border: 5px solid black;
+            border-radius: 50px;
+            border-bottom-right-radius: 100px;
+            padding: 20px;
+            background-color: green;
+            background-clip: content-box;
+        }
+        </style>
+</head>
+<body>
+    <div class="clipping"></div>
+</body>
+</html>

--- a/LayoutTests/fast/borders/border-radius-clip-iframe-content.html
+++ b/LayoutTests/fast/borders/border-radius-clip-iframe-content.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            display: block;
+            margin: 50px;
+            width: 300px;
+            height: 200px;
+            border: 5px solid black;
+            border-radius: 50px;
+            border-bottom-right-radius: 100px;
+            padding: 20px;
+        }
+        
+    </style>
+</head>
+<body>
+    <iframe srcdoc="
+        <style> :root { background-color: green; }</style>
+    "></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1584,9 +1584,6 @@ editing/text-iterator/backwards-text-iterator-basic.html [ Crash ]
 # rdar://107460005 ([UI Side Compositing] fast/text/web-font-load-invisible-during-loading.html fails)
 fast/text/web-font-load-invisible-during-loading.html [ Failure ]
 
-# rdar://107460054 ([UI-side compositing] imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clip-001.html fails)
-imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clip-001.html [ ImageOnlyFailure ]
-
 # rdar://107460135 ([UI-side compositing] svg/compositing/outermost-svg-with-border-padding.html fails)
 svg/compositing/outermost-svg-with-border-padding.html
 

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -74,9 +74,6 @@ public:
 private:
     void paintRootBoxFillLayers() const;
 
-    RoundedRect backgroundRoundedRectAdjustedForBleedAvoidance(const LayoutRect& borderRect, BackgroundBleedAvoidance, const InlineIterator::InlineBoxIterator&, bool includeLogicalLeftEdge, bool includeLogicalRightEdge) const;
-    RoundedRect backgroundRoundedRect(const LayoutRect& borderRect, const InlineIterator::InlineBoxIterator&, bool includeLogicalLeftEdge, bool includeLogicalRightEdge) const;
-
     static LayoutSize calculateFillTileSize(const RenderBoxModelObject&, const FillLayer&, const LayoutSize& positioningAreaSize);
 
     const Document& document() const;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -168,6 +168,8 @@ Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
 Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
 {
     auto pixelSnappedRect = innerEdgeRoundedRect().pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(pixelSnappedRect.isRenderable());
+
     Path path;
     addRoundedRectToPath(pixelSnappedRect, path);
     return path;
@@ -177,6 +179,8 @@ Path BorderShape::pathForBorderArea(float deviceScaleFactor) const
 {
     auto pixelSnappedOuterRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     auto pixelSnappedInnerRect = innerEdgeRoundedRect().pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+
+    ASSERT(pixelSnappedInnerRect.isRenderable());
 
     Path path;
     addRoundedRectToPath(pixelSnappedOuterRect, path);
@@ -196,6 +200,7 @@ void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFa
 void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFactor)
 {
     auto pixelSnappedRect = innerEdgeRoundedRect().pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(pixelSnappedRect.isRenderable());
     if (pixelSnappedRect.isRounded())
         context.clipRoundedRect(pixelSnappedRect);
     else
@@ -214,6 +219,16 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
 void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, float deviceScaleFactor)
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (pixelSnappedRect.isRounded())
+        context.fillRoundedRect(pixelSnappedRect, color);
+    else
+        context.fillRect(pixelSnappedRect.rect(), color);
+}
+
+void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, float deviceScaleFactor)
+{
+    auto pixelSnappedRect = innerEdgeRoundedRect().pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(pixelSnappedRect.isRenderable());
     if (pixelSnappedRect.isRounded())
         context.fillRoundedRect(pixelSnappedRect, color);
     else

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -77,6 +77,7 @@ public:
     void clipOutInnerShape(GraphicsContext&, float deviceScaleFactor);
 
     void fillOuterShape(GraphicsContext&, const Color&, float deviceScaleFactor);
+    void fillInnerShape(GraphicsContext&, const Color&, float deviceScaleFactor);
 
 private:
     RoundedRect innerEdgeRoundedRect() const;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -665,6 +665,9 @@ protected:
 
     void paintMaskImages(const PaintInfo&, const LayoutRect&);
 
+    void clipToPaddingBoxShape(GraphicsContext&, const LayoutPoint&, float deviceScaleFactor) const;
+    void clipToContentBoxShape(GraphicsContext&, const LayoutPoint&, float deviceScaleFactor) const;
+
     BackgroundBleedAvoidance determineBackgroundBleedAvoidance(GraphicsContext&) const;
     bool backgroundHasOpaqueTopLayer() const;
 
@@ -761,8 +764,6 @@ private:
     RepaintRects computeVisibleRectsUsingPaintOffset(const RepaintRects&) const;
     
     LayoutPoint topLeftLocationWithFlipping() const;
-
-    void clipContentForBorderRadius(GraphicsContext&, const LayoutPoint&, float);
 
     void addLayoutOverflow(const LayoutRect&, const LayoutRect& flippedClientRect);
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -29,6 +29,7 @@
 #include "BitmapImage.h"
 #include "BorderEdge.h"
 #include "BorderPainter.h"
+#include "BorderShape.h"
 #include "CachedImage.h"
 #include "ColorBlending.h"
 #include "Document.h"
@@ -867,14 +868,19 @@ bool RenderBoxModelObject::borderObscuresBackground() const
     return true;
 }
 
-RoundedRect RenderBoxModelObject::roundedContentBoxRect(const LayoutRect& borderBoxRect, bool includeLeftEdge, bool includeRightEdge) const
+BorderShape RenderBoxModelObject::borderShapeForContentClipping(const LayoutRect& borderBoxRect, bool includeLeftEdge, bool includeRightEdge) const
 {
     auto borderWidths = this->borderWidths();
     auto padding = this->padding();
-    return style().getRoundedInnerBorderFor(borderBoxRect,
-        borderWidths.top() + padding.top(), borderWidths.bottom() + padding.bottom(),
-        borderWidths.left() + padding.left(), borderWidths.right() + padding.right(),
-        includeLeftEdge, includeRightEdge);
+
+    auto contentBoxInsets = RectEdges<LayoutUnit> {
+        borderWidths.top() + padding.top(),
+        borderWidths.right() + padding.right(),
+        borderWidths.bottom() + padding.bottom(),
+        borderWidths.left() + padding.left(),
+    };
+
+    return BorderShape::shapeForBorderRect(style(), borderBoxRect, contentBoxInsets, includeLeftEdge, includeRightEdge);
 }
 
 LayoutUnit RenderBoxModelObject::containingBlockLogicalWidthForContent() const

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -59,6 +59,7 @@ enum ContentChangeType {
 };
 
 class BorderEdge;
+class BorderShape;
 class ImageBuffer;
 class RenderTextFragment;
 class StickyPositionViewportConstraints;
@@ -182,7 +183,7 @@ public:
     LayoutUnit marginLogicalHeight() const { return marginBefore() + marginAfter(); }
     LayoutUnit marginLogicalWidth() const { return marginStart() + marginEnd(); }
 
-    RoundedRect roundedContentBoxRect(const LayoutRect& borderBoxRect, bool includeLeftEdge = true, bool includeRightEdge = true) const;
+    BorderShape borderShapeForContentClipping(const LayoutRect& borderBoxRect, bool includeLeftEdge = true, bool includeRightEdge = true) const;
 
     inline bool hasInlineDirectionBordersPaddingOrMargin() const;
     inline bool hasInlineDirectionBordersOrPadding() const;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1871,7 +1871,8 @@ void RenderLayerBacking::updateContentsRects()
     m_graphicsLayer->setContentsRect(snapRectToDevicePixelsIfNeeded(contentsBox(), renderer()));
     
     if (CheckedPtr renderReplaced = dynamicDowncast<RenderReplaced>(renderer())) {
-        FloatRoundedRect contentsClippingRect = renderReplaced->roundedContentBoxRect(renderReplaced->borderBoxRect()).pixelSnappedRoundedRectForPainting(deviceScaleFactor());
+        auto borderShape = renderReplaced->borderShapeForContentClipping(renderReplaced->borderBoxRect());
+        auto contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
         contentsClippingRect.move(contentOffsetInCompositingLayer());
         m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
     }

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -304,8 +304,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         if (!completelyClippedOut) {
             // Push a clip if we have a border radius, since we want to round the foreground content that gets painted.
             paintInfo.context().save();
-            auto pixelSnappedRoundedRect = roundedContentBoxRect(paintRect).pixelSnappedRoundedRectForPainting(document().deviceScaleFactor());
-            BackgroundPainter::clipRoundedInnerRect(paintInfo.context(), pixelSnappedRoundedRect);
+            clipToContentBoxShape(paintInfo.context(), adjustedPaintOffset, document().deviceScaleFactor());
         }
     }
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -327,8 +327,7 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
         // Push a clip if we have a border radius, since we want to round the foreground content that gets painted.
         paintInfo.context().save();
-        auto roundedInnerRect = FloatRoundedRect(roundedContentBoxRect(borderRect));
-        BackgroundPainter::clipRoundedInnerRect(paintInfo.context(), roundedInnerRect);
+        clipToContentBoxShape(paintInfo.context(), adjustedPaintOffset, document().deviceScaleFactor());
     }
 
     if (m_widget && !isSkippedContentRoot())

--- a/Source/WebCore/rendering/shapes/BoxShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxShape.cpp
@@ -82,18 +82,8 @@ RoundedRect computeRoundedRectForBoxShape(CSSBoxType box, const RenderBox& rende
     // fill-box compute to content-box for HTML elements.
     case CSSBoxType::FillBox:
     case CSSBoxType::ContentBox: {
-        auto borderBoxRect = renderer.borderBoxRect();
-        auto contentBoxRect = renderer.contentBoxRect();
-
-        // top, right, bottom, left.
-        auto contentBoxInsets = RectEdges<LayoutUnit> {
-            contentBoxRect.y() - borderBoxRect.y(),
-            borderBoxRect.maxX() - contentBoxRect.maxX(),
-            borderBoxRect.maxY() - contentBoxRect.maxY(),
-            contentBoxRect.x() - borderBoxRect.x()
-        };
-
-        return BorderShape::shapeForBorderRect(style, renderer.borderBoxRect(), contentBoxInsets).deprecatedInnerRoundedRect();
+        auto borderShape = renderer.borderShapeForContentClipping(renderer.borderBoxRect());
+        return borderShape.deprecatedInnerRoundedRect();
     }
     // stroke-box, view-box compute to border-box for HTML elements.
     case CSSBoxType::BorderBox:


### PR DESCRIPTION
#### a0a37cafb8ea4595d6be7fbadb9e64b77718b67c
<pre>
Use BorderShape for rounded clips in background painting, and for content area clipping
<a href="https://bugs.webkit.org/show_bug.cgi?id=278509">https://bugs.webkit.org/show_bug.cgi?id=278509</a>
<a href="https://rdar.apple.com/134465598">rdar://134465598</a>

Reviewed by Antti Koivisto.

Continue the adoption of BorderShape.

First, replace `RenderBoxModelObject::roundedContentBoxRect()` with a function that returns a BorderShape
that is set up to clip to the content box (potentially with corner-rounding). This is used in
`RenderBox::clipContentForBorderRadius()`, which can be called by RenderWidget and RenderReplaced where
they need to clip to the content area. BoxShape can also use this for `CSSBoxType::ContentBox`,
and RenderLayerBacking also when setting up a content clip.

The second set of changes are in BackgroundPainter, using BorderShape to clip to and fill the inner or outer
shapes when drawing backgrounds. We&apos;re able to remove `BackgroundPainter::backgroundRoundedRect()`.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
(WebCore::BackgroundPainter::backgroundRoundedRectAdjustedForBleedAvoidance const): Deleted.
(WebCore::BackgroundPainter::backgroundRoundedRect const): Deleted.
* Source/WebCore/rendering/BackgroundPainter.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::pathForInnerShape const):
(WebCore::BorderShape::pathForBorderArea const):
(WebCore::BorderShape::clipToInnerShape):
(WebCore::BorderShape::fillOuterShape):
(WebCore::BorderShape::fillInnerShape):
* Source/WebCore/rendering/BorderShape.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::clipContentForBorderRadius):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::borderShapeForContentClipping const):
(WebCore::RenderBoxModelObject::roundedContentBoxRect const): Deleted.
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateContentsRects):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paint):
* Source/WebCore/rendering/shapes/BoxShape.cpp:
(WebCore::computeRoundedRectForBoxShape):

Canonical link: <a href="https://commits.webkit.org/282658@main">https://commits.webkit.org/282658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d72a5eef1372d3ce87fa97cbf621d1d0252ca473

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51389 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9940 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12582 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55296 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58867 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6418 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38946 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->