### PR TITLE
Make FormDataConsumer RefCounted

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -97,7 +97,7 @@ private:
     RefPtr<FetchBodySource> m_source;
     bool m_isLoading { false };
     RefPtr<UserGestureToken> m_userGestureToken;
-    std::unique_ptr<FormDataConsumer> m_formDataConsumer;
+    RefPtr<FormDataConsumer> m_formDataConsumer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -41,7 +41,6 @@ FormDataConsumer::FormDataConsumer(const FormData& formData, ScriptExecutionCont
     , m_callback(WTFMove(callback))
     , m_fileQueue(WorkQueue::create("FormDataConsumer file queue"_s))
 {
-    read();
 }
 
 FormDataConsumer::~FormDataConsumer() = default;
@@ -55,7 +54,8 @@ void FormDataConsumer::read()
     ASSERT(!m_blobLoader);
 
     if (m_currentElementIndex >= m_formData->elements().size()) {
-        m_callback(std::span<const uint8_t> { });
+        auto callback = std::exchange(m_callback, nullptr);
+        callback(std::span<const uint8_t> { });
         return;
     }
 
@@ -77,15 +77,16 @@ void FormDataConsumer::consumeFile(const String& filename)
 {
     m_fileQueue->dispatch([weakThis = WeakPtr { *this }, identifier = m_context->identifier(), path = filename.isolatedCopy()]() mutable {
         ScriptExecutionContext::postTaskTo(identifier, [weakThis = WTFMove(weakThis), content = FileSystem::readEntireFile(path)](auto&) {
-            if (!weakThis)
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             if (!content) {
-                weakThis->didFail(Exception { ExceptionCode::InvalidStateError, "Unable to read form data file"_s });
+                protectedThis->didFail(Exception { ExceptionCode::InvalidStateError, "Unable to read form data file"_s });
                 return;
             }
 
-            weakThis->consume(*content);
+            protectedThis->consume(*content);
         });
     });
 }
@@ -93,20 +94,21 @@ void FormDataConsumer::consumeFile(const String& filename)
 void FormDataConsumer::consumeBlob(const URL& blobURL)
 {
     m_blobLoader = makeUnique<BlobLoader>([weakThis = WeakPtr { *this }](BlobLoader&) mutable {
-        if (!weakThis)
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
-        auto loader = std::exchange(weakThis->m_blobLoader, { });
+        auto loader = std::exchange(protectedThis->m_blobLoader, { });
         if (!loader)
             return;
 
         if (auto optionalErrorCode = loader->errorCode()) {
-            weakThis->didFail(Exception { ExceptionCode::InvalidStateError, "Failed to read form data blob"_s });
+            protectedThis->didFail(Exception { ExceptionCode::InvalidStateError, "Failed to read form data blob"_s });
             return;
         }
 
         if (auto data = loader->arrayBufferResult())
-            weakThis->consume(data->span());
+            protectedThis->consume(data->span());
     });
 
     m_blobLoader->start(blobURL, m_context.get(), FileReaderLoader::ReadAsArrayBuffer);
@@ -120,7 +122,12 @@ void FormDataConsumer::consume(std::span<const uint8_t> content)
     if (!m_callback)
         return;
 
-    m_callback(WTFMove(content));
+    bool result = m_callback(WTFMove(content));
+    if (!result) {
+        cancel();
+        return;
+    }
+
     if (!m_callback)
         return;
 

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -30,18 +30,10 @@
 #include <span>
 #include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
-
-namespace WebCore {
-class FormDataConsumer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::FormDataConsumer> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -49,16 +41,19 @@ class BlobLoader;
 class FormData;
 class ScriptExecutionContext;
 
-class FormDataConsumer : public CanMakeWeakPtr<FormDataConsumer> {
+class FormDataConsumer : public RefCounted<FormDataConsumer>, public CanMakeWeakPtr<FormDataConsumer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FormDataConsumer, WEBCORE_EXPORT);
 public:
-    using Callback = Function<void(ExceptionOr<std::span<const uint8_t>>)>;
-    FormDataConsumer(const FormData&, ScriptExecutionContext&, Callback&&);
+    using Callback = Function<bool(ExceptionOr<std::span<const uint8_t>>)>;
+    static Ref<FormDataConsumer> create(const FormData& formData, ScriptExecutionContext& context, Callback&& callback) { return adoptRef(*new FormDataConsumer(formData, context, WTFMove(callback))); }
     WEBCORE_EXPORT ~FormDataConsumer();
 
+    void start() { read(); }
     void cancel();
 
 private:
+    FormDataConsumer(const FormData&, ScriptExecutionContext&, Callback&&);
+
     void consumeData(const Vector<uint8_t>&);
     void consumeFile(const String&);
     void consumeBlob(const URL&);


### PR DESCRIPTION
#### a4c2e8d62285d948d697c7f53e6e7e24b8540114
<pre>
Make FormDataConsumer RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=278518">https://bugs.webkit.org/show_bug.cgi?id=278518</a>
<a href="https://rdar.apple.com/134491795">rdar://134491795</a>

Reviewed by Chris Dumez.

To apply the hardening of protecting a weak pointer, we make FormDataConsumer RefCounted.
We can then protect it in FormDataConsumer::consumeFile and FormDataConsumer::consumeBlob.

We update FetchBodyConsumer to store a RefPtr&lt;FormDataConsumer&gt;.
We can no longer pass a reference to FetchBodyConsumer in FormDataConsumer callback since FormDataConsumer can outlive FetchBodyConsumer.
So we remove the reference and we store m_type in the first FormDataConsumer callback.

For the second callback, the FetchBodyConsumer reference was used to cancel the FormDataConsumer if we were not able to enqueue data in the ReadableStream.
We are now updating the callback to return true (to continue the load) or false (to stop the load).
We update FetchBodyConsumer and FormDataConsumer accordingly.

Covered by existing tests.

* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolveWithFormData):
(WebCore::FetchBodyConsumer::consumeFormDataAsStream):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::create):
(WebCore::FormDataConsumer::FormDataConsumer):
(WebCore::FormDataConsumer::~FormDataConsumer):
(WebCore::FormDataConsumer::read):
(WebCore::FormDataConsumer::consumeFile):
(WebCore::FormDataConsumer::consumeBlob):
(WebCore::FormDataConsumer::consume):
* Source/WebCore/Modules/fetch/FormDataConsumer.h:

Canonical link: <a href="https://commits.webkit.org/282653@main">https://commits.webkit.org/282653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a53a0ece84ba2763cc33b8f20c89bb6b086affc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51312 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66758 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31944 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12509 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13170 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58412 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); re-run-api-tests (failure); Compiled WebKit (warnings); run-api-tests-without-change (failure); analyze-api-tests-results (retry)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58588 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58798 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6347 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38866 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->