### PR TITLE
[GLib] Improve FPS counter

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperFPSCounter.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperFPSCounter.cpp
@@ -49,14 +49,8 @@ TextureMapperFPSCounter::TextureMapperFPSCounter()
 
 void TextureMapperFPSCounter::updateFPSAndDisplay(TextureMapper& textureMapper, const FloatPoint& location, const TransformationMatrix& matrix)
 {
-    if (!m_isShowingFPS) {
-#if USE(SYSPROF_CAPTURE)
-        if (!SysprofAnnotator::singletonIfCreated())
-            return;
-#else
+    if (!m_isShowingFPS)
         return;
-#endif
-    }
 
     m_frameCount++;
     Seconds delta = MonotonicTime::now() - m_fpsTimestamp;
@@ -66,10 +60,7 @@ void TextureMapperFPSCounter::updateFPSAndDisplay(TextureMapper& textureMapper, 
         m_fpsTimestamp += delta;
     }
 
-    WTFSetCounter(FPS, m_lastFPS);
-
-    if (m_isShowingFPS)
-        textureMapper.drawNumber(m_lastFPS, Color::black, location, matrix);
+    textureMapper.drawNumber(m_lastFPS, Color::black, location, matrix);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -489,6 +489,10 @@ void LayerTreeHost::didRenderFrame()
 {
     if (auto* drawingArea = m_webPage.drawingArea())
         drawingArea->didCompleteRenderingUpdateDisplay();
+    if (auto fps = m_compositor->fps()) {
+        if (RefPtr document = m_webPage.corePage()->localTopDocument())
+            document->addConsoleMessage(MessageSource::Rendering, MessageLevel::Info, makeString("FPS: "_s, *fps));
+    }
 }
 
 #if HAVE(DISPLAY_LINK)


### PR DESCRIPTION
#### b7df35a60c2f4dc6755f671ef6d5fc45c3482d10
<pre>
[GLib] Improve FPS counter
<a href="https://bugs.webkit.org/show_bug.cgi?id=278460">https://bugs.webkit.org/show_bug.cgi?id=278460</a>

Reviewed by Carlos Garcia Campos.

This change makes the FPS counter on GLib-based ports logging the FPS
periodically to the console instead of drawing as drawing interferes
with the measurements it takes due to the usage of the same graphics
pipeline.

* Source/WebCore/platform/graphics/texmap/TextureMapperFPSCounter.cpp:
(WebCore::TextureMapperFPSCounter::updateFPSAndDisplay):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::initializeFPSCounter):
(WebKit::ThreadedCompositor::updateFPSCounter):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
(WebKit::ThreadedCompositor::fps const):

Canonical link: <a href="https://commits.webkit.org/294148@main">https://commits.webkit.org/294148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45e8c5a8b8f8758839ba4ad1beae049f52ac7ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/102893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76797 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33831 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85760 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85303 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21990 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33163 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->