### PR TITLE
[JSC] Don't emit op_get_scope if restoring the scope register is unnecessary

### DIFF
--- a/JSTests/stress/regress-277219.js
+++ b/JSTests/stress/regress-277219.js
@@ -1,0 +1,80 @@
+function testScopeRestorationAfterExceptionInTry() {
+  try {
+    {
+      let x = 1;
+      var captureX = function() { print(x) };
+      throw new Error("foo");
+    }
+  } catch {
+    shouldBe(typeof x, "undefined");
+  } finally {
+    x
+  }
+}
+
+function testScopeRestorationAfterExceptionInTry2() {
+  try {
+    for (let x of [1, 2, 3]) {
+      var captureX = function() { print(x) };
+      throw new Error("foo");
+    }
+  } catch {
+    shouldBe(typeof x, "undefined");
+  } finally {
+    x
+  }
+}
+
+function testScopeRestorationAfterExceptionInCatch() {
+  try {
+    throw new Error("foo");
+  } catch (error) {
+    {
+      let x = 1;
+      var captureX = function() { print(x) };
+      throw new Error("foo");
+    }
+  } finally {
+    shouldBe(typeof x, "undefined");
+    x
+  }
+}
+
+function testScopeRestorationAfterExceptionInCatch2() {
+  try {
+    throw new Error("foo");
+  } catch {
+    for (let x of [1, 2, 3]) {
+      var captureX = function() { print(x) };
+      throw new Error("foo");
+    }
+  } finally {
+    shouldBe(typeof x, "undefined");
+    x
+  }
+}
+
+function shouldBe(actual, expected) {
+  if (actual !== expected)
+    throw new Error(`Bad value: ${actual}!`);
+}
+
+function shouldThrow(func, expectedMessage) {
+  let errorThrown = false;
+  try {
+    func();
+  } catch (error) {
+    errorThrown = true;
+    if (error.toString() !== expectedMessage)
+      throw new Error(`Bad error: ${error}`);
+  }
+  if (!errorThrown)
+    throw new Error(`Didn't throw!`);
+}
+
+for (var i = 0; i < 1e4; i++) {
+  shouldThrow(testScopeRestorationAfterExceptionInTry, "ReferenceError: Can't find variable: x");
+  shouldThrow(testScopeRestorationAfterExceptionInTry2, "ReferenceError: Can't find variable: x");
+  shouldThrow(testScopeRestorationAfterExceptionInCatch, "ReferenceError: Can't find variable: x");
+  shouldThrow(testScopeRestorationAfterExceptionInCatch2, "ReferenceError: Can't find variable: x");
+}

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -4280,6 +4280,7 @@ void BytecodeGenerator::pushLocalControlFlowScope()
     ControlFlowScope scope(ControlFlowScope::Label, currentLexicalScopeIndex());
     m_controlFlowScopeStack.append(WTFMove(scope));
     m_localScopeDepth++;
+    m_localScopeCount++;
 }
 
 void BytecodeGenerator::popLocalControlFlowScope()
@@ -4519,7 +4520,6 @@ void BytecodeGenerator::emitGenericEnumeration(ThrowableExpressionData* node, Ex
 
             // Finally fall through case.
             emitLabel(finallyBodyLabel.get());
-            restoreScopeRegister();
 
             Ref<Label> returnCallTryStart = newLabel();
             emitLabel(returnCallTryStart.get());
@@ -4663,7 +4663,6 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
 
             // Finally fall through case.
             emitLabel(finallyBodyLabel.get());
-            restoreScopeRegister();
 
             Ref<Label> returnCallTryStart = newLabel();
             emitLabel(returnCallTryStart.get());

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1280,6 +1280,8 @@ namespace JSC {
                 && !isArrowFunctionParseMode(parseMode())
                 && !isGeneratorOrAsyncFunctionBodyParseMode(parseMode());
         }
+
+        unsigned localScopeCount() const { return m_localScopeCount; }
     private:
         OptionSet<CodeGenerationMode> m_codeGenerationMode;
 
@@ -1324,6 +1326,7 @@ namespace JSC {
         SegmentedVector<RegisterID, 32> m_constantPoolRegisters;
         unsigned m_finallyDepth { 0 };
         unsigned m_localScopeDepth { 0 };
+        unsigned m_localScopeCount { 0 };
         const CodeType m_codeType;
 
         unsigned localScopeDepth() const;

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4953,6 +4953,11 @@ void TryNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     if (!m_catchBlock && m_finallyBlock)
         finallyTryData = tryData;
 
+    unsigned localScopeCountBeforeTryBlock = generator.localScopeCount();
+    auto scopeRegisterMayBeClobbered = [&]() {
+        return generator.localScopeCount() > localScopeCountBeforeTryBlock;
+    };
+
     if (tryCatchDst == generator.ignoredResult())
         generator.emitNodeInIgnoreResultPosition(m_tryBlock);
     else
@@ -4974,7 +4979,8 @@ void TryNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         RefPtr<RegisterID> thrownValueRegister = generator.newTemporary();
         RegisterID* completionTypeRegister = m_finallyBlock ? finallyContext->completionTypeRegister() : nullptr;
         generator.emitOutOfLineCatchHandler(thrownValueRegister.get(), completionTypeRegister, tryData);
-        generator.restoreScopeRegister();
+        if (scopeRegisterMayBeClobbered())
+            generator.restoreScopeRegister();
 
         if (m_finallyBlock) {
             // If the catch block throws an exception and we have a finally block, then the finally
@@ -5020,7 +5026,8 @@ void TryNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 
         // Entry to the finally block for CompletionTypes other than Throw.
         generator.emitLabel(*finallyLabel);
-        generator.restoreScopeRegister();
+        if (scopeRegisterMayBeClobbered())
+            generator.restoreScopeRegister();
 
         int finallyStartOffset = m_catchBlock ? m_catchBlock->endOffset() + 1 : m_tryBlock->endOffset() + 1;
         


### PR DESCRIPTION
#### f6fd2039015c4cbd575768f822ac036102dbc79c
<pre>
[JSC] Don&apos;t emit op_get_scope if restoring the scope register is unnecessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=277219">https://bugs.webkit.org/show_bug.cgi?id=277219</a>
&lt;<a href="https://rdar.apple.com/problem/132702544">rdar://problem/132702544</a>&gt;

Reviewed by Yusuke Suzuki.

This change:

1) in try/catch/finally, guards restoreScopeRegister() in `catch` and `finally` blocks to be called
   only if a new scope was created in any of the previous blocks (`try` or `catch`), which happens
   pretty rarely;

2) in for/of, removes restoreScopeRegister() because it&apos;s actually unnecessary: `finally` handler
   closes iterator without resolving any symbols; in case of `return` / `throw` completions, the
   function is terminated and clobbered scope is never accessed, while both same-level and nested
   `break` / `continue` completions restore scope on their own.

* JSTests/stress/regress-277219.js: Added.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::pushLocalControlFlowScope):
(JSC::BytecodeGenerator::emitGenericEnumeration):
(JSC::BytecodeGenerator::emitEnumeration):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::localScopeCount const):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::TryNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/282775@main">https://commits.webkit.org/282775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a15e1831dfc375c00ebd5daf8effd414f457fe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14281 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51300 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9867 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12499 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13154 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69390 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/62918 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58575 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58789 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6335 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/208 "Build was cancelled. Recent messages:OS: Ventura (13.6.9), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 9 flakes 21 failures; Uploaded test results; 10 flakes 21 failures; Compiled WebKit (cancelled)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84679 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9733 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38850 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14930 "Found 1 new JSC stress test failure: jsc-layout-tests.yaml/js/script-tests/function-apply-aliased.js.layout-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39929 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->