### PR TITLE
PluginsEnabled is an unsupported test header key after 274917@main

### DIFF
--- a/LayoutTests/fast/css/object-fit/object-fit-embed-expected.html
+++ b/LayoutTests/fast/css/object-fit/object-fit-embed-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ PluginsEnabled=false ] --><!-- Disable plugins, because otherwise the "Test WebKit PlugIn" steals <embed>s referencing PNGs. -->
+<!DOCTYPE html>
 
 <html>
   <head>

--- a/LayoutTests/fast/css/object-fit/object-fit-embed.html
+++ b/LayoutTests/fast/css/object-fit/object-fit-embed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ PluginsEnabled=false ] --><!-- Disable plugins, because otherwise the "Test WebKit PlugIn" steals <embed>s referencing PNGs. -->
+<!DOCTYPE html>
 
 <html>
   <head>

--- a/LayoutTests/fast/css/object-position/object-position-embed.html
+++ b/LayoutTests/fast/css/object-position/object-position-embed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ PluginsEnabled=false ] --><!-- Disable plugins, because otherwise the "Test WebKit PlugIn" steals <embed>s referencing PNGs. -->
+<!DOCTYPE html>
 
 <html>
 <head>

--- a/LayoutTests/fast/images/embed-image.html
+++ b/LayoutTests/fast/images/embed-image.html
@@ -1,2 +1,1 @@
-<!-- webkit-test-runner [ PluginsEnabled=false ] -->
 <embed src="../borders/resources/Balloon_8107502.tiff" width="38" height="24" type="image/tiff"></embed>

--- a/LayoutTests/fast/images/move-image-to-new-document.html
+++ b/LayoutTests/fast/images/move-image-to-new-document.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ PluginsEnabled=false ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/replaced/border-radius-clip-content-edge.html
+++ b/LayoutTests/fast/replaced/border-radius-clip-content-edge.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ PluginsEnabled=false ] -->
+<!DOCTYPE html>
 <style>
   body {
     width: 600px;

--- a/LayoutTests/fast/replaced/outline-replaced-elements.html
+++ b/LayoutTests/fast/replaced/outline-replaced-elements.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ PluginsEnabled=false ] --><!-- Disable plugins, because otherwise the "Test WebKit PlugIn" steals <embed>s referencing PNGs. -->
+<!DOCTYPE html>
 <style>
   .group {
     float: left; width: 180px;

--- a/LayoutTests/http/tests/download/convert-cached-load-to-download.html
+++ b/LayoutTests/http/tests/download/convert-cached-load-to-download.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true PluginsEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/platform/mac/plugins/disable-plugins.html
+++ b/LayoutTests/platform/mac/plugins/disable-plugins.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ PluginsEnabled=false ] -->
 <script>
 function runTest() {
     if (!window.testRunner)

--- a/LayoutTests/plugins/navigator-plugins-disabled.html
+++ b/LayoutTests/plugins/navigator-plugins-disabled.html
@@ -1,4 +1,4 @@
-<html><!-- webkit-test-runner [ PluginsEnabled=false ] -->
+<html>
 <head>
     <title>Test if navigator.plugins is (mostly) empty when plugins are disabled.</title>
 <body>


### PR DESCRIPTION
#### 3b95135338c01b753930e44a7754493ef6869882
<pre>
PluginsEnabled is an unsupported test header key after 274917@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=278517">https://bugs.webkit.org/show_bug.cgi?id=278517</a>
<a href="https://rdar.apple.com/134484647">rdar://134484647</a>

Reviewed by Alex Christensen.

We removed support for the PluginsEnabled preference in 274917@main, and
as such is now an invalid test header key.

This patch removes references to that preference in layout test headers.

* LayoutTests/fast/css/object-fit/object-fit-embed-expected.html:
* LayoutTests/fast/css/object-fit/object-fit-embed.html:
* LayoutTests/fast/css/object-position/object-position-embed.html:
* LayoutTests/fast/images/embed-image.html:
* LayoutTests/fast/images/move-image-to-new-document.html:
* LayoutTests/fast/replaced/border-radius-clip-content-edge.html:
* LayoutTests/fast/replaced/outline-replaced-elements.html:
* LayoutTests/http/tests/download/convert-cached-load-to-download.html:
* LayoutTests/platform/mac/plugins/disable-plugins.html:
* LayoutTests/plugins/navigator-plugins-disabled.html:

Canonical link: <a href="https://commits.webkit.org/282631@main">https://commits.webkit.org/282631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/967b9d84080f35d88693a16bd5904e8cc1d7cc09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51306 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9876 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66751 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/39914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31938 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12505 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13163 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12830 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.serviceworker.html?wss (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69399 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58792 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6344 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9638 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38859 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->