### PR TITLE
[WPE] Consider actual available size instead of whole screen size for screen.availHeight and screen.availWidth

### DIFF
--- a/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
@@ -81,7 +81,9 @@ ScreenProperties ScreenManager::collectScreenProperties() const
 
         ScreenData data;
         data.screenRect = FloatRect(wpe_monitor_get_x(monitor), wpe_monitor_get_y(monitor), width, height);
-        data.screenAvailableRect = data.screenRect;
+        // TODO: add some API to get the available position to support screen.availTop/Left if it become a standard in the future
+        // For now we're settling to 0,0 as Wayland doesn't provide this information to clients
+        data.screenAvailableRect = FloatRect(0, 0, wpe_monitor_get_available_width(monitor), wpe_monitor_get_available_height(monitor));
         data.screenDepth = 24;
         data.screenDepthPerComponent = 8;
         data.screenSize = { wpe_monitor_get_physical_width(monitor), wpe_monitor_get_physical_height(monitor) };

--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
@@ -38,6 +38,8 @@ struct _WPEMonitorPrivate {
     int y { -1 };
     int width { -1 };
     int height { -1 };
+    int availableWidth { -1 };
+    int availableHeight { -1 };
     int physicalWidth { -1 };
     int physicalHeight { -1 };
     gdouble scale { 1 };
@@ -54,6 +56,8 @@ enum {
     PROP_Y,
     PROP_WIDTH,
     PROP_HEIGHT,
+    PROP_AVAILABLE_WIDTH,
+    PROP_AVAILABLE_HEIGHT,
     PROP_PHYSICAL_WIDTH,
     PROP_PHYSICAL_HEIGHT,
     PROP_SCALE,
@@ -83,6 +87,12 @@ static void wpeMonitorSetProperty(GObject* object, guint propId, const GValue* v
         break;
     case PROP_HEIGHT:
         wpe_monitor_set_size(monitor, -1, g_value_get_int(value));
+        break;
+    case PROP_AVAILABLE_WIDTH:
+        wpe_monitor_set_available_size(monitor, g_value_get_int(value), -1);
+        break;
+    case PROP_AVAILABLE_HEIGHT:
+        wpe_monitor_set_available_size(monitor, -1, g_value_get_int(value));
         break;
     case PROP_PHYSICAL_WIDTH:
         wpe_monitor_set_physical_size(monitor, g_value_get_int(value), -1);
@@ -120,6 +130,12 @@ static void wpeMonitorGetProperty(GObject* object, guint propId, GValue* value, 
         break;
     case PROP_HEIGHT:
         g_value_set_int(value, wpe_monitor_get_height(monitor));
+        break;
+    case PROP_AVAILABLE_WIDTH:
+        g_value_set_int(value, wpe_monitor_get_available_width(monitor));
+        break;
+    case PROP_AVAILABLE_HEIGHT:
+        g_value_set_int(value, wpe_monitor_get_available_height(monitor));
         break;
     case PROP_PHYSICAL_WIDTH:
         g_value_set_int(value, wpe_monitor_get_physical_width(monitor));
@@ -200,6 +216,32 @@ static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
     sObjProperties[PROP_HEIGHT] =
         g_param_spec_int(
             "height",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:available-width:
+     *
+     * The available width of the monitor in logical coordinates. This is the
+     * width of the monitor excluding any reserved areas like docks or panels.
+     */
+    sObjProperties[PROP_AVAILABLE_WIDTH] =
+        g_param_spec_int(
+            "available-width",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:available-height:
+     *
+     * The available height of the monitor in logical coordinates. This is the
+     * height of the monitor excluding any reserved areas like docks or panels.
+     */
+    sObjProperties[PROP_AVAILABLE_HEIGHT] =
+        g_param_spec_int(
+            "available-height",
             nullptr, nullptr,
             -1, G_MAXINT, -1,
             WEBKIT_PARAM_READWRITE);
@@ -395,6 +437,64 @@ void wpe_monitor_set_size(WPEMonitor* monitor, int width, int height)
     if (height != -1 && height != monitor->priv->height) {
         monitor->priv->height = height;
         g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_HEIGHT]);
+    }
+}
+
+/**
+ * wpe_monitor_get_available_width:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the available width of @monitor in logical coordinates. This is the
+ * width of the monitor excluding any reserved areas like docks or panels.
+ *
+ * Returns: the available width of @monitor, or the full monitor width if available width could not be determined.
+ */
+int wpe_monitor_get_available_width(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->availableWidth != -1 ? monitor->priv->availableWidth : monitor->priv->width;
+}
+
+/**
+ * wpe_monitor_get_available_height:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the available height of @monitor in logical coordinates. This is the
+ * height of the monitor excluding any reserved areas like docks or panels.
+ *
+ * Returns: the available height of @monitor, or the full monitor height if available height could not be determined.
+ */
+int wpe_monitor_get_available_height(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->availableHeight != -1 ? monitor->priv->availableHeight : monitor->priv->height;
+}
+
+/**
+ * wpe_monitor_set_available_size:
+ * @monitor: a #WPEMonitor
+ * @width: the available width, or -1
+ * @height: the available height, o -1
+ *
+ * Set the available size of @monitor in logical coordinates. This is the
+ * size of the monitor excluding any reserved areas like docks or panels.
+ */
+void wpe_monitor_set_available_size(WPEMonitor* monitor, int width, int height)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+    g_return_if_fail(width == -1 || width >= 0);
+    g_return_if_fail(height == -1 || height >= 0);
+
+    if (width != -1 && width != monitor->priv->availableWidth) {
+        monitor->priv->availableWidth = width;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_AVAILABLE_WIDTH]);
+    }
+
+    if (height != -1 && height != monitor->priv->availableHeight) {
+        monitor->priv->availableHeight = height;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_AVAILABLE_HEIGHT]);
     }
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.h
@@ -59,6 +59,11 @@ WPE_API int     wpe_monitor_get_height          (WPEMonitor *monitor);
 WPE_API void    wpe_monitor_set_size            (WPEMonitor *monitor,
                                                  int         width,
                                                  int         height);
+WPE_API int     wpe_monitor_get_available_width (WPEMonitor *monitor);
+WPE_API int     wpe_monitor_get_available_height(WPEMonitor *monitor);
+WPE_API void    wpe_monitor_set_available_size  (WPEMonitor *monitor,
+                                                 int         width,
+                                                 int         height);
 WPE_API int     wpe_monitor_get_physical_width  (WPEMonitor *monitor);
 WPE_API int     wpe_monitor_get_physical_height (WPEMonitor *monitor);
 WPE_API void    wpe_monitor_set_physical_size   (WPEMonitor *monitor,

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -216,7 +216,7 @@ const struct wl_registry_listener registryListener = {
         if (!std::strcmp(interface, "wl_compositor"))
             priv->wlCompositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, std::min<uint32_t>(version, 5)));
         else if (!std::strcmp(interface, "xdg_wm_base"))
-            priv->xdgWMBase = static_cast<struct xdg_wm_base*>(wl_registry_bind(registry, name, &xdg_wm_base_interface, 1));
+            priv->xdgWMBase = static_cast<struct xdg_wm_base*>(wl_registry_bind(registry, name, &xdg_wm_base_interface, std::min<uint32_t>(version, 4)));
         // FIXME: support zxdg_shell_v6?
         else if (!std::strcmp(interface, "wl_seat"))
             priv->wlSeat = makeUnique<WPE::WaylandSeat>(static_cast<struct wl_seat*>(wl_registry_bind(registry, name, &wl_seat_interface, std::min<uint32_t>(version, 8))));


### PR DESCRIPTION
#### eeb1b7547fc469a63421727e9689a6053978545c
<pre>
[WPE] Consider actual available size instead of whole screen size for screen.availHeight and screen.availWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=278511">https://bugs.webkit.org/show_bug.cgi?id=278511</a>

Reviewed by NOBODY (OOPS!).

Add new wpe_monitor_get_available_width/height API to report the
available screen size. This is used to feed JS&apos;s
screen.availWidth/availHeight[1]. If not possible to detect the available
dimensions, fallback to the previous behavior of using the whole screen
size, as it&apos;s also one of the accepted values in the spec:

&gt; The Web-exposed available screen area is one of the following:
&gt; The available area of the rendering surface of the output device, in CSS pixels.
&gt; The area of the output device, in CSS pixels.

<a href="https://drafts.csswg.org/cssom-view/#dom-screen-availw">https://drafts.csswg.org/cssom-view/#dom-screen-availw</a>

In Wayland, use the `xdg_toplevel::configure_bounds` event to get the
information from the compositor. Given Wayland design decisions, we
can&apos;t get the actual screen position of the client, so we default to
(0,0).

This is not a problem regarding the `availWidth/availHeight`,
which is the information settled currently in the CSS spec. For the
record, this position limitation might become an issue when Window
Management&apos;s `availLeft/availTop`[2] eventually become an accepted
standard. This limitation is described in the Window Management github,
in [3].

[1] <a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight">https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight</a>
[2] <a href="https://w3c.github.io/window-management/#ref-for-dom-screendetailed-availleft">https://w3c.github.io/window-management/#ref-for-dom-screendetailed-availleft</a>
[3] <a href="https://github.com/w3c/window-management/issues/68">https://github.com/w3c/window-management/issues/68</a>

* Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp:
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp:
(wpeMonitorGetProperty):
(wpe_monitor_class_init):
(wpe_monitor_get_available_width):
(wpe_monitor_get_available_height):
(wpe_monitor_set_available_size):
* Source/WebKit/WPEPlatform/wpe/WPEMonitor.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpeToplevelWaylandConstructed):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeb1b7547fc469a63421727e9689a6053978545c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14307 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51319 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36694 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58820 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6356 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38876 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->