### PR TITLE
Remove runtime CryptoKit Enablement

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1999,20 +1999,6 @@ CrossOriginOpenerPolicyEnabled:
     WebCore:
       default: false
 
-CryptoKitEnabled:
-  type: bool
-  status: internal
-  category: security
-  humanReadableName: "Enable CryptoKit for supported Algorithms."
-  humanReadableDescription: "Enable CryptoKit for supported Algorithms."
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CursiveFontFamily:
   type: String
   status: embedder

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -35,7 +35,6 @@
 #include "WebAuthenticationUtils.h"
 
 namespace WebCore {
-static constexpr auto useCryptoKit = UseCryptoKit::Yes;
 
 static std::optional<cbor::CBORValue> coseKeyForAttestationObject(Ref<ArrayBuffer> attObj)
 {
@@ -170,11 +169,11 @@ RefPtr<ArrayBuffer> AuthenticatorAttestationResponse::getPublicKey() const
             return nullptr;
         }
         auto y = it->second.getByteString();
-        auto peerKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(x, y), true, CryptoKeyUsageDeriveBits, useCryptoKit);
+        auto peerKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(x, y), true, CryptoKeyUsageDeriveBits);
 
         if (!peerKey)
             return nullptr;
-        auto keySpki = peerKey->exportSpki(useCryptoKit).releaseReturnValue();
+        auto keySpki = peerKey->exportSpki().releaseReturnValue();
         return ArrayBuffer::tryCreate(keySpki);
     }
     default:

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -32,7 +32,6 @@
 namespace PAL {
 
 struct CryptoDigestContext;
-enum class UseCryptoKit : bool { No, Yes };
 
 class CryptoDigest {
     WTF_MAKE_NONCOPYABLE(CryptoDigest);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2625,7 +2625,7 @@ private:
             switch (key->type()) {
             case CryptoKey::Type::Public: {
                 write(CryptoKeyAsymmetricTypeSubtag::Public);
-                auto result = downcast<CryptoKeyEC>(*key).exportRaw(isUsingCryptoKit());
+                auto result = downcast<CryptoKeyEC>(*key).exportRaw();
                 ASSERT(!result.hasException());
                 write(result.releaseReturnValue());
                 break;
@@ -2633,7 +2633,7 @@ private:
             case CryptoKey::Type::Private: {
                 write(CryptoKeyAsymmetricTypeSubtag::Private);
                 // Use the standard complied method is not very efficient, but simple/reliable.
-                auto result = downcast<CryptoKeyEC>(*key).exportPkcs8(isUsingCryptoKit());
+                auto result = downcast<CryptoKeyEC>(*key).exportPkcs8();
                 ASSERT(!result.hasException());
                 write(result.releaseReturnValue());
                 break;
@@ -2665,11 +2665,6 @@ private:
             write(downcast<CryptoKeyOKP>(*key).platformKey());
             break;
         }
-    }
-
-    UseCryptoKit isUsingCryptoKit()
-    {
-        return executionContext(m_lexicalGlobalObject)->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     }
 
     void write(std::span<const uint8_t> data)
@@ -3312,11 +3307,6 @@ private:
     }
 
     enum class VisitNamedMemberResult : uint8_t { Error, Break, Start, Unknown };
-
-    UseCryptoKit isUsingCryptoKit()
-    {
-        return executionContext(m_lexicalGlobalObject)->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
-    }
 
     template<WalkerState endState>
     ALWAYS_INLINE VisitNamedMemberResult startVisitNamedMember(MarkedVector<JSObject*, 32>& outputObjectStack, Vector<Identifier, 16>& propertyNameStack, Vector<WalkerState, 16>& stateStack, JSValue& outValue)
@@ -4196,10 +4186,10 @@ private:
 
         switch (type) {
         case CryptoKeyAsymmetricTypeSubtag::Public:
-            result = CryptoKeyEC::importRaw(algorithm, curve->string(), WTFMove(keyData), extractable, usages, isUsingCryptoKit());
+            result = CryptoKeyEC::importRaw(algorithm, curve->string(), WTFMove(keyData), extractable, usages);
             break;
         case CryptoKeyAsymmetricTypeSubtag::Private:
-            result = CryptoKeyEC::importPkcs8(algorithm, curve->string(), WTFMove(keyData), extractable, usages, isUsingCryptoKit());
+            result = CryptoKeyEC::importPkcs8(algorithm, curve->string(), WTFMove(keyData), extractable, usages);
             break;
         }
 

--- a/Source/WebCore/crypto/CryptoAlgorithm.cpp
+++ b/Source/WebCore/crypto/CryptoAlgorithm.cpp
@@ -65,22 +65,22 @@ void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithm::importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&& exceptionCallback)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithm::exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&& exceptionCallback)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithm::wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithm::unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -70,10 +70,10 @@ public:
     virtual void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
     virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169262
-    virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit);
-    virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit);
-    virtual void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit);
-    virtual void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit);
+    virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&);
+    virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&);
+    virtual void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&);
+    virtual void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&);
     virtual ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
 
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Function<ExceptionOr<Vector<uint8_t>>()>&&);

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -54,8 +54,6 @@ enum class CryptoKeyClass {
     Raw,
 };
 
-enum class UseCryptoKit : bool { No, Yes };
-
 class CryptoKey : public ThreadSafeRefCounted<CryptoKey> {
 public:
     using Type = CryptoKeyType;

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -943,9 +943,8 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
 
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
-    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     WeakPtr weakThis { *this };
-    auto callback = [index, weakThis, importAlgorithm = WTFMove(importAlgorithm), importParams = crossThreadCopyImportParams(*importParams), extractable, keyUsagesBitmap, useCryptoKit](const Vector<uint8_t>& derivedKey) mutable {
+    auto callback = [index, weakThis, importAlgorithm = WTFMove(importAlgorithm), importParams = crossThreadCopyImportParams(*importParams), extractable, keyUsagesBitmap](const Vector<uint8_t>& derivedKey) mutable {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169395
         KeyData data = derivedKey;
         auto callback = [index, weakThis](CryptoKey& key) mutable {
@@ -962,7 +961,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
                 rejectWithException(promise.releaseNonNull(), ec);
         };
 
-        importAlgorithm->importKey(SubtleCrypto::KeyFormat::Raw, WTFMove(data), *importParams, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+        importAlgorithm->importKey(SubtleCrypto::KeyFormat::Raw, WTFMove(data), *importParams, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback));
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -1031,7 +1030,6 @@ void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDa
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
-    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     auto callback = [index, weakThis](CryptoKey& key) mutable {
         if (auto promise = getPromise(index, weakThis)) {
             if ((key.type() == CryptoKeyType::Private || key.type() == CryptoKeyType::Secret) && !key.usagesBitmap()) {
@@ -1049,7 +1047,7 @@ void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDa
     // The 11 December 2014 version of the specification suggests we should perform the following task asynchronously:
     // https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-importKey
     // It is not beneficial for less time consuming operations. Therefore, we perform it synchronously.
-    algorithm->importKey(format, WTFMove(keyData), *params, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+    algorithm->importKey(format, WTFMove(keyData), *params, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback));
 }
 
 void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromise>&& promise)
@@ -1069,7 +1067,6 @@ void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromi
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
-    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     auto callback = [index, weakThis](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
         if (auto promise = getPromise(index, weakThis)) {
             switch (format) {
@@ -1095,7 +1092,7 @@ void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromi
     // The 11 December 2014 version of the specification suggests we should perform the following task asynchronously:
     // https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-exportKey
     // It is not beneficial for less time consuming operations. Therefore, we perform it synchronously.
-    algorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+    algorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback));
 }
 
 void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoKey& key, CryptoKey& wrappingKey, AlgorithmIdentifier&& wrapAlgorithmIdentifier, Ref<DeferredPromise>&& promise)
@@ -1144,8 +1141,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
-    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
-    auto callback = [index, weakThis, wrapAlgorithm, wrappingKey = Ref { wrappingKey }, wrapParams = WTFMove(wrapParams), isEncryption, context, workQueue = m_workQueue, useCryptoKit](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
+    auto callback = [index, weakThis, wrapAlgorithm, wrappingKey = Ref { wrappingKey }, wrapParams = WTFMove(wrapParams), isEncryption, context, workQueue = m_workQueue](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
         if (!weakThis)
             return;
         RefPtr promise = weakThis->m_pendingPromises.get(index);
@@ -1183,7 +1179,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
             // The 11 December 2014 version of the specification suggests we should perform the following task asynchronously:
             // https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-wrapKey
             // It is not beneficial for less time consuming operations. Therefore, we perform it synchronously.
-            wrapAlgorithm->wrapKey(wrappingKey.get(), WTFMove(bytes), WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+            wrapAlgorithm->wrapKey(wrappingKey.get(), WTFMove(bytes), WTFMove(callback), WTFMove(exceptionCallback));
             return;
         }
         // The following operation should be performed asynchronously.
@@ -1195,7 +1191,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
     };
 
     // The following operation should be performed synchronously.
-    exportAlgorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+    exportAlgorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback));
 }
 
 void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, BufferSource&& wrappedKeyBufferSource, CryptoKey& unwrappingKey, AlgorithmIdentifier&& unwrapAlgorithmIdentifier, AlgorithmIdentifier&& unwrappedKeyAlgorithmIdentifier, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
@@ -1250,8 +1246,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
-    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
-    auto callback = [index, weakThis, format, importAlgorithm, unwrappedKeyAlgorithm = crossThreadCopyImportParams(*unwrappedKeyAlgorithm), extractable, keyUsagesBitmap, useCryptoKit](const Vector<uint8_t>& bytes) mutable {
+    auto callback = [index, weakThis, format, importAlgorithm, unwrappedKeyAlgorithm = crossThreadCopyImportParams(*unwrappedKeyAlgorithm), extractable, keyUsagesBitmap](const Vector<uint8_t>& bytes) mutable {
         if (!weakThis)
             return;
         RefPtr promise = weakThis->m_pendingPromises.get(index);
@@ -1303,7 +1298,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
         };
 
         // The following operation should be performed synchronously.
-        importAlgorithm->importKey(format, WTFMove(keyData), *unwrappedKeyAlgorithm, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+        importAlgorithm->importKey(format, WTFMove(keyData), *unwrappedKeyAlgorithm, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback));
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -1317,7 +1312,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
         RefPtr context = weakThis->scriptExecutionContext();
         if (!context)
             return;
-        unwrapAlgorithm->unwrapKey(unwrappingKey, WTFMove(wrappedKey), WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
+        unwrapAlgorithm->unwrapKey(unwrappingKey, WTFMove(wrappedKey), WTFMove(callback), WTFMove(exceptionCallback));
         return;
     }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
@@ -105,7 +105,7 @@ void CryptoAlgorithmAESCBC::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESCBCInternal;
 
@@ -146,7 +146,7 @@ void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESCBC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESCBC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESCBCInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.h
@@ -51,8 +51,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
@@ -105,7 +105,7 @@ void CryptoAlgorithmAESCFB::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESCFBInternal;
     
@@ -146,7 +146,7 @@ void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESCFB::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESCFB::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESCFBInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.h
@@ -45,8 +45,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
@@ -114,7 +114,7 @@ void CryptoAlgorithmAESCTR::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESCTRInternal;
 
@@ -155,7 +155,7 @@ void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESCTR::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESCTR::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESCTRInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.h
@@ -73,8 +73,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCtrParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
@@ -96,10 +96,9 @@ void CryptoAlgorithmAESGCM::encrypt(const CryptoAlgorithmParameters& parameters,
         return;
     }
 
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [parameters = crossThreadCopy(aesParameters), key = WTFMove(key), plainText = WTFMove(plainText), useCryptoKit] {
-            return platformEncrypt(parameters, downcast<CryptoKeyAES>(key.get()), plainText, useCryptoKit);
+        [parameters = crossThreadCopy(aesParameters), key = WTFMove(key), plainText = WTFMove(plainText)] {
+            return platformEncrypt(parameters, downcast<CryptoKeyAES>(key.get()), plainText);
     });
 }
 
@@ -154,7 +153,7 @@ void CryptoAlgorithmAESGCM::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESGCMInternal;
 
@@ -195,7 +194,7 @@ void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESGCM::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESGCM::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESGCMInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.h
@@ -46,11 +46,11 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
 };
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
@@ -69,7 +69,7 @@ void CryptoAlgorithmAESKW::generateKey(const CryptoAlgorithmParameters& paramete
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESKWInternal;
 
@@ -109,7 +109,7 @@ void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, con
     callback(*result);
 }
 
-void CryptoAlgorithmAESKW::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmAESKW::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmAESKWInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());
@@ -150,13 +150,13 @@ void CryptoAlgorithmAESKW::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& ke
     callback(format, WTFMove(result));
 }
 
-void CryptoAlgorithmAESKW::wrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
+void CryptoAlgorithmAESKW::wrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     if (data.size() % 8) {
         exceptionCallback(ExceptionCode::OperationError);
         return;
     }
-    auto result = platformWrapKey(downcast<CryptoKeyAES>(key.get()), WTFMove(data), useCryptoKit);
+    auto result = platformWrapKey(downcast<CryptoKeyAES>(key.get()), WTFMove(data));
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());
         return;
@@ -165,9 +165,9 @@ void CryptoAlgorithmAESKW::wrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data,
     callback(result.releaseReturnValue());
 }
 
-void CryptoAlgorithmAESKW::unwrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
+void CryptoAlgorithmAESKW::unwrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
-    auto result = platformUnwrapKey(downcast<CryptoKeyAES>(key.get()), WTFMove(data), useCryptoKit);
+    auto result = platformUnwrapKey(downcast<CryptoKeyAES>(key.get()), WTFMove(data));
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());
         return;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.h
@@ -43,14 +43,14 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit) final;
-    void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&) final;
+    void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformWrapKey(const CryptoKeyAES&, const Vector<uint8_t>&, UseCryptoKit);
-    static ExceptionOr<Vector<uint8_t>> platformUnwrapKey(const CryptoKeyAES&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformWrapKey(const CryptoKeyAES&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformUnwrapKey(const CryptoKeyAES&, const Vector<uint8_t>&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -45,7 +45,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmECDH::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context)
+void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
 {
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
 
@@ -53,8 +53,7 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
         exceptionCallback(ExceptionCode::SyntaxError);
         return;
     }
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
-    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, ecParameters.namedCurve, extractable, usages, useCryptoKit);
+    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, ecParameters.namedCurve, extractable, usages);
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());
         return;
@@ -107,19 +106,18 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
         (*derivedKey).shrink(lengthInBytes);
         callback(WTFMove(*derivedKey));
     };
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     // This is a special case that can't use dispatchOperation() because it bundles
     // the result validation and callback dispatch into unifiedCallback.
     workQueue.dispatch(
-        [baseKey = WTFMove(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTFMove(unifiedCallback), contextIdentifier = context.identifier(), useCryptoKit]() mutable {
-            auto derivedKey = platformDeriveBits(downcast<CryptoKeyEC>(baseKey.get()), downcast<CryptoKeyEC>(*publicKey), useCryptoKit);
+        [baseKey = WTFMove(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTFMove(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
+            auto derivedKey = platformDeriveBits(downcast<CryptoKeyEC>(baseKey.get()), downcast<CryptoKeyEC>(*publicKey));
             ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTFMove(derivedKey), length, unifiedCallback = WTFMove(unifiedCallback)](auto&) mutable {
                 unifiedCallback(WTFMove(derivedKey), length);
             });
         });
 }
 
-void CryptoAlgorithmECDH::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
+void CryptoAlgorithmECDH::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
     RefPtr<CryptoKeyEC> result;
@@ -144,7 +142,7 @@ void CryptoAlgorithmECDH::importKey(CryptoKeyFormat format, KeyData&& data, cons
             return;
         }
 
-        result = CryptoKeyEC::importJwk(ecParameters.identifier, ecParameters.namedCurve, WTFMove(key), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importJwk(ecParameters.identifier, ecParameters.namedCurve, WTFMove(key), extractable, usages);
         break;
     }
     case CryptoKeyFormat::Raw:
@@ -152,21 +150,21 @@ void CryptoAlgorithmECDH::importKey(CryptoKeyFormat format, KeyData&& data, cons
             exceptionCallback(ExceptionCode::SyntaxError);
             return;
         }
-        result = CryptoKeyEC::importRaw(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importRaw(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Spki:
         if (usages) {
             exceptionCallback(ExceptionCode::SyntaxError);
             return;
         }
-        result = CryptoKeyEC::importSpki(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importSpki(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Pkcs8:
         if (usages && (usages ^ CryptoKeyUsageDeriveKey) && (usages ^ CryptoKeyUsageDeriveBits) && (usages ^ (CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits))) {
             exceptionCallback(ExceptionCode::SyntaxError);
             return;
         }
-        result = CryptoKeyEC::importPkcs8(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importPkcs8(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     }
     if (!result) {
@@ -177,7 +175,7 @@ void CryptoAlgorithmECDH::importKey(CryptoKeyFormat format, KeyData&& data, cons
     callback(*result);
 }
 
-void CryptoAlgorithmECDH::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
+void CryptoAlgorithmECDH::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     const auto& ecKey = downcast<CryptoKeyEC>(key.get());
     if (!ecKey.keySizeInBits()) {
@@ -188,7 +186,7 @@ void CryptoAlgorithmECDH::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key
     KeyData result;
     switch (format) {
     case CryptoKeyFormat::Jwk: {
-        auto jwk = ecKey.exportJwk(useCryptoKit);
+        auto jwk = ecKey.exportJwk();
         if (jwk.hasException()) {
             exceptionCallback(jwk.releaseException().code());
             return;
@@ -197,7 +195,7 @@ void CryptoAlgorithmECDH::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key
         break;
     }
     case CryptoKeyFormat::Raw: {
-        auto raw = ecKey.exportRaw(useCryptoKit);
+        auto raw = ecKey.exportRaw();
         if (raw.hasException()) {
             exceptionCallback(raw.releaseException().code());
             return;
@@ -206,7 +204,7 @@ void CryptoAlgorithmECDH::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key
         break;
     }
     case CryptoKeyFormat::Spki: {
-        auto spki = ecKey.exportSpki(useCryptoKit);
+        auto spki = ecKey.exportSpki();
         if (spki.hasException()) {
             exceptionCallback(spki.releaseException().code());
             return;
@@ -215,7 +213,7 @@ void CryptoAlgorithmECDH::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key
         break;
     }
     case CryptoKeyFormat::Pkcs8: {
-        auto pkcs8 = ecKey.exportPkcs8(useCryptoKit);
+        auto pkcs8 = ecKey.exportPkcs8();
         if (pkcs8.hasException()) {
             exceptionCallback(pkcs8.releaseException().code());
             return;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h
@@ -38,7 +38,7 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     // Operations can be performed directly.
-    WEBCORE_EXPORT static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&, UseCryptoKit);
+    WEBCORE_EXPORT static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&);
 
 private:
     CryptoAlgorithmECDH() = default;
@@ -46,8 +46,8 @@ private:
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
@@ -60,10 +60,9 @@ void CryptoAlgorithmECDSA::sign(const CryptoAlgorithmParameters& parameters, Ref
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmEcdsaParams>(parameters)), key = WTFMove(key), data = WTFMove(data), useCryptoKit] {
-            return platformSign(parameters, downcast<CryptoKeyEC>(key.get()), data, useCryptoKit);
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmEcdsaParams>(parameters)), key = WTFMove(key), data = WTFMove(data)] {
+            return platformSign(parameters, downcast<CryptoKeyEC>(key.get()), data);
         });
 }
 
@@ -74,14 +73,13 @@ void CryptoAlgorithmECDSA::verify(const CryptoAlgorithmParameters& parameters, R
         return;
     }
 
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmEcdsaParams>(parameters)), key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data), useCryptoKit] {
-            return platformVerify(parameters, downcast<CryptoKeyEC>(key.get()), signature, data, useCryptoKit);
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmEcdsaParams>(parameters)), key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
+            return platformVerify(parameters, downcast<CryptoKeyEC>(key.get()), signature, data);
         });
 }
 
-void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context)
+void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
 {
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
 
@@ -89,8 +87,7 @@ void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& paramete
         exceptionCallback(ExceptionCode::SyntaxError);
         return;
     }
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
-    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDSA, ecParameters.namedCurve, extractable, usages, useCryptoKit);
+    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDSA, ecParameters.namedCurve, extractable, usages);
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());
         return;
@@ -102,7 +99,7 @@ void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& paramete
     callback(WTFMove(pair));
 }
 
-void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
+void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmECDSAInternal;
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
@@ -133,7 +130,7 @@ void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, con
             return;
         }
 
-        result = CryptoKeyEC::importJwk(ecParameters.identifier, ecParameters.namedCurve, WTFMove(key), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importJwk(ecParameters.identifier, ecParameters.namedCurve, WTFMove(key), extractable, usages);
         break;
     }
     case CryptoKeyFormat::Raw:
@@ -141,21 +138,21 @@ void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, con
             exceptionCallback(ExceptionCode::SyntaxError);
             return;
         }
-        result = CryptoKeyEC::importRaw(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importRaw(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Spki:
         if (usages && (usages ^ CryptoKeyUsageVerify)) {
             exceptionCallback(ExceptionCode::SyntaxError);
             return;
         }
-        result = CryptoKeyEC::importSpki(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importSpki(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Pkcs8:
         if (usages && (usages ^ CryptoKeyUsageSign)) {
             exceptionCallback(ExceptionCode::SyntaxError);
             return;
         }
-        result = CryptoKeyEC::importPkcs8(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages, useCryptoKit);
+        result = CryptoKeyEC::importPkcs8(ecParameters.identifier, ecParameters.namedCurve, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     }
     if (!result) {
@@ -166,7 +163,7 @@ void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, con
     callback(*result);
 }
 
-void CryptoAlgorithmECDSA::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
+void CryptoAlgorithmECDSA::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     const auto& ecKey = downcast<CryptoKeyEC>(key.get());
     if (!ecKey.keySizeInBits()) {
@@ -177,7 +174,7 @@ void CryptoAlgorithmECDSA::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& ke
     KeyData result;
     switch (format) {
     case CryptoKeyFormat::Jwk: {
-        auto jwk = ecKey.exportJwk(useCryptoKit);
+        auto jwk = ecKey.exportJwk();
         if (jwk.hasException()) {
             exceptionCallback(jwk.releaseException().code());
             return;
@@ -186,7 +183,7 @@ void CryptoAlgorithmECDSA::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& ke
         break;
     }
     case CryptoKeyFormat::Raw: {
-        auto raw = ecKey.exportRaw(useCryptoKit);
+        auto raw = ecKey.exportRaw();
         if (raw.hasException()) {
             exceptionCallback(raw.releaseException().code());
             return;
@@ -195,7 +192,7 @@ void CryptoAlgorithmECDSA::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& ke
         break;
     }
     case CryptoKeyFormat::Spki: {
-        auto spki = ecKey.exportSpki(useCryptoKit);
+        auto spki = ecKey.exportSpki();
         if (spki.hasException()) {
             exceptionCallback(spki.releaseException().code());
             return;
@@ -204,7 +201,7 @@ void CryptoAlgorithmECDSA::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& ke
         break;
     }
     case CryptoKeyFormat::Pkcs8: {
-        auto pkcs8 = ecKey.exportPkcs8(useCryptoKit);
+        auto pkcs8 = ecKey.exportPkcs8();
         if (pkcs8.hasException()) {
             exceptionCallback(pkcs8.releaseException().code());
             return;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.h
@@ -45,11 +45,11 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, UseCryptoKit);
-    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -35,14 +35,14 @@
 namespace WebCore {
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&)
 {
     ASSERT_NOT_REACHED();
     notImplemented();
     return Exception { ExceptionCode::NotSupportedError };
 }
 
-ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&)
 {
     ASSERT_NOT_REACHED();
     notImplemented();
@@ -80,10 +80,9 @@ void CryptoAlgorithmEd25519::sign(const CryptoAlgorithmParameters&, Ref<CryptoKe
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), data = WTFMove(data), useCryptoKit] {
-            return platformSign(downcast<CryptoKeyOKP>(key.get()), data, useCryptoKit);
+        [key = WTFMove(key), data = WTFMove(data)] {
+            return platformSign(downcast<CryptoKeyOKP>(key.get()), data);
     });
 }
 
@@ -93,14 +92,13 @@ void CryptoAlgorithmEd25519::verify(const CryptoAlgorithmParameters&, Ref<Crypto
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data), useCryptoKit] {
-            return platformVerify(downcast<CryptoKeyOKP>(key.get()), signature, data, useCryptoKit);
+        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
+            return platformVerify(downcast<CryptoKeyOKP>(key.get()), signature, data);
         });
 }
 
-void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     RefPtr<CryptoKeyOKP> result;
     switch (format) {
@@ -146,7 +144,7 @@ void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, c
     callback(*result);
 }
 
-void CryptoAlgorithmEd25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmEd25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     const auto& okpKey = downcast<CryptoKeyOKP>(key.get());
     if (!okpKey.keySizeInBits()) {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
@@ -46,11 +46,11 @@ private:
     void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&, UseCryptoKit);
-    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 };
 
 inline CryptoAlgorithmIdentifier CryptoAlgorithmEd25519::identifier() const

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -51,14 +51,13 @@ void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
 
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTFMove(baseKey), length, useCryptoKit] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length, useCryptoKit);
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTFMove(baseKey), length] {
+            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length);
         });
 }
 
-void CryptoAlgorithmHKDF::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmHKDF::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     if (format != CryptoKeyFormat::Raw) {
         exceptionCallback(ExceptionCode::NotSupportedError);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
@@ -43,10 +43,10 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
@@ -58,19 +58,17 @@ CryptoAlgorithmIdentifier CryptoAlgorithmHMAC::identifier() const
 
 void CryptoAlgorithmHMAC::sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), data = WTFMove(data), useCryptoKit] {
-            return platformSign(downcast<CryptoKeyHMAC>(key.get()), data, useCryptoKit);
+        [key = WTFMove(key), data = WTFMove(data)] {
+            return platformSign(downcast<CryptoKeyHMAC>(key.get()), data);
         });
 }
 
 void CryptoAlgorithmHMAC::verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&& key, Vector<uint8_t>&& signature, Vector<uint8_t>&& data, BoolCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
-        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data), useCryptoKit] {
-            return platformVerify(downcast<CryptoKeyHMAC>(key.get()), signature, data, useCryptoKit);
+        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
+            return platformVerify(downcast<CryptoKeyHMAC>(key.get()), signature, data);
         });
 }
 
@@ -97,7 +95,7 @@ void CryptoAlgorithmHMAC::generateKey(const CryptoAlgorithmParameters& parameter
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmHMACInternal;
 
@@ -146,7 +144,7 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
     callback(*result);
 }
 
-void CryptoAlgorithmHMAC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmHMAC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmHMACInternal;
     const auto& hmacKey = downcast<CryptoKeyHMAC>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h
@@ -38,8 +38,8 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     // Operations can be performed directly.
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyHMAC&, const Vector<uint8_t>&, UseCryptoKit);
-    static ExceptionOr<bool> platformVerify(const CryptoKeyHMAC&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyHMAC&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyHMAC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
 
 private:
     CryptoAlgorithmHMAC() = default;
@@ -48,8 +48,8 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -56,7 +56,7 @@ void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& paramete
         });
 }
 
-void CryptoAlgorithmPBKDF2::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmPBKDF2::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     if (format != CryptoKeyFormat::Raw) {
         exceptionCallback(ExceptionCode::NotSupportedError);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h
@@ -43,7 +43,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmPbkdf2Params&, const CryptoKeyRaw&, size_t);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp
@@ -92,7 +92,7 @@ void CryptoAlgorithmRSAES_PKCS1_v1_5::generateKey(const CryptoAlgorithmParameter
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSAES_PKCS1_v1_5, CryptoAlgorithmIdentifier::SHA_1, false, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSAES_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSAES_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     RefPtr<CryptoKeyRSA> result;
     switch (format) {
@@ -141,7 +141,7 @@ void CryptoAlgorithmRSAES_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&
     callback(*result);
 }
 
-void CryptoAlgorithmRSAES_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSAES_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.h
@@ -44,8 +44,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoKeyRSA&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
@@ -98,7 +98,7 @@ void CryptoAlgorithmRSASSA_PKCS1_v1_5::generateKey(const CryptoAlgorithmParamete
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5, rsaParameters.hashIdentifier, true, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmRSASSA_PKCS1_v1_5Internal;
 
@@ -176,7 +176,7 @@ void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData
     callback(*result);
 }
 
-void CryptoAlgorithmRSASSA_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSASSA_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmRSASSA_PKCS1_v1_5Internal;
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
@@ -44,8 +44,8 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
@@ -100,7 +100,7 @@ void CryptoAlgorithmRSA_OAEP::generateKey(const CryptoAlgorithmParameters& param
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSA_OAEP, rsaParameters.hashIdentifier, true, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmRSA_OAEPInternal;
 
@@ -190,7 +190,7 @@ void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, 
     callback(*result);
 }
 
-void CryptoAlgorithmRSA_OAEP::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSA_OAEP::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmRSA_OAEPInternal;
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.h
@@ -45,8 +45,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmRsaOaepParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmRsaOaepParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
@@ -102,7 +102,7 @@ void CryptoAlgorithmRSA_PSS::generateKey(const CryptoAlgorithmParameters& parame
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSA_PSS, rsaParameters.hashIdentifier, true, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmRSA_PSSInternal;
 
@@ -180,7 +180,7 @@ void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, c
     callback(*result);
 }
 
-void CryptoAlgorithmRSA_PSS::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmRSA_PSS::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     using namespace CryptoAlgorithmRSA_PSSInternal;
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.h
@@ -47,8 +47,8 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -57,7 +57,7 @@ void CryptoAlgorithmX25519::generateKey(const CryptoAlgorithmParameters&, bool e
 }
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)
-std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&, UseCryptoKit)
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&)
 {
     return std::nullopt;
 }
@@ -103,19 +103,18 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         (*derivedKey).shrink(lengthInBytes);
         callback(WTFMove(*derivedKey));
     };
-    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     // This is a special case that can't use dispatchOperation() because it bundles
     // the result validation and callback dispatch into unifiedCallback.
     workQueue.dispatch(
-        [baseKey = WTFMove(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTFMove(unifiedCallback), contextIdentifier = context.identifier(), useCryptoKit]() mutable {
-            auto derivedKey = platformDeriveBits(downcast<CryptoKeyOKP>(baseKey.get()), downcast<CryptoKeyOKP>(*publicKey), useCryptoKit);
+        [baseKey = WTFMove(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTFMove(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
+            auto derivedKey = platformDeriveBits(downcast<CryptoKeyOKP>(baseKey.get()), downcast<CryptoKeyOKP>(*publicKey));
             ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTFMove(derivedKey), length, unifiedCallback = WTFMove(unifiedCallback)](auto&) mutable {
                 unifiedCallback(WTFMove(derivedKey), length);
             });
         });
 }
 
-void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     RefPtr<CryptoKeyOKP> result;
     switch (format) {
@@ -172,7 +171,7 @@ void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmX25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
+void CryptoAlgorithmX25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
     const auto& ecKey = downcast<CryptoKeyOKP>(key.get());
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
@@ -37,10 +37,10 @@ private:
 
     void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 
-    static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&, UseCryptoKit);
+    static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+#if !HAVE(SWIFT_CPP_INTEROP)
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKW(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     Vector<uint8_t> result(CCSymmetricWrappedSize(kCCWRAPAES, data.size()));
@@ -59,8 +60,7 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKW(const Vector<uint8_t>& key, c
     result.shrink(resultSize);
     return WTFMove(result);
 }
-
-#if HAVE(SWIFT_CPP_INTEROP)
+#else
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = PAL::AesKw::wrap(data.span(), key.span());
@@ -78,26 +78,22 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t
 }
 #endif
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return wrapKeyAESKWCryptoKit(key.key(), data);
+    return wrapKeyAESKWCryptoKit(key.key(), data);
 #else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return wrapKeyAESKW(key.key(), data);
+#endif
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return unwrapKeyAESKWCryptoKit(key.key(), data);
+    return unwrapKeyAESKWCryptoKit(key.key(), data);
 #else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return unwrapKeyAESKW(key.key(), data);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp
@@ -34,46 +34,34 @@
 
 namespace WebCore {
 
+#if !HAVE(SWIFT_CPP_INTEROP)
 static std::optional<Vector<uint8_t>> platformDeriveBitsCC(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
     std::optional<Vector<uint8_t>> result = std::nullopt;
     Vector<uint8_t> derivedKey(baseKey.keySizeInBytes()); // Per https://tools.ietf.org/html/rfc6090#section-4.
     size_t size = derivedKey.size();
-#if HAVE(SWIFT_CPP_INTEROP)
-    const auto* priv = std::get_if<CCPlatformECKeyContainer>(&baseKey.platformKey());
-    const auto* pub = std::get_if<CCPlatformECKeyContainer>(&publicKey.platformKey());
 
-    if (!priv || !pub)
-        return std::nullopt;
-    if (!CCECCryptorComputeSharedSecret((*priv).get(), (*pub).get(), derivedKey.data(), &size))
-#else
     if (!CCECCryptorComputeSharedSecret(baseKey.platformKey().get(), publicKey.platformKey().get(), derivedKey.data(), &size))
-#endif
         result = std::make_optional(WTFMove(derivedKey));
     return result;
 }
-
-#if HAVE(SWIFT_CPP_INTEROP)
+#else
 static std::optional<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
-    const auto* priv  = std::get_if<CKPlatformECKeyContainer>(&baseKey.platformKey());
-    const auto* pub = std::get_if<CKPlatformECKeyContainer>(&publicKey.platformKey());
-    if (!priv || !pub)
-        return std::nullopt;
-    auto rv = (*priv)->deriveBits(*pub);
+    auto rv = baseKey.platformKey()->deriveBits(publicKey.platformKey());
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return std::nullopt;
     return std::make_optional(WTFMove(rv.result));
 }
 #endif
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey, [[maybe_unused]] UseCryptoKit useCryptoKit) {
-
+std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
+{
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return platformDeriveBitsCryptoKit(baseKey, publicKey);
-#endif
+    return platformDeriveBitsCryptoKit(baseKey, publicKey);
+#else
     return platformDeriveBitsCC(baseKey, publicKey);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -40,12 +40,9 @@ namespace WebCore {
 
 static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& data)
 {
-    const auto* priv = std::get_if<CKPlatformECKeyContainer>(&key);
-    if (!priv)
-        return Exception { ExceptionCode::OperationError };
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    auto rv = (*priv)->sign(data.span(), toCKHashFunction(hash));
+    auto rv = key->sign(data.span(), toCKHashFunction(hash));
     if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
     return WTFMove(rv.result);
@@ -53,14 +50,11 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
 
 static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
 {
-    const auto* pub = std::get_if<CKPlatformECKeyContainer>(&key);
-    if (!pub)
-        return Exception { ExceptionCode::OperationError };
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return (*pub)->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == Cpp::ErrorCodes::Success;
+    return key->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == Cpp::ErrorCodes::Success;
 }
-#endif
+#else
 
 static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, size_t keyLengthInBytes, const Vector<uint8_t>& data)
 {
@@ -81,14 +75,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     // tag + length(1) + tag + length(1) + InitialOctet(?) + keyLength in bytes + tag + length(1) + InitialOctet(?) + keyLength in bytes
     Vector<uint8_t> signature(8 + keyLengthInBytes * 2);
     size_t signatureSize = signature.size();
-#if HAVE(SWIFT_CPP_INTEROP)
-    const auto* priv = std::get_if<CCPlatformECKeyContainer>(&key);
-    if (!priv)
-        return Exception { ExceptionCode::OperationError };
-    CCCryptorStatus status = CCECCryptorSignHash((*priv).get(), digestData.data(), digestData.size(), signature.data(), &signatureSize);
-#else
     CCCryptorStatus status = CCECCryptorSignHash(key.get(), digestData.data(), digestData.size(), signature.data(), &signatureSize);
-#endif
     if (status)
         return Exception { ExceptionCode::OperationError };
 
@@ -181,37 +168,31 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     newSignature.append(signature.subspan(sStart, keyLengthInBytes * 2 - sStart));
 
     uint32_t valid;
-#if HAVE(SWIFT_CPP_INTEROP)
-    const auto* pub = std::get_if<CCPlatformECKeyContainer>(&key);
-    if (!pub)
-        return Exception { ExceptionCode::OperationError };
-    CCCryptorStatus status = CCECCryptorVerifyHash((*pub).get(), digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
-#else
     CCCryptorStatus status = CCECCryptorVerifyHash(key.get(), digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
-#endif
     if (status) {
         WTFLogAlways("ERROR: CCECCryptorVerifyHash() returns error=%d", status);
         return false;
     }
     return valid;
 }
+#endif
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data, [[maybe_unused]] UseCryptoKit useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return signECDSACryptoKit(parameters.hashIdentifier, key.platformKey(), data);
-#endif
+    return signECDSACryptoKit(parameters.hashIdentifier, key.platformKey(), data);
+#else
     return signECDSA(parameters.hashIdentifier, key.platformKey(), key.keySizeInBytes(), data);
+#endif
 }
 
-ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, [[maybe_unused]] UseCryptoKit useCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return verifyECDSACryptoKit(parameters.hashIdentifier, key.platformKey(), signature, data);
-#endif
+    return verifyECDSACryptoKit(parameters.hashIdentifier, key.platformKey(), signature, data);
+#else
     return verifyECDSA(parameters.hashIdentifier, key.platformKey(), key.keySizeInBytes(), signature, data);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+#if !HAVE(SWIFT_CPP_INTEROP)
 static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, const Vector<uint8_t>& data)
 {
     if (sk.size() != ed25519KeySize)
@@ -59,8 +60,7 @@ static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, const Vector<
     const struct ccdigest_info* di = ccsha512_di();
     return !cced25519_verify(di, data.size(), data.data(), signature.data(), key.data());
 }
-#if HAVE(SWIFT_CPP_INTEROP)
-
+#else
 static ExceptionOr<Vector<uint8_t>> signEd25519CryptoKit(const Vector<uint8_t>&sk, const Vector<uint8_t>& data)
 {
     if (sk.size() != ed25519KeySize)
@@ -80,26 +80,22 @@ static ExceptionOr<bool>  verifyEd25519CryptoKit(const Vector<uint8_t>& pubKey, 
 }
 #endif
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return signEd25519CryptoKit(key.platformKey(), data);
+    return signEd25519CryptoKit(key.platformKey(), data);
 #else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return signEd25519(key.platformKey(), data);
+#endif
 }
 
-ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return verifyEd25519CryptoKit(key.platformKey(), signature, data);
+    return verifyEd25519CryptoKit(key.platformKey(), signature, data);
 #else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return verifyEd25519(key.platformKey(), signature, data);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
@@ -56,14 +56,14 @@ static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgo
 }
 #endif
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length, UseCryptoKit useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes && parameters.hashIdentifier != CryptoAlgorithmIdentifier::SHA_224)
+    if (parameters.hashIdentifier != CryptoAlgorithmIdentifier::SHA_224)
         return platformDeriveBitsCryptoKit(parameters, key, length);
-#else
-UNUSED_PARAM(useCryptoKit);
-#endif
     return platformDeriveBitsCC(parameters, key, length);
+#else
+    return platformDeriveBitsCC(parameters, key, length);
+#endif
 }
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
@@ -89,25 +89,25 @@ static ExceptionOr<bool> platformVerifyCC(const CryptoKeyHMAC& key, const Vector
     return signature.size() == expectedSignature.size() && !constantTimeMemcmp(expectedSignature.data(), signature.data(), expectedSignature.size());
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes && key.hashAlgorithmIdentifier() != CryptoAlgorithmIdentifier::SHA_224)
+    if (key.hashAlgorithmIdentifier() != CryptoAlgorithmIdentifier::SHA_224)
         return platformSignCryptoKit(key, data);
-#else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return platformSignCC(key, data);
+#else
+    return platformSignCC(key, data);
+#endif
 }
 
-ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes && key.hashAlgorithmIdentifier() != CryptoAlgorithmIdentifier::SHA_224)
+    if (key.hashAlgorithmIdentifier() != CryptoAlgorithmIdentifier::SHA_224)
         return platformVerifyCryptoKit(key, signature, data);
-#else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return platformVerifyCC(key, signature, data);
+#else
+    return platformVerifyCC(key, signature, data);
+#endif
 }
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -38,7 +38,7 @@ static std::optional<Vector<uint8_t>> deriveBitsCryptoKit(const Vector<uint8_t>&
         return std::nullopt;
     return WTFMove(rv.result);
 }
-#endif
+#else
 static std::optional<Vector<uint8_t>> deriveBitsCoreCrypto(const Vector<uint8_t>& baseKey, const Vector<uint8_t>& publicKey)
 {
     if (baseKey.size() != ed25519KeySize || publicKey.size() != ed25519KeySize)
@@ -54,16 +54,13 @@ static std::optional<Vector<uint8_t>> deriveBitsCoreCrypto(const Vector<uint8_t>
 #endif
     return Vector<uint8_t>(std::span { derivedKey, ed25519KeySize });
 }
-
-std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey, UseCryptoKit useCryptoKit)
+#endif
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit == UseCryptoKit::Yes)
-        return deriveBitsCryptoKit(baseKey.platformKey(), publicKey.platformKey());
+    return deriveBitsCryptoKit(baseKey.platformKey(), publicKey.platformKey());
 #else
-    UNUSED_PARAM(useCryptoKit);
-#endif
     return deriveBitsCoreCrypto(baseKey.platformKey(), publicKey.platformKey());
-
+#endif
 }
 } // namespace WebCore

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
@@ -177,7 +177,7 @@ static std::optional<Vector<uint8_t>> gcryptDecrypt(const Vector<uint8_t>& key, 
     return output;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText)
 {
     auto output = gcryptEncrypt(key.key(), parameters.ivVector(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp
@@ -113,7 +113,7 @@ static std::optional<Vector<uint8_t>> gcryptUnwrapKey(const Vector<uint8_t>& key
     return output;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)
 {
     auto output = gcryptWrapKey(key.key(), data);
     if (!output)
@@ -121,7 +121,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoK
     return WTFMove(*output);
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)
 {
     auto output = gcryptUnwrapKey(key.key(), data);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp
@@ -98,7 +98,7 @@ static std::optional<Vector<uint8_t>> gcryptDerive(gcry_sexp_t baseKeySexp, gcry
     return mpiZeroPrefixedData(xMPI, keySizeInBytes);
 }
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey, UseCryptoKit)
+std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
     return gcryptDerive(baseKey.platformKey().get(), publicKey.platformKey().get(), (baseKey.keySizeInBits() + 7) / 8);
 }

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -168,7 +168,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
     return { error == GPG_ERR_NO_ERROR };
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
 {
     auto output = gcryptSign(key.platformKey().get(), data, parameters.hashIdentifier, (key.keySizeInBits() + 7) / 8);
     if (!output)
@@ -176,7 +176,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgo
     return WTFMove(*output);
 }
 
-ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     auto output = gcryptVerify(key.platformKey().get(), signature, data, parameters.hashIdentifier, (key.keySizeInBits() + 7)/ 8);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -143,12 +143,12 @@ static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLen
     return { error == GPG_ERR_NO_ERROR };
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)
 {
     return signEd25519(key.platformKey(), key.keySizeInBytes(), data);
 }
 
-ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     return verifyEd25519(key.platformKey(), key.keySizeInBytes(), signature, data);
 }

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
@@ -150,7 +150,7 @@ static std::optional<Vector<uint8_t>> gcryptDeriveBits(const Vector<uint8_t>& ke
     return output;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
 {
     auto output = gcryptDeriveBits(key.key(), parameters.saltVector(), parameters.infoVector(), length / 8, parameters.hashIdentifier);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
@@ -80,7 +80,7 @@ static std::optional<Vector<uint8_t>> calculateSignature(int algorithm, const Ve
     return signature;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
     auto algorithm = getGCryptDigestAlgorithm(key.hashAlgorithmIdentifier());
     if (algorithm == GCRY_MAC_NONE)
@@ -92,7 +92,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     return WTFMove(*result);
 }
 
-ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     auto algorithm = getGCryptDigestAlgorithm(key.hashAlgorithmIdentifier());
     if (algorithm == GCRY_MAC_NONE)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
@@ -32,7 +32,7 @@ static std::optional<Vector<uint8_t>> gcryptDerive(const Vector<uint8_t>& baseKe
     return GCrypt::RFC7748::X25519(baseKey, publicKey);
 }
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey, UseCryptoKit)
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
 {
     return gcryptDerive(baseKey.platformKey(), publicKey.platformKey());
 }

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -112,7 +112,7 @@ bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
     return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521;
 }
 
-std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages)
 {
     PAL::GCrypt::Handle<gcry_sexp_t> genkeySexp;
     gcry_error_t error = gcry_sexp_build(&genkeySexp, nullptr, "(genkey(ecc(curve %s)))", curveName(curve).characters());
@@ -138,7 +138,7 @@ std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmId
     return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     if (keyData.size() != curveUncompressedPointSize(curve))
         return nullptr;
@@ -154,7 +154,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
     return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(platformKey.release()), extractable, usages);
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap usages)
 {
     unsigned uncompressedFieldElementSize = curveUncompressedFieldElementSize(curve);
     if (x.size() != uncompressedFieldElementSize || y.size() != uncompressedFieldElementSize)
@@ -178,7 +178,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifi
     return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(platformKey.release()), extractable, usages);
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap usages)
 {
     unsigned uncompressedFieldElementSize = curveUncompressedFieldElementSize(curve);
     if (x.size() != uncompressedFieldElementSize || y.size() != uncompressedFieldElementSize || d.size() != uncompressedFieldElementSize)
@@ -243,7 +243,7 @@ static std::optional<CryptoKeyEC::NamedCurve> curveForIdentifier(const Vector<ui
     return std::nullopt;
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // Decode the `SubjectPublicKeyInfo` structure using the provided key data.
     PAL::TASN1::Structure spki;
@@ -339,7 +339,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
     return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(platformKey.release()), extractable, usages);
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // Decode the `PrivateKeyInfo` structure using the provided key data.
     PAL::TASN1::Structure pkcs8;
@@ -484,7 +484,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     return create(identifier, curve, CryptoKeyType::Private, PlatformECKeyContainer(platformKey.release()), extractable, usages);
 }
 
-Vector<uint8_t> CryptoKeyEC::platformExportRaw(UseCryptoKit) const
+Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
     PAL::GCrypt::Handle<gcry_ctx_t> context;
     gcry_error_t error = gcry_mpi_ec_new(&context, platformKey().get(), nullptr);
@@ -504,7 +504,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportRaw(UseCryptoKit) const
     return WTFMove(q.value());
 }
 
-bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit) const
+bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
 {
     PAL::GCrypt::Handle<gcry_ctx_t> context;
     gcry_error_t error = gcry_mpi_ec_new(&context, platformKey().get(), nullptr);
@@ -544,7 +544,7 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit) const
     return true;
 }
 
-Vector<uint8_t> CryptoKeyEC::platformExportSpki(UseCryptoKit) const
+Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
 {
     PAL::TASN1::Structure ecParameters;
     {
@@ -606,7 +606,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki(UseCryptoKit) const
     return WTFMove(result.value());
 }
 
-Vector<uint8_t> CryptoKeyEC::platformExportPkcs8(UseCryptoKit) const
+Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
 {
     PAL::TASN1::Structure ecParameters;
     {

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.cpp
@@ -73,14 +73,14 @@ RefPtr<CryptoKeyAES> CryptoKeyAES::generate(CryptoAlgorithmIdentifier algorithm,
     return adoptRef(new CryptoKeyAES(algorithm, randomData(lengthBits / 8), extractable, usages));
 }
 
-RefPtr<CryptoKeyAES> CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier algorithm, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyAES> CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier algorithm, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     if (!lengthIsValid(keyData.size() * 8))
         return nullptr;
     return adoptRef(new CryptoKeyAES(algorithm, WTFMove(keyData), extractable, usages));
 }
 
-RefPtr<CryptoKeyAES> CryptoKeyAES::importJwk(CryptoAlgorithmIdentifier algorithm, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages, CheckAlgCallback&& callback, UseCryptoKit)
+RefPtr<CryptoKeyAES> CryptoKeyAES::importJwk(CryptoAlgorithmIdentifier algorithm, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages, CheckAlgCallback&& callback)
 {
     if (keyData.kty != "oct"_s)
         return nullptr;

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.h
@@ -52,9 +52,9 @@ public:
     static bool isValidAESAlgorithm(CryptoAlgorithmIdentifier);
 
     static RefPtr<CryptoKeyAES> generate(CryptoAlgorithmIdentifier, size_t lengthBits, bool extractable, CryptoKeyUsageBitmap);
-    WEBCORE_EXPORT static RefPtr<CryptoKeyAES> importRaw(CryptoAlgorithmIdentifier, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
+    WEBCORE_EXPORT static RefPtr<CryptoKeyAES> importRaw(CryptoAlgorithmIdentifier, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
     using CheckAlgCallback = Function<bool(size_t, const String&)>;
-    static RefPtr<CryptoKeyAES> importJwk(CryptoAlgorithmIdentifier, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap, CheckAlgCallback&&, UseCryptoKit = UseCryptoKit::No);
+    static RefPtr<CryptoKeyAES> importJwk(CryptoAlgorithmIdentifier, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap, CheckAlgCallback&&);
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::AES; }
 

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -37,13 +37,7 @@ class ECKey;
 }
 
 namespace WebCore {
-struct CCECCryptorRefDeleter {
-    void operator()(CCECCryptorRef key) const { CCECCryptorRelease(key); }
-};
-
-using CCPlatformECKeyContainer = std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, CCECCryptorRefDeleter>;
-using CKPlatformECKeyContainer = UniqueRef<PAL::ECKey>;
-using PlatformECKeyContainer = std::variant<CCPlatformECKeyContainer, CKPlatformECKeyContainer>;
+using PlatformECKeyContainer = UniqueRef<PAL::ECKey>;
 }
 #else
 namespace WebCore {
@@ -87,16 +81,16 @@ public:
     }
     virtual ~CryptoKeyEC() = default;
 
-    WEBCORE_EXPORT static ExceptionOr<CryptoKeyPair> generatePair(CryptoAlgorithmIdentifier, const String& curve, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit);
-    WEBCORE_EXPORT static RefPtr<CryptoKeyEC> importRaw(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit);
-    static RefPtr<CryptoKeyEC> importJwk(CryptoAlgorithmIdentifier, const String& curve, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit);
-    static RefPtr<CryptoKeyEC> importSpki(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit);
-    static RefPtr<CryptoKeyEC> importPkcs8(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit);
+    WEBCORE_EXPORT static ExceptionOr<CryptoKeyPair> generatePair(CryptoAlgorithmIdentifier, const String& curve, bool extractable, CryptoKeyUsageBitmap);
+    WEBCORE_EXPORT static RefPtr<CryptoKeyEC> importRaw(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> importJwk(CryptoAlgorithmIdentifier, const String& curve, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> importSpki(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> importPkcs8(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
 
-    WEBCORE_EXPORT ExceptionOr<Vector<uint8_t>> exportRaw(UseCryptoKit) const;
-    ExceptionOr<JsonWebKey> exportJwk(UseCryptoKit) const;
-    ExceptionOr<Vector<uint8_t>> exportSpki(UseCryptoKit) const;
-    ExceptionOr<Vector<uint8_t>> exportPkcs8(UseCryptoKit) const;
+    WEBCORE_EXPORT ExceptionOr<Vector<uint8_t>> exportRaw() const;
+    ExceptionOr<JsonWebKey> exportJwk() const;
+    ExceptionOr<Vector<uint8_t>> exportSpki() const;
+    ExceptionOr<Vector<uint8_t>> exportPkcs8() const;
 
     size_t keySizeInBits() const;
     size_t keySizeInBytes() const { return std::ceil(keySizeInBits() / 8.); }
@@ -112,22 +106,17 @@ private:
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::EC; }
 
     KeyAlgorithm algorithm() const final;
-#if HAVE(SWIFT_CPP_INTEROP)
-    static PlatformECKeyContainer toCCPlatformECKeyContainer(CCECCryptorRef);
-    // FIXME: change this to a move construction when Swift reverse interop starts supporting move construction for value types. rdar://126558127
-    static PlatformECKeyContainer toCKPlatformECKeyContainer(PAL::ECKey);
-#endif
     static bool platformSupportedCurve(NamedCurve);
-    static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
-    static RefPtr<CryptoKeyEC> platformImportRaw(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
-    static RefPtr<CryptoKeyEC> platformImportJWKPublic(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
-    static RefPtr<CryptoKeyEC> platformImportJWKPrivate(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
-    static RefPtr<CryptoKeyEC> platformImportSpki(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
-    static RefPtr<CryptoKeyEC> platformImportPkcs8(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
-    Vector<uint8_t> platformExportRaw(UseCryptoKit = UseCryptoKit::No) const;
-    bool platformAddFieldElements(JsonWebKey&, UseCryptoKit = UseCryptoKit::No) const;
-    Vector<uint8_t> platformExportSpki(UseCryptoKit = UseCryptoKit::No) const;
-    Vector<uint8_t> platformExportPkcs8(UseCryptoKit = UseCryptoKit::No) const;
+    static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> platformImportRaw(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> platformImportJWKPublic(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> platformImportJWKPrivate(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> platformImportSpki(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyEC> platformImportPkcs8(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    Vector<uint8_t> platformExportRaw() const;
+    bool platformAddFieldElements(JsonWebKey&) const;
+    Vector<uint8_t> platformExportSpki() const;
+    Vector<uint8_t> platformExportPkcs8() const;
 
     PlatformECKeyContainer m_platformKey;
     NamedCurve m_curve;

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
@@ -161,7 +161,7 @@ static std::optional<Vector<uint8_t>> cryptDecrypt(const Vector<uint8_t>& key, c
     return plainText;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText)
 {
     auto output = cryptEncrypt(key.key(), parameters.ivVector(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
     if (!output)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp
@@ -63,7 +63,7 @@ static std::optional<Vector<uint8_t>> cryptUnwrapKey(const Vector<uint8_t>& key,
     return plainText;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)
 {
     auto output = cryptWrapKey(key.key(), data);
     if (!output)
@@ -71,7 +71,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoK
     return WTFMove(*output);
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data)
 {
     auto output = cryptUnwrapKey(key.key(), data);
     if (!output)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmECDHOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmECDHOpenSSL.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey, UseCryptoKit)
+std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
 {
     auto ctx = EvpPKeyCtxPtr(EVP_PKEY_CTX_new(baseKey.platformKey().get(), nullptr));
     if (!ctx)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
 {
     size_t keySizeInBytes = (key.keySizeInBits() + 7) / 8;
 
@@ -65,7 +65,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgo
     return signature;
 }
 
-ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     size_t keySizeInBytes = (key.keySizeInBits() + 7) / 8;
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const CryptoAlgorithmHkdfParams& parameters, const CryptoKeyRaw& key, size_t length)
 {
     auto algorithm = digestAlgorithm(parameters.hashIdentifier);
     if (!algorithm)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
@@ -57,7 +57,7 @@ static std::optional<Vector<uint8_t>> calculateSignature(const EVP_MD* algorithm
     return cipherText;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
     auto algorithm = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!algorithm)
@@ -69,7 +69,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     return WTFMove(*result);
 }
 
-ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
+ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
 {
     auto algorithm = digestAlgorithm(key.hashAlgorithmIdentifier());
     if (!algorithm)

--- a/Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp
@@ -98,7 +98,7 @@ bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
     return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521;
 }
 
-std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // To generate a key pair, we generate a private key and extract the public key from the private key.
     auto privateECKey = createECKey(curve);
@@ -132,7 +132,7 @@ std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmId
     return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     auto key = createECKey(curve);
     if (!key)
@@ -157,7 +157,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier ide
     return create(identifier, curve, CryptoKeyType::Public, WTFMove(pkey), extractable, usages);
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap usages)
 {
     auto key = createECKey(curve);
     if (!key)
@@ -183,7 +183,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifi
     return create(identifier, curve, CryptoKeyType::Public, WTFMove(pkey), extractable, usages);
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap usages)
 {
     auto key = createECKey(curve);
     if (!key)
@@ -245,7 +245,7 @@ static bool supportedAlgorithmIdentifier(CryptoAlgorithmIdentifier identifier, c
     }
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // In this function we extract the subjectPublicKey after verifying that the algorithm in the SPKI data
     // match the given identifier and curve. Then construct an EC key with the named curve and set the public key.
@@ -342,7 +342,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
     return adoptRef(new CryptoKeyEC(identifier, curve, CryptoKeyType::Public, WTFMove(pkey), extractable, usages));
 }
 
-RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
+RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // We need a local pointer variable to pass to d2i (DER to internal) functions().
     const uint8_t* ptr = keyData.data();
@@ -373,7 +373,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     return adoptRef(new CryptoKeyEC(identifier, curve, CryptoKeyType::Private, WTFMove(pkey), extractable, usages));
 }
 
-Vector<uint8_t> CryptoKeyEC::platformExportRaw(UseCryptoKit) const
+Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
     EC_KEY* key = EVP_PKEY_get0_EC_KEY(platformKey().get());
     if (!key)
@@ -392,7 +392,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportRaw(UseCryptoKit) const
     return keyData;
 }
 
-bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit) const
+bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
 {
     size_t keySizeInBytes = (keySizeInBits() + 7) / 8;
 
@@ -419,7 +419,7 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit) const
     return true;
 }
 
-Vector<uint8_t> CryptoKeyEC::platformExportSpki(UseCryptoKit) const
+Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
 {
     if (type() != CryptoKeyType::Public)
         return { };
@@ -436,7 +436,7 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki(UseCryptoKit) const
     return keyData;
 }
 
-Vector<uint8_t> CryptoKeyEC::platformExportPkcs8(UseCryptoKit) const
+Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
 {
     if (type() != CryptoKeyType::Private)
         return { };

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -48,7 +48,6 @@ using namespace WebCore;
 using namespace cbor;
 using namespace fido;
 using namespace fido::pin;
-static constexpr auto useCryptoKit = WebCore::UseCryptoKit::Yes;
 
 TEST(CtapPinTest, TestValidateAndConvertToUTF8)
 {
@@ -75,7 +74,7 @@ TEST(CtapPinTest, TestValidateAndConvertToUTF8)
 TEST(CtapPinTest, TestSetPinRequest)
 {
     // Generate an EC key pair as the peer key.
-    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits, useCryptoKit);
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
     ASSERT_FALSE(keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
@@ -127,11 +126,11 @@ TEST(CtapPinTest, TestSetPinRequest)
     EXPECT_NE(xIt, coseKey.end());
     const auto& yIt = coseKey.find(CBORValue(COSE::y));
     EXPECT_NE(yIt, coseKey.end());
-    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits, useCryptoKit);
+    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits);
     EXPECT_TRUE(cosePublicKey);
 
     // Check the encrypted Pin.
-    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey, useCryptoKit);
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey);
     EXPECT_TRUE(sharedKeyResult);
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
@@ -250,7 +249,7 @@ TEST(CtapPinTest, TestKeyAgreementResponse)
     // Success cases
     result = KeyAgreementResponse::parse(convertBytesToVector(TestData::kCtapClientPinKeyAgreementResponse, sizeof(TestData::kCtapClientPinKeyAgreementResponse)));
     EXPECT_TRUE(result);
-    auto exportedRawKey = result->peerKey->exportRaw(useCryptoKit);
+    auto exportedRawKey = result->peerKey->exportRaw();
     EXPECT_FALSE(exportedRawKey.hasException());
     Vector<uint8_t> expectedRawKey;
     expectedRawKey.reserveCapacity(65);
@@ -263,7 +262,7 @@ TEST(CtapPinTest, TestKeyAgreementResponse)
 TEST(CtapPinTest, TestTokenRequest)
 {
     // Generate an EC key pair as the peer key.
-    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits, useCryptoKit);
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
     ASSERT_FALSE(keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
@@ -315,11 +314,11 @@ TEST(CtapPinTest, TestTokenRequest)
     EXPECT_NE(xIt, coseKey.end());
     const auto& yIt = coseKey.find(CBORValue(COSE::y));
     EXPECT_NE(yIt, coseKey.end());
-    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits, useCryptoKit);
+    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits);
     EXPECT_TRUE(cosePublicKey);
 
     // Check the encrypted Pin.
-    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey, useCryptoKit);
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey);
     EXPECT_TRUE(sharedKeyResult);
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);


### PR DESCRIPTION
#### 63e903788f95a0c2dccb3d5c3034001e5d7d6018
<pre>
Remove runtime CryptoKit Enablement
<a href="https://bugs.webkit.org/show_bug.cgi?id=277699">https://bugs.webkit.org/show_bug.cgi?id=277699</a>
<a href="https://rdar.apple.com/133221998">rdar://133221998</a>

Reviewed by Alex Christensen.

With this change we are totally removing the option to switch back to CoreCrypto
at runtime.
A side effect of this is that the PlatformECKeyContainer(CryptoKeyEC.h) for Apple platforms
can no longer be a variant. It will either be CryptoKit or CommonCrypto depending on compile
time flags. As a result, the PlatformECKeyContainer also needs to be refactored to reflect
the same. Both of these changes have to go in lockstep.

No new tests have been added as this is just a refactor with no change in behavior.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::AuthenticatorAttestationResponse::getPublicKey const):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::makePinAuth):
(fido::pin::KeyAgreementResponse::parseFromCOSE):
(fido::pin::TokenRequest::tryCreate):
(fido::pin::SetPinRequest::tryCreate):
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
(WebCore::CloneDeserializer::readECKey):
(WebCore::CloneSerializer::isUsingCryptoKit): Deleted.
(WebCore::CloneDeserializer::isUsingCryptoKit): Deleted.
* Source/WebCore/crypto/CryptoAlgorithm.cpp:
(WebCore::CryptoAlgorithm::importKey):
(WebCore::CryptoAlgorithm::exportKey):
(WebCore::CryptoAlgorithm::wrapKey):
(WebCore::CryptoAlgorithm::unwrapKey):
* Source/WebCore/crypto/CryptoAlgorithm.h:
* Source/WebCore/crypto/CryptoKey.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::deriveKey):
(WebCore::SubtleCrypto::importKey):
(WebCore::SubtleCrypto::exportKey):
(WebCore::SubtleCrypto::wrapKey):
(WebCore::SubtleCrypto::unwrapKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp:
(WebCore::CryptoAlgorithmAESCBC::importKey):
(WebCore::CryptoAlgorithmAESCBC::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp:
(WebCore::CryptoAlgorithmAESCFB::importKey):
(WebCore::CryptoAlgorithmAESCFB::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp:
(WebCore::CryptoAlgorithmAESCTR::importKey):
(WebCore::CryptoAlgorithmAESCTR::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp:
(WebCore::CryptoAlgorithmAESGCM::encrypt):
(WebCore::CryptoAlgorithmAESGCM::importKey):
(WebCore::CryptoAlgorithmAESGCM::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp:
(WebCore::CryptoAlgorithmAESKW::importKey):
(WebCore::CryptoAlgorithmAESKW::exportKey):
(WebCore::CryptoAlgorithmAESKW::wrapKey):
(WebCore::CryptoAlgorithmAESKW::unwrapKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp:
(WebCore::CryptoAlgorithmECDH::generateKey):
(WebCore::CryptoAlgorithmECDH::deriveBits):
(WebCore::CryptoAlgorithmECDH::importKey):
(WebCore::CryptoAlgorithmECDH::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp:
(WebCore::CryptoAlgorithmECDSA::sign):
(WebCore::CryptoAlgorithmECDSA::verify):
(WebCore::CryptoAlgorithmECDSA::generateKey):
(WebCore::CryptoAlgorithmECDSA::importKey):
(WebCore::CryptoAlgorithmECDSA::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp:
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
(WebCore::CryptoAlgorithmEd25519::sign):
(WebCore::CryptoAlgorithmEd25519::verify):
(WebCore::CryptoAlgorithmEd25519::importKey):
(WebCore::CryptoAlgorithmEd25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
(WebCore::CryptoAlgorithmHKDF::deriveBits):
(WebCore::CryptoAlgorithmHKDF::importKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp:
(WebCore::CryptoAlgorithmHMAC::sign):
(WebCore::CryptoAlgorithmHMAC::verify):
(WebCore::CryptoAlgorithmHMAC::importKey):
(WebCore::CryptoAlgorithmHMAC::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp:
(WebCore::CryptoAlgorithmPBKDF2::importKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp:
(WebCore::CryptoAlgorithmRSAES_PKCS1_v1_5::importKey):
(WebCore::CryptoAlgorithmRSAES_PKCS1_v1_5::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp:
(WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey):
(WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp:
(WebCore::CryptoAlgorithmRSA_OAEP::importKey):
(WebCore::CryptoAlgorithmRSA_OAEP::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp:
(WebCore::CryptoAlgorithmRSA_PSS::importKey):
(WebCore::CryptoAlgorithmRSA_PSS::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
(WebCore::CryptoAlgorithmX25519::deriveBits):
(WebCore::CryptoAlgorithmX25519::importKey):
(WebCore::CryptoAlgorithmX25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp:
(WebCore::CryptoAlgorithmAESGCM::platformEncrypt):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp:
(WebCore::CryptoAlgorithmAESKW::platformWrapKey):
(WebCore::CryptoAlgorithmAESKW::platformUnwrapKey):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp:
(WebCore::platformDeriveBitsCC):
(WebCore::platformDeriveBitsCryptoKit):
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
(WebCore::signECDSA):
(WebCore::verifyECDSA):
(WebCore::CryptoAlgorithmECDSA::platformSign):
(WebCore::CryptoAlgorithmECDSA::platformVerify):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::toPlatformKey):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp:
(WebCore::CryptoAlgorithmAESGCM::platformEncrypt):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp:
(WebCore::CryptoAlgorithmAESKW::platformWrapKey):
(WebCore::CryptoAlgorithmAESKW::platformUnwrapKey):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp:
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp:
(WebCore::CryptoAlgorithmECDSA::platformSign):
(WebCore::CryptoAlgorithmECDSA::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp:
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp:
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/keys/CryptoKeyAES.cpp:
(WebCore::CryptoKeyAES::importRaw):
(WebCore::CryptoKeyAES::importJwk):
* Source/WebCore/crypto/keys/CryptoKeyAES.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
(WebCore::CryptoKeyEC::generatePair):
(WebCore::CryptoKeyEC::importRaw):
(WebCore::CryptoKeyEC::importJwk):
(WebCore::CryptoKeyEC::importSpki):
(WebCore::CryptoKeyEC::importPkcs8):
(WebCore::CryptoKeyEC::exportRaw const):
(WebCore::CryptoKeyEC::exportJwk const):
(WebCore::CryptoKeyEC::exportSpki const):
(WebCore::CryptoKeyEC::exportPkcs8 const):
(WebCore::CryptoKeyEC::toCCPlatformECKeyContainer): Deleted.
(WebCore::CryptoKeyEC::toCKPlatformECKeyContainer): Deleted.
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp:
(WebCore::CryptoAlgorithmAESGCM::platformEncrypt):
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp:
(WebCore::CryptoAlgorithmAESKW::platformWrapKey):
(WebCore::CryptoAlgorithmAESKW::platformUnwrapKey):
* Source/WebCore/crypto/openssl/CryptoAlgorithmECDHOpenSSL.cpp:
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp:
(WebCore::CryptoAlgorithmECDSA::platformSign):
(WebCore::CryptoAlgorithmECDSA::platformVerify):
* Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp:
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST(CtapPinTest, TestSetPinRequest)):
(TestWebKitAPI::TEST(CtapPinTest, TestKeyAgreementResponse)):
(TestWebKitAPI::TEST(CtapPinTest, TestTokenRequest)):

Canonical link: <a href="https://commits.webkit.org/282660@main">https://commits.webkit.org/282660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87d5c0ab1ac3e0f83f5611616e4ee592784fa3d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63833 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51435 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9985 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12644 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13314 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/56945 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69550 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63078 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7780 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12512 "Found 2 new test failures: http/tests/media/fairplay/fps-mse-multi-key-renewal.html http/tests/navigation/forward-to-fragment-fires-onload.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58902 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6471 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/84839 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9650 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39010 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14965 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->