### PR TITLE
REGRESSION (280975@main) Null pointer deref crash in WebCore::AudioWorkletGlobalScope::createProcessor

### DIFF
--- a/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
@@ -28,6 +28,7 @@
 
 #include "AudioWorkletGlobalScope.h"
 #include "AudioWorkletProcessor.h"
+#include "WebCoreOpaqueRootInlines.h"
 
 #if ENABLE(WEB_AUDIO)
 
@@ -36,6 +37,8 @@ namespace WebCore {
 template<typename Visitor>
 void JSAudioWorkletGlobalScope::visitAdditionalChildren(Visitor& visitor)
 {
+    addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
+
     wrapped().visitProcessors(visitor);
 }
 


### PR DESCRIPTION
#### 2ef9bf886adc838c1e70bec46da48a5e33c9b7e8
<pre>
REGRESSION (280975@main) Null pointer deref crash in WebCore::AudioWorkletGlobalScope::createProcessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=278512">https://bugs.webkit.org/show_bug.cgi?id=278512</a>
<a href="https://rdar.apple.com/133250806">rdar://133250806</a>

Reviewed by Chris Dumez.

After 280975@main, Audio Worklet processor constructors are weak
handles and may be garbage collected prematurely, especially in WK1.
This can lead to null pointer deref crashes in WebAudio WPT when trying
to construct a new Audio Worklet processor.

This change adds the AudioWorkletGlobalScope as a WebCore opaque root in
order to keep registered processor constructors alive via the
isReachableFromOpaqueRoots mechanism.

* Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp:
(WebCore::JSAudioWorkletGlobalScope::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/282644@main">https://commits.webkit.org/282644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fae741ee3490a99a4fc917439e7fdf78b98ee2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67734 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51329 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9898 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31961 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36601 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.sharedworker.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13194 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6367 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38890 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->